### PR TITLE
[YARR] Skip dead errorCodePoint checks in 16-bit ignoreCase backreference loop for non-Unicode patterns

### DIFF
--- a/JSTests/stress/regexp-backreference-16bit-ignorecase-errorCodePoint.js
+++ b/JSTests/stress/regexp-backreference-16bit-ignorecase-errorCodePoint.js
@@ -1,0 +1,54 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null && expected !== null)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got null`);
+    if (actual === null && expected === null)
+        return;
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+// 16-bit ignoreCase backreference — non-Unicode mode
+// These exercise the 16-bit ignoreCase backreference loop where
+// errorCodePoint checks are dead when !m_decodeSurrogatePairs.
+for (let i = 0; i < testLoopCount; i++) {
+    // Force Char16 strings by including a character above 0xFF.
+    shouldBeArray(/(abc)\1/i.exec("abc\u0100abcABC"), ["abcABC", "abc"], "16-bit ignoreCase backref");
+    shouldBe(/(abc)\1/i.exec("abc\u0100abcDEF"), null, "16-bit ignoreCase backref mismatch");
+
+    shouldBeArray(/(Hello)\1/i.exec("\u0100HelloHELLO"), ["HelloHELLO", "Hello"], "16-bit ignoreCase Hello");
+    shouldBe(/(Hello)\1/i.exec("\u0100HelloWorld"), null, "16-bit ignoreCase Hello mismatch");
+
+    shouldBeArray(/(ab)\1{3}/i.exec("\u0100ababABAb"), ["ababABAb", "ab"], "16-bit ignoreCase quantified backref");
+    shouldBe(/(ab)\1{3}/i.exec("\u0100ababAcd"), null, "16-bit ignoreCase quantified backref mismatch");
+
+    // Lone surrogates in non-Unicode mode — should be treated as plain code units.
+    let highSurrogate = "\uD800";
+    let input1 = highSurrogate + "x" + highSurrogate + "X";
+    shouldBeArray(/(..)\1/i.exec(input1), [highSurrogate + "x" + highSurrogate + "X", highSurrogate + "x"], "16-bit ignoreCase lone high surrogate backref");
+
+    let lowSurrogate = "\uDC00";
+    let input2 = lowSurrogate + "a" + lowSurrogate + "A";
+    shouldBeArray(/(..)\1/i.exec(input2), [lowSurrogate + "a" + lowSurrogate + "A", lowSurrogate + "a"], "16-bit ignoreCase lone low surrogate backref");
+}
+
+// 16-bit ignoreCase backreference — Unicode mode
+// These exercise the same loop but with m_decodeSurrogatePairs=true,
+// ensuring errorCodePoint checks are still emitted when needed.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/(abc)\1/iu.exec("abc\u0100abcABC"), ["abcABC", "abc"], "unicode 16-bit ignoreCase backref");
+    shouldBe(/(abc)\1/iu.exec("abc\u0100abcDEF"), null, "unicode 16-bit ignoreCase backref mismatch");
+
+    shouldBeArray(/(\u{1F600})\1/u.exec("\u{1F600}\u{1F600}"), ["\u{1F600}\u{1F600}", "\u{1F600}"], "unicode non-BMP backref");
+    shouldBe(/(\u{1F600})\1/u.exec("\u{1F600}\u{1F601}"), null, "unicode non-BMP backref mismatch");
+
+    shouldBeArray(/(abc)\1/iu.exec("\u{10000}abcABC"), ["abcABC", "abc"], "unicode 16-bit ignoreCase after non-BMP");
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2044,9 +2044,14 @@ class YarrGenerator final : public YarrJITInfo {
             RELEASE_ASSERT(m_regs.regUnicodeInputAndTrail == areCanonicallyEquivalentCanonicalModeArgReg);
             ASSERT(m_decode16BitForBackreferencesWithCalls);
 
-            // Fail matching for dangling surrogates.
-            characterMatchFails.append(m_jit.branch32(MacroAssembler::Equal, character, MacroAssembler::TrustedImm32(errorCodePoint)));
-            characterMatchFails.append(m_jit.branch32(MacroAssembler::Equal, patternCharacter, MacroAssembler::TrustedImm32(errorCodePoint)));
+            // When !m_decodeSurrogatePairs, readCharacter() emits load8/load16
+            // (zero-extended), so the result is always in [0, 0xFFFF] and can
+            // never equal errorCodePoint (-1). Only tryReadUnicodeChar() —
+            // reached when m_decodeSurrogatePairs — can produce errorCodePoint.
+            if (m_decodeSurrogatePairs) {
+                characterMatchFails.append(m_jit.branch32(MacroAssembler::Equal, character, MacroAssembler::TrustedImm32(errorCodePoint)));
+                characterMatchFails.append(m_jit.branch32(MacroAssembler::Equal, patternCharacter, MacroAssembler::TrustedImm32(errorCodePoint)));
+            }
 
             MacroAssembler::JumpList charactersMatch;
             charactersMatch.append(m_jit.branch32(MacroAssembler::Equal, character, patternCharacter));


### PR DESCRIPTION
#### d25fc500fa9490878ef1d494f8c15be43054d7cd
<pre>
[YARR] Skip dead errorCodePoint checks in 16-bit ignoreCase backreference loop for non-Unicode patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=308299">https://bugs.webkit.org/show_bug.cgi?id=308299</a>

Reviewed by Yusuke Suzuki.

In the 16-bit ignoreCase backreference matching loop, YarrJIT
unconditionally emitted two errorCodePoint checks (cmn + b.eq) before
comparing the input character and the pattern character. However,
errorCodePoint (-1) can only be produced by tryReadUnicodeChar() when
decoding surrogate pairs. In non-Unicode mode, readCharacter() emits
load16Unaligned which zero-extends the result, so the value is always
in [0, 0xFFFF] and can never equal errorCodePoint.

Guard the errorCodePoint checks with m_decodeSurrogatePairs so they are
only emitted in Unicode mode. On AArch64 this reduces the inner loop
from 13 to 11 instructions and from 6 to 4 branches per iteration.

This is the ignoreCase counterpart of r307900, which applied the same
optimization to the case-sensitive backreference loop.

Test: JSTests/stress/regexp-backreference-16bit-ignorecase-errorCodePoint.js

* JSTests/stress/regexp-backreference-16bit-ignorecase-errorCodePoint.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/308607@main">https://commits.webkit.org/308607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd61f92dac1e4ce727d65e34c71a0e979cc42be1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99479 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112238 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80364 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13928 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11675 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2047 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137906 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156913 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6727 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120248 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120589 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31352 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74172 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7373 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177232 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81846 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45497 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->