### PR TITLE
[JSC] Implement Quick DFG Tier-Up for proven-stable functions

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -759,6 +759,10 @@ public:
     bool shouldReoptimizeNow();
     bool shouldReoptimizeFromLoopNow();
 
+    void didInstallDFGCode();
+    void didDFGJettison(Profiler::JettisonReason);
+    void didFailDFGCompilation();
+
 #else // No JIT
     void optimizeAfterWarmUp() { }
     unsigned numberOfDFGCompiles() { return 0; }

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -175,6 +175,11 @@ public:
     bool hasCheckpoints() const { return m_hasCheckpoints; }
     void setHasCheckpoints() { m_hasCheckpoints = true; }
 
+    bool hasQuickDFGTierUpUpdated() const { return m_quickDFGTierUp != TriState::Indeterminate; }
+    bool isQuickDFGTierUp() const { return m_quickDFGTierUp == TriState::True; }
+    void setQuickDFGTierUp(TriState state) { m_quickDFGTierUp = state; }
+    TriState quickDFGTierUp() const { return m_quickDFGTierUp; }
+
     // Special registers
     void setThisRegister(VirtualRegister thisRegister) { m_thisRegister = thisRegister; }
     void setScopeRegister(VirtualRegister scopeRegister) { m_scopeRegister = scopeRegister; }
@@ -429,6 +434,7 @@ private:
     static_assert(((1U << 3) - 1) >= maxAge);
     bool m_hasCheckpoints : 1;
     LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures { 0 };
+    TriState m_quickDFGTierUp : 2 { TriState::Indeterminate };
 public:
     ConcurrentJSLock m_lock;
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -3114,7 +3114,7 @@ JSC_DEFINE_JIT_OPERATION(operationOptimize, UGPRPair, (VM* vmPointer, uint32_t b
             OPERATION_RETURN(scope, encodeResult(nullptr, nullptr));
         }
 
-        dataLogLnIf(Options::verboseOSR(), "Triggering optimized compilation of ", *codeBlock);
+        dataLogLnIf(Options::verboseOSR(), "Triggering optimized compilation of ", *codeBlock, " quickDFGTierUpState=", codeBlock->unlinkedCodeBlock()->quickDFGTierUp(), " counter=", codeBlock->baselineExecuteCounter(), ", optimizationDelayCounter=", codeBlock->optimizationDelayCounter(), " bytecodeCost=", codeBlock->bytecodeCost(), " codeType=", codeBlock->codeType());
 
         unsigned numVarsWithValues = 0;
         if (bytecodeIndex)

--- a/Source/JavaScriptCore/jit/JITToDFGDeferredCompilationCallback.cpp
+++ b/Source/JavaScriptCore/jit/JITToDFGDeferredCompilationCallback.cpp
@@ -58,10 +58,12 @@ void JITToDFGDeferredCompilationCallback::compilationDidComplete(
     ASSERT(codeBlock->alternative()->jitType() == JITType::BaselineJIT);
     
     dataLogLnIf(Options::verboseOSR(), "Optimizing compilation of ", *codeBlock, " result: ", result);
-    
-    if (result == CompilationResult::CompilationSuccessful)
+
+    if (result == CompilationResult::CompilationSuccessful) {
         codeBlock->ownerExecutable()->installCode(codeBlock);
-    
+        codeBlock->didInstallDFGCode();
+    }
+
     codeBlock->alternative()->setOptimizationThresholdBasedOnCompilationResult(result);
 
     DeferredCompilationCallback::compilationDidComplete(codeBlock, profiledDFGCodeBlock, result);

--- a/Source/JavaScriptCore/profiler/ProfilerJettisonReason.h
+++ b/Source/JavaScriptCore/profiler/ProfilerJettisonReason.h
@@ -41,6 +41,26 @@ enum JettisonReason {
     JettisonDueToVMTraps
 };
 
+inline bool isSpeculationFailure(JettisonReason reason)
+{
+    switch (reason) {
+    case JettisonDueToOSRExit:
+    case JettisonDueToUnprofiledWatchpoint:
+    case JettisonDueToProfiledWatchpoint:
+    case JettisonDueToBaselineLoopReoptimizationTrigger:
+    case JettisonDueToBaselineLoopReoptimizationTriggerOnOSREntryFail:
+        return true;
+    case JettisonDueToWeakReference:
+    case JettisonDueToDebuggerBreakpoint:
+    case JettisonDueToDebuggerStepping:
+    case JettisonDueToOldAge:
+    case JettisonDueToVMTraps:
+    case NotJettisoned:
+        return false;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } } // namespace JSC::Profiler
 
 namespace WTF {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -380,6 +380,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, desiredProfileLivenessRate, 0.75, Normal, nullptr) \
     v(Double, desiredProfileFullnessRate, 0.35, Normal, nullptr) \
     \
+    v(Double, quickDFGTierUpThresholdFactor, 0.2, Normal, "Threshold factor for quick DFG tier-up"_s) \
+    \
     v(Double, doubleVoteRatioForDoubleFormat, 2, Normal, nullptr) \
     v(Double, structureCheckVoteRatioForHoisting, 1, Normal, nullptr) \
     v(Double, checkArrayVoteRatioForHoisting, 1, Normal, nullptr) \


### PR DESCRIPTION
#### 1837781c8a2a49b3ad065d4ac46a638aacdda804
<pre>
[JSC] Implement Quick DFG Tier-Up for proven-stable functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308315">https://bugs.webkit.org/show_bug.cgi?id=308315</a>
<a href="https://rdar.apple.com/170810503">rdar://170810503</a>

Reviewed by Yusuke Suzuki, Dan Hecht, and Keith Miller.

This patch introduces a Quick DFG Tier-Up mechanism that tracks DFG compilation
stability across invocations using UnlinkedCodeBlock state. Functions with proven
DFG stability from previous iterations use an aggressive threshold,
while unstable or unproven functions use the standard threshold.

State tracking uses WTF::TriState with three states:
- Indeterminate: Initial state, no DFG history yet
- True: Proven stable (first DFG compilation succeeded)
- False: Proven unstable (compilation or speculation failed)

Valid state transitions (once False, always False):
- Indeterminate -&gt; True: First DFG compilation succeeds
- Indeterminate -&gt; False: First DFG compilation fails
- True -&gt; False: DFG jettison due to speculation failure or recompilation fails
- False -&gt; False: Remains unstable (no recovery possible)

We focus on pure stable functions - once a function proves unstable at any
point, we treat it conservatively in future runs to avoid wasted
compilation attempts.

The patch distinguishes between speculation failures (OSR exits, watchpoint
invalidations, failed OSR entry) and external events (GC, debugger, old age).
Only speculation failures mark functions as Unstable, ensuring that transient
external events don&apos;t unnecessarily penalize otherwise-stable code.

To disable the optimization, set --quickDFGTierUpThresholdFactor=1.0

Canonical link: <a href="https://commits.webkit.org/307998@main">https://commits.webkit.org/307998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e233665e5233ce82c0590f477584ee8ab71d9b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99567 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/498bfdfe-d062-41bb-aaf0-ebafb2820e8c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112393 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80419 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8eb8fde-074d-4660-a0aa-9db18e16db97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93264 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c45cdf98-9e41-4e74-ab74-7bf1c087f803) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14011 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11766 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 2 api tests failed or timed out; 3 api tests failed or timed out; Compiled WebKit (warnings); 1 api test failed or timed out; Passed API tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2194 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138049 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157066 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6873 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120405 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30947 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74278 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7512 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177366 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81951 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45524 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->