### PR TITLE
Use more Ref instead of RefPtr in assorted WebCore directories

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -126,6 +126,7 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
     ModifyHeadersAction(EmptyValueTag) : hashTableType(HashTableType::Empty) { }
     ModifyHeadersAction(DeletedValueTag) : hashTableType(HashTableType::Deleted) { }
     bool isDeletedValue() const { return hashTableType == HashTableType::Deleted; }
+    bool isEmptyValue() const { return hashTableType == HashTableType::Empty; }
     static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
     static Expected<ModifyHeadersAction, std::error_code> parse(const JSON::Object&);
@@ -226,6 +227,7 @@ struct WEBCORE_EXPORT RedirectAction {
     RedirectAction(EmptyValueTag) : hashTableType(HashTableType::Empty) { }
     RedirectAction(DeletedValueTag) : hashTableType(HashTableType::Deleted) { }
     bool isDeletedValue() const { return hashTableType == HashTableType::Deleted; }
+    bool isEmptyValue() const { return hashTableType == HashTableType::Empty; }
     static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
     static Expected<RedirectAction, std::error_code> parse(const JSON::Object&, const String& urlFilter);

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -241,7 +241,7 @@ Blob::~Blob()
 {
     ThreadableBlobRegistry::unregisterBlobURL(m_internalURL, std::nullopt);
     while (!m_blobLoaders.isEmpty())
-        RefPtr { (*m_blobLoaders.begin()).get() }->cancel();
+        protect(*m_blobLoaders.begin())->cancel();
 }
 
 Ref<Blob> Blob::slice(long long start, long long end, const String& contentType) const

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -172,7 +172,7 @@ private:
     // into an HTML or for FileRead'ing, public blob URLs must be used for those purposes.
     URL m_internalURL;
 
-    HashSet<RefPtr<BlobLoader>> m_blobLoaders;
+    HashSet<Ref<BlobLoader>> m_blobLoaders;
 };
 
 WebCoreOpaqueRoot root(Blob*);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -204,14 +204,14 @@ class RevalidateStyleAttributeTask final : public CanMakeCheckedPtr<RevalidateSt
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RevalidateStyleAttributeTask);
 public:
     RevalidateStyleAttributeTask(InspectorDOMAgent*);
-    void scheduleFor(Element*);
+    void scheduleFor(Element&);
     void reset() { m_timer.stop(); }
     void timerFired();
 
 private:
     const CheckedPtr<InspectorDOMAgent> m_domAgent;
     Timer m_timer;
-    HashSet<RefPtr<Element>> m_elements;
+    HashSet<Ref<Element>> m_elements;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RevalidateStyleAttributeTask);
@@ -222,7 +222,7 @@ RevalidateStyleAttributeTask::RevalidateStyleAttributeTask(InspectorDOMAgent* do
 {
 }
 
-void RevalidateStyleAttributeTask::scheduleFor(Element* element)
+void RevalidateStyleAttributeTask::scheduleFor(Element& element)
 {
     m_elements.add(element);
     if (!m_timer.isActive())
@@ -234,7 +234,7 @@ void RevalidateStyleAttributeTask::timerFired()
     // The timer is stopped on m_domAgent destruction, so this method will never be called after m_domAgent has been destroyed.
     Vector<Element*> elements;
     for (auto& element : m_elements)
-        elements.append(element.get());
+        elements.append(element.ptr());
     m_domAgent->styleAttributeInvalidated(elements);
 
     m_elements.clear();
@@ -2862,7 +2862,7 @@ void InspectorDOMAgent::didInvalidateStyleAttr(Element& element)
 
     if (!m_revalidateStyleAttrTask)
         m_revalidateStyleAttrTask = makeUnique<RevalidateStyleAttributeTask>(this);
-    m_revalidateStyleAttrTask->scheduleFor(&element);
+    m_revalidateStyleAttrTask->scheduleFor(element);
 }
 
 void InspectorDOMAgent::didPushShadowRoot(Element& host, ShadowRoot& root)

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -81,12 +81,12 @@ StorageNamespace& StorageNamespaceProvider::localStorageNamespace(PAL::SessionID
 
 StorageNamespace& StorageNamespaceProvider::transientLocalStorageNamespace(SecurityOrigin& securityOrigin, PAL::SessionID sessionID)
 {
-    auto& slot = m_transientLocalStorageNamespaces.add(securityOrigin.data(), nullptr).iterator->value;
-    if (!slot)
-        slot = createTransientLocalStorageNamespace(securityOrigin, localStorageDatabaseQuotaInBytes, sessionID);
+    auto& slot = m_transientLocalStorageNamespaces.ensure(securityOrigin.data(), [&] {
+        return createTransientLocalStorageNamespace(securityOrigin, localStorageDatabaseQuotaInBytes, sessionID);
+    }).iterator->value;
 
     ASSERT(slot->sessionID() == sessionID);
-    return *slot;
+    return slot;
 }
 
 void StorageNamespaceProvider::setSessionIDForTesting(PAL::SessionID newSessionID)

--- a/Source/WebCore/storage/StorageNamespaceProvider.h
+++ b/Source/WebCore/storage/StorageNamespaceProvider.h
@@ -70,7 +70,7 @@ private:
     virtual Ref<StorageNamespace> createTransientLocalStorageNamespace(SecurityOrigin&, unsigned quota, PAL::SessionID) = 0;
 
     const RefPtr<StorageNamespace> m_localStorageNamespace;
-    HashMap<SecurityOriginData, RefPtr<StorageNamespace>> m_transientLocalStorageNamespaces;
+    HashMap<SecurityOriginData, Ref<StorageNamespace>> m_transientLocalStorageNamespaces;
 
     unsigned m_sessionStorageQuota { 0 };
 };

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -159,17 +159,17 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
     if (!renderer())
         return false;
 
-    HashSet<RefPtr<SVGGradientElement>> processedGradients;
-    RefPtr<SVGGradientElement> current = this;
+    HashSet<Ref<SVGGradientElement>> processedGradients;
+    Ref<SVGGradientElement> current { *this };
 
-    setGradientAttributes(*current, attributes);
+    setGradientAttributes(current, attributes);
     processedGradients.add(current);
 
     while (true) {
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
         if (RefPtr gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
-            current = WTF::move(gradientElement);
+            current = gradientElement.releaseNonNull();
 
             // Cycle detection
             if (processedGradients.contains(current))
@@ -178,7 +178,7 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
             if (!current->renderer())
                 return false;
 
-            setGradientAttributes(*current, attributes, current->hasTagName(SVGNames::radialGradientTag));
+            setGradientAttributes(current, attributes, current->hasTagName(SVGNames::radialGradientTag));
             processedGradients.add(current);
         } else
             break;

--- a/Source/WebCore/testing/MockPageOverlayClient.cpp
+++ b/Source/WebCore/testing/MockPageOverlayClient.cpp
@@ -50,11 +50,11 @@ MockPageOverlayClient::MockPageOverlayClient() = default;
 
 Ref<MockPageOverlay> MockPageOverlayClient::installOverlay(Page& page, PageOverlay::OverlayType overlayType)
 {
-    auto overlay = PageOverlay::create(*this, overlayType);
+    Ref overlay = PageOverlay::create(*this, overlayType);
     page.pageOverlayController().installPageOverlay(overlay, PageOverlay::FadeMode::DoNotFade);
 
-    auto mockOverlay = MockPageOverlay::create(overlay.ptr());
-    m_overlays.add(mockOverlay.ptr());
+    Ref mockOverlay = MockPageOverlay::create(overlay.ptr());
+    m_overlays.add(mockOverlay);
 
     return mockOverlay;
 }

--- a/Source/WebCore/testing/MockPageOverlayClient.h
+++ b/Source/WebCore/testing/MockPageOverlayClient.h
@@ -60,7 +60,7 @@ private:
     bool copyAccessibilityAttributeBoolValueForPoint(PageOverlay&, String /* attribute */, FloatPoint, bool&) override;
     Vector<String> copyAccessibilityAttributeNames(PageOverlay&, bool /* parameterizedNames */) override;
 
-    HashSet<RefPtr<MockPageOverlay>> m_overlays;
+    HashSet<Ref<MockPageOverlay>> m_overlays;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 733834fd0b1022832e8a355b14dc7a9f5ab0d674
<pre>
Use more Ref instead of RefPtr in assorted WebCore directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=308279">https://bugs.webkit.org/show_bug.cgi?id=308279</a>

Reviewed by Darin Adler.

Improve code clarity. This also updates HashTraits to make it possible
to use Ref inside a std::tuple, similar to what has already been done
for std::pair and fixes an issue with std::pair. Code comments are
added as it&apos;s all somewhat subtle.

Canonical link: <a href="https://commits.webkit.org/308099@main">https://commits.webkit.org/308099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57ff69919c5a9fedf431bd1e714e96426b5aa25d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146151 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99621 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f68f95d-1907-4969-ab7e-da245d0507e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112453 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80453 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9376cd5-2af8-4563-aadb-f4384a1cbe45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6824daa-88da-4d8c-ba41-261ffa4fc398) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14071 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11827 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2266 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138122 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157139 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6943 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120475 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31004 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129920 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74362 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7627 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177451 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82018 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45535 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18000 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18166 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18057 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->