### PR TITLE
[GTK] Use GdkMemoryTextureBuilder when possible in AcceleratedBackingStore

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
@@ -211,14 +211,23 @@ private:
 
         Buffer::Type type() const override { return Buffer::Type::Gbm; }
         void didUpdateContents(Buffer*, const Rects&) override;
+#if GTK_CHECK_VERSION(4, 16, 0)
+        GdkTexture* texture() const override { return m_texture.get(); }
+#else
         cairo_surface_t* surface() const override { return m_surface.get(); }
+#endif
         RendererBufferDescription description() const override;
         RefPtr<WebCore::NativeImage> asNativeImageForTesting() const override;
         void release() override;
 
         WTF::UnixFileDescriptor m_fd;
         struct gbm_bo* m_buffer { nullptr };
+#if GTK_CHECK_VERSION(4, 16, 0)
+        GRefPtr<GdkMemoryTextureBuilder> m_builder;
+        GRefPtr<GdkTexture> m_texture;
+#else
         RefPtr<cairo_surface_t> m_surface;
+#endif
     };
 #endif
 
@@ -231,13 +240,22 @@ private:
 
         Buffer::Type type() const override { return Buffer::Type::SharedMemory; }
         void didUpdateContents(Buffer*, const Rects&) override;
+#if GTK_CHECK_VERSION(4, 16, 0)
+        GdkTexture* texture() const override { return m_texture.get(); }
+#else
         cairo_surface_t* surface() const override { return m_surface.get(); }
+#endif
         RendererBufferDescription description() const override;
         RefPtr<WebCore::NativeImage> asNativeImageForTesting() const override;
         void release() override;
 
         RefPtr<WebCore::ShareableBitmap> m_bitmap;
+#if GTK_CHECK_VERSION(4, 16, 0)
+        GRefPtr<GdkMemoryTextureBuilder> m_builder;
+        GRefPtr<GdkTexture> m_texture;
+#else
         RefPtr<cairo_surface_t> m_surface;
+#endif
     };
 
     WeakPtr<WebPageProxy> m_webPage;


### PR DESCRIPTION
#### 8397430899548c4d25e9302da87c84dca03efaff
<pre>
[GTK] Use GdkMemoryTextureBuilder when possible in AcceleratedBackingStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=308280">https://bugs.webkit.org/show_bug.cgi?id=308280</a>

Reviewed by Adrian Perez de Castro.

This way we avoid using cairo and the damage information is used to optimize the rendering.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::BufferGBM::BufferGBM):
(WebKit::AcceleratedBackingStore::BufferGBM::didUpdateContents):
(WebKit::AcceleratedBackingStore::BufferGBM::release):
(WebKit::AcceleratedBackingStore::BufferSHM::BufferSHM):
(WebKit::AcceleratedBackingStore::BufferSHM::didUpdateContents):
(WebKit::AcceleratedBackingStore::BufferSHM::release):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h:

Canonical link: <a href="https://commits.webkit.org/307905@main">https://commits.webkit.org/307905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22c3494a465c13f5f134ff83d68c6636e3054a93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154560 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112203 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123437 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156872 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/118 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120209 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74140 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7320 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81811 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->