### PR TITLE
Improve readability of StyleLogicalHeight by adopting a switch on statement.

### DIFF
--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5406,6 +5406,7 @@
 		BC675B6C2DEE8BB700AD4D79 /* StyleMaximumSize.h in Headers */ = {isa = PBXBuildFile; fileRef = BC675B672DEE8B7100AD4D79 /* StyleMaximumSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC675B6D2DEE8BB700AD4D79 /* StyleFlexBasis.h in Headers */ = {isa = PBXBuildFile; fileRef = BC675B692DEE8B8200AD4D79 /* StyleFlexBasis.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC675B6E2DEE8BB700AD4D79 /* StylePreferredSize.h in Headers */ = {isa = PBXBuildFile; fileRef = BC675B642DEE883300AD4D79 /* StylePreferredSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		214FAAB5DFD52EFEDBCC69DA /* StyleSizing.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A8E16BBFC5C15C30A27B8F /* StyleSizing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC6932740D7E293900AE44D1 /* JSDOMWindowBase.h in Headers */ = {isa = PBXBuildFile; fileRef = BC6932720D7E293900AE44D1 /* JSDOMWindowBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC6A708F2FDC6D3800872C12 /* StylePrimitiveNumericTypes+EvaluationMinimum.h in Headers */ = {isa = PBXBuildFile; fileRef = BC6A708E2FDC695D00872C12 /* StylePrimitiveNumericTypes+EvaluationMinimum.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC6A7EB52FDCDCDE00872C12 /* StylePrimitiveData.h in Headers */ = {isa = PBXBuildFile; fileRef = BC6A7EB32FDCDCD300872C12 /* StylePrimitiveData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19839,6 +19840,7 @@
 		BC675B672DEE8B7100AD4D79 /* StyleMaximumSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleMaximumSize.h; sourceTree = "<group>"; };
 		BC675B682DEE8B7100AD4D79 /* StyleMinimumSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleMinimumSize.h; sourceTree = "<group>"; };
 		BC675B692DEE8B8200AD4D79 /* StyleFlexBasis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleFlexBasis.h; sourceTree = "<group>"; };
+		F3A8E16BBFC5C15C30A27B8F /* StyleSizing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleSizing.h; sourceTree = "<group>"; };
 		BC675B722DEEB1A600AD4D79 /* StyleFlexBasis.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleFlexBasis.cpp; sourceTree = "<group>"; };
 		BC6768342CE5116A0087ED47 /* CSSValueTypes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSValueTypes.cpp; sourceTree = "<group>"; };
 		BC6932710D7E293900AE44D1 /* JSDOMWindowBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMWindowBase.cpp; sourceTree = "<group>"; };
@@ -38175,6 +38177,7 @@
 				BC675B682DEE8B7100AD4D79 /* StyleMinimumSize.h */,
 				BC675B652DEE883300AD4D79 /* StylePreferredSize.cpp */,
 				BC675B642DEE883300AD4D79 /* StylePreferredSize.h */,
+				F3A8E16BBFC5C15C30A27B8F /* StyleSizing.h */,
 			);
 			path = sizing;
 			sourceTree = "<group>";
@@ -49129,6 +49132,7 @@
 				BCCE02912E766AA30028EA38 /* StyleSingleTransitionDelay.h in Headers */,
 				BCCE02922E766AAA0028EA38 /* StyleSingleTransitionDuration.h in Headers */,
 				BC7320022E732F3F00A6584F /* StyleSingleTransitionProperty.h in Headers */,
+				214FAAB5DFD52EFEDBCC69DA /* StyleSizing.h in Headers */,
 				BC4F32B52E89C4DA00F6AEC1 /* StyleSkewTransformFunction.h in Headers */,
 				BC4529E92ECBAD6E00FD066C /* StyleSpeakAs.h in Headers */,
 				BC66AF692F7E152000345E91 /* StyleString.h in Headers */,

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -64,6 +64,7 @@
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+EvaluationMinimum.h"
+#include "StyleSizing.h"
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -359,24 +360,48 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalWidthToCo
 
 template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToComputedHeight(const SizeType& styleLogicalHeight)
 {
+    CheckedRef checkedThis { *this };
     LayoutUnit borderAndPaddingBefore = borderBefore() + (collapseBorders() ? 0_lu : paddingBefore());
     LayoutUnit borderAndPaddingAfter = borderAfter() + (collapseBorders() ? 0_lu : paddingAfter());
     LayoutUnit borderAndPadding = borderAndPaddingBefore + borderAndPaddingAfter;
-    if (auto fixedStyleLogicalHeight =  styleLogicalHeight.tryFixed()) {
-        // HTML tables size as though CSS height includes border/padding, CSS tables do not.
-        LayoutUnit borders;
-        // FIXME: We cannot apply box-sizing: content-box on <table> which other browsers allow.
-        if (is<HTMLTableElement>(element()) || style().boxSizing() == BoxSizing::BorderBox) {
-            borders = borderAndPadding;
+    return WTF::switchOn(styleLogicalHeight,
+        [&](const typename SizeType::Fixed& fixedStyleLogicalHeight) {
+            // HTML tables size as though CSS height includes border/padding, CSS tables do not.
+            LayoutUnit borders;
+            // FIXME: We cannot apply box-sizing: content-box on <table> which other browsers allow.
+            if (is<HTMLTableElement>(checkedThis->element()) || checkedThis->style().boxSizing() == BoxSizing::BorderBox)
+                borders = borderAndPadding;
+            return Style::evaluate<LayoutUnit>(fixedStyleLogicalHeight, checkedThis->style().usedZoomForLength()) - borders;
+        },
+        [&](const typename SizeType::Percentage&) {
+            return checkedThis->computePercentageLogicalHeight(styleLogicalHeight).value_or(0_lu);
+        },
+        [&](const typename SizeType::Calc& calc) {
+            return checkedThis->computePercentageLogicalHeight(calc).value_or(0_lu);
+        },
+        [&](Style::IsIntrinsicOrStretchSizeKeyword auto const&) {
+            return checkedThis->computeSizingKeywordLogicalContentHeightUsing(styleLogicalHeight, checkedThis->logicalHeight() - borderAndPadding, borderAndPadding).value_or(0_lu);
+        },
+        // The remaining keywords are not valid computed values for a table's logical height. They are
+        // enumerated explicitly (rather than caught by a generic handler) so that adding a new keyword
+        // to any of the sizing types fails to compile here and forces this switch to be revisited.
+        [&](const CSS::Keyword::Auto&) {
+            ASSERT_NOT_REACHED();
+            return 0_lu;
+        },
+        [&](const CSS::Keyword::None&) {
+            ASSERT_NOT_REACHED();
+            return 0_lu;
+        },
+        [&](const CSS::Keyword::Intrinsic&) {
+            ASSERT_NOT_REACHED();
+            return 0_lu;
+        },
+        [&](const CSS::Keyword::MinIntrinsic&) {
+            ASSERT_NOT_REACHED();
+            return 0_lu;
         }
-        return Style::evaluate<LayoutUnit>(*fixedStyleLogicalHeight, style().usedZoomForLength()) - borders;
-    } else if (styleLogicalHeight.isPercentOrCalculated())
-        return computePercentageLogicalHeight(styleLogicalHeight).value_or(0);
-    else if (styleLogicalHeight.isIntrinsicOrStretch())
-        return computeSizingKeywordLogicalContentHeightUsing(styleLogicalHeight, logicalHeight() - borderAndPadding, borderAndPadding).value_or(0);
-    else
-        ASSERT_NOT_REACHED();
-    return 0_lu;
+    );
 }
 
 void RenderTable::layoutCaption(RenderTableCaption& caption)

--- a/Source/WebCore/style/values/sizing/StyleSizing.h
+++ b/Source/WebCore/style/values/sizing/StyleSizing.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+#include <concepts>
+
+namespace WebCore {
+namespace Style {
+
+// Compile-time analog of the `isIntrinsicOrStretch()` predicate shared by the sizing
+// types (PreferredSize, MinimumSize, MaximumSize, FlexBasis). It matches exactly the
+// keywords those types classify as intrinsic-or-stretch, for use as a constraint on
+// `WTF::switchOn` visitor lambdas.
+template<typename T>
+concept IsIntrinsicOrStretchSizeKeyword = std::same_as<T, CSS::Keyword::MinContent>
+    || std::same_as<T, CSS::Keyword::MaxContent>
+    || std::same_as<T, CSS::Keyword::FitContent>
+    || std::same_as<T, CSS::Keyword::Stretch>
+    || std::same_as<T, CSS::Keyword::WebkitFillAvailable>;
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### 27059d44ca3687792473995c99ee26b7fb9040d3
<pre>
Improve readability of StyleLogicalHeight by adopting a switch on statement.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303746">https://bugs.webkit.org/show_bug.cgi?id=303746</a>
<a href="https://rdar.apple.com/166529986">rdar://166529986</a>

Reviewed by Sam Weinig.

Replace the if/else chain in RenderTable::convertStyleLogicalHeightToComputedHeight()
with WTF::switchOn() for improved readability, matching the pattern already used in
RenderFlexibleBox and other rendering code.

The intrinsic and stretch sizing keywords are coalesced behind a new
Style::IsIntrinsicOrStretchSizeKeyword concept (the compile-time analog of the sizing
types&apos; isIntrinsicOrStretch() predicate), placed in a new
style/values/sizing/StyleSizing.h header. The remaining keywords are enumerated
explicitly rather than caught by a generic handler, so that adding a new sizing keyword
fails to compile here and forces this switch to be revisited.

No new tests, no change of functionality.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::convertStyleLogicalHeightToComputedHeight):
* Source/WebCore/style/values/sizing/StyleSizing.h: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/317491@main">https://commits.webkit.org/317491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9645d796d7679e8356354c061b1d257f26169ca6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185050 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e748ac8-8987-4717-91f2-a4e9b84d3a3c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136614 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c0323fb-ffcc-417d-a739-62ce1ada66b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117092 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7dd046d4-2db8-435e-92a0-2a019f83582e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37057 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36861 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33525 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41083 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/41260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187475 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49063 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39162 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49743 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145419 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40235 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121936 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115663 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48249 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11837 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47709 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->