### PR TITLE
[Tools] Skip export-w3c-test-changes for already-exported WPT bugs

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -231,6 +231,25 @@ class WebPlatformTestExporter(object):
         self._run_wpt_git(['checkout', self._wpt_repo.default_branch])
         self._run_wpt_git(['reset', '--hard', 'origin/master'])
 
+    def wpt_already_has_bug_export(self):
+        if not self._bug_id:
+            return False
+
+        grep_patterns = [str(self._bug_id), f'bugs.webkit.org/show_bug.cgi?id={self._bug_id}']
+        for pattern in grep_patterns:
+            result = self._run_wpt_git(['log', '--oneline', '-n', '1', f'--grep={pattern}'], capture_output=True)
+            if result.stdout and result.stdout.strip():
+                summary = result.stdout.decode("utf-8", "replace").strip()
+
+                if getattr(self._options, "force_export", False):
+                    _log.warning(f'Bug {self._bug_id} appears already exported to WPT: {summary} (continuing due to --force-export)')
+                    return False
+
+                _log.warning(f'Bug {self._bug_id} appears already exported to WPT: {summary} (skipping; use --force-export to export anyway)')
+                return True
+
+        return False
+
     def create_branch_with_patch(self, patch):
         _log.info('Applying patch to web-platform-tests branch ' + self._branch_name)
         try:
@@ -353,6 +372,10 @@ class WebPlatformTestExporter(object):
         self._run_wpt_git(['fetch', 'origin', '--prune'])
         self.clean()
 
+        if self.wpt_already_has_bug_export():
+            _log.info(f'Bug {self._bug_id} appears already exported to WPT. Use --force-export to export anyway.')
+            return 0
+
         if not self.set_up_wpt_fork():
             self.delete_local_branch(is_success=False)
             return 1
@@ -362,7 +385,7 @@ class WebPlatformTestExporter(object):
             self.delete_local_branch(is_success=False)
             return 1
 
-        if git_patch_file and self.clean:
+        if git_patch_file and self._options.clean:
             self._filesystem.remove(git_patch_file)
 
         if self._options.use_linter:
@@ -428,6 +451,8 @@ def parse_args(args):
     parser.add_argument('--no-clean', action='store_false', dest='clean', help='Do not clean up.')
     parser.add_argument('--clean-on-failure', action='store_true', dest='clean_on_failure', help='Do not clean up on failure.')
     parser.add_argument('--dry-run', action='store_true', dest='dry_run', default=False, help='Create local branch and commit but do not push to remote.')
+    parser.add_argument('--force-export', action='store_true', dest='force_export', default=False,
+                        help='Export even if an existing WPT export for this bug is detected.')
 
     options, args = parser.parse_known_args(args)
 


### PR DESCRIPTION
#### 2e4a7f6a6661ada33e584a332810215384add73d
<pre>
[Tools] Skip export-w3c-test-changes for already-exported WPT bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=307398">https://bugs.webkit.org/show_bug.cgi?id=307398</a>

When re-running export-w3c-test-changes for the same bug, the exporter can create a WPT branch
but end up with no changes to apply, leading to confusing failures / no-op exports.

Add a helper to detect whether the bug id (or bug URL) already appears in WPT history and exit
early with an informational message.

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.wpt_already_has_bug_export): New helper to search WPT git history for bug id/URL.
(WebPlatformTestExporter.push_to_wpt_fork): Early-return when the export already exists.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c52537034fef32920c163c9279c9f452af19f654

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112280 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80378 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14660 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93181 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/145297 "Passed tests") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11703 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2095 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156961 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120362 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120625 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129465 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74206 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16333 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18113 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->