### PR TITLE
Use Markable<PseudoElementIdentifier> instead of std::optional

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -276,6 +276,7 @@ using WTF::Logger;
 using WTF::MachSendRight;
 using WTF::MachSendRightAnnotated;
 using WTF::MainThreadDispatcher;
+using WTF::Markable;
 using WTF::MarkableTraits;
 using WTF::MonotonicTime;
 using WTF::NativePromise;

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -432,7 +432,7 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
         keyframeEffect->computeStyleOriginatedAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
 }
 
-Ref<StyleOriginatedAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+Ref<StyleOriginatedAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return CSSAnimationEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoElementIdentifier, m_animationName.name);
 }

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -65,7 +65,7 @@ private:
     void syncPropertiesWithBackingAnimation() final;
     AnimationPlayState backingAnimationPlayState() const final;
     TimingFunction* backingAnimationTimingFunction() const final;
-    Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
+    Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>&) final;
 
     AnimationTimeline* bindingsTimeline() const final;
     void setBindingsTimeline(RefPtr<AnimationTimeline>&&) final;

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -38,7 +38,7 @@ CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, Init&& initializer,
 {
 }
 
-CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String& animationName)
+CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String& animationName)
     : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier)
     , m_animationName(animationName)
 {

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -32,7 +32,7 @@ namespace WebCore {
 class CSSAnimationEvent final : public StyleOriginatedAnimationEvent {
     WTF_MAKE_TZONE_ALLOCATED(CSSAnimationEvent);
 public:
-    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String& animationName)
+    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String& animationName)
     {
         return adoptRef(*new CSSAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier, animationName));
     }
@@ -53,7 +53,7 @@ public:
     const String& animationName() const { return m_animationName; }
 
 private:
-    CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String& animationName);
+    CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>&, const String& animationName);
     CSSAnimationEvent(const AtomString&, Init&&, IsTrusted);
 
     String m_animationName;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -87,7 +87,7 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
     unsuspendEffectInvalidation();
 }
 
-Ref<StyleOriginatedAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+Ref<StyleOriginatedAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return CSSTransitionEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoElementIdentifier, transitionProperty());
 }

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -59,7 +59,7 @@ public:
 private:
     CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Style::Transition&, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
-    Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
+    Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>&) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }
 

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSTransitionEvent);
 
-CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String propertyName)
+CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String propertyName)
     : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier)
     , m_propertyName(propertyName)
 {

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class CSSTransitionEvent final : public StyleOriginatedAnimationEvent {
     WTF_MAKE_TZONE_ALLOCATED(CSSTransitionEvent);
 public:
-    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String propertyName)
+    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String propertyName)
     {
         return adoptRef(*new CSSTransitionEvent(type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier, propertyName));
     }
@@ -54,7 +54,7 @@ public:
     const String& propertyName() const { return m_propertyName; }
 
 private:
-    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String propertyName);
+    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>&, const String propertyName);
     CSSTransitionEvent(const AtomString& type, Init&&, IsTrusted);
 
     String m_propertyName;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -823,12 +823,12 @@ Ref<KeyframeEffect> KeyframeEffect::create(Ref<KeyframeEffect>&& source)
     return keyframeEffect;
 }
 
-Ref<KeyframeEffect> KeyframeEffect::create(const Element& target, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+Ref<KeyframeEffect> KeyframeEffect::create(const Element& target, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return adoptRef(*new KeyframeEffect(const_cast<Element*>(&target), pseudoElementIdentifier));
 }
 
-KeyframeEffect::KeyframeEffect(Element* target, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+KeyframeEffect::KeyframeEffect(Element* target, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
     : m_target(target)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)
 {

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -66,7 +66,7 @@ class KeyframeEffect final : public AnimationEffect, public Style::Interpolation
 public:
     static ExceptionOr<Ref<KeyframeEffect>> create(JSC::JSGlobalObject&, Document&, Element*, JSC::Strong<JSC::JSObject>&&, Variant<double, KeyframeEffectOptions>&&);
     static Ref<KeyframeEffect> create(Ref<KeyframeEffect>&&);
-    static Ref<KeyframeEffect> create(const Element&, const std::optional<Style::PseudoElementIdentifier>&);
+    static Ref<KeyframeEffect> create(const Element&, const Markable<Style::PseudoElementIdentifier>&);
 
     using KeyframeOffset = Variant<std::nullptr_t, double, TimelineRangeOffset, String>;
 
@@ -198,7 +198,7 @@ public:
 #endif
 
 private:
-    KeyframeEffect(Element*, const std::optional<Style::PseudoElementIdentifier>&);
+    KeyframeEffect(Element*, const Markable<Style::PseudoElementIdentifier>&);
     ~KeyframeEffect();
 
     enum class AcceleratedAction : uint8_t { Play, Pause, UpdateProperties, TransformChange, Stop };
@@ -265,7 +265,7 @@ private:
     private:
         RefPtr<KeyframeEffect> m_effect;
         RefPtr<Element> m_originalTarget;
-        std::optional<Style::PseudoElementIdentifier> m_originalPseudoElementIdentifier;
+        Markable<Style::PseudoElementIdentifier> m_originalPseudoElementIdentifier;
     };
 
     void scheduleAssociatedAcceleratedEffectStackUpdate(const std::optional<const Styleable>& = std::nullopt);
@@ -308,7 +308,7 @@ private:
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { };
+    Markable<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { };
 
 #if ENABLE(THREADED_ANIMATIONS)
     WeakPtr<AcceleratedEffect> m_acceleratedRepresentation;

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -78,7 +78,7 @@ protected:
 
     void initialize(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     virtual void syncPropertiesWithBackingAnimation();
-    virtual Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) = 0;
+    virtual Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>&) = 0;
 
 private:
     void disassociateFromOwningElement();
@@ -96,7 +96,7 @@ private:
     AnimationEffectPhase m_previousPhase { AnimationEffectPhase::Idle };
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_owningElement;
-    std::optional<Style::PseudoElementIdentifier> m_owningPseudoElementIdentifier;
+    Markable<Style::PseudoElementIdentifier> m_owningPseudoElementIdentifier;
     double m_previousIteration;
 };
 

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleOriginatedAnimationEvent);
 
-StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
     : AnimationEventBase(eventInterface, type, animation, scheduledTime)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
@@ -37,16 +37,16 @@ public:
 
     double elapsedTime() const { return m_elapsedTime; }
     const String& pseudoElement();
-    const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier() const { return m_pseudoElementIdentifier; }
+    const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier() const { return m_pseudoElementIdentifier; }
 
 protected:
-    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const std::optional<Style::PseudoElementIdentifier>&);
+    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const Markable<Style::PseudoElementIdentifier>&);
     StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted, double, String&&);
 
 private:
     double m_elapsedTime;
     String m_pseudoElement;
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { };
+    Markable<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -66,7 +66,7 @@ static bool compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeO
     //     - ::after
     //     - element children
     enum SortingIndex : uint8_t { NotPseudo, Marker, Before, FirstLetter, FirstLine, GrammarError, Highlight, WebKitScrollbar, Selection, SpellingError, TargetText, Checkmark, After, PickerIcon, ViewTransition, ViewTransitionGroup, ViewTransitionImagePair, ViewTransitionOld, ViewTransitionNew, Other };
-    auto sortingIndex = [](const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) -> SortingIndex {
+    auto sortingIndex = [](const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) -> SortingIndex {
         if (!pseudoElementIdentifier)
             return NotPseudo;
 
@@ -319,7 +319,7 @@ bool compareAnimationEventsByCompositeOrder(const AnimationEventBase& a, const A
 
 // FIXME: This should be owned by CSSSelector.
 // FIXME: Generate this function.
-String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+String pseudoElementIdentifierAsString(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     if (!pseudoElementIdentifier)
         return emptyString();
@@ -378,8 +378,8 @@ String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementI
     }
 }
 
-// bool represents whether parsing was successful, std::optional<Style::PseudoElementIdentifier> is the result of the parsing when successful.
-std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String& pseudoElement, Document* document)
+// bool represents whether parsing was successful, Markable<Style::PseudoElementIdentifier> is the result of the parsing when successful.
+std::pair<bool, Markable<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String& pseudoElement, Document* document)
 {
     // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudoelement
     if (pseudoElement.isNull())

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -63,8 +63,8 @@ const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
-String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementIdentifier>&);
-std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String&, Document*);
+String pseudoElementIdentifierAsString(const Markable<Style::PseudoElementIdentifier>&);
+std::pair<bool, Markable<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String&, Document*);
 AtomString animatablePropertyAsString(AnimatableCSSProperty);
 bool animatablePropertiesContainTransformRelatedProperty(const HashSet<AnimatableCSSProperty>&);
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -60,7 +60,7 @@ CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, IsEmp
 {
 }
 
-CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
     : m_element(element)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)
 {
@@ -73,7 +73,7 @@ Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& el
     return adoptRef(*new CSSComputedStyleDeclaration(element, allowVisited));
 }
 
-Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& element, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return adoptRef(*new CSSComputedStyleDeclaration(element, pseudoElementIdentifier));
 }

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -42,7 +42,7 @@ public:
 
     enum class AllowVisited : bool { No, Yes };
     WEBCORE_EXPORT static Ref<CSSComputedStyleDeclaration> create(Element&, AllowVisited);
-    static Ref<CSSComputedStyleDeclaration> create(Element&, const std::optional<Style::PseudoElementIdentifier>&);
+    static Ref<CSSComputedStyleDeclaration> create(Element&, const Markable<Style::PseudoElementIdentifier>&);
     static Ref<CSSComputedStyleDeclaration> createEmpty(Element&);
 
     WEBCORE_EXPORT virtual ~CSSComputedStyleDeclaration();
@@ -53,7 +53,7 @@ private:
     enum class IsEmpty : bool { No, Yes };
     CSSComputedStyleDeclaration(Element&, AllowVisited);
     CSSComputedStyleDeclaration(Element&, IsEmpty);
-    CSSComputedStyleDeclaration(Element&, const std::optional<Style::PseudoElementIdentifier>&);
+    CSSComputedStyleDeclaration(Element&, const Markable<Style::PseudoElementIdentifier>&);
 
     // CSSOM functions. Don't make these public.
     CSSRule* NODELETE parentRule() const final;
@@ -81,7 +81,7 @@ private:
     Style::Extractor extractor() const;
 
     const Ref<Element> m_element;
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { std::nullopt };
+    Markable<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { std::nullopt };
     bool m_isEmpty { false };
     bool m_allowVisitedStyle { false };
 };

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -277,7 +277,7 @@ unsigned CSSSelector::specificityForPage() const
     return s;
 }
 
-std::optional<PseudoElementType> CSSSelector::stylePseudoElementTypeFor(PseudoElement type)
+Markable<PseudoElementType> CSSSelector::stylePseudoElementTypeFor(PseudoElement type)
 {
     switch (type) {
     case PseudoElement::FirstLine:

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -126,7 +126,7 @@ public:
     enum AttributeMatchType { CaseSensitive, CaseInsensitive };
 
     // Maps from the selector pseudo-element type to the style type. Only pseudo-elements that are not element-backed have a type in style.
-    static std::optional<PseudoElementType> NODELETE stylePseudoElementTypeFor(PseudoElement);
+    static Markable<PseudoElementType> NODELETE stylePseudoElementTypeFor(PseudoElement);
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElementName(StringView, const CSSSelectorParserContext&);

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -87,7 +87,7 @@ static bool matchesActiveViewTransitionTypePseudoClass(const Element& element, c
 }
 
 struct SelectorChecker::LocalContext {
-    LocalContext(const CSSSelector& selector, const Element& element, VisitedMatchType visitedMatchType, std::optional<Style::PseudoElementIdentifier> requestedPseudoElement)
+    LocalContext(const CSSSelector& selector, const Element& element, VisitedMatchType visitedMatchType, Markable<Style::PseudoElementIdentifier> requestedPseudoElement)
         : selector(&selector)
         , element(&element)
         , visitedMatchType(visitedMatchType)
@@ -99,7 +99,7 @@ struct SelectorChecker::LocalContext {
     const Element* element;
     VisitedMatchType visitedMatchType;
     const CSSSelector* firstSelectorOfTheFragment;
-    std::optional<Style::PseudoElementIdentifier> requestedPseudoElement;
+    Markable<Style::PseudoElementIdentifier> requestedPseudoElement;
     bool isMatchElement { true };
     bool isSubjectOrAdjacentElement { true };
     bool inFunctionalPseudoClass { false };
@@ -205,7 +205,7 @@ void SelectorChecker::CheckingContext::setRequestedPseudoElement(Style::PseudoEl
     pseudoElementNameArgument = pseudoElementIdentifier.nameArgument;
 }
 
-std::optional<Style::PseudoElementIdentifier> SelectorChecker::CheckingContext::requestedPseudoElement() const
+Markable<Style::PseudoElementIdentifier> SelectorChecker::CheckingContext::requestedPseudoElement() const
 {
     if (!hasRequestedPseudoElement)
         return { };

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -94,7 +94,7 @@ public:
         const SelectorChecker::Mode resolvingMode;
 
         void NODELETE setRequestedPseudoElement(Style::PseudoElementIdentifier);
-        std::optional<Style::PseudoElementIdentifier> NODELETE requestedPseudoElement() const;
+        Markable<Style::PseudoElementIdentifier> requestedPseudoElement() const;
 
     private:
         friend class SelectorCompiler::SelectorCodeGenerator;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1443,7 +1443,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
     return CSSSelectorList { WTF::move(result) };
 }
 
-static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement selectorPseudoElement)
+static Markable<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement selectorPseudoElement)
 {
     auto type = CSSSelector::stylePseudoElementTypeFor(selectorPseudoElement);
     if (!type)
@@ -1453,7 +1453,7 @@ static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(
 
 // FIXME: It's probably worth investigating if more logic can be shared with
 // CSSSelectorParser::consumePseudo(), though note that the requirements are subtly different.
-std::pair<bool, std::optional<Style::PseudoElementIdentifier>> CSSSelectorParser::parsePseudoElement(const String& input, const CSSSelectorParserContext& context)
+std::pair<bool, Markable<Style::PseudoElementIdentifier>> CSSSelectorParser::parsePseudoElement(const String& input, const CSSSelectorParserContext& context)
 {
     auto tokenizer = CSSTokenizer { input };
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -62,7 +62,7 @@ public:
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
-    static std::pair<bool, std::optional<Style::PseudoElementIdentifier>> parsePseudoElement(const String&, const CSSSelectorParserContext&);
+    static std::pair<bool, Markable<Style::PseudoElementIdentifier>> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 
 private:
     template<typename ConsumeSelector> MutableCSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3183,7 +3183,7 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
     return result;
 }
 
-std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets(Element& element, const RenderStyle* parentStyleArg, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets(Element& element, const RenderStyle* parentStyleArg, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     ASSERT(&element.document() == this);
     ASSERT(!element.isPseudoElement() || !pseudoElementIdentifier);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -794,7 +794,7 @@ public:
     // so calling this may cause a flash of unstyled content (FOUC).
     WEBCORE_EXPORT UpdateLayoutResult updateLayoutIgnorePendingStylesheets(OptionSet<LayoutOptions> = { }, const Element* = nullptr);
 
-    std::unique_ptr<RenderStyle> styleForElementIgnoringPendingStylesheets(Element&, const RenderStyle* parentStyle, const std::optional<Style::PseudoElementIdentifier>& = std::nullopt);
+    std::unique_ptr<RenderStyle> styleForElementIgnoringPendingStylesheets(Element&, const RenderStyle* parentStyle, const Markable<Style::PseudoElementIdentifier>& = std::nullopt);
 
     // Returns true if page box (margin boxes and page borders) is visible.
     WEBCORE_EXPORT bool isPageBoxVisible(int pageIndex);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4630,7 +4630,7 @@ const RenderStyle* Element::renderOrDisplayContentsStyle() const
     return renderOrDisplayContentsStyle({ });
 }
 
-const RenderStyle* Element::renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+const RenderStyle* Element::renderOrDisplayContentsStyle(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (pseudoElementIdentifier) {
         if (CheckedPtr style = renderOrDisplayContentsStyle()) {
@@ -4762,7 +4762,7 @@ const RenderStyle& Element::resolvePseudoElementStyle(const Style::PseudoElement
     return *computedStyle.unsafeGet();
 }
 
-const RenderStyle* Element::computedStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+const RenderStyle* Element::computedStyle(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     if (!isConnected())
         return nullptr;
@@ -5233,39 +5233,39 @@ bool Element::mayHaveKeyframeEffects() const
     return hasRareData() && elementRareData()->hasAnimationRareData();
 }
 
-ElementAnimationRareData* Element::animationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+ElementAnimationRareData* Element::animationRareData(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     return hasRareData() ? elementRareData()->animationRareData(pseudoElementIdentifier) : nullptr;
 }
 
-ElementAnimationRareData& Element::ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+ElementAnimationRareData& Element::ensureAnimationRareData(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return ensureElementRareData().ensureAnimationRareData(pseudoElementIdentifier);
 }
 
-AtomString Element::viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+AtomString Element::viewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     return hasRareData() ? elementRareData()->viewTransitionCapturedName(pseudoElementIdentifier) : nullAtom();
 }
 
-void Element::setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, AtomString captureName)
+void Element::setViewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, AtomString captureName)
 {
     return ensureElementRareData().setViewTransitionCapturedName(pseudoElementIdentifier, captureName);
 }
 
-KeyframeEffectStack* Element::keyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+KeyframeEffectStack* Element::keyframeEffectStack(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return animationData->keyframeEffectStack();
     return nullptr;
 }
 
-KeyframeEffectStack& Element::ensureKeyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+KeyframeEffectStack& Element::ensureKeyframeEffectStack(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return ensureAnimationRareData(pseudoElementIdentifier).ensureKeyframeEffectStack();
 }
 
-bool Element::hasKeyframeEffects(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+bool Element::hasKeyframeEffects(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier)) {
         if (auto* keyframeEffectStack = animationData->keyframeEffectStack())
@@ -5274,83 +5274,83 @@ bool Element::hasKeyframeEffects(const std::optional<Style::PseudoElementIdentif
     return false;
 }
 
-const AnimationCollection* Element::animations(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+const AnimationCollection* Element::animations(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return &animationData->animations();
     return nullptr;
 }
 
-bool Element::hasCompletedTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const AnimatableCSSProperty& property) const
+bool Element::hasCompletedTransitionForProperty(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const AnimatableCSSProperty& property) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return animationData->completedTransitionsByProperty().contains(property);
     return false;
 }
 
-bool Element::hasRunningTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const AnimatableCSSProperty& property) const
+bool Element::hasRunningTransitionForProperty(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const AnimatableCSSProperty& property) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return animationData->runningTransitionsByProperty().contains(property);
     return false;
 }
 
-bool Element::hasRunningTransitions(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+bool Element::hasRunningTransitions(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return !animationData->runningTransitionsByProperty().isEmpty();
     return false;
 }
 
-const AnimatableCSSPropertyToTransitionMap* Element::completedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+const AnimatableCSSPropertyToTransitionMap* Element::completedTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return &animationData->completedTransitionsByProperty();
     return nullptr;
 }
 
-const AnimatableCSSPropertyToTransitionMap* Element::runningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+const AnimatableCSSPropertyToTransitionMap* Element::runningTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return &animationData->runningTransitionsByProperty();
     return nullptr;
 }
 
-AnimationCollection& Element::ensureAnimations(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+AnimationCollection& Element::ensureAnimations(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return ensureAnimationRareData(pseudoElementIdentifier).animations();
 }
 
-CSSAnimationCollection& Element::animationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+CSSAnimationCollection& Element::animationsCreatedByMarkup(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return ensureAnimationRareData(pseudoElementIdentifier).animationsCreatedByMarkup();
 }
 
-void Element::setAnimationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, CSSAnimationCollection&& animations)
+void Element::setAnimationsCreatedByMarkup(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, CSSAnimationCollection&& animations)
 {
     if (animations.isEmpty() && !animationRareData(pseudoElementIdentifier))
         return;
     ensureAnimationRareData(pseudoElementIdentifier).setAnimationsCreatedByMarkup(WTF::move(animations));
 }
 
-AnimatableCSSPropertyToTransitionMap& Element::ensureCompletedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+AnimatableCSSPropertyToTransitionMap& Element::ensureCompletedTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return ensureAnimationRareData(pseudoElementIdentifier).completedTransitionsByProperty();
 }
 
-AnimatableCSSPropertyToTransitionMap& Element::ensureRunningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+AnimatableCSSPropertyToTransitionMap& Element::ensureRunningTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return ensureAnimationRareData(pseudoElementIdentifier).runningTransitionsByProperty();
 }
 
-const RenderStyle* Element::lastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+const RenderStyle* Element::lastStyleChangeEventStyle(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return animationData->lastStyleChangeEventStyle();
     return nullptr;
 }
 
-void Element::setLastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, std::unique_ptr<const RenderStyle>&& style)
+void Element::setLastStyleChangeEventStyle(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, std::unique_ptr<const RenderStyle>&& style)
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         animationData->setLastStyleChangeEventStyle(WTF::move(style));
@@ -5358,14 +5358,14 @@ void Element::setLastStyleChangeEventStyle(const std::optional<Style::PseudoElem
         ensureAnimationRareData(pseudoElementIdentifier).setLastStyleChangeEventStyle(WTF::move(style));
 }
 
-bool Element::hasPropertiesOverridenAfterAnimation(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+bool Element::hasPropertiesOverridenAfterAnimation(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))
         return animationData->hasPropertiesOverridenAfterAnimation();
     return false;
 }
 
-void Element::setHasPropertiesOverridenAfterAnimation(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, bool value)
+void Element::setHasPropertiesOverridenAfterAnimation(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, bool value)
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier)) {
         animationData->setHasPropertiesOverridenAfterAnimation(value);
@@ -5375,17 +5375,17 @@ void Element::setHasPropertiesOverridenAfterAnimation(const std::optional<Style:
         ensureAnimationRareData(pseudoElementIdentifier).setHasPropertiesOverridenAfterAnimation(true);
 }
 
-void Element::cssAnimationsDidUpdate(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+void Element::cssAnimationsDidUpdate(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     ensureAnimationRareData(pseudoElementIdentifier).cssAnimationsDidUpdate();
 }
 
-void Element::keyframesRuleDidChange(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+void Element::keyframesRuleDidChange(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     ensureAnimationRareData(pseudoElementIdentifier).keyframesRuleDidChange();
 }
 
-bool Element::hasPendingKeyframesUpdate(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+bool Element::hasPendingKeyframesUpdate(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     auto* data = animationRareData(pseudoElementIdentifier);
     return data && data->hasPendingKeyframesUpdate();
@@ -6444,7 +6444,7 @@ RefPtr<HTMLElement> Element::topmostPopoverAncestor(TopLayerElementType topLayer
     return topmostAncestor;
 }
 
-double Element::lookupCSSRandomBaseValue(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const CSSCalc::RandomCachingKey& key) const
+double Element::lookupCSSRandomBaseValue(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const CSSCalc::RandomCachingKey& key) const
 {
     return const_cast<Element*>(this)->ensureElementRareData().ensureRandomCachingKeyMap(pseudoElementIdentifier)->lookupCSSRandomBaseValue(key);
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -529,7 +529,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> insertAdjacentText(const String& where, String&& text);
 
     using Node::computedStyle;
-    const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&) override;
+    const RenderStyle* computedStyle(const Markable<Style::PseudoElementIdentifier>&) override;
     const RenderStyle* computedStyleForEditability();
 
     bool needsStyleInvalidation() const;
@@ -686,33 +686,33 @@ public:
 
     virtual bool childShouldCreateRenderer(const Node&) const;
 
-    KeyframeEffectStack* keyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&) const;
-    KeyframeEffectStack& ensureKeyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&);
-    bool hasKeyframeEffects(const std::optional<Style::PseudoElementIdentifier>&) const;
+    KeyframeEffectStack* keyframeEffectStack(const Markable<Style::PseudoElementIdentifier>&) const;
+    KeyframeEffectStack& ensureKeyframeEffectStack(const Markable<Style::PseudoElementIdentifier>&);
+    bool hasKeyframeEffects(const Markable<Style::PseudoElementIdentifier>&) const;
     bool NODELETE mayHaveKeyframeEffects() const;
 
-    const AnimationCollection* animations(const std::optional<Style::PseudoElementIdentifier>&) const;
-    bool hasCompletedTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
-    bool hasRunningTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
-    bool hasRunningTransitions(const std::optional<Style::PseudoElementIdentifier>&) const;
-    AnimationCollection& ensureAnimations(const std::optional<Style::PseudoElementIdentifier>&);
+    const AnimationCollection* animations(const Markable<Style::PseudoElementIdentifier>&) const;
+    bool hasCompletedTransitionForProperty(const Markable<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
+    bool hasRunningTransitionForProperty(const Markable<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
+    bool hasRunningTransitions(const Markable<Style::PseudoElementIdentifier>&) const;
+    AnimationCollection& ensureAnimations(const Markable<Style::PseudoElementIdentifier>&);
 
-    const AnimatableCSSPropertyToTransitionMap* completedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) const;
-    const AnimatableCSSPropertyToTransitionMap* runningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) const;
+    const AnimatableCSSPropertyToTransitionMap* completedTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>&) const;
+    const AnimatableCSSPropertyToTransitionMap* runningTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>&) const;
 
-    AnimatableCSSPropertyToTransitionMap& ensureCompletedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&);
-    AnimatableCSSPropertyToTransitionMap& ensureRunningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&);
-    CSSAnimationCollection& animationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>&);
-    void setAnimationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>&, CSSAnimationCollection&&);
+    AnimatableCSSPropertyToTransitionMap& ensureCompletedTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>&);
+    AnimatableCSSPropertyToTransitionMap& ensureRunningTransitionsByProperty(const Markable<Style::PseudoElementIdentifier>&);
+    CSSAnimationCollection& animationsCreatedByMarkup(const Markable<Style::PseudoElementIdentifier>&);
+    void setAnimationsCreatedByMarkup(const Markable<Style::PseudoElementIdentifier>&, CSSAnimationCollection&&);
 
-    const RenderStyle* lastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
-    void setLastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>&, std::unique_ptr<const RenderStyle>&&);
-    bool hasPropertiesOverridenAfterAnimation(const std::optional<Style::PseudoElementIdentifier>&) const;
-    void setHasPropertiesOverridenAfterAnimation(const std::optional<Style::PseudoElementIdentifier>&, bool);
+    const RenderStyle* lastStyleChangeEventStyle(const Markable<Style::PseudoElementIdentifier>&) const;
+    void setLastStyleChangeEventStyle(const Markable<Style::PseudoElementIdentifier>&, std::unique_ptr<const RenderStyle>&&);
+    bool hasPropertiesOverridenAfterAnimation(const Markable<Style::PseudoElementIdentifier>&) const;
+    void setHasPropertiesOverridenAfterAnimation(const Markable<Style::PseudoElementIdentifier>&, bool);
 
-    void cssAnimationsDidUpdate(const std::optional<Style::PseudoElementIdentifier>&);
-    void keyframesRuleDidChange(const std::optional<Style::PseudoElementIdentifier>&);
-    bool hasPendingKeyframesUpdate(const std::optional<Style::PseudoElementIdentifier>&) const;
+    void cssAnimationsDidUpdate(const Markable<Style::PseudoElementIdentifier>&);
+    void keyframesRuleDidChange(const Markable<Style::PseudoElementIdentifier>&);
+    bool hasPendingKeyframesUpdate(const Markable<Style::PseudoElementIdentifier>&) const;
     // FIXME: do we need a counter style didChange here? (rdar://103018993).
 
     bool isLink() const { return hasStateFlag(StateFlag::IsLink); }
@@ -798,7 +798,7 @@ public:
 
     const RenderStyle* existingComputedStyle() const;
     WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle() const;
-    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
+    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle(const Markable<Style::PseudoElementIdentifier>&) const;
 
     void clearBeforePseudoElement();
     void clearAfterPseudoElement();
@@ -908,10 +908,10 @@ public:
     void updateEffectiveTextDirection();
     void updateEffectiveTextDirectionIfNeeded();
 
-    AtomString viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&) const;
-    void setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&, AtomString);
+    AtomString viewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>&) const;
+    void setViewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>&, AtomString);
 
-    double lookupCSSRandomBaseValue(const std::optional<Style::PseudoElementIdentifier>&, const CSSCalc::RandomCachingKey&) const;
+    double lookupCSSRandomBaseValue(const Markable<Style::PseudoElementIdentifier>&, const CSSCalc::RandomCachingKey&) const;
     bool NODELETE hasRandomCachingKeyMap() const;
 
     void addShadowRoot(Ref<ShadowRoot>&&);
@@ -1027,8 +1027,8 @@ private:
     inline ElementRareData* elementRareData() const;
     ElementRareData& ensureElementRareData();
 
-    ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const;
-    ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&);
+    ElementAnimationRareData* animationRareData(const Markable<Style::PseudoElementIdentifier>&) const;
+    ElementAnimationRareData& ensureAnimationRareData(const Markable<Style::PseudoElementIdentifier>&);
 
     virtual int defaultTabIndex() const;
 

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -38,8 +38,8 @@ struct SameSizeAsElementRareData : NodeRareData {
     int m_tabIndex;
     uint8_t contentRelevancy;
     IntPoint savedLayerScrollPosition;
-    HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
-    HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
+    HashMap<Markable<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
+    HashMap<Markable<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
     void* pointers[18];
     void* intersectionObserverData;
     void* resizeObserverData;
@@ -48,7 +48,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     Markable<LayoutUnit> lastRemembedSize[2];
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
     uint8_t visibilityAdjustment;
-    HashMap<std::optional<Style::PseudoElementIdentifier>, Ref<CSSCalc::RandomCachingKeyMap>> randomCachingKeyMaps;
+    HashMap<Markable<Style::PseudoElementIdentifier>, Ref<CSSCalc::RandomCachingKeyMap>> randomCachingKeyMaps;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> invokedPopoverWeakPtr;
 };
 

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -109,11 +109,11 @@ public:
     void setSavedLayerScrollPosition(ScrollPosition position) { m_savedLayerScrollPosition = position; }
 
     bool hasAnimationRareData() const { return !m_animationRareData.isEmpty(); }
-    ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const;
-    ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&);
+    ElementAnimationRareData* animationRareData(const Markable<Style::PseudoElementIdentifier>&) const;
+    ElementAnimationRareData& ensureAnimationRareData(const Markable<Style::PseudoElementIdentifier>&);
 
-    AtomString viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&) const;
-    void setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&, AtomString);
+    AtomString viewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>&) const;
+    void setViewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>&, AtomString);
 
     DOMTokenList* partList() const { return m_partList.get(); }
     void setPartList(const std::unique_ptr<DOMTokenList>&& partList) { lazyInitialize(m_partList, std::move(partList)); }
@@ -163,7 +163,7 @@ public:
     OptionSet<VisibilityAdjustment> visibilityAdjustment() const { return m_visibilityAdjustment; }
     void setVisibilityAdjustment(OptionSet<VisibilityAdjustment> adjustment) { m_visibilityAdjustment = adjustment; }
 
-    Ref<CSSCalc::RandomCachingKeyMap> ensureRandomCachingKeyMap(const std::optional<Style::PseudoElementIdentifier>&);
+    Ref<CSSCalc::RandomCachingKeyMap> ensureRandomCachingKeyMap(const Markable<Style::PseudoElementIdentifier>&);
     bool hasRandomCachingKeyMap() const;
 
 #if DUMP_NODE_STATISTICS
@@ -256,9 +256,9 @@ private:
     Markable<LayoutUnit> m_lastRememberedLogicalWidth;
     Markable<LayoutUnit> m_lastRememberedLogicalHeight;
 
-    HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> m_animationRareData;
+    HashMap<Markable<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> m_animationRareData;
 
-    HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> m_viewTransitionCapturedName;
+    HashMap<Markable<Style::PseudoElementIdentifier>, AtomString> m_viewTransitionCapturedName;
 
     RefPtr<PseudoElement> m_beforePseudoElement;
     RefPtr<PseudoElement> m_afterPseudoElement;
@@ -281,7 +281,7 @@ private:
 
     OptionSet<VisibilityAdjustment> m_visibilityAdjustment;
 
-    HashMap<std::optional<Style::PseudoElementIdentifier>, Ref<CSSCalc::RandomCachingKeyMap>> m_randomCachingKeyMaps;
+    HashMap<Markable<Style::PseudoElementIdentifier>, Ref<CSSCalc::RandomCachingKeyMap>> m_randomCachingKeyMaps;
 };
 
 inline ElementRareData::ElementRareData()
@@ -325,12 +325,12 @@ inline void ElementRareData::setUnusualTabIndex(int tabIndex)
     m_unusualTabIndex = tabIndex;
 }
 
-inline ElementAnimationRareData* ElementRareData::animationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+inline ElementAnimationRareData* ElementRareData::animationRareData(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     return m_animationRareData.get(pseudoElementIdentifier);
 }
 
-inline ElementAnimationRareData& ElementRareData::ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+inline ElementAnimationRareData& ElementRareData::ensureAnimationRareData(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     if (auto* animationRareData = this->animationRareData(pseudoElementIdentifier))
         return *animationRareData;
@@ -340,17 +340,17 @@ inline ElementAnimationRareData& ElementRareData::ensureAnimationRareData(const 
     return *result.iterator->value.get();
 }
 
-inline AtomString ElementRareData::viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+inline AtomString ElementRareData::viewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     return m_viewTransitionCapturedName.get(pseudoElementIdentifier);
 }
 
-inline void ElementRareData::setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, AtomString captureName)
+inline void ElementRareData::setViewTransitionCapturedName(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, AtomString captureName)
 {
     m_viewTransitionCapturedName.set(pseudoElementIdentifier, captureName);
 }
 
-inline Ref<CSSCalc::RandomCachingKeyMap> ElementRareData::ensureRandomCachingKeyMap(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+inline Ref<CSSCalc::RandomCachingKeyMap> ElementRareData::ensureRandomCachingKeyMap(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     return m_randomCachingKeyMaps.ensure(pseudoElementIdentifier, [] {
         return CSSCalc::RandomCachingKeyMap::create();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1256,7 +1256,7 @@ const RenderStyle* Node::computedStyle()
     return computedStyle(std::nullopt);
 }
 
-const RenderStyle* Node::computedStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+const RenderStyle* Node::computedStyle(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     RefPtr composedParent = parentElementInComposedTree();
     return composedParent ? composedParent->computedStyle(pseudoElementIdentifier) : nullptr;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -254,8 +254,8 @@ public:
     bool isPseudoElement() const { return isElementNode() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
     inline bool isBeforePseudoElement() const;
     inline bool isAfterPseudoElement() const;
-    inline std::optional<PseudoElementType> pseudoElementType() const;
-    inline std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
+    inline Markable<PseudoElementType> pseudoElementType() const;
+    inline Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
 
 #if ENABLE(VIDEO)
     virtual bool isWebVTTElement() const { return false; }
@@ -512,7 +512,7 @@ public:
     inline const RenderStyle* renderStyle() const; // Defined in NodeRenderStyle.h
 
     WEBCORE_EXPORT const RenderStyle* computedStyle();
-    virtual const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&);
+    virtual const RenderStyle* computedStyle(const Markable<Style::PseudoElementIdentifier>&);
 
     enum class InsertedIntoAncestorResult {
         Done,

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -113,14 +113,14 @@ bool Node::isAfterPseudoElement() const
     return pseudoElement && pseudoElement->pseudoElementType() == PseudoElementType::After;
 }
 
-std::optional<PseudoElementType> Node::pseudoElementType() const
+Markable<PseudoElementType> Node::pseudoElementType() const
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(*this))
         return pseudoElement->pseudoElementType();
     return { };
 }
 
-std::optional<Style::PseudoElementIdentifier> Node::pseudoElementIdentifier() const
+Markable<Style::PseudoElementIdentifier> Node::pseudoElementIdentifier() const
 {
     if (auto type = pseudoElementType())
         return Style::PseudoElementIdentifier { *type };

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -525,7 +525,7 @@ Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Pr
                     continue;
 
                 if (auto protocolPseudoId = protocolValueForPseudoElementType(pseudoElementType)) {
-                    auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, pseudoElementType, Style::Resolver::AllCSSRules);
+                    auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, Style::PseudoElementIdentifier { pseudoElementType }, Style::Resolver::AllCSSRules);
                     if (!matchedRules.isEmpty()) {
                         auto matches = Inspector::Protocol::CSS::PseudoIdMatches::create()
                             .setPseudoId(protocolPseudoId.value())
@@ -1370,7 +1370,7 @@ RefPtr<Inspector::Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(
     return bindStyleSheet(rule->parentStyleSheet()).buildObjectForRule(rule);
 }
 
-Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier)
+Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier)
 {
     auto result = JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>::create();
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -179,7 +179,7 @@ private:
 
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(const StyleRule*, Style::Resolver&, Element&);
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(CSSStyleRule*);
-    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>&, Style::Resolver&, Element&, std::optional<Style::PseudoElementIdentifier>);
+    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>&, Style::Resolver&, Element&, Markable<Style::PseudoElementIdentifier>);
     RefPtr<Inspector::Protocol::CSS::CSSStyle> buildObjectForAttributesStyle(StyledElement&);
 
     void nodeHasLayoutFlagsChange(Node&);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -211,12 +211,12 @@ void HitTestResult::setLocalPoint(const LayoutPoint& p)
     m_localPoint = m_pseudoElementIdentifier ? LayoutPoint() : p;
 }
 
-std::optional<Style::PseudoElementIdentifier> HitTestResult::pseudoElementIdentifier() const
+Markable<Style::PseudoElementIdentifier> HitTestResult::pseudoElementIdentifier() const
 {
     return m_pseudoElementIdentifier;
 }
 
-void HitTestResult::setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier)
+void HitTestResult::setPseudoElementIdentifier(Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier)
 {
     m_pseudoElementIdentifier = pseudoElementIdentifier;
 }

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -77,8 +77,8 @@ public:
     bool isOverWidget() const { return m_isOverWidget; }
     void setIsOverWidget(bool isOverWidget) { m_isOverWidget = isOverWidget; }
 
-    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
-    void setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>);
+    Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
+    void setPseudoElementIdentifier(Markable<Style::PseudoElementIdentifier>);
 
     WEBCORE_EXPORT String linkSuggestedFilename() const;
 
@@ -197,7 +197,7 @@ private:
     RefPtr<Element> m_innerURLElement;
     RefPtr<Scrollbar> m_scrollbar;
     bool m_isOverWidget { false }; // Returns true if we are over a widget (and not in the border/padding area of a RenderWidget for example).
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
+    Markable<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
 
     mutable std::unique_ptr<NodeSet> m_listBasedTestResult;
 };

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -320,7 +320,7 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoElementType> pseudoElementType)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, Markable<PseudoElementType> pseudoElementType)
 {
     auto extractDecorations = [&] (const RenderStyle& style, Style::TextDecorationLine decorations) {
         if (!decorations.containsAny({ Style::TextDecorationLine::Flag::Underline, Style::TextDecorationLine::Flag::Overline, Style::TextDecorationLine::Flag::LineThrough }))
@@ -390,7 +390,7 @@ Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet
     return style.visitedDependentTextDecorationColorApplyingColorFilter(paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, std::optional<PseudoElementType> pseudoElementType) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, Markable<PseudoElementType> pseudoElementType) -> Styles
 {
     if (requestedDecorations.isNone())
         return { };

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -74,7 +74,7 @@ public:
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
     static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
-    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, std::optional<PseudoElementType> = { });
+    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, Markable<PseudoElementType> = { });
     static Style::TextDecorationLine textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -279,7 +279,7 @@ inline bool RenderStyle::hasPseudoStyle(PseudoElementType pseudo) const
     return m_computedStyle.hasPseudoStyle(pseudo);
 }
 
-inline std::optional<PseudoElementType> RenderStyle::pseudoElementType() const
+inline Markable<PseudoElementType> RenderStyle::pseudoElementType() const
 {
     return m_computedStyle.pseudoElementType();
 }
@@ -289,7 +289,7 @@ inline const AtomString& RenderStyle::pseudoElementNameArgument() const
     return m_computedStyle.pseudoElementNameArgument();
 }
 
-inline std::optional<Style::PseudoElementIdentifier> RenderStyle::pseudoElementIdentifier() const
+inline Markable<Style::PseudoElementIdentifier> RenderStyle::pseudoElementIdentifier() const
 {
     return m_computedStyle.pseudoElementIdentifier();
 }

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -254,7 +254,7 @@ inline void RenderStyle::setHasPseudoStyles(EnumSet<PseudoElementType> set)
     m_computedStyle.setHasPseudoStyles(set);
 }
 
-inline void RenderStyle::setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>&& identifier)
+inline void RenderStyle::setPseudoElementIdentifier(Markable<Style::PseudoElementIdentifier>&& identifier)
 {
     m_computedStyle.setPseudoElementIdentifier(WTF::move(identifier));
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -199,11 +199,11 @@ public:
 
     // MARK: - Pseudo element/style
 
-    std::optional<PseudoElementType> pseudoElementType() const;
+    Markable<PseudoElementType> pseudoElementType() const;
     const AtomString& pseudoElementNameArgument() const;
 
-    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
-    inline void setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>&&);
+    Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
+    inline void setPseudoElementIdentifier(Markable<Style::PseudoElementIdentifier>&&);
 
     inline bool hasAnyPublicPseudoStyles() const;
     inline bool hasPseudoStyle(PseudoElementType) const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -32,6 +32,7 @@
 #include <type_traits>
 #include <wtf/EnumSet.h>
 #include <wtf/EnumTraits.h>
+#include <wtf/Markable.h>
 
 namespace WTF {
 class TextStream;
@@ -117,7 +118,7 @@ constexpr auto allInternalPseudoElementTypes = EnumSet {
 
 constexpr auto allPseudoElementTypes = allPublicPseudoElementTypes | allInternalPseudoElementTypes;
 
-inline std::optional<PseudoElementType> parentPseudoElement(PseudoElementType pseudoElementType)
+inline Markable<PseudoElementType> parentPseudoElement(PseudoElementType pseudoElementType)
 {
     switch (pseudoElementType) {
     case PseudoElementType::FirstLetter: return PseudoElementType::FirstLine;
@@ -125,7 +126,7 @@ inline std::optional<PseudoElementType> parentPseudoElement(PseudoElementType ps
     case PseudoElementType::ViewTransitionImagePair: return PseudoElementType::ViewTransitionGroup;
     case PseudoElementType::ViewTransitionNew: return PseudoElementType::ViewTransitionImagePair;
     case PseudoElementType::ViewTransitionOld: return PseudoElementType::ViewTransitionImagePair;
-    default: return std::nullopt;
+    default: return { };
     }
 }
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -87,7 +87,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         }
     }
 
-    firstLetterStyle.setPseudoElementIdentifier({ { PseudoElementType::FirstLetter } });
+    firstLetterStyle.setPseudoElementIdentifier(Style::PseudoElementIdentifier { PseudoElementType::FirstLetter });
     // Force inline display (except for floating first-letters).
     firstLetterStyle.setDisplay(firstLetterStyle.floating() != Float::None ? Style::DisplayType::BlockFlow : Style::DisplayType::InlineFlow);
     // CSS2 says first-letter can't be positioned.

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -227,7 +227,7 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
         // For display:contents we create an inline wrapper that inherits its
         // style from the display:contents style.
         auto contentsStyle = RenderStyle::createPtr();
-        contentsStyle->setPseudoElementIdentifier({ { pseudoElementType } });
+        contentsStyle->setPseudoElementIdentifier(Style::PseudoElementIdentifier { pseudoElementType });
         contentsStyle->inheritFrom(*updateStyle);
         contentsStyle->copyContentFrom(*updateStyle);
         contentsStyle->copyPseudoElementsFrom(*updateStyle);

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -131,7 +131,7 @@ struct AnchorPositionedState {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedState);
 };
 
-using AnchorPositionedKey = std::pair<RefPtr<const Element>, std::optional<PseudoElementIdentifier>>;
+using AnchorPositionedKey = std::pair<RefPtr<const Element>, Markable<PseudoElementIdentifier>>;
 using AnchorPositionedStates = HashMap<AnchorPositionedKey, std::unique_ptr<AnchorPositionedState>>;
 
 using AnchorsForAnchorName = HashMap<ResolvedScopedName, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
@@ -155,7 +155,7 @@ struct AnchorPositionedToAnchorEntry {
     // The pseudo-element identifier can be used to access the AnchorPositionedState struct
     // of the current element in an AnchorPositionedStates map, in combination with the relevant
     // Element object.
-    std::optional<PseudoElementIdentifier> pseudoElementIdentifier;
+    Markable<PseudoElementIdentifier> pseudoElementIdentifier;
 
     Vector<ResolvedAnchor> anchors;
 

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/RenderStyleConstants.h>
+#include <wtf/Markable.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/TextStream.h>
@@ -41,6 +42,49 @@ struct PseudoElementIdentifier {
     friend bool operator==(const PseudoElementIdentifier& a, const PseudoElementIdentifier& b) = default;
 };
 
+} // namespace WebCore
+
+namespace WTF {
+
+template<>
+struct MarkableTraits<WebCore::Style::PseudoElementIdentifier> {
+    static bool isEmptyValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return EnumMarkableTraits<WebCore::PseudoElementType>::isEmptyValue(identifer.type); }
+    static WebCore::Style::PseudoElementIdentifier emptyValue() { return { EnumMarkableTraits<WebCore::PseudoElementType>::emptyValue() }; }
+};
+
+template<>
+struct HashTraits<WebCore::Style::PseudoElementIdentifier> : GenericHashTraits<WebCore::Style::PseudoElementIdentifier> {
+    typedef WebCore::Style::PseudoElementIdentifier EmptyValueType;
+
+    static constexpr bool emptyValueIsZero = false;
+    static EmptyValueType emptyValue() { return { { }, emptyAtom() }; }
+
+    static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& identifer) { new (NotNull, &identifer.nameArgument) AtomString { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return identifer.nameArgument.isHashTableDeletedValue(); }
+};
+
+template<>
+struct HashTraits<Markable<WebCore::Style::PseudoElementIdentifier>> : GenericHashTraits<Markable<WebCore::Style::PseudoElementIdentifier>> {
+    typedef Markable<WebCore::Style::PseudoElementIdentifier> EmptyValueType;
+
+    static constexpr bool emptyValueIsZero = false;
+    // We want empty Markable to be a valid hash table value so this differs from the Markable empty value.
+    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { { }, emptyAtom() }; }
+
+    static void constructDeletedValue(Markable<WebCore::Style::PseudoElementIdentifier>& identifer)
+    {
+        HashTraits<WebCore::Style::PseudoElementIdentifier>::constructDeletedValue(identifer.unsafeValue());
+    }
+    static bool isDeletedValue(const Markable<WebCore::Style::PseudoElementIdentifier>& identifer)
+    {
+        return HashTraits<WebCore::Style::PseudoElementIdentifier>::isDeletedValue(identifer.unsafeValue());
+    }
+};
+
+} // namespace WTF
+
+namespace WebCore::Style {
+
 inline void add(Hasher& hasher, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
     add(hasher, pseudoElementIdentifier.type, pseudoElementIdentifier.nameArgument);
@@ -54,7 +98,7 @@ inline WTF::TextStream& operator<<(WTF::TextStream& ts, const PseudoElementIdent
     return ts;
 }
 
-inline bool isNamedViewTransitionPseudoElement(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+inline bool isNamedViewTransitionPseudoElement(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     if (!pseudoElementIdentifier)
         return false;
@@ -72,34 +116,3 @@ inline bool isNamedViewTransitionPseudoElement(const std::optional<Style::Pseudo
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<>
-struct HashTraits<WebCore::Style::PseudoElementIdentifier> : GenericHashTraits<WebCore::Style::PseudoElementIdentifier> {
-    typedef WebCore::Style::PseudoElementIdentifier EmptyValueType;
-
-    static constexpr bool emptyValueIsZero = false;
-    static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { { }, emptyAtom() }; }
-
-    static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& identifer) { new (NotNull, &identifer.nameArgument) AtomString { HashTableDeletedValue }; }
-    static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return identifer.nameArgument.isHashTableDeletedValue(); }
-};
-
-template<>
-struct HashTraits<std::optional<WebCore::Style::PseudoElementIdentifier>> : GenericHashTraits<std::optional<WebCore::Style::PseudoElementIdentifier>> {
-    typedef std::optional<WebCore::Style::PseudoElementIdentifier> EmptyValueType;
-
-    static constexpr bool emptyValueIsZero = false;
-    static EmptyValueType emptyValue() { return HashTraits<WebCore::Style::PseudoElementIdentifier>::emptyValue(); }
-
-    static void constructDeletedValue(std::optional<WebCore::Style::PseudoElementIdentifier>& identifer)
-    {
-        HashTraits<WebCore::Style::PseudoElementIdentifier>::constructDeletedValue(identifer.emplace());
-    }
-    static bool isDeletedValue(const std::optional<WebCore::Style::PseudoElementIdentifier>& identifer)
-    {
-        return identifer && HashTraits<WebCore::Style::PseudoElementIdentifier>::isDeletedValue(*identifer);
-    }
-};
-
-} // namespace WTF

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -74,7 +74,7 @@ static Element* styleElementForNode(Node* node)
     return composedTreeAncestors(*node).first();
 }
 
-Extractor::Extractor(Node* node, bool allowVisitedStyle, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+Extractor::Extractor(Node* node, bool allowVisitedStyle, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
     : Extractor(styleElementForNode(node), allowVisitedStyle, pseudoElementIdentifier)
 {
 }
@@ -84,7 +84,7 @@ Extractor::Extractor(Node* node, bool allowVisitedStyle)
 {
 }
 
-Extractor::Extractor(Element* element, bool allowVisitedStyle, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+Extractor::Extractor(Element* element, bool allowVisitedStyle, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
     : m_element(element)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)
     , m_allowVisitedStyle(allowVisitedStyle)
@@ -203,7 +203,7 @@ bool Extractor::updateStyleIfNeededForProperty(Element& element, CSSPropertyID p
     return true;
 }
 
-static inline const RenderStyle* computeRenderStyleForProperty(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, CSSPropertyID propertyID, std::unique_ptr<RenderStyle>& ownedStyle)
+static inline const RenderStyle* computeRenderStyleForProperty(Element& element, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier, CSSPropertyID propertyID, std::unique_ptr<RenderStyle>& ownedStyle)
 {
     if (Style::Interpolation::isAccelerated(propertyID, element.document().settings())) {
         Styleable styleable(element, pseudoElementIdentifier);

--- a/Source/WebCore/style/StyleExtractor.h
+++ b/Source/WebCore/style/StyleExtractor.h
@@ -56,9 +56,9 @@ public:
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Extractor, Extractor);
 public:
     Extractor(Node*, bool allowVisitedStyle = false);
-    Extractor(Node*, bool allowVisitedStyle, const std::optional<Style::PseudoElementIdentifier>&);
+    Extractor(Node*, bool allowVisitedStyle, const Markable<Style::PseudoElementIdentifier>&);
     Extractor(Element*, bool allowVisitedStyle = false);
-    Extractor(Element*, bool allowVisitedStyle, const std::optional<Style::PseudoElementIdentifier>&);
+    Extractor(Element*, bool allowVisitedStyle, const Markable<Style::PseudoElementIdentifier>&);
 
     enum class UpdateLayout : bool { No, Yes };
 
@@ -104,7 +104,7 @@ private:
     const RenderStyle* computeStyleForCustomProperty(std::unique_ptr<RenderStyle>&) const;
 
     RefPtr<Element> m_element;
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
+    Markable<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
     bool m_allowVisitedStyle;
 };
 

--- a/Source/WebCore/style/StyleExtractorState.h
+++ b/Source/WebCore/style/StyleExtractorState.h
@@ -44,7 +44,7 @@ struct ExtractorState {
     const RenderStyle& style;
 
     Ref<Element> element;
-    const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier;
+    const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier;
 
     const RenderElement* renderer;
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -659,7 +659,7 @@ Vector<Ref<const StyleRule>> Resolver::styleRulesForElement(const Element* eleme
     return pseudoStyleRulesForElement(element, { }, rulesToInclude);
 }
 
-Vector<Ref<const StyleRule>> Resolver::pseudoStyleRulesForElement(const Element* element, const std::optional<Style::PseudoElementRequest>& pseudoElementIdentifier, unsigned rulesToInclude)
+Vector<Ref<const StyleRule>> Resolver::pseudoStyleRulesForElement(const Element* element, const Markable<PseudoElementIdentifier>& pseudoElementIdentifier, unsigned rulesToInclude)
 {
     if (!element)
         return { };

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -141,7 +141,7 @@ public:
         AllCSSRules         = AllButEmptyCSSRules | EmptyCSSRules,
     };
     Vector<Ref<const StyleRule>> styleRulesForElement(const Element*, unsigned rulesToInclude = AllButEmptyCSSRules);
-    Vector<Ref<const StyleRule>> pseudoStyleRulesForElement(const Element*, const std::optional<Style::PseudoElementRequest>&, unsigned rulesToInclude = AllButEmptyCSSRules);
+    Vector<Ref<const StyleRule>> pseudoStyleRulesForElement(const Element*, const Markable<PseudoElementIdentifier>&, unsigned rulesToInclude = AllButEmptyCSSRules);
 
     bool hasSelectorForId(const AtomString&) const;
     bool hasSelectorForAttribute(const Element&, const AtomString&) const;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -557,7 +557,7 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
             // ::first-line can inherit to ::before/::after
             if (auto firstLineContext = makeResolutionContextForInheritedFirstLine(elementUpdate, *elementUpdate.style)) {
                 auto firstLineStyle = scope().resolver->styleForPseudoElement(element, pseudoElementIdentifier, *firstLineContext);
-                firstLineStyle->style->setPseudoElementIdentifier({ { PseudoElementType::FirstLine } });
+                firstLineStyle->style->setPseudoElementIdentifier(PseudoElementIdentifier { PseudoElementType::FirstLine });
                 animatedUpdate.style->addCachedPseudoStyle(WTF::move(firstLineStyle->style));
             }
         }
@@ -622,7 +622,7 @@ std::optional<ResolvedStyle> TreeResolver::resolveAncestorFirstLinePseudoElement
             return { };
 
         auto elementStyle = scope().resolver->styleForElement(element, *resolutionContext);
-        elementStyle.style->setPseudoElementIdentifier({ { PseudoElementType::FirstLine } });
+        elementStyle.style->setPseudoElementIdentifier(PseudoElementIdentifier { PseudoElementType::FirstLine });
 
         return elementStyle;
     }
@@ -1871,7 +1871,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
         style.setIsForceHidden();
 }
 
-const RenderStyle* TreeResolver::beforeResolutionStyle(const Element& element, std::optional<PseudoElementIdentifier> pseudo)
+const RenderStyle* TreeResolver::beforeResolutionStyle(const Element& element, Markable<PseudoElementIdentifier> pseudo)
 {
     auto resolvePseudoStyle = [&](auto* style) -> const RenderStyle* {
         if (!pseudo)

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -184,7 +184,7 @@ private:
 
     // This returns the style that was in effect (applied to the render tree) before we started the style resolution.
     // Layout interleaving may cause different styles to be applied during the style resolution.
-    const RenderStyle* beforeResolutionStyle(const Element&, std::optional<PseudoElementIdentifier>);
+    const RenderStyle* beforeResolutionStyle(const Element&, Markable<PseudoElementIdentifier>);
     void saveBeforeResolutionStyleForInterleaving(const Element&, const RenderStyle*);
 
     bool hasUnresolvedAnchorPosition(const Styleable&) const;

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -51,9 +51,9 @@ enum class IsInDisplayNoneTree : bool;
 
 struct Styleable {
     Element& element;
-    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier;
+    Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier;
 
-    Styleable(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+    Styleable(Element& element, const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
         : element(element)
         , pseudoElementIdentifier(pseudoElementIdentifier)
     {
@@ -230,11 +230,11 @@ public:
     }
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> element() const { return m_element; }
-    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const { return m_pseudoElementIdentifier; }
+    Markable<Style::PseudoElementIdentifier> pseudoElementIdentifier() const { return m_pseudoElementIdentifier; }
 
 private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
-    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
+    Markable<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
 };
 
 // FIXME: using PairHashTraits would give us constructDeletedValue() and isDeletedValue() for free.
@@ -246,7 +246,7 @@ struct WeakStyleableHashTraits : HashTraits<WeakStyleable> {
 };
 
 struct WeakStyleableHash {
-    static unsigned hash(const WeakStyleable& styleable) { return WTF::PairHash<Element*, std::optional<Style::PseudoElementIdentifier>>::hash({ styleable.element().get(), styleable.pseudoElementIdentifier() }); }
+    static unsigned hash(const WeakStyleable& styleable) { return WTF::PairHash<Element*, Markable<Style::PseudoElementIdentifier>>::hash({ styleable.element().get(), styleable.pseudoElementIdentifier() }); }
     static bool equal(const WeakStyleable& a, const WeakStyleable& b)
     {
         if (!a || !b)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -263,7 +263,7 @@ inline AppleVisualEffect ComputedStyleBase::usedAppleVisualEffectForSubtree() co
 
 #endif
 
-inline std::optional<PseudoElementType> ComputedStyleBase::pseudoElementType() const
+inline Markable<PseudoElementType> ComputedStyleBase::pseudoElementType() const
 {
     return m_nonInheritedFlags.pseudoElementType ? std::make_optional(static_cast<PseudoElementType>(m_nonInheritedFlags.pseudoElementType - 1)) : std::nullopt;
 }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -224,7 +224,7 @@ inline void ComputedStyleBase::setHasPseudoStyles(EnumSet<PseudoElementType> set
     m_nonInheritedFlags.setHasPseudoStyles(set);
 }
 
-inline void ComputedStyleBase::setPseudoElementIdentifier(std::optional<PseudoElementIdentifier>&& identifier)
+inline void ComputedStyleBase::setPseudoElementIdentifier(Markable<PseudoElementIdentifier>&& identifier)
 {
     if (identifier) {
         m_nonInheritedFlags.pseudoElementType = std::to_underlying(identifier->type) + 1;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -93,7 +93,7 @@ void ComputedStyleBase::setAutosizeStatus(AutosizeStatus autosizeStatus)
 
 // MARK: - Pseudo element/style
 
-std::optional<PseudoElementIdentifier> ComputedStyleBase::pseudoElementIdentifier() const
+Markable<PseudoElementIdentifier> ComputedStyleBase::pseudoElementIdentifier() const
 {
     if (!pseudoElementType())
         return { };

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -574,11 +574,11 @@ public:
 
     // MARK: - Pseudo element/style
 
-    inline std::optional<PseudoElementType> pseudoElementType() const;
+    inline Markable<PseudoElementType> pseudoElementType() const;
     const AtomString& pseudoElementNameArgument() const;
 
-    std::optional<PseudoElementIdentifier> pseudoElementIdentifier() const;
-    void setPseudoElementIdentifier(std::optional<PseudoElementIdentifier>&&);
+    Markable<PseudoElementIdentifier> pseudoElementIdentifier() const;
+    void setPseudoElementIdentifier(Markable<PseudoElementIdentifier>&&);
 
     inline bool hasAnyPublicPseudoStyles() const;
     inline bool hasPseudoStyle(PseudoElementType) const;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -689,7 +689,7 @@ inline const RenderStyle* SVGElementRareData::overrideComputedStyle(Element& ele
     return m_overrideComputedStyle.get();
 }
 
-const RenderStyle* SVGElement::computedStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+const RenderStyle* SVGElement::computedStyle(const Markable<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     if (!m_svgRareData || !m_svgRareData->useOverrideComputedStyle())
         return Element::computedStyle(pseudoElementIdentifier);

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -178,7 +178,7 @@ public:
     void animatorWillBeDeleted(const QualifiedName&);
 
     using Node::computedStyle;
-    const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&) final;
+    const RenderStyle* computedStyle(const Markable<Style::PseudoElementIdentifier>&) final;
 
     ColorInterpolation colorInterpolation() const;
 


### PR DESCRIPTION
#### 1c100fc7b30a01cf7aaf4c12e99321e4d450ee9f
<pre>
Use Markable&lt;PseudoElementIdentifier&gt; instead of std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=308285">https://bugs.webkit.org/show_bug.cgi?id=308285</a>
<a href="https://rdar.apple.com/163361093">rdar://163361093</a>

Reviewed by NOBODY (OOPS!).

More efficient storage for empty values.

Also std::optional&lt;PseudoElementType&gt; -&gt; Markable&lt;PseudoElementType&gt;

* Source/WTF/wtf/Forward.h:
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSAnimationEvent.cpp:
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::create):
(WebCore::KeyframeEffect::KeyframeEffect):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp:
(WebCore::StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.h:
(WebCore::StyleOriginatedAnimationEvent::pseudoElementIdentifier const):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder):
(WebCore::pseudoElementIdentifierAsString):
(WebCore::pseudoElementIdentifierFromString):
* Source/WebCore/animation/WebAnimationUtilities.h:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
(WebCore::CSSComputedStyleDeclaration::create):
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::LocalContext::LocalContext):
(WebCore::SelectorChecker::CheckingContext::requestedPseudoElement const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::pseudoElementIdentifierFor):
(WebCore::CSSSelectorParser::parsePseudoElement):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::styleForElementIgnoringPendingStylesheets):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::renderOrDisplayContentsStyle const):
(WebCore::Element::computedStyle):
(WebCore::Element::animationRareData const):
(WebCore::Element::ensureAnimationRareData):
(WebCore::Element::viewTransitionCapturedName const):
(WebCore::Element::setViewTransitionCapturedName):
(WebCore::Element::keyframeEffectStack const):
(WebCore::Element::ensureKeyframeEffectStack):
(WebCore::Element::hasKeyframeEffects const):
(WebCore::Element::animations const):
(WebCore::Element::hasCompletedTransitionForProperty const):
(WebCore::Element::hasRunningTransitionForProperty const):
(WebCore::Element::hasRunningTransitions const):
(WebCore::Element::completedTransitionsByProperty const):
(WebCore::Element::runningTransitionsByProperty const):
(WebCore::Element::ensureAnimations):
(WebCore::Element::animationsCreatedByMarkup):
(WebCore::Element::setAnimationsCreatedByMarkup):
(WebCore::Element::ensureCompletedTransitionsByProperty):
(WebCore::Element::ensureRunningTransitionsByProperty):
(WebCore::Element::lastStyleChangeEventStyle const):
(WebCore::Element::setLastStyleChangeEventStyle):
(WebCore::Element::hasPropertiesOverridenAfterAnimation const):
(WebCore::Element::setHasPropertiesOverridenAfterAnimation):
(WebCore::Element::cssAnimationsDidUpdate):
(WebCore::Element::keyframesRuleDidChange):
(WebCore::Element::hasPendingKeyframesUpdate const):
(WebCore::Element::lookupCSSRandomBaseValue const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::animationRareData const):
(WebCore::ElementRareData::ensureAnimationRareData):
(WebCore::ElementRareData::viewTransitionCapturedName const):
(WebCore::ElementRareData::setViewTransitionCapturedName):
(WebCore::ElementRareData::ensureRandomCachingKeyMap):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::computedStyle):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::pseudoElementIdentifier const):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):
(WebCore::InspectorCSSAgent::buildArrayForMatchedRuleList):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::pseudoElementIdentifier const):
(WebCore::HitTestResult::setPseudoElementIdentifier):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
(WebCore::RenderStyle::pseudoElementIdentifier const):
* Source/WebCore/rendering/style/RenderStyle+SettersInlines.h:
(WebCore::RenderStyle::setPseudoElementIdentifier):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/PseudoElementIdentifier.h:
(WTF::MarkableTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::isEmptyValue):
(WTF::MarkableTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::Style::PseudoElementIdentifier&gt;::isDeletedValue):
(WTF::HashTraits&lt;Markable&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;Markable&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::constructDeletedValue):
(WTF::HashTraits&lt;Markable&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::isDeletedValue):
(WebCore::Style::isNamedViewTransitionPseudoElement):
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::emptyValue): Deleted.
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::constructDeletedValue): Deleted.
(WTF::HashTraits&lt;std::optional&lt;WebCore::Style::PseudoElementIdentifier&gt;&gt;::isDeletedValue): Deleted.
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::Extractor):
(WebCore::Style::computeRenderStyleForProperty):
* Source/WebCore/style/StyleExtractor.h:
* Source/WebCore/style/StyleExtractorState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::pseudoStyleRulesForElement):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::beforeResolutionStyle):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::Styleable):
(WebCore::WeakStyleable::pseudoElementIdentifier const):
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setPseudoElementIdentifier):
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::pseudoElementIdentifier const):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::computedStyle):
* Source/WebCore/svg/SVGElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c100fc7b30a01cf7aaf4c12e99321e4d450ee9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99498 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d17f0743-dfbf-484f-bfb8-86d807cbc46a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112262 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80380 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93167 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11693 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2076 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137936 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156942 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6757 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/173 "Found 2 new failures in rendering/RenderObject.cpp, accessibility/AXStitchUtilities.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120272 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120611 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74195 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16330 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7405 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177261 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18099 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81871 "Found 2 new failures in rendering/RenderObject.cpp, accessibility/AXStitchUtilities.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18019 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->