### PR TITLE
[threaded-animations] failed assertion `ASSERT(sourceScrollableArea->scrollingNodeID())` in `ScrollTimeline::computeProgressResolutionData()`

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8489,4 +8489,6 @@ webkit.org/b/308084 [ Release ] imported/w3c/web-platform-tests/css/filter-effec
 
 webkit.org/b/308243 [ Release ] http/tests/site-isolation/mixedContent/redirect-https-to-http-iframe-in-main-frame.html [ Pass Failure ]
 
+webkit.org/b/308304 webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline.html [ Pass Crash ]
+
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-across-elements.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2494,6 +2494,8 @@ webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/executionContext
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 
+webkit.org/b/308304 webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline.html [ Pass Crash ]
+
 webkit.org/b/308243 [ Release ] http/tests/site-isolation/mixedContent/redirect-https-to-http-iframe-in-main-frame.html [ Pass Failure ]
 
 webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.html [ Pass Failure ]

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+
+#container {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    width: 400px;
+    height: 400px;
+    overflow: scroll;
+}
+
+@keyframes grow {
+    from { scale: 0 1 }
+    to { scale: 1 1 }
+}
+
+#progress {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 2000px;
+    background-color: blue;
+
+    transform-origin: top left;
+
+    animation: grow auto;
+    animation-timeline: scroll();
+}
+        
+</style>
+</head>
+<body>
+
+<div id="container">
+    <div id="progress"></div>
+</div>
+
+<div>PASS if this does not crash.</div>
+
+<script src="threaded-animations-utils.js"></script>
+<script>
+
+(async function () {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    await animationAcceleration(document.getAnimations()[0]);
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -44,7 +44,7 @@ AnimationTimeline::AnimationTimeline(std::optional<WebAnimationTime> duration)
 {
     m_duration = duration;
 #if ENABLE(THREADED_ANIMATIONS)
-    m_canBeAccelerated = computeCanBeAccelerated();
+    m_couldBeAcceleratedDuringLastRenderingUpdate = canBeAccelerated();
 #endif
 }
 
@@ -148,8 +148,8 @@ Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation() co
 
 void AnimationTimeline::runPostRenderingUpdateTasks()
 {
-    bool previousCanBeAccelerated = std::exchange(m_canBeAccelerated, computeCanBeAccelerated());
-    if (m_canBeAccelerated == previousCanBeAccelerated)
+    bool previousCanBeAccelerated = std::exchange(m_couldBeAcceleratedDuringLastRenderingUpdate, canBeAccelerated());
+    if (m_couldBeAcceleratedDuringLastRenderingUpdate == previousCanBeAccelerated)
         return;
 
     for (const auto& animation : m_animations) {

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -80,8 +80,7 @@ public:
     static void updateGlobalPosition(WebAnimation&);
 
 #if ENABLE(THREADED_ANIMATIONS)
-    bool canBeAccelerated() const { return m_canBeAccelerated; }
-    virtual bool computeCanBeAccelerated() const { return false; }
+    virtual bool canBeAccelerated() const { return false; }
     Ref<AcceleratedTimeline> acceleratedRepresentation();
     void runPostRenderingUpdateTasks();
     const TimelineIdentifier& acceleratedTimelineIdentifier() const { return m_acceleratedTimelineIdentifier; }
@@ -103,7 +102,7 @@ protected:
 
 private:
 #if ENABLE(THREADED_ANIMATIONS)
-    bool m_canBeAccelerated { false };
+    bool m_couldBeAcceleratedDuringLastRenderingUpdate { false };
 #endif
     std::optional<WebAnimationTime> m_currentTime;
     std::optional<WebAnimationTime> m_duration;

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -98,7 +98,7 @@ private:
 
     AnimationTimelinesController* controller() const override;
 #if ENABLE(THREADED_ANIMATIONS)
-    bool computeCanBeAccelerated() const final { return true; }
+    bool canBeAccelerated() const final { return true; }
     Ref<AcceleratedTimeline> createAcceleratedRepresentation() const final;
 #endif
 

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -413,7 +413,7 @@ bool ScrollTimeline::matchesAnonymousScrollFunctionForSource(const Style::Scroll
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
-bool ScrollTimeline::computeCanBeAccelerated() const
+bool ScrollTimeline::canBeAccelerated() const
 {
     RefPtr source = this->source();
     if (!source)

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -90,6 +90,7 @@ public:
 #if ENABLE(THREADED_ANIMATIONS)
     WEBCORE_EXPORT std::optional<ScrollingNodeID> scrollingNodeIDForTesting() const;
     void updateAcceleratedRepresentation();
+    bool canBeAccelerated() const final;
 #endif
 
 protected:
@@ -117,7 +118,6 @@ private:
 
     bool isScrollTimeline() const final { return true; }
 #if ENABLE(THREADED_ANIMATIONS)
-    bool computeCanBeAccelerated() const final;
     Ref<AcceleratedTimeline> createAcceleratedRepresentation() const final;
 #endif
 


### PR DESCRIPTION
#### 05c8899231202b50589166d9b02a851f3e6a7178
<pre>
[threaded-animations] failed assertion `ASSERT(sourceScrollableArea-&gt;scrollingNodeID())` in `ScrollTimeline::computeProgressResolutionData()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308303">https://bugs.webkit.org/show_bug.cgi?id=308303</a>
<a href="https://rdar.apple.com/168255217">rdar://168255217</a>

Reviewed by Anne van Kesteren.

We use `ScrollTimeline::canBeAccelerated()` to determine that a timeline can be accelerated in `AcceleratedEffectStackUpdater::takeTimelinesUpdate()`
and guard calls to `ScrollTimeline::updateAcceleratedRepresentation()` and, under it,  `ScrollTimeline::computeProgressResolutionData()`,
letting those methods assume that they have a source with a scrolling node ID.

However, `ScrollTimeline::canBeAccelerated()` is not live and returns the cached result of `ScrollTimeline::computeCanBeAccelerated()` computed when
`AnimationTimeline::runPostRenderingUpdateTasks()` is called (so that we can determine when that status changes one per animation frame).

What `computeCanBeAccelerated()` returns can change between those two call chains because the former happen as the layer tree is being committed
and the latter during the page rendering update.

We change `canBeAccelerated()` to be live and rename the flag where we cache the value to clarify its purpose.

Finally, we had to make the `canBeAccelerated()` override to be public rather than private because it&apos;s called specifically on downcast
`ScrollTimeline` instance in `AcceleratedEffectStackUpdater::takeTimelinesUpdate()`.

Note that this test hits another failed assertion when run across several iterations, we mark it as a flaky crash. This will be dealt with
in a separate patch for bug 308304.

Test: webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline.html

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-driven-animation-failed-assertion-in-scroll-timeline.html: Added.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::AnimationTimeline):
(WebCore::AnimationTimeline::runPostRenderingUpdateTasks):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::canBeAccelerated const):
(WebCore::AnimationTimeline::computeCanBeAccelerated const): Deleted.
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::canBeAccelerated const):
(WebCore::ScrollTimeline::computeCanBeAccelerated const): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:

Canonical link: <a href="https://commits.webkit.org/307965@main">https://commits.webkit.org/307965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8801fdf75b719dd72b123cb397933cde32923221

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18770 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/11023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154762 "Failed to checkout and rebase branch from PR 59093") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18664 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/154762 "Failed to checkout and rebase branch from PR 59093") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149055 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/14754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/154762 "Failed to checkout and rebase branch from PR 59093") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2208 "Failed to checkout and rebase branch from PR 59093") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/8243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157080 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/9504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/18592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/120726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/129680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22521 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/18210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/17946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->