### PR TITLE
Support user agent shadow root pseudo-elements after ::slotted

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -657,7 +657,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-many-options.tentative.html [ Skip ]
@@ -5737,10 +5736,6 @@ webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/spelling-erro
 webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/host-context-specificity-001.html [ ImageOnlyFailure ]
 webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/host-context-specificity-002.html [ ImageOnlyFailure ]
 webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/host-context-specificity-003.html [ ImageOnlyFailure ]
-webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/slotted-placeholder.html [ ImageOnlyFailure ]
-
-webkit.org/b/287169 imported/w3c/web-platform-tests/css/css-scoping/slotted-details-content.html [ ImageOnlyFailure ]
-webkit.org/b/287169 imported/w3c/web-platform-tests/css/css-scoping/slotted-file-selector-button.html [ ImageOnlyFailure ]
 
 webkit.org/b/214464 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-ink-skip-dilation.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/the-picker-icon-pseudo-element.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/the-picker-icon-pseudo-element.tentative-expected.txt
@@ -13,6 +13,6 @@ PASS "::picker-icon::after" should be an invalid selector
 PASS "::picker-icon::marker" should be an invalid selector
 PASS "::picker-icon::placeholder" should be an invalid selector
 PASS "::slotted(*)::picker-icon::slotted(*)" should be an invalid selector
-FAIL "::slotted(*)::picker-icon" should be a valid selector '::slotted(*)::picker-icon' is not a valid selector.
+PASS "::slotted(*)::picker-icon" should be a valid selector
 PASS "::part(foo)::picker-icon" should be a valid selector
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing-expected.txt
@@ -24,11 +24,14 @@ PASS "::slotted(*):where(#id)" should be a valid selector
 PASS "::slotted(*):where(::before)" should be a valid selector
 PASS "::slotted(*)::before" should be a valid selector
 PASS "::slotted(*)::after" should be a valid selector
-FAIL "::slotted(*)::details-content" should be a valid selector '::slotted(*)::details-content' is not a valid selector.
-FAIL "::slotted(*)::file-selector-button" should be a valid selector '::slotted(*)::file-selector-button' is not a valid selector.
-FAIL "::slotted(*)::placeholder" should be a valid selector '::slotted(*)::placeholder' is not a valid selector.
+PASS "::slotted(*)::details-content" should be a valid selector
+PASS "::slotted(*)::file-selector-button" should be a valid selector
+PASS "::slotted(*)::placeholder" should be a valid selector
 PASS "::slotted(*)::marker" should be a valid selector
+PASS "::slotted(select)::picker(select)" should be a valid selector
+PASS "::slotted(*)::picker-icon" should be a valid selector
 PASS "::slotted(*)::first-line" should be an invalid selector
 PASS "::slotted(*)::first-letter" should be an invalid selector
 PASS "::slotted(*)::selection" should be an invalid selector
+PASS "::slotted(select)::picker" should be an invalid selector
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html
@@ -43,9 +43,12 @@
   test_valid_selector("::slotted(*)::file-selector-button");
   test_valid_selector("::slotted(*)::placeholder");
   test_valid_selector("::slotted(*)::marker");
+  test_valid_selector("::slotted(select)::picker(select)");
+  test_valid_selector("::slotted(*)::picker-icon");
 
   // Other pseudo elements not valid after ::slotted
   test_invalid_selector("::slotted(*)::first-line");
   test_invalid_selector("::slotted(*)::first-letter");
   test_invalid_selector("::slotted(*)::selection");
+  test_invalid_selector("::slotted(select)::picker");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+select::picker(select) {
+  border: thick solid blue;
+  background: lime;
+  color: maroon;
+}
+</style>
+
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector('select').showPicker();
+  document.documentElement.classList.remove('reftest-wait');
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+select::picker(select) {
+  border: thick solid blue;
+  background: lime;
+  color: maroon;
+}
+</style>
+
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector('select').showPicker();
+  document.documentElement.classList.remove('reftest-wait');
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted-invalidation.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Style invalidation for ::slotted(select)::picker(select)</title>
+<link rel=match href="picker-and-slotted-invalidation-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<div id="host">
+  <select>
+    <option>one</option>
+    <option>two</option>
+  </select>
+</div>
+
+<script>
+const select = document.querySelector("select");
+const root = host.attachShadow({mode: "open"});
+root.innerHTML = `
+  <style>
+    ::slotted(select), ::slotted(select)::picker(select) {
+      appearance: base-select;
+    }
+    .active ::slotted(select)::picker(select) {
+      border: thick solid blue;
+      background: lime;
+      color: maroon;
+    }
+  </style>
+  <div id="wrapper"><slot></slot></div>
+`;
+
+(async () => {
+  await test_driver.bless();
+  select.showPicker();
+  root.querySelector("#wrapper").className = "active";
+  document.documentElement.classList.remove('reftest-wait');
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<style>
+select {
+  appearance: base-select;
+}
+select::picker-icon {
+  color: red;
+}
+</style>
+
+<select>
+  <option>option</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<style>
+select {
+  appearance: base-select;
+}
+select::picker-icon {
+  color: red;
+}
+</style>
+
+<select>
+  <option>option</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-icon-and-slotted.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta name=fuzzy content="maxDifference=0-41;totalPixels=0-6">
+<link rel=match href="picker-icon-and-slotted-ref.html">
+
+<div id="host">
+  <select>
+    <option>option</option>
+  </select>
+</div>
+
+<script>
+let host = document.getElementById("host");
+let shadow = host.attachShadow({mode: "open"});
+shadow.innerHTML = `
+  <style>
+    ::slotted(select) {
+      appearance: base-select;
+    }
+    ::slotted(select)::picker-icon {
+      color: red;
+    }
+  </style>
+  <slot></slot>
+`;
+</script>

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -87,6 +87,7 @@ private:
     void matchUserAgentPartRules(DeclarationOrigin);
     void matchHostPseudoClassRules(DeclarationOrigin);
     void matchSlottedPseudoElementRules(DeclarationOrigin);
+    void matchSlottedPseudoElementRulesInUserAgentShadowTree(DeclarationOrigin);
     void matchPartPseudoElementRules(DeclarationOrigin);
     void matchPartPseudoElementRulesForScope(const Element& partMatchingElement, DeclarationOrigin);
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -347,6 +347,13 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             return;
         }
 
+        if (previousSelector && previousSelector->match() == CSSSelector::Match::PseudoElement && previousSelector->pseudoElement() == CSSSelector::PseudoElement::Slotted) {
+            // Handle selectors like ::slotted(select)::picker(select) with the slotted codepath.
+            ruleData.disableSelectorFiltering();
+            m_slottedPseudoElementRules.append(ruleData);
+            return;
+        }
+
         if (pickerPseudoElementSelector) [[unlikely]] {
             // Look up useragentpart="picker(...)".
             addToRuleSet(AtomString(makeString("picker("_s, pickerPseudoElementSelector->stringList()->at(0), ')')), m_userAgentPartRules, ruleData);


### PR DESCRIPTION
#### 64c77be99cd4c1ffd3c645e2208efc44a02229fb
<pre>
Support user agent shadow root pseudo-elements after ::slotted
<a href="https://bugs.webkit.org/show_bug.cgi?id=308321">https://bugs.webkit.org/show_bug.cgi?id=308321</a>

Reviewed by Antti Koivisto.

In CSSSelectorParser we generalize isTreeAbidingPseudoElement()
slightly so it can support both ordinary pseudo-elements and user agent
part pseudo-elements.

And in splitCompoundAtImplicitShadowCrossingCombinator() we add
isSlotted to the recursion condition so the compound is correctly
split.

In RuleSet we mirror the logic for ::part()::placeholder to route
selectors with ::slotted as preceding selector to
m_slottedPseudoElementRules.

In ElementRuleCollector we check if the shadow host is slotted, and if
so, collect ::slotted rules from the slot&apos;s scope.

SelectorChecker already handles the resulting selector chain correctly.

New tests are upstreamed here:

    <a href="https://github.com/web-platform-tests/wpt/pull/57958">https://github.com/web-platform-tests/wpt/pull/57958</a>

Canonical link: <a href="https://commits.webkit.org/308039@main">https://commits.webkit.org/308039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a0b487676fab33d8c21bd37c9d4dde2c315f20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99606 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7b19c4c-fa97-40ec-afb1-dbed5157a984) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112439 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80443 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db688851-c13b-4cee-acac-6792b9d32ee7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93310 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df7bb7a8-f6d6-4fad-90f4-335ab194b982) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14058 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11813 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2251 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157123 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/294 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120462 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120763 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129818 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74331 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22558 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7597 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82002 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18150 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18041 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->