### PR TITLE
[YARR] Fix non-BMP advance latch and simplify `tryReadUnicodeCharImpl`

### DIFF
--- a/JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js
+++ b/JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js
@@ -1,0 +1,76 @@
+// When a match attempt fails at a start position, /u patterns advance the start position past a whole
+// surrogate pair only if the character at the match start is a complete non-BMP surrogate pair and
+// every alternative consumes at least one character. Character reads elsewhere in the pattern must not
+// affect this. This test should pass with both --useRegExpJIT=true and --useRegExpJIT=false.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(msg + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+function shouldBeMatch(re, input, expected) {
+    let result = re.exec(input);
+    let actual = result === null ? null : [result.index, [...result]];
+    shouldBe(JSON.stringify(actual), JSON.stringify(expected), re + " on " + JSON.stringify(input));
+}
+
+// A non-BMP character read after the match start must not corrupt the advance amount.
+shouldBeMatch(/.x/u, "a\u{10000}x", [1, ["\u{10000}x"]]);
+shouldBeMatch(/[^z]x/u, "a\u{10000}x", [1, ["\u{10000}x"]]);
+shouldBeMatch(/(.)x/u, "a\u{10000}x", [1, ["\u{10000}x", "\u{10000}"]]);
+shouldBeMatch(/.{2}x/u, "ab\u{10000}x", [1, ["b\u{10000}x"]]);
+shouldBeMatch(/a|.x/u, "b\u{10000}x", [1, ["\u{10000}x"]]);
+shouldBeMatch(/.x/u, "\u{10002}\u{10001}a\u{10000}x", [5, ["\u{10000}x"]]);
+shouldBeMatch(/.x/u, "\u{10000}abx", [3, ["bx"]]);
+shouldBeMatch(/.x/u, "a\u{10000}y", null);
+shouldBeMatch(/.x/u, "\u{10000}", null);
+
+// A lone lead or trail surrogate at the match start advances by only one code unit.
+shouldBeMatch(/abc/u, "\uD800abc", [1, ["abc"]]);
+shouldBeMatch(/abc/iu, "\uD800ABC", [1, ["ABC"]]);
+shouldBeMatch(/q/u, "\uDC00\uD800q", [2, ["q"]]);
+shouldBeMatch(/x/u, "\uD800\u{10000}x", [3, ["x"]]);
+shouldBeMatch(/\uDC00/u, "\u{10000}\uDC00", [2, ["\uDC00"]]);
+shouldBeMatch(/\uD800(?!\uDC00)/u, "\u{10000}\uD800", [2, ["\uD800"]]);
+
+// When longer alternatives no longer fit, a shorter alternative is entered directly at that start position.
+shouldBeMatch(/\u{10400}X|Y/u, "\u{10400}ZY", [3, ["Y"]]);
+shouldBeMatch(/\u{1F600}ab|c/u, "\u{1F600}xc", [3, ["c"]]);
+shouldBeMatch(/\u{1F600}\u{1F600}xy|\u{1F600}z|q/u, "\u{1F600}\u{1F600}q", [4, ["q"]]);
+shouldBeMatch(/[a\u{10000}]{3}Z|b/u, "a\u{10000}Xb", [4, ["b"]]);
+
+// A zero minimum-size alternative can match in the middle of a surrogate pair, so the start position
+// must then advance one code unit at a time.
+shouldBeMatch(/aa|\B/u, "X\u{1F600}Z", [2, [""]]);
+shouldBeMatch(/a?\B|q/u, "X\u{1F600}Z", [2, [""]]);
+shouldBeMatch(/[\u{1F600}]X|\B/u, "X\u{1F600}Z", [2, [""]]);
+shouldBeMatch(/\B|[\u{1F600}]X/u, "X\u{1F600}Z", [2, [""]]);
+shouldBeMatch(/aa|(?=Z)/u, "X\u{1F600}Z", [3, [""]]);
+shouldBeMatch(/x+|q/u, "\u{1F600}\u{1F600}q", [4, ["q"]]);
+
+// Start-position prefilters (Boyer-Moore lookahead, alternation SIMD search, shared-lead surrogate scan)
+// settle on a candidate position before the advance amount is decided.
+shouldBeMatch(/jsc/u, "\u{1F600}\u{1F601}\u{1F602}jsc", [6, ["jsc"]]);
+shouldBeMatch(/xyz|abd/u, "\u{1F600}\u{1F600}abd", [4, ["abd"]]);
+shouldBeMatch(/\u{1F600}X|\u{1F603}Y/u, "\u{1F603}Q\u{1F603}Y", [3, ["\u{1F603}Y"]]);
+shouldBeMatch(/[\u{1F600}-\u{1F64F}]{2}Z|q/u, "\u{1F600}\u{1F601}Wq", [5, ["q"]]);
+
+// Global matching advances lastIndex over surrogate pairs consistently with the above.
+{
+    let re = /.x/gu;
+    let input = "ax\u{10000}x\u{10001}x";
+    shouldBe(JSON.stringify(input.match(re)), JSON.stringify(["ax", "\u{10000}x", "\u{10001}x"]), "global .x");
+
+    re = /\B/gu;
+    input = "X\u{1F600}Z";
+    let indices = [];
+    let m;
+    while ((m = re.exec(input))) {
+        indices.push(m.index);
+        re.lastIndex++;
+    }
+    shouldBe(JSON.stringify(indices), JSON.stringify([2]), "global \\B");
+}
+
+// /v (unicodeSets) shares the /u semantics.
+shouldBeMatch(new RegExp(".x", "v"), "a\u{10000}x", [1, ["\u{10000}x"]]);

--- a/JSTests/stress/temporal-hebrew-day-constrain.js
+++ b/JSTests/stress/temporal-hebrew-day-constrain.js
@@ -1,0 +1,42 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(errorType, callback, message) {
+    try {
+        callback();
+    } catch (error) {
+        if (error instanceof errorType)
+            return;
+        throw new Error(`${message}: expected ${errorType.name}, got ${error}`);
+    }
+    throw new Error(`${message}: expected ${errorType.name}`);
+}
+
+// Hebrew is lunisolar but not Chinese/Dangi, so day clamping consults the ICU actual maximum for the month.
+for (const [monthCode, ordinal, daysInMonth, iso] of [
+    ["M02", 2, 29, "2023-11-13"],
+    ["M04", 4, 29, "2024-01-10"],
+    ["M05L", 6, 30, "2024-03-10"],
+    ["M06", 7, 29, "2024-04-08"],
+    ["M12", 13, 29, "2024-10-02"],
+]) {
+    const byCode = Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, monthCode, day: 31 });
+    shouldBe(byCode.day, daysInMonth, `${monthCode} constrained day`);
+    shouldBe(byCode.daysInMonth, daysInMonth, `${monthCode} daysInMonth`);
+    shouldBe(byCode.monthCode, monthCode, `${monthCode} monthCode`);
+    shouldBe(byCode.toString(), `${iso}[u-ca=hebrew]`, `${monthCode} constrained date`);
+
+    const byOrdinal = Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, month: ordinal, day: 31 });
+    shouldBe(byOrdinal.day, daysInMonth, `month ${ordinal} constrained day`);
+    shouldBe(byOrdinal.monthCode, monthCode, `month ${ordinal} monthCode`);
+    shouldBe(byOrdinal.toString(), `${iso}[u-ca=hebrew]`, `month ${ordinal} constrained date`);
+
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, monthCode, day: daysInMonth + 1 }, { overflow: "reject" }),
+        `${monthCode} rejects out-of-range day`);
+    shouldThrow(RangeError, () => Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, month: ordinal, day: daysInMonth + 1 }, { overflow: "reject" }),
+        `month ${ordinal} rejects out-of-range day`);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -45,7 +45,6 @@
 #include <wtf/BitVector.h>
 #include <wtf/ListDump.h>
 #include <wtf/MathExtras.h>
-#include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -61,13 +60,7 @@ static constexpr bool verbose = false;
 static constexpr int32_t errorCodePoint = -1;
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-enum class TryReadUnicodeCharGenFirstNonBMPOptimization { DontUseOptimization, UseOptimization };
-
 static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharSlowThunkGenerator(VM&);
-
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharIncForNonBMPSlowThunkGenerator(VM&);
-#endif
 #endif
 
 #if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
@@ -460,8 +453,7 @@ static constexpr MacroAssembler::TrustedImm32 surrogatePairTags = MacroAssembler
 static constexpr MacroAssembler::TrustedImm32 surrogateTagShiftedRight11 = MacroAssembler::TrustedImm32(0xd800 >> 11);
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-template<TryReadUnicodeCharGenFirstNonBMPOptimization useNonBMPOptimization>
-void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterID resultReg)
+static void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterID resultReg)
 {
     MacroAssembler::JumpList slowCases;
     MacroAssembler::JumpList done;
@@ -497,27 +489,17 @@ void tryReadUnicodeCharImpl(VM& vm, CCallHelpers& jit, MacroAssembler::RegisterI
     jit.getEffectiveAddress(MacroAssembler::BaseIndex(regs.unicodeAndSubpatternIdTemp, resultReg, MacroAssembler::TimesOne, -U16_SURROGATE_OFFSET), resultReg);
 #endif
 
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-    if (useNonBMPOptimization == TryReadUnicodeCharGenFirstNonBMPOptimization::UseOptimization)
-        jit.move(MacroAssembler::TrustedImm32(1), regs.firstCharacterAdditionalReadSize);
-#endif
     done.append(jit.jump());
 
     slowCases.link(&jit);
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-    if constexpr (useNonBMPOptimization == TryReadUnicodeCharGenFirstNonBMPOptimization::UseOptimization)
-        jit.nearCallThunk(CodeLocationLabel { vm.getCTIStub(tryReadUnicodeCharIncForNonBMPSlowThunkGenerator).template retaggedCode<NoPtrTag>() });
-    else
-#endif
-        jit.nearCallThunk(CodeLocationLabel { vm.getCTIStub(tryReadUnicodeCharSlowThunkGenerator).template retaggedCode<NoPtrTag>() });
+    jit.nearCallThunk(CodeLocationLabel { vm.getCTIStub(tryReadUnicodeCharSlowThunkGenerator).template retaggedCode<NoPtrTag>() });
     done.link(&jit);
 
     if (resultReg != regs.regT0)
         jit.swap(regs.regT0, resultReg);
 }
 
-template<TryReadUnicodeCharGenFirstNonBMPOptimization useNonBMPOptimization>
-void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
+static void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
 {
     MacroAssembler::JumpList bmpOnly;
     MacroAssembler::JumpList isBMP;
@@ -528,16 +510,14 @@ void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
 
     YarrJITDefaultRegisters regs;
 
-    // This code generator is used to build two variations of a character reader that handles Unicode non-BMP surrogate pairs.
-    // This code generator is used to build thunks or as inline code. Its "calling convention" is unconventional.
+    // Slow path for tryReadUnicodeCharImpl. Handles edge cases like dangling surrogates.
+    // Its "calling convention" is unconventional.
     // It assumes the following registers are already populated with these values:
     // regs.regUnicodeInputAndTrail is the string address to start reading from.
     // regs.input contains the pointer of the beginning of the string.
     // regs.endOfStringAddress contains the address one past the end of the string.
     // For architectures that put the surrogate masks and tags in registers,
     // regs.surrogateTagMask contains 0xfc00fc00 and regs.surrogatePairTags contains 0xdc00d800.
-    // When the YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP optimization is enabled and used,
-    // regs.firstCharacterAdditionalReadSize is used to advance 2 characters when we read a non-BMP codepoint.
     // regs.unicodeAndSubpatternIdTemp is used as a temporary.
     // The result is returned via regs.regT0.
 
@@ -1417,13 +1397,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         m_jit.getEffectiveAddress(address, m_regs.regUnicodeInputAndTrail);
 
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        if (m_useFirstNonBMPCharacterOptimization) {
-            tryReadUnicodeCharImpl<TryReadUnicodeCharGenFirstNonBMPOptimization::UseOptimization>(*m_vm, m_jit, resultReg);
-            return;
-        }
-#endif
-        tryReadUnicodeCharImpl<TryReadUnicodeCharGenFirstNonBMPOptimization::DontUseOptimization>(*m_vm, m_jit, resultReg);
+        tryReadUnicodeCharImpl(*m_vm, m_jit, resultReg);
     }
 
     void tryReadNonBMPUnicodeChar(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg, MacroAssembler::RegisterID indexReg)
@@ -1433,7 +1407,7 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::BaseIndex address = negativeOffsetIndexedAddress(negativeCharacterOffset, resultReg, indexReg);
 
         m_jit.getEffectiveAddress(address, m_regs.regUnicodeInputAndTrail);
-        tryReadUnicodeCharImpl<TryReadUnicodeCharGenFirstNonBMPOptimization::DontUseOptimization>(*m_vm, m_jit, resultReg);
+        tryReadUnicodeCharImpl(*m_vm, m_jit, resultReg);
     }
 
     // Specialized read+match for character classes whose codepoints all share a single UTF-16
@@ -1555,6 +1529,34 @@ class YarrGenerator final : public YarrJITInfo {
         std::ranges::sort(dest.m_matches32);
         std::ranges::sort(dest.m_ranges32, [](auto& a, auto& b) { return a.begin < b.begin; });
     }
+
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+    // Sets firstCharacterAdditionalReadSize to 1 iff the match start position (index - minimumSize) holds a
+    // complete non-BMP surrogate pair, so that a failed match attempt advances past the whole code point.
+    // Emitted whenever an alternative is entered as the first one attempted at a start position;
+    // |minimumSize| code units are known to be readable there.
+    void initAdvanceLatch(unsigned minimumSize)
+    {
+        if (!m_useFirstNonBMPCharacterOptimization)
+            return;
+
+        ASSERT(minimumSize);
+
+        m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
+
+        // If only one unit is known readable and it is the last one, no pair can follow.
+        MacroAssembler::Jump startIsLastUnit;
+        if (minimumSize == 1)
+            startIsLastUnit = atEndOfInput();
+
+        m_jit.load32(negativeOffsetIndexedAddress(minimumSize, m_regs.regT0, m_regs.index), m_regs.regT0);
+        m_jit.and32(surrogateTagMask, m_regs.regT0);
+        m_jit.compare32(MacroAssembler::Equal, m_regs.regT0, surrogatePairTags, m_regs.firstCharacterAdditionalReadSize);
+
+        if (minimumSize == 1)
+            startIsLastUnit.link(&m_jit);
+    }
+#endif
 #endif
 
     void readCharacter(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg)
@@ -2230,10 +2232,6 @@ class YarrGenerator final : public YarrJITInfo {
         const MacroAssembler::RegisterID character = m_regs.regT0;
         const MacroAssembler::RegisterID scratch = m_regs.regT1;
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        // Prevent word boundary assertion reads from corrupting firstCharacterAdditionalReadSize.
-        SetForScope useOptimizationScope(m_useFirstNonBMPCharacterOptimization, false);
-#endif
 
         MacroAssembler::Jump atBegin;
         MacroAssembler::JumpList matchDest;
@@ -2295,9 +2293,6 @@ class YarrGenerator final : public YarrJITInfo {
         unsigned subpatternId = term->backReferenceSubpatternId;
         unsigned duplicateNamedGroupId = m_pattern.hasDuplicateNamedCaptureGroups() ? m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId] : 0;
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        SetForScope useOptimizationScope(m_useFirstNonBMPCharacterOptimization, false);
-#endif
 
         MacroAssembler::Label loop(&m_jit);
 
@@ -2905,14 +2900,6 @@ class YarrGenerator final : public YarrJITInfo {
             }
 
             auto numRealCharsToCheck = roundUpToPowerOfTwo(lastCharInLoad - firstCharInLoad + 1);
-
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-            if (m_useFirstNonBMPCharacterOptimization && numRealCharsToCheck > 1) {
-                // We are going to try matching more than one character at a time,
-                // so we should only advance one character at a time as normal.
-                m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
-            }
-#endif
 
             MatchTargets* matchTargetForFinalComparison = (opListIdx + numCharsToCheck >= opList.size()) ? &lastMatchTargets : &defaultMatchTargets;
 
@@ -3866,13 +3853,8 @@ class YarrGenerator final : public YarrJITInfo {
                 // set as appropriate to this alternative.
                 defineReentryLabel(op);
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                // Initialize after reentry to ensure fresh register state on backtrack retries,
-                // since character reading operations modify this register during execution.
-                if (m_useFirstNonBMPCharacterOptimization)
-                    m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
-#endif
-
+                // These may advance |index| to a candidate position before entering the body.
+                auto emitStartPositionPrefilters = [&] {
 #if CPU(ARM64) || CPU(X86_64)
                 // Try multi-pattern SIMD search first if available (more selective for alternation patterns)
                 if (op.m_maskedAltInfo) {
@@ -3906,11 +3888,11 @@ class YarrGenerator final : public YarrJITInfo {
                             } else
                                 setMatchStart(m_regs.index);
                         }
-                        break;
+                        return;
                     }
 
                     ASSERT(matched.empty());
-                    break;
+                    return;
                 }
 #endif
 
@@ -3928,7 +3910,7 @@ class YarrGenerator final : public YarrJITInfo {
                         dataLogLnIf(YarrJITInternal::verbose, "BM Bitmap is ", map);
                         // Patterns like /[]/ have zero candidates. Since it is rare, we do not do nothing for now.
                         if (!mapCount)
-                            break;
+                            return;
 
                         unsigned strideLength = endIndex - beginIndex;
 #if CPU(ARM64) || CPU(X86_64)
@@ -3962,7 +3944,7 @@ class YarrGenerator final : public YarrJITInfo {
                                 } else
                                     setMatchStart(m_regs.index);
                             }
-                            break;
+                            return;
                         }
 #endif
 
@@ -3995,7 +3977,7 @@ class YarrGenerator final : public YarrJITInfo {
                         }
                     } else
                         dataLogLnIf(Options::verboseRegExpCompilation(), "BM search candidates were not efficient enough. Not using BM search");
-                    break;
+                    return;
                 }
 
                 if (op.m_bodyAltSharedLead) {
@@ -4034,6 +4016,12 @@ class YarrGenerator final : public YarrJITInfo {
                             setMatchStart(m_regs.index);
                     }
                 }
+                };
+                emitStartPositionPrefilters();
+
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                initAdvanceLatch(alternative->m_minimumSize);
+#endif
                 break;
             }
             case YarrOpCode::BodyAlternativeNext:
@@ -4075,13 +4063,6 @@ class YarrGenerator final : public YarrJITInfo {
                     // PRIOR alteranative, and we will only check input availability if we
                     // need to progress it forwards.
                     defineReentryLabel(op);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                    // Reset on reentry: a prior alternative may have read a non-BMP codepoint
-                    // and left this register set to 1. The next alternative starts a fresh
-                    // first-character read.
-                    if (m_useFirstNonBMPCharacterOptimization)
-                        m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
-#endif
                     if (shouldRecordSubpatterns() && priorAlternative->needToCleanupCaptures()) {
                         for (unsigned subpattern = priorAlternative->firstCleanupSubpatternId(); subpattern <= priorAlternative->m_lastSubpatternId; subpattern++)
                             clearSubpattern(subpattern);
@@ -4095,11 +4076,6 @@ class YarrGenerator final : public YarrJITInfo {
                     // This is the reentry point for the End of 'once through' alternatives,
                     // jumped to when the last alternative fails to match.
                     defineReentryLabel(op);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                    // Reset on reentry: see BodyAlternativeNext above.
-                    if (m_useFirstNonBMPCharacterOptimization)
-                        m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
-#endif
                     m_jit.sub32(MacroAssembler::Imm32(priorAlternative->m_minimumSize), m_regs.index);
                 }
                 break;
@@ -4802,6 +4778,11 @@ class YarrGenerator final : public YarrJITInfo {
                         unsigned delta = prevOp->m_alternative->m_minimumSize - nextOp->m_alternative->m_minimumSize;
                         m_jit.sub32(MacroAssembler::Imm32(delta), m_regs.index);
                         MacroAssembler::Jump fail = jumpIfNoAvailableInput();
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                        // The next alternative is entered as the first one attempted at this start position,
+                        // bypassing the latch setup in BodyAlternativeBegin.
+                        initAdvanceLatch(nextOp->m_alternative->m_minimumSize);
+#endif
                         m_jit.add32(MacroAssembler::Imm32(delta), m_regs.index);
                         m_jit.jump(nextOp->m_reentry);
                         fail.link(&m_jit);
@@ -6976,7 +6957,8 @@ public:
         }
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        if (m_decodeSurrogatePairs && m_executionMode != ExecutionMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers) {
+        // A zero minimum-size alternative (e.g. /aa|\B/u) can match in the middle of a surrogate pair, so it must not be skipped.
+        if (m_decodeSurrogatePairs && m_executionMode != ExecutionMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers && m_pattern.m_body->m_minimumSize) {
             ASSERT(m_regs.firstCharacterAdditionalReadSize != InvalidGPRReg);
             m_useFirstNonBMPCharacterOptimization = true;
         }
@@ -7577,28 +7559,13 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharSlowThunkGenerato
     CCallHelpers jit(nullptr);
 
     jit.tagReturnAddress();
-    tryReadUnicodeCharSlowImpl<TryReadUnicodeCharGenFirstNonBMPOptimization::DontUseOptimization>(jit);
+    tryReadUnicodeCharSlowImpl(jit);
     jit.ret();
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
 
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "Yarr tryReadUnicodeChar"_s, "YARR tryReadUnicodeChar thunk");
 }
-
-#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-static MacroAssemblerCodeRef<JITThunkPtrTag> tryReadUnicodeCharIncForNonBMPSlowThunkGenerator(VM&)
-{
-    CCallHelpers jit(nullptr);
-
-    jit.tagReturnAddress();
-    tryReadUnicodeCharSlowImpl<TryReadUnicodeCharGenFirstNonBMPOptimization::UseOptimization>(jit);
-    jit.ret();
-
-    LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
-
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "Yarr tryReadUnicodeChar w/Inc for non-BMP"_s, "YARR tryReadUnicodeChar w/Inc for non-BMP thunk");
-}
-#endif
 #endif
 
 #if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)


### PR DESCRIPTION
#### 54916608d7d648c662f4524d57000ec33b0eb431
<pre>
[YARR] Fix non-BMP advance latch and simplify `tryReadUnicodeCharImpl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308288">https://bugs.webkit.org/show_bug.cgi?id=308288</a>

Reviewed by Yusuke Suzuki.

For /u patterns, YARR JIT uses firstCharacterAdditionalReadSize (the advance latch)
to move the match start past both units of a surrogate pair when a match attempt
fails. The latch was set as a side effect of every non-BMP character read, so a read
anywhere in the pattern could corrupt it, e.g. /.x/u.exec(&quot;a\u{10000}x&quot;) returned null
because the U+10000 read at position 1 latched the register while the start character
&apos;a&apos; is BMP. Several workarounds (word boundary and backreference read guards, latch
resets at alternative reentry, and after wide character compares) papered over
individual instances of this.

This change makes the latch a function of the match start position alone:

1. initAdvanceLatch() sets the latch iff the code units at the match start form a
   complete surrogate pair (a lone lead advances by one code unit, like
   AdvanceStringIndex). It is emitted where an alternative is entered as the first one
   attempted at a start position: right before the alternative body after any
   start-position prefilter (Boyer-Moore lookahead / SIMD searches move the index),
   and on the path that enters a shorter alternative directly when longer ones no
   longer fit.

2. tryReadUnicodeCharImpl no longer touches the latch, so
   TryReadUnicodeCharGenFirstNonBMPOptimization, its second slow-path thunk, and all of
   the workarounds above are removed.

3. Skipping the trail surrogate position is only unobservable when every alternative
   consumes at least one character, since a character read at that position yields
   errorCodePoint. A zero minimum-size alternative (e.g. /aa|\B/u) can match there, so
   the optimization now also requires m_body-&gt;m_minimumSize; this fixes
   /a?\B|q/u.exec(&quot;X\u{1F600}Z&quot;) returning null instead of the empty match at 2.

Test: JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js

* JSTests/stress/regexp-unicode-nonbmp-advance-latch-bug.js: Added.
(shouldBe):
(shouldBeMatch):
* JSTests/stress/temporal-hebrew-day-constrain.js: Added.
(shouldBe):
(shouldBe.byCode.toString):
(shouldBe.byOrdinal.toString):
(Temporal.PlainDate.from):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::tryReadUnicodeCharImpl):
(JSC::Yarr::tryReadUnicodeCharSlowImpl):
(JSC::Yarr::tryReadUnicodeCharSlowThunkGenerator):
(JSC::Yarr::tryReadUnicodeCharIncForNonBMPSlowThunkGenerator): Deleted.

Canonical link: <a href="https://commits.webkit.org/318209@main">https://commits.webkit.org/318209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f10b7085916442e1ad7970eed811672471b02d86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187059 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140702 "Build is in progress. Recent messages:") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138298 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/140702 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40463 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38836 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/732 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7546 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38544 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35526 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38726 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189487 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51060 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39637 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51742 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147185 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41900 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123957 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118317 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50250 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13522 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->