### PR TITLE
Prevent recursions in ReadableStreamToSharedBufferSink::enqueue

### DIFF
--- a/LayoutTests/http/wpt/fetch/response-put-expected.txt
+++ b/LayoutTests/http/wpt/fetch/response-put-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Put response with plenty of chunks in DOM cache
+

--- a/LayoutTests/http/wpt/fetch/response-put.html
+++ b/LayoutTests/http/wpt/fetch/response-put.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+promise_test(async () => {
+    const request = new Request("/hot-potato");
+    const stream = new ReadableStream({
+         type: "bytes",
+         start : c => {
+            for (let i = 0; i < 32000; ++i)
+                c.enqueue(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]));
+            c.close();
+        }
+    });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const response = new Response(stream);
+
+    const cache = await self.caches.open("test");
+    await cache.put(request, response);
+}, "Put response with plenty of chunks in DOM cache");
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.h
@@ -61,6 +61,8 @@ private:
     void error(Exception&&);
     void error(JSC::JSValue);
 
+    void keepReading();
+
     Callback m_callback;
     RefPtr<ReadableStreamDefaultReader> m_reader;
     RefPtr<SinkReadRequest> m_readRequest;


### PR DESCRIPTION
#### 2b7c1daae5fef81defd4b418c9e37669d7cfa88b
<pre>
Prevent recursions in ReadableStreamToSharedBufferSink::enqueue
<a href="https://rdar.apple.com/170649636">rdar://170649636</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308286">https://bugs.webkit.org/show_bug.cgi?id=308286</a>

Reviewed by Chris Dumez.

Before we transitioned from ReadableStream to ReadableByteStream, the chunk steps were done within a microtask.
This prevented recursion in case of many chunks already enqueued in the stream.

When running the chunk steps for ReadableStreamToSharedBufferSink, we immediately call the callback to process the data.
But instead of reading the next chunk synchronously, we do this in the next microtask.

Test: http/wpt/fetch/response-put.html
Canonical link: <a href="https://commits.webkit.org/307911@main">https://commits.webkit.org/307911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e86397a2dab060c56e3ce591f69c670f2c85a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154583 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6baa0bb1-5df8-404b-9e3d-ab03dc42566b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/814138d7-0279-47dd-ba80-79fda1c4ae61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93127 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9059fa1-46c5-4caf-828b-d47c2d7a238b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11655 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2029 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156895 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/136 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120231 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30907 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74158 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7341 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81828 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17789 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17982 "Failed to checkout and rebase branch from PR 59077") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->