### PR TITLE
Disable the ::picker pseudo-element on watchOS

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker-expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Reftest Reference</title>
+		<style>
+			div {
+				background-color:green;
+				height:100px;
+				width:100px;
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker-icon-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker-icon-expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Reftest Reference</title>
+		<style>
+			div {
+				background-color:green;
+				height:100px;
+				width:100px;
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker-icon.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker-icon.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): @supports selector() with ::picker-icon pseudo-element</title>
+		<link rel="help" href="https://www.w3.org/TR/css-conditional-3/#at-supports">
+		<link rel="match" href="at-supports-001-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+			}
+			@supports selector(select::picker-icon) {
+				div { background-color:green; }
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-picker.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): @supports selector() with ::picker() pseudo-element</title>
+		<link rel="help" href="https://www.w3.org/TR/css-conditional-3/#at-supports">
+		<link rel="match" href="at-supports-001-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+			}
+			@supports selector(select::picker(select)) {
+				div { background-color:green; }
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-picker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-picker-expected.txt
@@ -1,0 +1,8 @@
+
+PASS ::picker-icon pseudo-element is supported
+PASS ::picker(select) pseudo-element is supported
+PASS ::picker-icon without element is supported
+PASS ::picker(select) without element is supported
+PASS ::picker without argument is not supported
+PASS ::picker with empty argument is not supported
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-picker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-picker.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS.supports() for ::picker() and ::picker-icon pseudo-elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-3/#the-css-namespace">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(function() {
+    assert_equals(CSS.supports("selector(select::picker-icon)"), true);
+  }, "::picker-icon pseudo-element is supported");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(select::picker(select))"), true);
+  }, "::picker(select) pseudo-element is supported");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(::picker-icon)"), true);
+  }, "::picker-icon without element is supported");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(::picker(select))"), true);
+  }, "::picker(select) without element is supported");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(select::picker)"), false);
+  }, "::picker without argument is not supported");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(select::picker())"), false);
+  }, "::picker with empty argument is not supported");
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1316,6 +1316,23 @@ CSSPaintingAPIEnabled:
     WebCore:
       default: false
 
+CSSPickerPseudoElementEnabled:
+  type: bool
+  status: internal
+  category: css
+  humanReadableName: "CSS ::picker() pseudo-element"
+  humanReadableDescription: "Enable the CSS ::picker() pseudo-element"
+  defaultValue:
+    WebKitLegacy:
+      "PLATFORM(WATCHOS)": false
+      default: true
+    WebKit:
+      "PLATFORM(WATCHOS)": false
+      default: true
+    WebCore:
+      "PLATFORM(WATCHOS)": false
+      default: true
+
 CSSRandomFunctionEnabled:
   type: bool
   category: css

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -554,7 +554,7 @@
         },
         "picker": {
             "argument": "required",
-            "settings-flag": "htmlEnhancedSelectEnabled"
+            "settings-flag": ["htmlEnhancedSelectEnabled", "cssPickerPseudoElementEnabled"]
         },
         "picker-icon": {
             "settings-flag": "htmlEnhancedSelectEnabled"

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -109,6 +109,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , imageControlsEnabled { settings.imageControlsEnabled() }
 #endif
     , colorLayersEnabled { settings.cssColorLayersEnabled() }
+    , cssPickerPseudoElementEnabled { settings.cssPickerPseudoElementEnabled() }
     , targetTextPseudoElementEnabled { settings.targetTextPseudoElementEnabled() }
     , htmlEnhancedSelectEnabled { settings.htmlEnhancedSelectEnabled() }
     , cssRandomFunctionEnabled { settings.cssRandomFunctionEnabled() }
@@ -147,6 +148,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.imageControlsEnabled,
 #endif
         context.colorLayersEnabled,
+        context.cssPickerPseudoElementEnabled,
         context.targetTextPseudoElementEnabled,
         context.htmlEnhancedSelectEnabled,
         context.cssRandomFunctionEnabled,

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -72,6 +72,7 @@ struct CSSParserContext {
     bool imageControlsEnabled : 1 { false };
 #endif
     bool colorLayersEnabled : 1 { false };
+    bool cssPickerPseudoElementEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
     bool htmlEnhancedSelectEnabled : 1 { false };
     bool cssRandomFunctionEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -39,6 +39,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , imageControlsEnabled(context.imageControlsEnabled)
 #endif
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
+    , cssPickerPseudoElementEnabled(context.cssPickerPseudoElementEnabled)
     , htmlEnhancedSelectEnabled(context.htmlEnhancedSelectEnabled)
     , targetTextPseudoElementEnabled(context.targetTextPseudoElementEnabled)
     , cssAppearanceBaseEnabled(context.cssAppearanceBaseEnabled)
@@ -54,6 +55,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , imageControlsEnabled(document.settings().imageControlsEnabled())
 #endif
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
+    , cssPickerPseudoElementEnabled(document.settings().cssPickerPseudoElementEnabled())
     , htmlEnhancedSelectEnabled(document.settings().htmlEnhancedSelectEnabled())
     , targetTextPseudoElementEnabled(document.settings().targetTextPseudoElementEnabled())
     , cssAppearanceBaseEnabled(document.settings().cssAppearanceBaseEnabled())
@@ -70,6 +72,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.imageControlsEnabled,
 #endif
         context.popoverAttributeEnabled,
+        context.cssPickerPseudoElementEnabled,
         context.htmlEnhancedSelectEnabled,
         context.targetTextPseudoElementEnabled,
         context.cssAppearanceBaseEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -40,6 +40,7 @@ struct CSSSelectorParserContext {
     bool imageControlsEnabled : 1 { false };
 #endif
     bool popoverAttributeEnabled : 1 { false };
+    bool cssPickerPseudoElementEnabled : 1 { false };
     bool htmlEnhancedSelectEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
     bool cssAppearanceBaseEnabled : 1 { false };

--- a/Source/WebCore/css/scripts/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/scripts/process-css-pseudo-selectors.py
@@ -38,7 +38,7 @@ COMMON_KNOWN_KEY_TYPES = {
     'argument': [str],
     'comment': [str],
     'conditional': [str],
-    'settings-flag': [str],
+    'settings-flag': [str, list],
     'status': [str],
 }
 
@@ -629,10 +629,12 @@ class CSSSelectorInlinesGenerator:
     def format_enablement_condition(self, settings_flag, is_internal):
         conditions = []
         if settings_flag is not None:
-            if settings_flag.startswith('DeprecatedGlobalSettings::'):
-                conditions.append(f'{settings_flag}()')
-            else:
-                conditions.append(f'context.{settings_flag}')
+            flags = settings_flag if isinstance(settings_flag, list) else [settings_flag]
+            for flag in flags:
+                if flag.startswith('DeprecatedGlobalSettings::'):
+                    conditions.append(f'{flag}()')
+                else:
+                    conditions.append(f'context.{flag}')
 
         if is_internal:
             conditions.append('isUASheetBehavior(context.mode)')


### PR DESCRIPTION
#### 9c4cb85e7c5fa54bdfd76c48170539379bfe1ea8
<pre>
Disable the ::picker pseudo-element on watchOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=308284">https://bugs.webkit.org/show_bug.cgi?id=308284</a>
<a href="https://rdar.apple.com/170792387">rdar://170792387</a>

Reviewed by Tim Nguyen.

There is not enough screen real estate for custom pickers. While here,

ensure ::picker and ::picker-icon can be feature-tested.
Canonical link: <a href="https://commits.webkit.org/307921@main">https://commits.webkit.org/307921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5247e5d8817a949b3ffe64a1274a21dd4f5084b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99455 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdb59cb2-39a1-4dea-95f1-2e46aab87a71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18467 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/218116bb-5eef-4d5c-9414-d95e7dc9224f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32c9d842-879c-49e2-8142-271b3c40cb43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13895 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2013 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137875 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156879 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6694 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120215 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15390 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74145 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22500 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7335 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177199 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81815 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45489 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->