### PR TITLE
[scroll-animations] stop using smart pointer references in `AcceleratedTimelinesUpdater`

### DIFF
--- a/Source/WebCore/animation/AcceleratedTimelinesUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedTimelinesUpdater.cpp
@@ -39,7 +39,7 @@ void AcceleratedTimelinesUpdater::scrollTimelineDidChange(ScrollTimeline& timeli
 
 void AcceleratedTimelinesUpdater::processTimelinesSeenDuringEffectStacksUpdate(HashSet<Ref<AcceleratedTimeline>>&& timelinesInUpdate)
 {
-    for (auto& timeline : timelinesInUpdate) {
+    for (Ref timeline : timelinesInUpdate) {
         auto& timelineIdentifier = timeline->identifier();
         auto addResult = m_timelines.add(timelineIdentifier, timeline.ptr());
         if (addResult.isNewEntry)
@@ -63,7 +63,7 @@ AcceleratedTimelinesUpdate AcceleratedTimelinesUpdater::takeTimelinesUpdate()
     // Finally, process all timelines that were marked as requiring an update, either
     // marking them as modified or destroyed if they no longer are accelerated.
     auto scrollTimelinesPendingUpdate = std::exchange(m_scrollTimelinesPendingUpdate, { });
-    for (auto& scrollTimeline : scrollTimelinesPendingUpdate) {
+    for (Ref scrollTimeline : scrollTimelinesPendingUpdate) {
         auto timelineIdentifier = scrollTimeline->acceleratedTimelineIdentifier();
         auto acceleratedTimeline = m_timelines.getOptional(timelineIdentifier);
         if (acceleratedTimeline && scrollTimeline->canBeAccelerated()) {


### PR DESCRIPTION
#### 37e981d71a9b6fa02aac795dc3e0c919e38bec1e
<pre>
[scroll-animations] stop using smart pointer references in `AcceleratedTimelinesUpdater`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308287">https://bugs.webkit.org/show_bug.cgi?id=308287</a>
<a href="https://rdar.apple.com/170794173">rdar://170794173</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/animation/AcceleratedTimelinesUpdater.cpp:
(WebCore::AcceleratedTimelinesUpdater::processTimelinesSeenDuringEffectStacksUpdate):
(WebCore::AcceleratedTimelinesUpdater::takeTimelinesUpdate):

Canonical link: <a href="https://commits.webkit.org/307913@main">https://commits.webkit.org/307913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa28252b79d1a52f7752b6bb5f7c51e1c7ed8bc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154575 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e5697db-1036-4c87-9136-f19f96575fc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112216 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ae946d1-ad37-40b9-82e3-0c2d34270452) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93122 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11650 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2021 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156887 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120222 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120566 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74151 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7334 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81821 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17781 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17840 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->