### PR TITLE
RTCPeerConnection: implement spec "final steps to create an offer" step 2

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createOffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createOffer-expected.txt
@@ -2,6 +2,6 @@
 PASS createOffer() returns RTCSessionDescriptionInit
 PASS createOffer() and then setLocalDescription() should succeed
 PASS createOffer() after connection is closed should reject with InvalidStateError
-FAIL When media stream is added when createOffer() is running in parallel, the result offer should contain the new media stream assert_equals: Expect m=audio line to be found in offer SDP expected 1 but got 0
+PASS When media stream is added when createOffer() is running in parallel, the result offer should contain the new media stream
 PASS createOffer() should fail when signaling state is not stable or have-local-offer
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -143,6 +143,9 @@ ExceptionOr<Ref<RTCRtpSender>> RTCPeerConnection::addTrack(Ref<MediaStreamTrack>
     if (isClosed())
         return Exception { ExceptionCode::InvalidStateError };
 
+    if (m_isCreatingOffer)
+        m_shouldRecreateAnOffer = true;
+
     for (auto& transceiver : m_transceiverSet.list()) {
         if (transceiver->sender().trackId() == track->id())
             return Exception { ExceptionCode::InvalidAccessError };
@@ -227,6 +230,9 @@ ExceptionOr<Ref<RTCRtpTransceiver>> RTCPeerConnection::addTransceiver(AddTransce
 
     if (auto exception = validateSendEncodings(init.sendEncodings, isAudioTransceiver(withTrack)))
         return WTF::move(*exception);
+
+    if (m_isCreatingOffer)
+        m_shouldRecreateAnOffer = true;
 
     if (std::holds_alternative<String>(withTrack)) {
         const String& kind = std::get<String>(withTrack);
@@ -325,18 +331,40 @@ void RTCPeerConnection::createOffer(RTCOfferOptions&& options, Ref<DeferredPromi
             promise->reject(ExceptionCode::InvalidStateError);
             return;
         }
-        protect(*m_backend)->createOffer(WTF::move(options), [this, protectedThis = Ref { *this }, promise = PeerConnection::SessionDescriptionPromise(WTF::move(promise))](auto&& result) mutable {
-            if (isClosed())
-                return;
-            if (result.hasException()) {
-                promise.reject(result.releaseException());
-                return;
-            }
-            // https://w3c.github.io/webrtc-pc/#dfn-final-steps-to-create-an-offer steps 4,5 and 6.
-            m_lastCreatedOffer = result.returnValue().sdp;
-            promise.resolve(result.releaseReturnValue());
-        });
+        m_isCreatingOffer = true;
+        m_shouldRecreateAnOffer = false;
+        runInParallelStepsToCreateAnOffer(WTF::move(options), PeerConnection::SessionDescriptionPromise(WTF::move(promise)));
     });
+}
+
+// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer step 5.
+void RTCPeerConnection::runInParallelStepsToCreateAnOffer(RTCOfferOptions&& options, PeerConnection::SessionDescriptionPromise&& promise)
+{
+    protect(*m_backend)->createOffer(WTF::move(options), [this, protectedThis = Ref { *this }, promise = WTF::move(promise)](auto&& result) mutable {
+        if (isClosed())
+            return;
+        if (result.hasException()) {
+            m_isCreatingOffer = false;
+            promise.reject(result.releaseException());
+            return;
+        }
+        runFinalStepsToCreateAnOffer(result.releaseReturnValue(), WTF::move(promise));
+    });
+}
+
+// https://w3c.github.io/webrtc-pc/#dfn-final-steps-to-create-an-offer
+void RTCPeerConnection::runFinalStepsToCreateAnOffer(RTCSessionDescriptionInit&& description, PeerConnection::SessionDescriptionPromise&& promise)
+{
+    // Step 2: If connection was modified, restart.
+    if (m_shouldRecreateAnOffer) {
+        m_shouldRecreateAnOffer = false;
+        runInParallelStepsToCreateAnOffer(RTCOfferOptions { }, WTF::move(promise));
+        return;
+    }
+    m_isCreatingOffer = false;
+    // Steps 4, 5 and 6.
+    m_lastCreatedOffer = description.sdp;
+    promise.resolve(WTF::move(description));
 }
 
 void RTCPeerConnection::createAnswer(RTCAnswerOptions&& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -249,6 +249,8 @@ private:
 
     ExceptionOr<Vector<MediaEndpointConfiguration::CertificatePEM>> certificatesFromConfiguration(const RTCConfiguration&);
     void chainOperation(Ref<DeferredPromise>&&, Function<void(Ref<DeferredPromise>&&)>&&);
+    void runInParallelStepsToCreateAnOffer(RTCOfferOptions&&, PeerConnection::SessionDescriptionPromise&&);
+    void runFinalStepsToCreateAnOffer(RTCSessionDescriptionInit&&, PeerConnection::SessionDescriptionPromise&&);
     friend class RTCRtpSender;
 
     ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> iceServersFromConfiguration(RTCConfiguration& newConfiguration, const RTCConfiguration* existingConfiguration, bool isLocalDescriptionSet);
@@ -282,6 +284,8 @@ private:
     bool m_shouldDelayTasks { false };
     Deque<std::pair<Ref<DeferredPromise>, Function<void(Ref<DeferredPromise>&&)>>> m_operations;
     bool m_hasPendingOperation { false };
+    bool m_shouldRecreateAnOffer { false };
+    bool m_isCreatingOffer { false };
     std::optional<uint32_t> m_negotiationNeededEventId;
     Vector<Ref<RTCDtlsTransport>> m_dtlsTransports;
     Vector<Ref<RTCIceTransport>> m_iceTransports;


### PR DESCRIPTION
#### 09a8f86b2d6473aa5210f798974869703f0c2b9b
<pre>
RTCPeerConnection: implement spec &quot;final steps to create an offer&quot; step 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=308291">https://bugs.webkit.org/show_bug.cgi?id=308291</a>
<a href="https://rdar.apple.com/170798759">rdar://170798759</a>

Reviewed by NOBODY (OOPS!).

If addTrack() or addTransceiver() is called while a createOffer is
in flight, the connection has been modified and the spec requires
re-inspecting system state before resolving. Implement this by
tracking whether a createOffer is active (m_isCreatingOffer) and
whether the connection was modified during that window
(m_shouldRecreateAnOffer). When the backend callback fires and the
flag is set, re-invoke createOffer on the backend instead of
resolving the promise immediately.

Spec: <a href="https://w3c.github.io/webrtc-pc/#dfn-final-steps-to-create-an-offer">https://w3c.github.io/webrtc-pc/#dfn-final-steps-to-create-an-offer</a>

* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::addTrack):
(WebCore::RTCPeerConnection::addTransceiver):
(WebCore::RTCPeerConnection::createOffer):
(WebCore::RTCPeerConnection::runInParallelStepsToCreateAnOffer):
(WebCore::RTCPeerConnection::runFinalStepsToCreateAnOffer):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createOffer-expected.txt: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a8f86b2d6473aa5210f798974869703f0c2b9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101960 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc7a3b1c-9814-4f10-bd23-796267615bef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114505 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81549 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95275 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1b483ff-ca1f-440d-8af6-00ced1e38986) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15823 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13654 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4650 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159549 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122553 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122774 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77180 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9815 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84457 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20363 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->