### PR TITLE
Make update-safer-cpp-expectations work well with expectations with a platform specifier

### DIFF
--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -70,35 +70,7 @@ def parser():
     return parser.parse_args()
 
 
-def modify_expectations_for_checker_from_file(checker, unexpected_contents, project, add=False):
-    path_to_expectations = checker.expectations_path(project)
-    with open(path_to_expectations) as expectations_file:
-        expectations = expectations_file.readlines()
-        prev_len = len(expectations)
-    for line in unexpected_contents:
-        if '=>' in line:
-            new_checker_type = line.split()[-1]
-            modify_expectations_for_checker_from_file(Checker.find_checker_by_name(new_checker_type), unexpected_contents, project, add)
-        elif line.strip():
-            if not add:
-                try:
-                    expectations.remove(line)
-                except ValueError:
-                    print(f'Error: {line.strip()} is not in {os.path.relpath(path_to_expectations)}!')
-            elif line not in expectations:
-                expectations.append(line)
-            else:
-                print(f'Error: {line.strip()} is already in {os.path.relpath(path_to_expectations)}!\n')
-    with open(path_to_expectations, 'w') as expectations_file:
-        expectations_file.writelines(sorted(expectations))
-    print(f'Updated expectations for {checker.name()}!')
-    if not add:
-        print(f'Removed {prev_len - len(expectations)} fixed files.\n')
-    else:
-        print(f'Added {len(expectations) - prev_len} files with issues.\n')
-
-
-def update_expectations_from_file(unexpected_results, project, add=False):
+def update_expectations_from_file(unexpected_results, project, add=False, platform=None):
     filename = os.path.basename(unexpected_results)
     if not project:
         projects = [p for p in Checker.projects() if p in filename]
@@ -109,10 +81,24 @@ def update_expectations_from_file(unexpected_results, project, add=False):
             return
     print(f"{'Adding' if add else 'Removing'} unexpected failures in {project}...\n")
     with open(unexpected_results, 'r') as unexpected_contents:
+        checker_type = None
+        file_list = []
         for line in unexpected_contents:
             if '=>' in line:
+                if checker_type and file_list:
+                    print(checker_type, file_list)
+                    modify_expectations_for_checker(Checker.find_checker_by_name(checker_type), file_list, project, add, platform)
                 checker_type = line.split()[-1]
-                modify_expectations_for_checker_from_file(Checker.find_checker_by_name(checker_type), unexpected_contents, project, add)
+                file_list = []
+                continue
+            file_path = line.strip()
+            if file_path:
+                file_list.append(file_path)
+
+        if checker_type and file_list:
+            print(checker_type, file_list)
+            modify_expectations_for_checker(Checker.find_checker_by_name(checker_type), file_list, project, add, platform)
+
     print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
 
 
@@ -141,8 +127,13 @@ def modify_expectations_for_checker(checker, unexpected_contents, project, add, 
             expectation_platform = match.group('platform')
             path = match.group('path')
             if path in expectation_map:
-                print(f'Conflicting or duplicate line in {expectation_relpath}: {path}')
-                continue
+                if expectation_platform.lower() == 'mac' and platform == 'ios':
+                    expectation_platform = None
+                elif expectation_platform.lower() == 'ios' and platform == 'mac':
+                    expectation_platform = None
+                else:
+                    print(f'Conflicting or duplicate line in {expectation_relpath}: {path}')
+                    continue
             expectation_map[match.group('path')] = {'platform': expectation_platform, 'comments': comments}
             comments = []
 
@@ -159,6 +150,8 @@ def modify_expectations_for_checker(checker, unexpected_contents, project, add, 
                     print(f'Unexpected platform in {expectation_relpath}: {expectation_platform}')
                     continue
                 expectation_map[path]['platform'] = None
+            else:
+                expectation_map[path] = {'platform': platform, 'comments': []}
             count += 1
         print(f'Added {count} files with issues.\n')
     else:
@@ -169,7 +162,7 @@ def modify_expectations_for_checker(checker, unexpected_contents, project, add, 
             if platform:
                 expectation_platform = expectation_map[path]['platform']
                 lowercase_platform = expectation_platform.lower() if expectation_platform else None
-                if lowercase_platform != platform:
+                if lowercase_platform and lowercase_platform != platform:
                     platform_name = 'Mac' if platform == 'mac' else 'iOS'
                     print(f'Expectation not found in {expectation_relpath}: {path} for {platform_name}')
                     continue # Expectation is for another platform. We're done
@@ -242,7 +235,7 @@ def main():
         if user_input[0].lower() != 'y':
             return
     if args.unexpected_results_file:
-        update_expectations_from_file(args.unexpected_results_file, args.project, args.add)
+        update_expectations_from_file(args.unexpected_results_file, args.project, args.add, args.platform)
     else:
         update_expectations(vars(args), args.project, args.add, args.platform)
 


### PR DESCRIPTION
#### 23e98bacf9cc6b54ccf6e70d2c96c5a52bbe3dd2
<pre>
Make update-safer-cpp-expectations work well with expectations with a platform specifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=308289">https://bugs.webkit.org/show_bug.cgi?id=308289</a>

Reviewed by Brianna Fan.

This PR fixes a few bugs in update-safer-cpp-expectations to make it work better with
a platform specifier in the safer C++ expectations.

update_expectations_from_file is updated to support adding / removing platform specific
expectations by re-using modify_expectations_for_checker, which already supports parsing
and sorting expectations instead of calling modify_expectations_for_checker_from_file,
which has been deleted.

update_expectations_from_file now parses the list of files and checker type using the
for loop instead of delegating that work to modify_expectations_for_checker_from_file.

Fixed a bug in modify_expectations_for_checker that it treated having expectations for
both macOS and iOS as a conflict by simply removing the platform specifier. And added
the missing code to add a new expectation entry in modify_expectations_for_checker.

* Tools/Scripts/update-safer-cpp-expectations:
(modify_expectations_for_checker_from_file): Deleted.
(update_expectations_from_file): Updated to use modify_expectations_for_checker. Now
parses the input file&apos;s content and calls modify_expectations_for_checker with it.
(modify_expectations_for_checker): Now consolidates two entries for the same file in
macOS and iOS and fixed the bug that it wasn&apos;t adding new entries.
(main):

Canonical link: <a href="https://commits.webkit.org/308059@main">https://commits.webkit.org/308059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09bb62bfb25f50f4c5d6c67b0b392c6f81570bed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99469 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6db93162-b0ee-41e4-889a-bd50e04a57ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112223 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80357 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abe8fbcb-cfb2-4cae-ba57-17350b36f7a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93129 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/caf40092-4249-4aff-852f-1d6bd48b0bc9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13902 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156897 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120232 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120573 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74160 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22569 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7342 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18054 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17791 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->