### PR TITLE
REGRESSION(306638@main): [iOS] Fullscreen mode cannot change caption language

### DIFF
--- a/Source/WebCore/platform/ios/WebAVPlayerController.h
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.h
@@ -39,12 +39,13 @@ class PlaybackSessionInterfaceIOS;
 @class AVTimeRange;
 
 @interface WebAVMediaSelectionOption : NSObject
-- (instancetype)initWithMediaType:(AVMediaType)type displayName:(NSString *)displayName extendedLanguageTag:(NSString *)extendedLanguageTag;
+- (instancetype)initWithMediaType:(AVMediaType)type displayName:(NSString *)displayName extendedLanguageTag:(NSString *)extendedLanguageTag tag:(NSInteger)tag;
 
 @property (nonatomic, readonly) NSString *displayName;
 @property (nonatomic, readonly) NSString *localizedDisplayName;
 @property (nonatomic, readonly) AVMediaType mediaType;
 @property (nonatomic, readonly, nullable) NSString *extendedLanguageTag;
+@property (nonatomic, assign) NSInteger tag;
 @end
 
 @interface WebAVPlayerController : NSObject

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -784,18 +784,8 @@ Class webAVPlayerControllerClassSingleton()
 
     _currentLegibleMediaSelectionOption = option;
 
-    if (!self.delegate)
-        return;
-
-    NSInteger index = NSNotFound;
-
-    if (option && self.legibleMediaSelectionOptions)
-        index = [self.legibleMediaSelectionOptions indexOfObject:option];
-
-    if (index == NSNotFound)
-        return;
-
-    self.delegate->selectLegibleMediaOption(index);
+    if (self.delegate && option)
+        self.delegate->selectLegibleMediaOption(option.tag);
 }
 
 - (BOOL)isPlayingOnExternalScreen
@@ -1199,7 +1189,7 @@ Class webAVPlayerControllerClassSingleton()
     RetainPtr<NSLocale> _locale;
 }
 
-- (instancetype)initWithMediaType:(AVMediaType)mediaType displayName:(NSString *)displayName extendedLanguageTag:(NSString *)extendedLanguageTag
+- (instancetype)initWithMediaType:(AVMediaType)mediaType displayName:(NSString *)displayName extendedLanguageTag:(NSString *)extendedLanguageTag tag:(NSInteger)tag
 {
     self = [super init];
     if (!self)
@@ -1209,6 +1199,7 @@ Class webAVPlayerControllerClassSingleton()
     _localizedDisplayName = displayName;
     _extendedLanguageTag = extendedLanguageTag;
     _locale = adoptNS([[NSLocale alloc] initWithLocaleIdentifier:_extendedLanguageTag.get()]);
+    _tag = tag;
 
     return self;
 }
@@ -1216,7 +1207,7 @@ Class webAVPlayerControllerClassSingleton()
 - (id)copyWithZone:(NSZone *)zone
 {
     RetainPtr displayName = adoptNS([_localizedDisplayName copyWithZone:zone]);
-    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType.get() displayName:displayName.get() extendedLanguageTag:_extendedLanguageTag.get()];
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType.get() displayName:displayName.get() extendedLanguageTag:_extendedLanguageTag.get() tag:_tag];
 }
 
 - (NSString *)displayName


### PR DESCRIPTION
#### e27392506a42418b63500c544900c3aa03c9b806
<pre>
REGRESSION(306638@main): [iOS] Fullscreen mode cannot change caption language
<a href="https://rdar.apple.com/169458486">rdar://169458486</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308275">https://bugs.webkit.org/show_bug.cgi?id=308275</a>

Reviewed by Andy Estes.

In 306638@main, the &quot;On&quot; and &quot;Auto&quot; menu items were filtered out from the
list of media selection options given to AVPlayerController, however the
index used when those options were selected were not similarly adjusted,
so selecting the first language would result in the missing &quot;On&quot; menu item
being selected.

Instead of using the index of the filtered selection option, attach the index
of the original option as the WebAVMediaSelectionOption&apos;s &quot;tag&quot; property.
That tag can be read when the option is selected by AVKit and passed along
to the WebContent process as the original media selection option&apos;s index.

* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm:
(WebCore::mediaSelectionOptions):
(WebCore::mediaSelectionOptionWithTag):
(WebCore::PlaybackSessionInterfaceAVKitLegacy::audioMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceAVKitLegacy::legibleMediaSelectionOptionsChanged):
* Source/WebCore/platform/ios/WebAVPlayerController.h:
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVPlayerController setCurrentLegibleMediaSelectionOption:]):
(-[WebAVMediaSelectionOption initWithMediaType:displayName:extendedLanguageTag:tag:]):
(-[WebAVMediaSelectionOption copyWithZone:]):
(-[WebAVMediaSelectionOption initWithMediaType:displayName:extendedLanguageTag:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/307947@main">https://commits.webkit.org/307947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f76d069504679dce5151ea975ac080307273bb4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99514 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a772034c-8b56-493c-8d48-a7e1258f8393) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b3fe370-7b83-4089-bfde-183ea6e2b628) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93188 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a00b2e85-1ca9-41ab-909e-39d06f5c2578) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11707 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156968 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/189 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120296 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120634 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30924 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74212 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7424 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17856 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->