### PR TITLE
Remove non-standard `display: block-ruby`

### DIFF
--- a/LayoutTests/fast/ruby/ruby-display-types-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-display-types-expected.txt
@@ -1,0 +1,7 @@
+
+PASS display: block ruby
+PASS display: inline ruby
+PASS display: ruby
+PASS display: ruby-base
+PASS display: ruby-text
+

--- a/LayoutTests/fast/ruby/ruby-display-types.html
+++ b/LayoutTests/fast/ruby/ruby-display-types.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CSSRubyDisplayTypesInAuthorStylesEnabled=true ] -->
+<html>
+<head>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function test_ruby_display_type(specified, expected) {
+  test((t) => {
+    const target = document.createElement("div");
+    document.body.append(target);
+    t.add_cleanup(() => {
+      target.remove();
+    });
+    target.style['display'] = specified;
+    assert_equals(target.style['display'], expected);
+    assert_equals(window.getComputedStyle(target)['display'], expected);
+  }, `display: ${specified}`);
+}
+
+test_ruby_display_type('block ruby', 'block ruby');
+test_ruby_display_type('inline ruby', 'ruby');
+test_ruby_display_type('ruby', 'ruby');
+test_ruby_display_type('ruby-base', 'ruby-base');
+test_ruby_display_type('ruby-text', 'ruby-text');
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1375,6 +1375,20 @@ CSSRhythmicSizingEnabled:
     WebCore:
       default: false
 
+CSSRubyDisplayTypesInAuthorStylesEnabled:
+  type: bool
+  status: unstable
+  category: css
+  humanReadableName: "CSS Ruby Display Types in Author Styles"
+  humanReadableDescription: "Enable CSS Ruby Display types in author styles"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSScrollAnchoringEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -539,7 +539,6 @@ flow
 -webkit-inline-flex
 -webkit-flex
 // ruby
-block-ruby
 ruby-base
 ruby-text
 // none

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -48,6 +48,7 @@ static void NODELETE applyUASheetBehaviorsToContext(CSSParserContext& context)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     context.cssAppearanceBaseEnabled = true;
+    context.cssRubyDisplayTypesEnabled = true;
     context.cssTextTransformMathAutoEnabled = true;
     context.popoverAttributeEnabled = true;
     context.propertySettings.cssInputSecurityEnabled = true;
@@ -113,6 +114,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , targetTextPseudoElementEnabled { settings.targetTextPseudoElementEnabled() }
     , htmlEnhancedSelectEnabled { settings.htmlEnhancedSelectEnabled() }
     , cssRandomFunctionEnabled { settings.cssRandomFunctionEnabled() }
+    , cssRubyDisplayTypesEnabled { settings.cssRubyDisplayTypesInAuthorStylesEnabled() }
     , cssTreeCountingFunctionsEnabled { settings.cssTreeCountingFunctionsEnabled() }
     , cssURLModifiersEnabled { settings.cssURLModifiersEnabled() }
     , cssURLIntegrityModifierEnabled { settings.cssURLIntegrityModifierEnabled() }
@@ -152,6 +154,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.targetTextPseudoElementEnabled,
         context.htmlEnhancedSelectEnabled,
         context.cssRandomFunctionEnabled,
+        context.cssRubyDisplayTypesEnabled,
         context.cssTreeCountingFunctionsEnabled,
         context.cssURLModifiersEnabled,
         context.cssURLIntegrityModifierEnabled,

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -76,6 +76,7 @@ struct CSSParserContext {
     bool targetTextPseudoElementEnabled : 1 { false };
     bool htmlEnhancedSelectEnabled : 1 { false };
     bool cssRandomFunctionEnabled : 1 { false };
+    bool cssRubyDisplayTypesEnabled : 1 { false };
     bool cssTreeCountingFunctionsEnabled : 1 { false };
     bool cssURLModifiersEnabled : 1 { false };
     bool cssURLIntegrityModifierEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -38,9 +39,39 @@ struct PropertyParserState;
 
 namespace CSSPropertyParserHelpers {
 
+enum class DisplayOutside : uint8_t { NoOutside, Block, Inline };
+enum class DisplayInside  : uint8_t { NoInside, Flow, FlowRoot, Table, Flex, Grid, GridLanes, Ruby };
+
 // MARK: <'display'> consuming
 // https://drafts.csswg.org/css-display/#propdef-display
 RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::CSSPropertyParserHelpers::DisplayOutside> {
+    using values = EnumValues<
+        WebCore::CSSPropertyParserHelpers::DisplayOutside,
+        WebCore::CSSPropertyParserHelpers::DisplayOutside::NoOutside,
+        WebCore::CSSPropertyParserHelpers::DisplayOutside::Block,
+        WebCore::CSSPropertyParserHelpers::DisplayOutside::Inline
+    >;
+};
+
+template<> struct EnumTraits<WebCore::CSSPropertyParserHelpers::DisplayInside> {
+    using values = EnumValues<
+        WebCore::CSSPropertyParserHelpers::DisplayInside,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::NoInside,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::Flow,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::FlowRoot,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::Table,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::Flex,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::Grid,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::GridLanes,
+        WebCore::CSSPropertyParserHelpers::DisplayInside::Ruby
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -336,8 +336,11 @@ static bool shouldInlinifyForRuby(const RenderStyle& style, const RenderStyle& p
     return hasRubyParent && !style.hasOutOfFlowPosition() && style.floating() == Float::None;
 }
 
-static bool hasUnsupportedRubyDisplay(Display display, const Element* element)
+static bool hasUnsupportedRubyDisplay(Display display, const Element* element, const Document& document)
 {
+    if (document.settings().cssRubyDisplayTypesInAuthorStylesEnabled())
+        return false;
+
     // Only allow ruby elements to have ruby display types for now.
     switch (display.value) {
     case DisplayType::InlineRuby:
@@ -459,7 +462,7 @@ void Adjuster::adjust(RenderStyle& style) const
                 style.setDisplayMaintainingOriginalDisplay(style.display().blockified());
         }
 
-        if (hasUnsupportedRubyDisplay(style.display(), m_element.get()))
+        if (hasUnsupportedRubyDisplay(style.display(), m_element.get(), m_document))
             style.setDisplayMaintainingOriginalDisplay(style.display() == DisplayType::BlockRuby ? DisplayType::BlockFlow : DisplayType::InlineFlow);
 
         // Top layer elements are always position: absolute; unless the position is set to fixed.

--- a/Source/WebCore/style/values/display/StyleDisplay.cpp
+++ b/Source/WebCore/style/values/display/StyleDisplay.cpp
@@ -27,93 +27,190 @@
 #include "StyleDisplay.h"
 
 #include "AnimationUtilities.h"
+#include "CSSPropertyParserConsumer+Display.h"
 #include "StyleBuilderChecking.h"
+#include <wtf/EnumeratedArray.h>
 
 namespace WebCore {
 namespace Style {
+
+using DisplayOutsideInsideToDisplayTypeMap = EnumeratedArray<CSSPropertyParserHelpers::DisplayOutside, EnumeratedArray<CSSPropertyParserHelpers::DisplayInside, std::optional<DisplayType>>>;
+
+consteval DisplayOutsideInsideToDisplayTypeMap NODELETE makeDisplayOutsideInsideToDisplayTypeMap()
+{
+    using enum CSSPropertyParserHelpers::DisplayOutside;
+    using enum CSSPropertyParserHelpers::DisplayInside;
+
+    DisplayOutsideInsideToDisplayTypeMap result;
+
+    result[NoOutside][NoInside]  = std::nullopt;
+
+    result[Block][NoInside]      = DisplayType::BlockFlow;
+    result[Block][Flow]          = DisplayType::BlockFlow;
+    result[Block][FlowRoot]      = DisplayType::BlockFlowRoot;
+    result[Block][Table]         = DisplayType::BlockTable;
+    result[Block][Flex]          = DisplayType::BlockFlex;
+    result[Block][Grid]          = DisplayType::BlockGrid;
+    result[Block][GridLanes]     = DisplayType::BlockGridLanes;
+    result[Block][Ruby]          = DisplayType::BlockRuby;
+
+    result[Inline][NoInside]     = DisplayType::InlineFlow;
+    result[Inline][Flow]         = DisplayType::InlineFlow;
+    result[Inline][FlowRoot]     = DisplayType::InlineFlowRoot;
+    result[Inline][Table]        = DisplayType::InlineTable;
+    result[Inline][Flex]         = DisplayType::InlineFlex;
+    result[Inline][Grid]         = DisplayType::InlineGrid;
+    result[Inline][GridLanes]    = DisplayType::InlineGridLanes;
+    result[Inline][Ruby]         = DisplayType::InlineRuby;
+
+    result[NoOutside][Flow]      = result[Block][Flow];
+    result[NoOutside][FlowRoot]  = result[Block][FlowRoot];
+    result[NoOutside][Table]     = result[Block][Table];
+    result[NoOutside][Flex]      = result[Block][Flex];
+    result[NoOutside][Grid]      = result[Block][Grid];
+    result[NoOutside][GridLanes] = result[Block][GridLanes];
+    result[NoOutside][Ruby]      = result[Inline][Ruby];
+
+    return result;
+}
+
+constexpr auto displayOutsideInsideToDisplayTypeMap = makeDisplayOutsideInsideToDisplayTypeMap();
+
+template<CSSPropertyParserHelpers::DisplayOutside outside, CSSPropertyParserHelpers::DisplayInside inside>
+consteval DisplayType NODELETE mappedDisplayType()
+{
+    return *displayOutsideInsideToDisplayTypeMap[outside][inside];
+}
 
 // MARK: - Conversion
 
 auto CSSValueConversion<Display>::operator()(BuilderState& state, const CSSValue& value) -> Display
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return DisplayType::InlineFlow;
+    using enum CSSPropertyParserHelpers::DisplayOutside;
+    using enum CSSPropertyParserHelpers::DisplayInside;
 
-    switch (primitiveValue->valueID()) {
-    // [ <display-outside> || <display-inside> ] and <-webkit-display>
-    case CSSValueBlock:
-        return Style::DisplayType::BlockFlow;
-    case CSSValueFlowRoot:
-        return Style::DisplayType::BlockFlowRoot;
-    case CSSValueTable:
-        return Style::DisplayType::BlockTable;
-    case CSSValueFlex:
-        return Style::DisplayType::BlockFlex;
-    case CSSValueGrid:
-        return Style::DisplayType::BlockGrid;
-    case CSSValueGridLanes:
-        return Style::DisplayType::BlockGridLanes;
-    case CSSValueBlockRuby:
-        return Style::DisplayType::BlockRuby;
-    case CSSValueWebkitBox:
-        return Style::DisplayType::BlockDeprecatedFlex;
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        // [ <display-outside> || <display-inside> ]
+        case CSSValueBlock:
+            return DisplayType::BlockFlow;
+        case CSSValueFlowRoot:
+            return DisplayType::BlockFlowRoot;
+        case CSSValueTable:
+            return DisplayType::BlockTable;
+        case CSSValueFlex:
+            return DisplayType::BlockFlex;
+        case CSSValueGrid:
+            return DisplayType::BlockGrid;
+        case CSSValueGridLanes:
+            return DisplayType::BlockGridLanes;
 
-    case CSSValueInline:
-        return Style::DisplayType::InlineFlow;
-    case CSSValueInlineBlock:
-        return Style::DisplayType::InlineFlowRoot;
-    case CSSValueInlineTable:
-        return Style::DisplayType::InlineTable;
-    case CSSValueInlineFlex:
-        return Style::DisplayType::InlineFlex;
-    case CSSValueInlineGrid:
-        return Style::DisplayType::InlineGrid;
-    case CSSValueInlineGridLanes:
-        return Style::DisplayType::InlineGridLanes;
-    case CSSValueRuby:
-        return Style::DisplayType::InlineRuby;
-    case CSSValueWebkitInlineBox:
-        return Style::DisplayType::InlineDeprecatedFlex;
+        case CSSValueInline:
+            return DisplayType::InlineFlow;
+        case CSSValueInlineBlock:
+            return DisplayType::InlineFlowRoot;
+        case CSSValueInlineTable:
+            return DisplayType::InlineTable;
+        case CSSValueInlineFlex:
+            return DisplayType::InlineFlex;
+        case CSSValueInlineGrid:
+            return DisplayType::InlineGrid;
+        case CSSValueInlineGridLanes:
+            return DisplayType::InlineGridLanes;
+        case CSSValueRuby:
+            return DisplayType::InlineRuby;
 
-    // <display-listitem>
-    case CSSValueListItem:
-        return Style::DisplayType::BlockFlowListItem;
+        // <display-listitem>
+        case CSSValueListItem:
+            return DisplayType::BlockFlowListItem;
 
-    // <display-internal>
-    case CSSValueTableRowGroup:
-        return Style::DisplayType::TableRowGroup;
-    case CSSValueTableHeaderGroup:
-        return Style::DisplayType::TableHeaderGroup;
-    case CSSValueTableFooterGroup:
-        return Style::DisplayType::TableFooterGroup;
-    case CSSValueTableRow:
-        return Style::DisplayType::TableRow;
-    case CSSValueTableColumnGroup:
-        return Style::DisplayType::TableColumnGroup;
-    case CSSValueTableColumn:
-        return Style::DisplayType::TableColumn;
-    case CSSValueTableCell:
-        return Style::DisplayType::TableCell;
-    case CSSValueTableCaption:
-        return Style::DisplayType::TableCaption;
-    case CSSValueRubyBase:
-        return Style::DisplayType::RubyBase;
-    case CSSValueRubyText:
-        return Style::DisplayType::RubyText;
+        // <display-internal>
+        case CSSValueTableRowGroup:
+            return DisplayType::TableRowGroup;
+        case CSSValueTableHeaderGroup:
+            return DisplayType::TableHeaderGroup;
+        case CSSValueTableFooterGroup:
+            return DisplayType::TableFooterGroup;
+        case CSSValueTableRow:
+            return DisplayType::TableRow;
+        case CSSValueTableColumnGroup:
+            return DisplayType::TableColumnGroup;
+        case CSSValueTableColumn:
+            return DisplayType::TableColumn;
+        case CSSValueTableCell:
+            return DisplayType::TableCell;
+        case CSSValueTableCaption:
+            return DisplayType::TableCaption;
+        case CSSValueRubyBase:
+            return DisplayType::RubyBase;
+        case CSSValueRubyText:
+            return DisplayType::RubyText;
 
-    // <display-box>
-    case CSSValueContents:
-        return Style::DisplayType::Contents;
-    case CSSValueNone:
-        return Style::DisplayType::None;
+        // <display-box>
+        case CSSValueContents:
+            return DisplayType::Contents;
+        case CSSValueNone:
+            return DisplayType::None;
 
-    default:
-        break;
+        // <-webkit-display>
+        case CSSValueWebkitBox:
+            return DisplayType::BlockDeprecatedFlex;
+        case CSSValueWebkitInlineBox:
+            return DisplayType::InlineDeprecatedFlex;
+
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return DisplayType::InlineFlow;
+        }
     }
 
-    state.setCurrentPropertyInvalidAtComputedValueTime();
-    return Style::DisplayType::InlineFlow;
+    auto pair = requiredPairDowncast<CSSPrimitiveValue>(state, value);
+    if (!pair)
+        return DisplayType::InlineFlow;
+
+    auto handleInside = []<CSSPropertyParserHelpers::DisplayOutside outside>(BuilderState& state, CSSValueID inside) {
+        switch (inside) {
+        case CSSValueFlow:
+            return mappedDisplayType<outside, Flow>();
+
+        case CSSValueFlowRoot:
+            return mappedDisplayType<outside, FlowRoot>();
+
+        case CSSValueTable:
+            return mappedDisplayType<outside, Table>();
+
+        case CSSValueFlex:
+            return mappedDisplayType<outside, Flex>();
+
+        case CSSValueGrid:
+            return mappedDisplayType<outside, Grid>();
+
+        case CSSValueGridLanes:
+            return mappedDisplayType<outside, GridLanes>();
+
+        case CSSValueRuby:
+            return mappedDisplayType<outside, Ruby>();
+
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return DisplayType::InlineFlow;
+        }
+    };
+
+    Ref first = pair->first;
+    Ref second = pair->second;
+
+    switch (first->valueID()) {
+    case CSSValueBlock:
+        return handleInside.template operator()<Block>(state, second->valueID());
+
+    case CSSValueInline:
+        return handleInside.template operator()<Inline>(state, second->valueID());
+
+    default:
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return DisplayType::InlineFlow;
+    }
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/display/StyleDisplay.h
+++ b/Source/WebCore/style/values/display/StyleDisplay.h
@@ -368,7 +368,7 @@ template<> struct ValueRepresentation<DisplayType> {
         case DisplayType::BlockGridLanes:
             return visitor(CSS::Keyword::GridLanes { });
         case DisplayType::BlockRuby:
-            return visitor(CSS::Keyword::BlockRuby { });
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Block { }, CSS::Keyword::Ruby { } });
         case DisplayType::BlockDeprecatedFlex:
             return visitor(CSS::Keyword::WebkitBox { });
 


### PR DESCRIPTION
#### b8670f8cdf8e4bc2c211b2ea4c5b8dbf59284a8b
<pre>
Remove non-standard `display: block-ruby`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308317">https://bugs.webkit.org/show_bug.cgi?id=308317</a>

Reviewed by Tim Nguyen.

Remove support for parsing and serializing display: `block-ruby`. It should
always be represented as the space separated pair `block ruby`.

Also added more conservative support for `display` CSSValueConversion, so
any valid pair that might make its way in from the CSS typedom gets handled
correctly.

To test this, a new off by default setting, CSSRubyDisplayTypesInAuthorStylesEnabled,
was added to enable use of ruby display types outside of UA style sheets.

Test: fast/ruby/ruby-display-types.html
* LayoutTests/fast/ruby/ruby-display-types-expected.txt: Added.
* LayoutTests/fast/ruby/ruby-display-types.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.h:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/values/display/StyleDisplay.cpp:
* Source/WebCore/style/values/display/StyleDisplay.h:

Canonical link: <a href="https://commits.webkit.org/308000@main">https://commits.webkit.org/308000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6b2e21b0a164a1c84ac8702d36fc49314b8cee0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146187 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154856 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99653 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14836 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14102 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11864 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2302 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138158 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157175 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6979 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120509 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30949 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74410 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7701 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177486 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82054 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18035 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->