### PR TITLE
AX: -[WebAccessibilityObjectWrapperMac accessibilityAttributeValue] and the parameterized equivalent do O(n) comparisons to try to find matching attribute

### DIFF
--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -730,6 +730,8 @@ static bool isTestAXClientType(AXClientType client)
     return client == kAXClientTypeWebKitTesting || client == kAXClientTypeXCTest;
 }
 
+// FIXME: We should inline this function, otherwise we probably aren't
+// benefiting much from the unlikely annotation.
 bool AXObjectCache::clientIsInTestMode()
 {
     if (isTestAXClientType(_AXGetClientForCurrentRequestUntrusted())) [[unlikely]]


### PR DESCRIPTION
#### 27d1f9cc4510863db64c73d0c5739deb8d8d44b3
<pre>
AX: -[WebAccessibilityObjectWrapperMac accessibilityAttributeValue] and the parameterized equivalent do O(n) comparisons to try to find matching attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=308256">https://bugs.webkit.org/show_bug.cgi?id=308256</a>
<a href="https://rdar.apple.com/170762901">rdar://170762901</a>

Reviewed by Joshua Hoffman.

Replace O(n) if/else chains with O(1) HashMap lookup for attribute dispatch in
-accessibilityAttributeValue: and -accessibilityAttributeValue:forParameter:.

Extract each attribute handler into a static function and build a
MemoryCompactLookupOnlyRobinHoodHashMap mapping attribute names to handler
entries. Handler entries include an optional span of preconditions (e.g.,
IsWebArea, IsTextControl, IsExposableTable) with OR semantics - if any
precondition passes, the handler is invoked.

* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleWindowAttribute):
(handleTopLevelUIElementAttribute):
(handleRoleAttribute):
(handleParentAttribute):
(handleSubroleAttribute):
(handlePrimaryScreenHeightAttribute):
(handleRelativeFrameAttribute):
(handleTitleAttribute):
(handleDescriptionAttribute):
(handleInlineTextAttribute):
(handleValueAttribute):
(handleChildrenAttribute):
(handleDatetimeValueAttribute):
(handleARIACurrentAttribute):
(handleEnabledAttribute):
(handleTitleUIElementAttribute):
(handleValueDescriptionAttribute):
(handleFocusedAttribute):
(handleRoleDescriptionAttribute):
(handleLanguageAttribute):
(handleURLAttribute):
(handleSelectedTextMarkerRangeAttribute):
(handleDisclosureLevelAttribute):
(handlePlaceholderValueAttribute):
(handleRequiredAttribute):
(handlePopupValueAttribute):
(handleInvalidAttribute):
(handleHasPopupAttribute):
(handleLinkedUIElementsAttribute):
(handleElementBusyAttribute):
(handleIntersectionWithSelectionRangeAttribute):
(handleDRTSpeechAttribute):
(handleExpandedAttribute):
(handleSelectedChildrenAttribute):
(handleSelectedAttribute):
(handleSizeAttribute):
(handleOrientationAttribute):
(handleVisitedAttribute):
(handleBlockQuoteLevelAttribute):
(handleEmbeddedImageDescriptionAttribute):
(handleContentsAttribute):
(handleHelpAttribute):
(handleDisclosingAttribute):
(handleActiveElementAttribute):
(handleVisibleChildrenAttribute):
(handleLinkUIElementsAttribute):
(handleLoadedAttribute):
(handleLayoutCountAttribute):
(handleLoadingProgressAttribute):
(handlePreventKeyboardDOMEventDispatchAttribute):
(handleCaretBrowsingEnabledAttribute):
(handleNumberOfCharactersAttribute):
(handleSelectedTextAttribute):
(handleSelectedTextRangeAttribute):
(handleInsertionPointLineNumberAttribute):
(handleVisibleCharacterRangeAttribute):
(handleIncrementButtonAttribute):
(handleDecrementButtonAttribute):
(handleDateTimeComponentsAttribute):
(handleMenuItemMarkCharAttribute):
(handleMinValueAttribute):
(handleMaxValueAttribute):
(handlePositionAttribute):
(handlePathAttribute):
(handleLineRectsAndTextAttribute):
(handleImageOverlayElementsAttribute):
(handleAccessKeyAttribute):
(handleLinkRelationshipTypeAttribute):
(handleTabsAttribute):
(handleRowsAttribute):
(handleVisibleRowsAttribute):
(handleColumnsAttribute):
(handleTableSelectedRowsAttribute):
(handleSelectedColumnsAttribute):
(handleSelectedCellsAttribute):
(handleColumnHeaderUIElementsAttribute):
(handleHeaderAttribute):
(handleRowHeaderUIElementsAttribute):
(handleVisibleCellsAttribute):
(handleColumnCountAttribute):
(handleRowCountAttribute):
(handleARIAColumnCountAttribute):
(handleARIARowCountAttribute):
(handleRowIndexRangeAttribute):
(handleColumnIndexRangeAttribute):
(handleARIAColumnIndexAttribute):
(handleARIARowIndexAttribute):
(handleColumnIndexDescriptionAttribute):
(handleRowIndexDescriptionAttribute):
(handleIndexAttribute):
(handleDisclosedRowsAttribute):
(handleDisclosedByRowAttribute):
(handleStartTextMarkerAttribute):
(handleEndTextMarkerAttribute):
(handleTableLevelAttribute):
(handleHorizontalScrollBarAttribute):
(handleVerticalScrollBarAttribute):
(handleSortDirectionAttribute):
(handleOwnsAttribute):
(handleARIAPosInSetAttribute):
(handleARIASetSizeAttribute):
(handleGrabbedAttribute):
(handleDropEffectsAttribute):
(handleValueAutofillAvailableAttribute):
(handleValueAutofillTypeAttribute):
(handleARIALiveAttribute):
(handleARIARelevantAttribute):
(handleARIAAtomicAttribute):
(handleMathRootIndexAttribute):
(handleMathRootRadicandAttribute):
(handleMathFractionNumeratorAttribute):
(handleMathFractionDenominatorAttribute):
(handleMathBaseAttribute):
(handleMathSubscriptAttribute):
(handleMathSuperscriptAttribute):
(handleMathUnderAttribute):
(handleMathOverAttribute):
(handleMathFencedOpenAttribute):
(handleMathFencedCloseAttribute):
(handleMathLineThicknessAttribute):
(handleMathPostscriptsAttribute):
(handleMathPrescriptsAttribute):
(handleExpandedTextValueAttribute):
(handleDOMIdentifierAttribute):
(handleDOMClassListAttribute):
(handleAssociatedPluginParentAttribute):
(handleKeyShortcutsAttribute):
(handleIsInDescriptionListTermAttribute):
(handleDetailsElementsAttribute):
(handleBrailleLabelAttribute):
(handleBrailleRoleDescriptionAttribute):
(handleErrorMessageElementsAttribute):
(handleFocusableAncestorAttribute):
(handleEditableAncestorAttribute):
(handleHighestEditableAncestorAttribute):
(handleTextInputMarkedRangeAttribute):
(handleTextInputMarkedTextMarkerRangeAttribute):
(handleAutoInteractableAttribute):
(createAttributeHandlerMap):
(matchesPrecondition):
(matchesAnyPrecondition):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(handleUIElementsForSearchPredicateAttribute):
(handleUIElementForTextMarkerAttribute):
(handleTextMarkerRangeForUIElementAttribute):
(handleTextMarkerRangeForTextMarkersAttribute):
(handleParamAttributedStringForRangeAttribute):
(handleParamLineForIndexAttribute):
(handleParamRangeForLineAttribute):
(handleParamRangeForPositionAttribute):
(handleParamRangeForIndexAttribute):
(handleParamRTFForRangeAttribute):
(handleParamStyleRangeForIndexAttribute):
(handleAttributedStringForTextMarkerRangeAttribute):
(handleSelectTextWithCriteriaAttribute):
(handleSearchTextWithCriteriaAttribute):
(handleTextOperationAttribute):
(handleRangesForSearchPredicateAttribute):
(handleEndTextMarkerForBoundsAttribute):
(handleStartTextMarkerForBoundsAttribute):
(handleLineTextMarkerRangeForTextMarkerAttribute):
(handleMisspellingTextMarkerRangeAttribute):
(handleTextMarkerIsValidAttribute):
(handleIndexForTextMarkerAttribute):
(handleTextMarkerForIndexAttribute):
(handleLineForTextMarkerAttribute):
(handleTextMarkerRangeForLineAttribute):
(handleStringForTextMarkerRangeAttribute):
(handleTextMarkerForPositionAttribute):
(handleBoundsForTextMarkerRangeAttribute):
(handleBoundsForRangeParameterizedAttribute):
(handleStringForRangeParameterizedAttribute):
(handleAttributedStringForTextMarkerRangeWithOptionsAttribute):
(handleNextTextMarkerForTextMarkerAttribute):
(handlePreviousTextMarkerForTextMarkerAttribute):
(handleLeftWordTextMarkerRangeForTextMarkerAttribute):
(handleRightWordTextMarkerRangeForTextMarkerAttribute):
(handleLeftLineTextMarkerRangeForTextMarkerAttribute):
(handleRightLineTextMarkerRangeForTextMarkerAttribute):
(handleSentenceTextMarkerRangeForTextMarkerAttribute):
(handleParagraphTextMarkerRangeForTextMarkerAttribute):
(handleNextWordEndTextMarkerForTextMarkerAttribute):
(handlePreviousWordStartTextMarkerForTextMarkerAttribute):
(handleNextLineEndTextMarkerForTextMarkerAttribute):
(handlePreviousLineStartTextMarkerForTextMarkerAttribute):
(handleNextSentenceEndTextMarkerForTextMarkerAttribute):
(handlePreviousSentenceStartTextMarkerForTextMarkerAttribute):
(handleNextParagraphEndTextMarkerForTextMarkerAttribute):
(handlePreviousParagraphStartTextMarkerForTextMarkerAttribute):
(handleStyleTextMarkerRangeForTextMarkerAttribute):
(handleLengthForTextMarkerRangeAttribute):
(handleIntersectTextMarkerRangesAttribute):
(handleCellForColumnAndRowParameterizedAttribute):
(handleConvertRelativeFrameParameterizedAttribute):
(createParameterizedAttributeHandlerMap):
(checkParameterizedAttributePrecondition):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/308339@main">https://commits.webkit.org/308339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12af50523621585474875cde851eb48d0d61f751

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147181 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100595 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80906 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94187 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14832 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12619 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3305 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158194 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121453 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31162 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75631 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8694 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83033 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->