### PR TITLE
Enhanced <select>: toggle picker on mousedown

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -656,6 +656,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-grid-before-after.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
@@ -1,8 +1,5 @@
 invoker
-one
-two
-popover button other text
 
-FAIL Buttons in the popover should be rendered and should not close the popover when clicked. assert_false: Clicking invoker button should close select. expected false got true
-FAIL Non-interactive content in the popover should not close the popover when clicked. assert_false: Select should be closed at the start of the test. expected false got true
+PASS Buttons in the popover should be rendered and should not close the popover when clicked.
+PASS Non-interactive content in the popover should not close the popover when clicked.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt
@@ -2,7 +2,7 @@ one select0-button
              select7-button
 
 FAIL Button controller code should not run if the mousedown event is preventDefaulted. assert_false: Listbox shouldn't have opened yet expected false got true
-PASS Listbox controller code should not run if the mousedown event is preventDefaulted.
+FAIL Listbox controller code should not run if the mousedown event is preventDefaulted. assert_true: Listbox shouldn't have closed yet expected true got false
 PASS <select> should fire input and change events when new option is selected.
 PASS <select> should not fire input and change events when new selected option has the same value as the old.
 PASS <select> should fire input and change events when option in listbox is clicked

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt
@@ -1,8 +1,6 @@
 button
 
-one
-two
 
-FAIL Attempting to focus the previous option while focused on the first option should not crash. assert_false: select should be closed at the end of the test. expected false got true
-FAIL Keyboard navigating backwards over an <hr> and <optgroup> should not crash. assert_false: select should be closed at the end of the test. expected false got true
+PASS Attempting to focus the previous option while focused on the first option should not crash.
+PASS Keyboard navigating backwards over an <hr> and <optgroup> should not crash.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
@@ -1,19 +1,13 @@
-
-one
-two
-three
- custom button
-
-Harness Error (FAIL), message = Test named 'defaultbutton: When the listbox is open, the tab key should close the listbox.' specified 1 'cleanup' function, and 1 failed.
+custom button
 
 PASS defaultbutton: When the listbox is closed, spacebar should open the listbox.
 FAIL defaultbutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
 PASS defaultbutton: When the listbox is closed, the enter key should not trigger form submission.
 PASS defaultbutton: When the listbox is open, the enter key should commit the selected option.
 FAIL defaultbutton: When the listbox is open, the tab key should close the listbox. assert_false: Tab should close the listbox. expected false got true
-NOTRUN custombutton: When the listbox is closed, spacebar should open the listbox.
-NOTRUN custombutton: When the listbox is closed, all arrow keys should open the listbox.
-NOTRUN custombutton: When the listbox is closed, the enter key should not trigger form submission.
-NOTRUN custombutton: When the listbox is open, the enter key should commit the selected option.
-NOTRUN custombutton: When the listbox is open, the tab key should close the listbox.
+PASS custombutton: When the listbox is closed, spacebar should open the listbox.
+FAIL custombutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
+FAIL custombutton: When the listbox is closed, the enter key should not trigger form submission. assert_false: Enter should not submit the form when the listbox is closed. expected false got true
+PASS custombutton: When the listbox is open, the enter key should commit the selected option.
+FAIL custombutton: When the listbox is open, the tab key should close the listbox. assert_false: Tab should close the listbox. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-hover-active-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-hover-active-pseudo-expected.txt
@@ -1,8 +1,8 @@
   button
 option
 
-FAIL defaultbutton: select should match :hover and :active when interacting with button. assert_false: select should be closed at the end of the test. expected false got true
-FAIL defaultbutton: select should not match :hover or :active when interacting with elements in the picker. assert_false: select should be closed at the start of the test. expected false got true
-FAIL custombutton: select should match :hover and :active when interacting with button. assert_false: select should be closed at the end of the test. expected false got true
-FAIL custombutton: select should not match :hover or :active when interacting with elements in the picker. assert_false: select should be closed at the start of the test. expected false got true
+PASS defaultbutton: select should match :hover and :active when interacting with button.
+FAIL defaultbutton: select should not match :hover or :active when interacting with elements in the picker. assert_false: select should not match :hover. expected false got true
+PASS custombutton: select should match :hover and :active when interacting with button.
+FAIL custombutton: select should not match :hover or :active when interacting with elements in the picker. assert_false: select should not match :hover. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt
@@ -3,5 +3,7 @@ button
 option
 
 
-FAIL Clicking interactive elements inside the select picker should focus them. assert_equals: button expected Element node <button id="button">button</button> but got Element node <option>option</option>
+FAIL Clicking interactive elements inside the select picker should focus them. assert_equals: button expected Element node <button id="button">button</button> but got Element node <select>
+  <button>invoker</button>
+  <button id="button"...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
@@ -1,7 +1,5 @@
 
-one
-two
 
 PASS select should support :open pseudo selector.
-FAIL select :open and :not(:open) should invalidate correctly. assert_equals: The style rules from :not(:open) should apply when the select is opened and closed again. expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
+PASS select :open and :not(:open) should invalidate correctly.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
@@ -1,8 +1,5 @@
 invoker
-one
-two
-popover button other text
 
-FAIL Buttons in the popover should be rendered and should not close the popover when clicked. assert_false: Clicking invoker button should close select. expected false got true
-FAIL Non-interactive content in the popover should not close the popover when clicked. assert_false: Select should be closed at the start of the test. expected false got true
+PASS Buttons in the popover should be rendered and should not close the popover when clicked.
+FAIL Non-interactive content in the popover should not close the popover when clicked. assert_true: Clicking non-interactive, non-option content should not close the popover. expected true got false
 


### PR DESCRIPTION
#### 7b7f2638a60d196a14ce32fa6bc2e443822370f7
<pre>
Enhanced &lt;select&gt;: toggle picker on mousedown
<a href="https://bugs.webkit.org/show_bug.cgi?id=308296">https://bugs.webkit.org/show_bug.cgi?id=308296</a>
<a href="https://rdar.apple.com/170742798">rdar://170742798</a>

Reviewed by Tim Nguyen.

appearance: base-select ::picker(select) appears below a &lt;select&gt; by
default and as such clicking the &lt;select&gt; is expected to close it. This
also happens for normal &lt;select&gt;s on macOS as a side effect of how the
OS picker works.

To distinguish a click on the &lt;select&gt;&apos;s &quot;button&quot; from a click anywhere
on ::picker(select) some composed tree traversal is necessary
unfortunately.

We also add some early returns for the different event types for
clarity.

What appears as a regression in select-events-2.optional.html is
actually a progression as before we did not get into a state where it
could fail. Both of the failures in that test are due to
preventDefault() being called in a microtask which at least in
combination with WebKit&apos;s test runner does not happen at the right
point in time.

select-popover-exit-animation.html likewise did not get into a state
where it could fail before.

Canonical link: <a href="https://commits.webkit.org/307925@main">https://commits.webkit.org/307925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8bdd2fe18d198cb843e369e3f4ad40e13eb894

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145958 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18648 "Failed to checkout and rebase branch from PR 59085") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/10784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/154637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147833 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/19130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18537 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/154637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148921 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/19130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/154637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/19130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/2082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/19130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/8052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156948 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/9287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/18488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/120616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/129462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22503 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/18105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/17842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->