### PR TITLE
Convert FrameEdge, TableRules, and CellBorders to scoped enum classes

### DIFF
--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -83,8 +83,8 @@ private:
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 
-    enum TableRules { UnsetRules, NoneRules, GroupsRules, RowsRules, ColsRules, AllRules };
-    enum CellBorders { NoBorders, SolidBorders, InsetBorders, SolidBordersColsOnly, SolidBordersRowsOnly };
+    enum class TableRules : uint8_t { Unset, None, Groups, Rows, Cols, All };
+    enum class CellBorders : uint8_t { None, Solid, Inset, SolidColsOnly, SolidRowsOnly };
 
     CellBorders NODELETE cellBorders() const;
 
@@ -94,7 +94,7 @@ private:
 
     bool m_borderAttr { false }; // Sets a precise border width and creates an outset border for the table and for its cells.
     bool m_frameAttr { false }; // Implies a thin border width if no border is set and then a certain set of solid/hidden borders based off the value.
-    TableRules m_rulesAttr { UnsetRules }; // Implies a thin border width, a collapsing border model, and all borders on the table becoming set to hidden (if frame/border are present, to none otherwise).
+    TableRules m_rulesAttr { TableRules::Unset }; // Implies a thin border width, a collapsing border model, and all borders on the table becoming set to hidden (if frame/border are present, to none otherwise).
     unsigned short m_padding { 1 };
     mutable RefPtr<const MutableStyleProperties> m_sharedCellStyle;
 };

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -365,22 +365,22 @@ void RenderFrameSet::notifyFrameEdgeInfoChanged()
 
 void RenderFrameSet::fillFromEdgeInfo(const FrameEdgeInfo& edgeInfo, int r, int c)
 {
-    if (edgeInfo.allowBorder(LeftFrameEdge))
+    if (edgeInfo.allowBorder(FrameEdge::Left))
         m_cols.m_allowBorder[c] = true;
-    if (edgeInfo.allowBorder(RightFrameEdge))
+    if (edgeInfo.allowBorder(FrameEdge::Right))
         m_cols.m_allowBorder[c + 1] = true;
-    if (edgeInfo.preventResize(LeftFrameEdge))
+    if (edgeInfo.preventResize(FrameEdge::Left))
         m_cols.m_preventResize[c] = true;
-    if (edgeInfo.preventResize(RightFrameEdge))
+    if (edgeInfo.preventResize(FrameEdge::Right))
         m_cols.m_preventResize[c + 1] = true;
-    
-    if (edgeInfo.allowBorder(TopFrameEdge))
+
+    if (edgeInfo.allowBorder(FrameEdge::Top))
         m_rows.m_allowBorder[r] = true;
-    if (edgeInfo.allowBorder(BottomFrameEdge))
+    if (edgeInfo.allowBorder(FrameEdge::Bottom))
         m_rows.m_allowBorder[r + 1] = true;
-    if (edgeInfo.preventResize(TopFrameEdge))
+    if (edgeInfo.preventResize(FrameEdge::Top))
         m_rows.m_preventResize[r] = true;
-    if (edgeInfo.preventResize(BottomFrameEdge))
+    if (edgeInfo.preventResize(FrameEdge::Bottom))
         m_rows.m_preventResize[r + 1] = true;
 }
 
@@ -419,14 +419,14 @@ FrameEdgeInfo RenderFrameSet::edgeInfo() const
     int rows = frameSetElement().totalRows();
     int cols = frameSetElement().totalCols();
     if (rows && cols) {
-        result.setPreventResize(LeftFrameEdge, m_cols.m_preventResize[0]);
-        result.setAllowBorder(LeftFrameEdge, m_cols.m_allowBorder[0]);
-        result.setPreventResize(RightFrameEdge, m_cols.m_preventResize[cols]);
-        result.setAllowBorder(RightFrameEdge, m_cols.m_allowBorder[cols]);
-        result.setPreventResize(TopFrameEdge, m_rows.m_preventResize[0]);
-        result.setAllowBorder(TopFrameEdge, m_rows.m_allowBorder[0]);
-        result.setPreventResize(BottomFrameEdge, m_rows.m_preventResize[rows]);
-        result.setAllowBorder(BottomFrameEdge, m_rows.m_allowBorder[rows]);
+        result.setPreventResize(FrameEdge::Left, m_cols.m_preventResize[0]);
+        result.setAllowBorder(FrameEdge::Left, m_cols.m_allowBorder[0]);
+        result.setPreventResize(FrameEdge::Right, m_cols.m_preventResize[cols]);
+        result.setAllowBorder(FrameEdge::Right, m_cols.m_allowBorder[cols]);
+        result.setPreventResize(FrameEdge::Top, m_rows.m_preventResize[0]);
+        result.setAllowBorder(FrameEdge::Top, m_rows.m_allowBorder[0]);
+        result.setPreventResize(FrameEdge::Bottom, m_rows.m_preventResize[rows]);
+        result.setAllowBorder(FrameEdge::Bottom, m_rows.m_allowBorder[rows]);
     }
     
     return result;

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "RenderBox.h"
+#include <utility>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class RenderFrame;
 
 struct HTMLDimensionsListValue;
 
-enum FrameEdge { LeftFrameEdge, RightFrameEdge, TopFrameEdge, BottomFrameEdge };
+enum class FrameEdge : uint8_t { Left, Right, Top, Bottom };
 
 struct FrameEdgeInfo {
     explicit FrameEdgeInfo(bool preventResize = false, bool allowBorder = true)
@@ -42,11 +43,11 @@ struct FrameEdgeInfo {
     {
     }
 
-    bool preventResize(FrameEdge edge) const { return m_preventResize[edge]; }
-    bool allowBorder(FrameEdge edge) const { return m_allowBorder[edge]; }
+    bool preventResize(FrameEdge edge) const { return m_preventResize[std::to_underlying(edge)]; }
+    bool allowBorder(FrameEdge edge) const { return m_allowBorder[std::to_underlying(edge)]; }
 
-    void setPreventResize(FrameEdge edge, bool preventResize) { m_preventResize[edge] = preventResize; }
-    void setAllowBorder(FrameEdge edge, bool allowBorder) { m_allowBorder[edge] = allowBorder; }
+    void setPreventResize(FrameEdge edge, bool preventResize) { m_preventResize[std::to_underlying(edge)] = preventResize; }
+    void setAllowBorder(FrameEdge edge, bool allowBorder) { m_allowBorder[std::to_underlying(edge)] = allowBorder; }
 
 private:
     Vector<bool> m_preventResize;


### PR DESCRIPTION
#### 1fe26bdedc5bbac6a581b16c599702fd537170f9
<pre>
Convert FrameEdge, TableRules, and CellBorders to scoped enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308236">https://bugs.webkit.org/show_bug.cgi?id=308236</a>
<a href="https://rdar.apple.com/170742890">rdar://170742890</a>

Reviewed by Sammy Gill.

Convert three C-style enums to enum class : uint8_t for stronger type
safety. Remove redundant prefixes from enumerator names (e.g.
LeftFrameEdge → Left, UnsetRules → Unset, NoBorders → None).

No new tests, no change in functionality.

* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLTableElement::attributeChanged):
(WebCore::HTMLTableElement::additionalPresentationalHintStyle const):
(WebCore::HTMLTableElement::cellBorders const):
(WebCore::HTMLTableElement::createSharedCellStyle const):
(WebCore::HTMLTableElement::additionalGroupStyle const):
* Source/WebCore/html/HTMLTableElement.h:
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::fillFromEdgeInfo):
(WebCore::RenderFrameSet::edgeInfo const):
* Source/WebCore/rendering/RenderFrameSet.h:
(WebCore::FrameEdgeInfo::preventResize const):
(WebCore::FrameEdgeInfo::allowBorder const):
(WebCore::FrameEdgeInfo::setPreventResize):
(WebCore::FrameEdgeInfo::setAllowBorder):

Canonical link: <a href="https://commits.webkit.org/308088@main">https://commits.webkit.org/308088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5457f9bba2c39c4f7d016b89521ef739e327ede1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99439 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd585ed8-d5d9-4c54-b463-e79d8c5ad645) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112183 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80334 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/635ff46f-7184-40b9-add8-fac68ee50573) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13861 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11619 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1981 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156847 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/101 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120188 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120533 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30996 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129279 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74123 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7296 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81794 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17747 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->