### PR TITLE
Workaround absence of .pointee

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -279,6 +279,12 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module IPCTesterReceiver {
+        requires cplusplus20
+        header "../../Shared/IPCTesterReceiver.h"
+        export *
+    }
+
     // FIXME: These parts of the module map needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 
     module WebKit_Internal_Objc {

--- a/Source/WebKit/Shared/IPCTesterReceiver.h
+++ b/Source/WebKit/Shared/IPCTesterReceiver.h
@@ -55,3 +55,16 @@ private:
 }
 
 #endif
+
+#if ENABLE(IPC_TESTING_API) && ENABLE(IPC_TESTING_SWIFT)
+
+#include "IPCTesterReceiverMessages.h"
+
+// Workaround for rdar://170233903
+// The Swift call can be replaced with fn.pointee(args) when this is fixed
+inline void callFunction(CompletionHandlers::IPCTesterReceiver::AsyncMessageCompletionHandler& fn, uint32_t value)
+{
+    (*fn)(value);
+}
+
+#endif

--- a/Source/WebKit/Shared/IPCTesterReceiver.swift
+++ b/Source/WebKit/Shared/IPCTesterReceiver.swift
@@ -43,7 +43,7 @@ final class IPCTesterReceiver {
     }
 
     func asyncMessage(data: UInt32, completionHandler: CompletionHandlers.IPCTesterReceiver.AsyncMessageCompletionHandler) {
-        completionHandler.pointee(data + 2)
+        callFunction(completionHandler, data + 2)
     }
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -539,7 +539,7 @@ final class WebBackForwardList {
         }
 
         for (i, entry) in entries.enumerated() {
-            if filter.pointee.__convertToBool() && !filter.pointee(entry) {
+            if filterSpecified(filter) && !callFilter(filter, entry) {
                 if let stateCurrentIndex = Optional(fromCxx: backForwardListState.currentIndex) {
                     if i < stateCurrentIndex && stateCurrentIndex != 0 {
                         setOptionalUInt32Value(&backForwardListState.currentIndex, stateCurrentIndex - 1)
@@ -603,7 +603,7 @@ final class WebBackForwardList {
     }
 
     func setItemsAsRestoredFromSessionIf(functor: WebBackForwardListItemFilter) {
-        for entry in entries where functor.pointee(entry) {
+        for entry in entries where callFilter(functor, entry) {
             entry.setWasRestoredFromSession()
         }
     }
@@ -910,7 +910,7 @@ final class WebBackForwardList {
         // value. Since the load is really going on in a new provisional process, we want to ignore such requests from the committed process.
         // Any real new load in the committed process would have cleared m_provisionalPage.
         if let webPageProxy = page.get(), webPageProxy.hasProvisionalPage() {
-            completionHandler.pointee(consuming: counts())
+            callCompletionHandler(completionHandler, consuming: counts())
             return
         }
 
@@ -921,7 +921,7 @@ final class WebBackForwardList {
         itemID: WebCore.BackForwardItemIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListContainsItemCompletionHandler
     ) {
-        completionHandler.pointee(itemForID(identifier: itemID) != nil)
+        callCompletionHandler(completionHandler, itemForID(identifier: itemID) != nil)
     }
 
     func backForwardGoToItemShared(
@@ -931,7 +931,7 @@ final class WebBackForwardList {
         if let webPageProxy = page.get() {
             if messageCheckCompletion(
                 process: WebKit.RefWebProcessProxy(webPageProxy.legacyMainFrameProcess()),
-                completionHandler: { completionHandler.pointee(consuming: counts()) },
+                completionHandler: { callCompletionHandler(completionHandler, consuming: counts()) },
                 !WebKit.isInspectorPage(webPageProxy)
             ) {
                 return
@@ -942,7 +942,7 @@ final class WebBackForwardList {
             goToItem(item: item)
         }
 
-        completionHandler.pointee(consuming: counts())
+        callCompletionHandler(completionHandler, consuming: counts())
     }
 
     func backForwardAllItems(
@@ -955,7 +955,7 @@ final class WebBackForwardList {
                 frameStates.append(frameItem.copyFrameStateWithChildren().ptr())
             }
         }
-        completionHandler.pointee(consuming: WebKit.VectorRefFrameState(array: frameStates))
+        callCompletionHandler(completionHandler, consuming: WebKit.VectorRefFrameState(array: frameStates))
     }
 
     func backForwardItemAtIndex(
@@ -966,18 +966,18 @@ final class WebBackForwardList {
         // FIXME: This should verify that the web process requesting the item hosts the specified frame.
         let index = Int(index)
         guard let item = itemAtIndex(index: index) else {
-            completionHandler.pointee(consuming: WebKit.RefPtrFrameState())
+            callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState())
             return
         }
         guard let frameItem = item.mainFrameItem().childItemForFrameID(frameID) else {
-            completionHandler.pointee(consuming: WebKit.RefPtrFrameState(item.mainFrameState().ptr()))
+            callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState(item.mainFrameState().ptr()))
             return
         }
-        completionHandler.pointee(consuming: WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr()))
+        callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr()))
     }
 
     func backForwardListCounts(completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListCountsCompletionHandler) {
-        completionHandler.pointee(consuming: counts())
+        callCompletionHandler(completionHandler, consuming: counts())
     }
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Logging.h"
+#include "SessionState.h"
 #include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
 #include "WebProcessProxy.h"
@@ -66,5 +67,32 @@ inline void setOptionalUInt32Value(std::optional<uint32_t>& optional, uint32_t v
 }
 
 using WebBackForwardListItemFilter = WTF::RefCountable<WTF::Function<bool (WebKit::WebBackForwardListItem&)>>;
+
+// Workaround for rdar://170233903
+// In each case the Swift call can be replaced with fn.pointee(args) when this is fixed
+inline bool callFilter(WebBackForwardListItemFilter& fn, WebKit::WebBackForwardListItem& item)
+{
+    return (*fn)(item);
+}
+inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardGoToItemCompletionHandler& fn, WebKit::WebBackForwardListCounts&& counts)
+{
+    (*fn)(WTF::move(counts));
+}
+inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardListContainsItemCompletionHandler& fn, bool found)
+{
+    (*fn)(found);
+}
+inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardAllItemsCompletionHandler& fn, WebKit::VectorRefFrameState&& items)
+{
+    (*fn)(WTF::move(items));
+}
+inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackForwardItemAtIndexCompletionHandler& fn, WebKit::RefPtrFrameState&& state)
+{
+    (*fn)(WTF::move(state));
+}
+inline bool filterSpecified(WebBackForwardListItemFilter& fn)
+{
+    return bool(*fn);
+}
 
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)


### PR DESCRIPTION
#### 882a43a5ccc5d5a0af67981ec84a37906b92e0a9
<pre>
Workaround absence of .pointee
<a href="https://bugs.webkit.org/show_bug.cgi?id=308298">https://bugs.webkit.org/show_bug.cgi?id=308298</a>
<a href="https://rdar.apple.com/170801574">rdar://170801574</a>

Reviewed by Richard Robinson.

This removes all uses of the Swift .pointee syntax with inline C++ functions,
to work around a regression in the Swift compiler, <a href="https://rdar.apple.com/170233903">rdar://170233903</a>, which is
fixed in <a href="https://github.com/swiftlang/swift/pull/87195">https://github.com/swiftlang/swift/pull/87195</a> but will take a while to
get to us in WebKit.

Canonical link: <a href="https://commits.webkit.org/307936@main">https://commits.webkit.org/307936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/116c895906b80fd021754ce05a68e1e4822750f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99478 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37523615-03e8-4a70-b0ad-669ec83e66ba) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f003e98-196f-4281-a6a0-500731dca3d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93142 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61898937-bba9-4d4e-91b6-4bf5f1771a92) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11671 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2046 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123468 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156912 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120246 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30919 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74171 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7372 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81845 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17806 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->