### PR TITLE
[table] Properly handle rowspan=0 when display:none rows are present

### DIFF
--- a/LayoutTests/fast/table/rowspan-zero-insert-row-crash-expected.txt
+++ b/LayoutTests/fast/table/rowspan-zero-insert-row-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/fast/table/rowspan-zero-insert-row-crash.html
+++ b/LayoutTests/fast/table/rowspan-zero-insert-row-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script>
+  function main() {
+    document.body.offsetHeight;
+    x2.setAttribute("rowspan", "0");
+    document.body.offsetHeight;
+    table.insertRow();
+  }
+  window.testRunner?.dumpAsText();
+</script>
+<body onload="main()">
+<p>This test passes if it doesn't crash.</p>
+<table id=table>
+  <tr style="display: none"></tr>
+  <tr><td id=x2></td></tr>
+</table>
+</body>

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -36,7 +36,6 @@
 #include "HTMLNames.h"
 #include "HTMLTableCellElement.h"
 #include "HTMLTableRowElement.h"
-#include "HTMLTableSectionElement.h"
 #include "LayoutScope.h"
 #include "PaintInfo.h"
 #include "RenderBoxInlines.h"
@@ -152,25 +151,19 @@ unsigned RenderTableCell::parseRowSpanFromDOM() const
     return 1;
 }
 
-unsigned RenderTableCell::calculateRowSpanForRowspanZero() const
+unsigned RenderTableCell::calculateRowSpanForRowSpanZero() const
 {
     // Handle rowspan="0" which means "span all remaining rows in the row group"
     // Per HTML spec: https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
-    //
-    // We use the DOM to count total rows because during grid construction (recalcCells),
-    // the DOM structure is complete even though the grid is still being built.
-
     if (CheckedPtr renderSection = this->section()) {
-        if (RefPtr sectionElement = dynamicDowncast<HTMLTableSectionElement>(renderSection->element())) {
-            unsigned totalRows = sectionElement->numRows();
-            unsigned currentRow = this->rowIndex();
-
-            if (currentRow < totalRows)
-                return totalRows - currentRow;
-        }
+        unsigned totalRows = 0;
+        for (CheckedPtr<RenderTableRow> row = renderSection->firstRow(); row; row = row->nextRow())
+            ++totalRows;
+        unsigned currentRow = this->rowIndex();
+        if (currentRow < totalRows)
+            return totalRows - currentRow;
     }
-
-    // Fallback: couldn't get section or DOM count
+    // Fallback: couldn't get section
     return 1;
 }
 

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -47,6 +47,7 @@ public:
     
     unsigned colSpan() const;
     unsigned rowSpan() const;
+    bool hasRowSpanZero() const;
 
     // Called from HTMLTableCellElement.
     void colSpanOrRowSpanChanged();
@@ -203,7 +204,7 @@ private:
 
     unsigned parseRowSpanFromDOM() const;
     unsigned parseColSpanFromDOM() const;
-    unsigned calculateRowSpanForRowspanZero() const;
+    unsigned calculateRowSpanForRowSpanZero() const;
 
     void nextSibling() const = delete;
     void previousSibling() const = delete;
@@ -252,9 +253,14 @@ inline unsigned RenderTableCell::rowSpan() const
     // Handle rowspan="0" which means "span all remaining rows in the row group"
     // Per HTML spec: https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
     if (!span)
-        span = calculateRowSpanForRowspanZero();
+        span = calculateRowSpanForRowSpanZero();
 
     return std::min(span, maxRowIndex);
+}
+
+inline bool RenderTableCell::hasRowSpanZero() const
+{
+    return m_hasRowSpan && !parseRowSpanFromDOM();
 }
 
 inline void RenderTableCell::setCol(unsigned column)

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -138,7 +138,11 @@ void RenderTableRow::didInsertTableCell(RenderTableCell& child, RenderObject* be
     // Generated content can result in us having a null section so make sure to null check our parent.
     if (auto* section = this->section()) {
         section->addCell(&child, this);
-        if (beforeChild || nextRow())
+        // rowspan=0 means "span all remaining rows," but during initial construction rows are
+        // inserted one at a time, so calculateRowSpanForRowspanZero()'s render tree walk will
+        // undercount. Force a full cell recalc so the span is resolved correctly at layout time
+        // once all rows are present in the render tree.
+        if (beforeChild || nextRow() || child.hasRowSpanZero())
             section->setNeedsCellRecalc();
     }
     if (auto* table = this->table())


### PR DESCRIPTION
#### 934b6b65a06e071b0ca74a1ea432b627de893a79
<pre>
[table] Properly handle rowspan=0 when display:none rows are present
<a href="https://bugs.webkit.org/show_bug.cgi?id=308235">https://bugs.webkit.org/show_bug.cgi?id=308235</a>
&lt;<a href="https://rdar.apple.com/170463967">rdar://170463967</a>&gt;

Reviewed by Alan Baradlay.

This PR fixes an issue where calculateRowSpanForRowspanZero() was
counting total rows in the DOM tree which included rows with display:none.
However, these rows are not part of the render tree and caused rowSpan()
for rowspan=0 cells to return a span larger than that of m_grid.size(),
leading to an out of bounds error in layoutRows().

This PR fixes this bug by:

1. updating calculateRowSpanForRowspanZero() to count
the total number of rows by walking the render tree.

We should walk the render tree to count the total number of rows because:

        1) The DOM structure includes rows with display:none which are not created in the
        render tree. This causes overcounting and an eventual index out of bounds error.

        2) renderSection-&gt;numRows() returns m_grid.size(), but m_grid is cleared and rebuilt
        incrementally during recalcCells(), so it would undercount rows not yet processed.
        When called during initial construction (before all rows exist), calculateRowSpanForRowSpanZero()
        may return a temporarily incorrect value. However, inserting a table cell with the
        rowspan=0 property will setNeedsCellRecalc() and recalcCells() will recompute the span
        correctly at layout time once the full render tree is available.

2. updating didInsertTableCell() to call setNeedsCellRecalc() when
an item with rowspan=0 is inserted. This is necessary because render
tree walks in calculateRowSpanForRowspanZero() undercount future rows
that have not been inserted yet. setNeedsCellRecalc() triggers a
full rebuild by recalcCells() at layout time when the correct span
can be computed.

* LayoutTests/fast/table/rowspan-zero-insert-row-crash-expected.txt: Added.
* LayoutTests/fast/table/rowspan-zero-insert-row-crash.html: Added.
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::calculateRowSpanForRowSpanZero const):
(WebCore::RenderTableCell::calculateRowSpanForRowspanZero const):
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::rowSpan const):
(WebCore::RenderTableCell::hasRowSpanZero const):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::didInsertTableCell):

Canonical link: <a href="https://commits.webkit.org/308093@main">https://commits.webkit.org/308093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4611defcdc313a7f9d7dc3a39d11cbe2d35c3aba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99841 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26d1a390-3acd-47fa-ac53-d91216c7bc6d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112676 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80570 "Exiting early after 60 failures. 15428 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aee315c5-5591-4175-a6d5-df5aa225b73d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93539 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14293 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2518 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157395 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10843 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15847 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74706 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16671 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8088 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82270 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18248 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->