### PR TITLE
Convert SVGMarkerType and EIndentType to enum classes

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -456,7 +456,7 @@ static bool executeIgnoreSpelling(LocalFrame& frame, Event*, EditorCommandSource
 static bool executeIndent(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
     ASSERT(frame.document());
-    IndentOutdentCommand::create(*frame.document(), IndentOutdentCommand::Indent)->apply();
+    IndentOutdentCommand::create(*frame.document(), IndentOutdentCommand::IndentType::Indent)->apply();
     return true;
 }
 
@@ -894,7 +894,7 @@ static bool executeMoveToRightEndOfLineAndModifySelection(LocalFrame& frame, Eve
 static bool executeOutdent(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
     ASSERT(frame.document());
-    IndentOutdentCommand::create(*frame.document(), IndentOutdentCommand::Outdent)->apply();
+    IndentOutdentCommand::create(*frame.document(), IndentOutdentCommand::IndentType::Outdent)->apply();
     return true;
 }
 

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -52,7 +52,7 @@ static bool isListOrIndentBlockquote(const Node& node)
     return node.hasTagName(ulTag) || node.hasTagName(olTag) || node.hasTagName(blockquoteTag);
 }
 
-IndentOutdentCommand::IndentOutdentCommand(Ref<Document>&& document, EIndentType typeOfAction)
+IndentOutdentCommand::IndentOutdentCommand(Ref<Document>&& document, IndentType typeOfAction)
     : ApplyBlockElementCommand(WTF::move(document), blockquoteTag, "margin: 0 0 0 40px; border: none; padding: 0px;"_s)
     , m_typeOfAction(typeOfAction)
 {
@@ -257,7 +257,7 @@ void IndentOutdentCommand::outdentRegion(const VisiblePosition& startOfSelection
 
 void IndentOutdentCommand::formatSelection(const VisiblePosition& startOfSelection, const VisiblePosition& endOfSelection)
 {
-    if (m_typeOfAction == Indent)
+    if (m_typeOfAction == IndentType::Indent)
         ApplyBlockElementCommand::formatSelection(startOfSelection, endOfSelection);
     else
         outdentRegion(startOfSelection, endOfSelection);

--- a/Source/WebCore/editing/IndentOutdentCommand.h
+++ b/Source/WebCore/editing/IndentOutdentCommand.h
@@ -32,8 +32,8 @@ namespace WebCore {
 
 class IndentOutdentCommand : public ApplyBlockElementCommand {
 public:
-    enum EIndentType { Indent, Outdent };
-    static Ref<IndentOutdentCommand> create(Ref<Document>&& document, EIndentType type)
+    enum class IndentType : uint8_t { Indent, Outdent };
+    static Ref<IndentOutdentCommand> create(Ref<Document>&& document, IndentType type)
     {
         return adoptRef(*new IndentOutdentCommand(WTF::move(document), type));
     }
@@ -41,9 +41,9 @@ public:
     bool preservesTypingStyle() const override { return true; }
 
 private:
-    IndentOutdentCommand(Ref<Document>&&, EIndentType);
+    IndentOutdentCommand(Ref<Document>&&, IndentType);
 
-    EditAction editingAction() const override { return m_typeOfAction == Indent ? EditAction::Indent : EditAction::Outdent; }
+    EditAction editingAction() const override { return m_typeOfAction == IndentType::Indent ? EditAction::Indent : EditAction::Outdent; }
 
     void outdentRegion(const VisiblePosition&, const VisiblePosition&);
     void outdentParagraph();
@@ -53,7 +53,7 @@ private:
     void formatSelection(const VisiblePosition& startOfSelection, const VisiblePosition& endOfSelection) override;
     void formatRange(const Position& start, const Position& end, const Position& endOfSelection, RefPtr<Element>& blockquoteForNextIndent) override;
 
-    EIndentType m_typeOfAction;
+    IndentType m_typeOfAction;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -193,11 +193,11 @@ void RenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) const
 static inline RenderSVGResourceMarker* NODELETE markerForType(SVGMarkerType type, RenderSVGResourceMarker* markerStart, RenderSVGResourceMarker* markerMid, RenderSVGResourceMarker* markerEnd)
 {
     switch (type) {
-    case StartMarker:
+    case SVGMarkerType::Start:
         return markerStart;
-    case MidMarker:
+    case SVGMarkerType::Middle:
         return markerMid;
-    case EndMarker:
+    case SVGMarkerType::End:
         return markerEnd;
     }
 

--- a/Source/WebCore/rendering/svg/SVGMarkerData.h
+++ b/Source/WebCore/rendering/svg/SVGMarkerData.h
@@ -27,10 +27,10 @@ namespace WebCore {
 
 class RenderSVGResourceMarker;
 
-enum SVGMarkerType {
-    StartMarker,
-    MidMarker,
-    EndMarker
+enum class SVGMarkerType : uint8_t {
+    Start,
+    Middle,
+    End
 };
 
 struct MarkerPosition {
@@ -62,12 +62,12 @@ public:
 
         // Record the marker for the previous element.
         if (markerData.m_elementIndex > 0) {
-            SVGMarkerType markerType = markerData.m_elementIndex == 1 ? StartMarker : MidMarker;
+            SVGMarkerType markerType = markerData.m_elementIndex == 1 ? SVGMarkerType::Start : SVGMarkerType::Middle;
             SVGMarkerType markerTypeForOrientation;
             if (markerData.m_previousWasMoveTo)
-                markerTypeForOrientation = StartMarker;
+                markerTypeForOrientation = SVGMarkerType::Start;
             else if (element.type == PathElement::Type::MoveToPoint)
-                markerTypeForOrientation = EndMarker;
+                markerTypeForOrientation = SVGMarkerType::End;
             else
                 markerTypeForOrientation = markerType;
             markerData.m_positions.append(MarkerPosition(markerType, markerData.m_origin, markerData.currentAngle(markerTypeForOrientation)));
@@ -81,7 +81,7 @@ public:
 
     void pathIsDone()
     {
-        m_positions.append(MarkerPosition(EndMarker, m_origin, currentAngle(EndMarker)));
+        m_positions.append(MarkerPosition(SVGMarkerType::End, m_origin, currentAngle(SVGMarkerType::End)));
     }
 
 private:
@@ -95,16 +95,16 @@ private:
         double outAngle = rad2deg(outSlope.slopeAngleRadians());
 
         switch (type) {
-        case StartMarker:
+        case SVGMarkerType::Start:
             if (m_reverseStart)
                 return narrowPrecisionToFloat(outAngle - 180);
             return narrowPrecisionToFloat(outAngle);
-        case MidMarker:
+        case SVGMarkerType::Middle:
             // WK193015: Prevent bugs due to angles being non-continuous.
             if (std::abs(inAngle - outAngle) > 180)
                 inAngle += 360;
             return narrowPrecisionToFloat((inAngle + outAngle) / 2);
-        case EndMarker:
+        case SVGMarkerType::End:
             return narrowPrecisionToFloat(inAngle);
         }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -208,11 +208,11 @@ void LegacyRenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) con
 static inline LegacyRenderSVGResourceMarker* NODELETE markerForType(SVGMarkerType type, LegacyRenderSVGResourceMarker* markerStart, LegacyRenderSVGResourceMarker* markerMid, LegacyRenderSVGResourceMarker* markerEnd)
 {
     switch (type) {
-    case StartMarker:
+    case SVGMarkerType::Start:
         return markerStart;
-    case MidMarker:
+    case SVGMarkerType::Middle:
         return markerMid;
-    case EndMarker:
+    case SVGMarkerType::End:
         return markerEnd;
     }
 


### PR DESCRIPTION
#### 16cba163b0a1d81a754d0d0d8c722165ec25be36
<pre>
Convert SVGMarkerType and EIndentType to enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308238">https://bugs.webkit.org/show_bug.cgi?id=308238</a>
<a href="https://rdar.apple.com/170743512">rdar://170743512</a>

Reviewed by Vitor Roriz and Sammy Gill.

Convert two C-style enums to enum class : uint8_t for stronger type
safety. Remove redundant prefixes from SVGMarkerType enumerators (e.g.
StartMarker → Start). Rename EIndentType to IndentType, dropping the
Hungarian enum prefix.

No new tests, no new functionality.

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeIndent):
(WebCore::executeOutdent):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::IndentOutdentCommand):
(WebCore::IndentOutdentCommand::formatSelection):
* Source/WebCore/editing/IndentOutdentCommand.h:
(WebCore::IndentOutdentCommand::create):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::markerForType):
* Source/WebCore/rendering/svg/SVGMarkerData.h:
(WebCore::SVGMarkerData::updateFromPathElement):
(WebCore::SVGMarkerData::pathIsDone):
(WebCore::SVGMarkerData::currentAngle const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::markerForType):

Canonical link: <a href="https://commits.webkit.org/308167@main">https://commits.webkit.org/308167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff50f8cf8920856c1e71f20b91a4c2f3c1e2e4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155331 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d69eea1-f251-4a53-918d-a6dc8a638282) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113006 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a360270b-bda3-4ab3-a821-bc13fb8061ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149630 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31212ba5-6897-4925-9a50-c61cf9387528) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2775 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157660 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121010 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19146 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121222 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31047 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131403 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18762 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18492 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->