### PR TITLE
Popover light dismiss doesn't account for disabled command buttons

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button-expected.txt
@@ -1,0 +1,6 @@
+command/commandfor popovertarget
+
+PASS Clicking on disabled command button should just close popover like normal
+PASS Clicking on disabled popovertarget button should just close popover like normal
+PASS Clicking on disabled popovertarget input button should just close popover like normal
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Popover light dismiss behavior with disabled buttons</title>
+<meta name="timeout" content="long">
+<link rel="author" href="mailto:lwarlow@igalia.com">
+<link rel=help href="https://html.spec.whatwg.org/multipage/popover.html">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/popover-utils.js"></script>
+<style>
+  [popover] {
+    /* Position most popovers at the bottom-right, out of the way */
+    inset:auto;
+    bottom:0;
+    right:0;
+  }
+  [popover]::backdrop {
+    /* This should *not* affect anything: */
+    pointer-events: auto;
+  }
+</style>
+<button id="commandButton" command="toggle-popover" commandfor="popover" disabled>command/commandfor</button>
+<button id="popovertargetButton" popovertarget="popover" disabled>popovertarget</button>
+<input type="button" id="popovertargetInputButton" popovertarget="popover" disabled value="input popovertarget">
+<div id="popover" popover>Popover</div>
+
+<script>
+  let popoverHideCount = 0;
+  popover.addEventListener('beforetoggle',(e) => {
+    if (e.newState !== "closed")
+      return;
+    ++popoverHideCount;
+    e.preventDefault(); // 'beforetoggle' should not be cancellable.
+  });
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+        popover.hidePopover();
+    });
+    popover.showPopover();
+    assert_true(popover.matches(':popover-open'));
+    await waitForRender();
+    pHideCount = popoverHideCount;
+    await clickOn(commandButton);
+    assert_false(popover.matches(':popover-open'),'popover should be closed');
+    assert_equals(popoverHideCount,pHideCount+1,'popover should get hidden once');
+  }, 'Clicking on disabled command button should just close popover like normal');
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+        popover.hidePopover();
+    });
+    popover.showPopover();
+    assert_true(popover.matches(':popover-open'));
+    await waitForRender();
+    pHideCount = popoverHideCount;
+    await clickOn(popovertargetButton);
+    assert_false(popover.matches(':popover-open'),'popover should be closed');
+    assert_equals(popoverHideCount,pHideCount+1,'popover should get hidden once');
+  }, 'Clicking on disabled popovertarget button should just close popover like normal');
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+        popover.hidePopover();
+    });
+    popover.showPopover();
+    assert_true(popover.matches(':popover-open'));
+    await waitForRender();
+    pHideCount = popoverHideCount;
+    await clickOn(popovertargetInputButton);
+    assert_false(popover.matches(':popover-open'),'popover should be closed');
+    assert_equals(popoverHideCount,pHideCount+1,'popover should get hidden once');
+  }, 'Clicking on disabled popovertarget input button should just close popover like normal');
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4823,6 +4823,7 @@ imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scro
 webkit.org/b/310625 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Failure ]
 webkit.org/b/310625 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-input-button.html [ Failure ]
 webkit.org/b/310625 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-input-text.html [ Failure ]
+webkit.org/b/310625 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button.html [ Failure ]
 
 # Failing word-break: auto-phrase tests.
 webkit.org/b/257698 imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase/word-break-auto-phrase-004.html [ ImageOnlyFailure ]

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -138,13 +138,10 @@ void HTMLButtonElement::attributeChanged(const QualifiedName& name, const AtomSt
 
 RefPtr<Element> HTMLButtonElement::commandForElement() const
 {
-    auto canInvoke = [](const HTMLFormControlElement& element) -> bool {
-        if (!element.document().settings().commandAttributesEnabled())
-            return false;
-        return is<HTMLButtonElement>(element);
-    };
+    if (!document().settings().commandAttributesEnabled())
+        return nullptr;
 
-    if (!canInvoke(*this))
+    if (isDisabledFormControl())
         return nullptr;
 
     return elementForAttributeInternal(commandforAttr);


### PR DESCRIPTION
#### 4ac8cc7833adeadf1bc4dcc117b1e9c88243e8bb
<pre>
Popover light dismiss doesn&apos;t account for disabled command buttons
<a href="https://bugs.webkit.org/show_bug.cgi?id=308308">https://bugs.webkit.org/show_bug.cgi?id=308308</a>

Reviewed by Tim Nguyen.

Updates HTMLButtonElement::commandForElement to return null when the button is disabled.
Importantly this doesn&apos;t impact the commandForElement property as that uses the [Reflect]
IDL extended attribute, NOT the commandForElement function.

Popover light dismiss spec: <a href="https://html.spec.whatwg.org/multipage/popover.html#light-dismiss-open-popovers">https://html.spec.whatwg.org/multipage/popover.html#light-dismiss-open-popovers</a>

Spec PR to account for command buttons: <a href="https://github.com/whatwg/html/pull/12184">https://github.com/whatwg/html/pull/12184</a>

Test: imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-disabled-button.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::commandForElement const):

Canonical link: <a href="https://commits.webkit.org/314400@main">https://commits.webkit.org/314400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9de72ac21acf737ef4439519306a72124bde080

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177505 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137305 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36991 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148580 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102759 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25447 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38084 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3529 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->