### PR TITLE
[JSC] CLI should dump disassembly when `-d` option is passed

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -486,7 +486,6 @@ public:
     String m_profilerOutput;
     String m_uncaughtExceptionName;
     bool m_interactive { false };
-    bool m_dump { false };
     bool m_module { false };
     bool m_exitCode { false };
     bool m_destroyVM { false };
@@ -3798,8 +3797,6 @@ static void checkException(GlobalObject* globalObject, bool isLastFile, bool has
 
     if (!options.m_uncaughtExceptionName || !isLastFile) {
         success = success && (!hasException || options.m_ignoreUncaughtExceptions);
-        if (options.m_dump && !hasException)
-            printf("End: %s\n", value.toWTFString(globalObject).utf8().data());
         if (hasException && !options.m_ignoreUncaughtExceptions)
             dumpException(globalObject, value);
     } else
@@ -3990,7 +3987,7 @@ static void runInteractive(GlobalObject* globalObject)
 [[noreturn]] static void printUsageStatement(bool help = false)
 {
     fprintf(stderr, "Usage: jsc [options] [files] [-- arguments]\n");
-    fprintf(stderr, "  -d         Dumps bytecode\n");
+    fprintf(stderr, "  -d         Dumps bytecode and disassembly\n");
     fprintf(stderr, "  -s         Synchronous compilation (equivalent to `--useConcurrentJIT=0`)\n");
     fprintf(stderr, "  -e         Evaluate argument as script code\n");
     fprintf(stderr, "  -f         Specifies a source file (deprecated)\n");
@@ -4131,7 +4128,8 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
             continue;
         }
         if (!strcmp(arg, "-d")) {
-            m_dump = true;
+            Options::dumpGeneratedBytecodes() = true;
+            Options::dumpDisassembly() = true;
             continue;
         }
         if (!strcmp(arg, "-s")) {
@@ -4546,8 +4544,6 @@ int jscmain(int argc, char** argv)
     {
         Options::AllowUnfinalizedAccessScope scope;
         processConfigFile(Options::configFile(), "jsc");
-        if (mainCommandLine->m_dump)
-            Options::dumpGeneratedBytecodes() = true;
     }
 
     JSC::initialize();


### PR DESCRIPTION
#### e5cc0aa4ae3847781b7677158f5b241bb1a3d072
<pre>
[JSC] CLI should dump disassembly when `-d` option is passed
<a href="https://bugs.webkit.org/show_bug.cgi?id=308323">https://bugs.webkit.org/show_bug.cgi?id=308323</a>
<a href="https://rdar.apple.com/170823171">rdar://170823171</a>

Reviewed by Dan Hecht.

When debugging it&apos;s useful to have a single letter option to get the
disassembly. I, at least, almost never just want the bytecode by itself
especially when the JITs are enabled. This change adds disassembly
dumping when `-d` is passed to the CLI in addition to the bytecode
dumping.

There was also an unrelated dump of the script result value when -d was
passed. I don&apos;t know of anyone using that so I removed it.

No new tests, just a debug option change.

Canonical link: <a href="https://commits.webkit.org/308047@main">https://commits.webkit.org/308047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/308cfcb38a721ffcbf52a08ed92d84a1b43ec1ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145996 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99528 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112303 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80395 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93203 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ac3e561-5ced-41ed-8a50-df6b8a032c56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11721 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2119 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137978 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156986 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6800 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120316 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74227 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16351 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7434 "Too many flaky failures: http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/media/modern-media-controls/skip-back-support/skip-back-support-button-click.html, http/tests/misc/single-character-pi-stylesheet.xhtml, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/postredirect-reload.html, http/tests/navigation/subframe-pagehide-handler-starts-load2.html, http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/register-bypassing-scheme.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177300 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81902 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45510 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17872 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17932 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->