### PR TITLE
Enhanced <select>: <button> changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
@@ -7,7 +7,7 @@ PASS defaultbutton: When the listbox is open, the enter key should commit the se
 FAIL defaultbutton: When the listbox is open, the tab key should close the listbox. assert_false: Tab should close the listbox. expected false got true
 PASS custombutton: When the listbox is closed, spacebar should open the listbox.
 FAIL custombutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
-FAIL custombutton: When the listbox is closed, the enter key should not trigger form submission. assert_false: Enter should not submit the form when the listbox is closed. expected false got true
+PASS custombutton: When the listbox is closed, the enter key should not trigger form submission.
 PASS custombutton: When the listbox is open, the enter key should commit the selected option.
 FAIL custombutton: When the listbox is open, the tab key should close the listbox. assert_false: Tab should close the listbox. expected false got true
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-behaviors-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-behaviors-expected.txt
@@ -1,4 +1,5 @@
 button in select
+option
   button in form
 
 PASS Select button should not be the default form submit button.

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -62,6 +62,8 @@ private:
     int defaultTabIndex() const final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) final;
+    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void defaultEventHandler(Event&) final;
 


### PR DESCRIPTION
#### b9d6a1ccaa5a39868d35584d59a41beb9ceb602d
<pre>
Enhanced &lt;select&gt;: &lt;button&gt; changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308302">https://bugs.webkit.org/show_bug.cgi?id=308302</a>

Reviewed by Tim Nguyen.

Since you can use the &lt;button&gt; element inside a &lt;select&gt; element, it
can&apos;t use its default type of Submit. The specification lazily computes
this with an Auto state, but this is not possible for us because we
want to cache the &lt;form&gt;&apos;s default button.

Canonical link: <a href="https://commits.webkit.org/307941@main">https://commits.webkit.org/307941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/543dbd2ee58db72d9062b626ce5f9edb363be1df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99507 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/321ece91-fad5-4baa-91cb-14b888a0df4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a268bd94-7782-4534-90cd-0ef8855d2608) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93174 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ed61f6d-ddca-4209-a74a-dd909c791e50) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2088 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156954 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120281 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120619 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74204 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22511 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7406 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81880 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17848 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->