### PR TITLE
Log when the VideoTrack or AudioTrack configurations change

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2657,7 +2657,7 @@ void HTMLMediaElement::videoTrackSelectedChanged(VideoTrack& track)
 void HTMLMediaElement::videoTrackConfigurationChanged(VideoTrack& track)
 {
     UNUSED_PARAM(track);
-    ALWAYS_LOG(LOGIDENTIFIER, ", "_s, MediaElementSession::descriptionForTrack(track));
+    ALWAYS_LOG(LOGIDENTIFIER, MediaElementSession::descriptionForTrack(track));
 }
 
 void HTMLMediaElement::videoTrackKindChanged(VideoTrack& track)

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -162,7 +162,8 @@ void AudioTrack::enabledChanged(bool enabled)
 
 void AudioTrack::configurationChanged(const PlatformAudioTrackConfiguration& configuration)
 {
-    m_configuration->setState(configuration);
+    if (m_configuration->updateState(configuration) == AudioTrackConfiguration::StateChanged::No)
+        return;
     m_clients.forEach([this] (auto& client) {
         client.audioTrackConfigurationChanged(*this);
     });
@@ -228,7 +229,7 @@ void AudioTrack::updateKindFromPrivate()
 
 void AudioTrack::updateConfigurationFromPrivate()
 {
-    m_configuration->setState(m_private->configuration());
+    configurationChanged(m_private->configuration());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/html/track/AudioTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.cpp
@@ -35,6 +35,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackConfiguration);
 
+auto AudioTrackConfiguration::updateState(const AudioTrackConfigurationInit& state) -> StateChanged
+{
+    if (state == m_state)
+        return StateChanged::No;
+    m_state = state;
+    return StateChanged::Yes;
+}
+
 Ref<JSON::Object> AudioTrackConfiguration::toJSON() const
 {
     Ref json = JSON::Object::create();

--- a/Source/WebCore/html/track/AudioTrackConfiguration.h
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.h
@@ -41,7 +41,8 @@ public:
     static Ref<AudioTrackConfiguration> create(AudioTrackConfigurationInit&& init) { return adoptRef(*new AudioTrackConfiguration(WTF::move(init))); }
     static Ref<AudioTrackConfiguration> create() { return adoptRef(*new AudioTrackConfiguration()); }
 
-    void setState(const AudioTrackConfigurationInit& state) { m_state = state; }
+    enum class StateChanged : bool { No, Yes };
+    StateChanged updateState(const AudioTrackConfigurationInit&);
 
     String codec() const { return m_state.codec; }
     void setCodec(String codec) { m_state.codec = codec; }

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -141,7 +141,8 @@ void VideoTrack::selectedChanged(bool selected)
 
 void VideoTrack::configurationChanged(const PlatformVideoTrackConfiguration& configuration)
 {
-    m_configuration->setState(configuration);
+    if (m_configuration->updateState(configuration) == VideoTrackConfiguration::StateChanged::No)
+        return;
     m_clients.forEach([this] (auto& client) {
         client.videoTrackConfigurationChanged(*this);
     });
@@ -245,7 +246,7 @@ void VideoTrack::updateKindFromPrivate()
 
 void VideoTrack::updateConfigurationFromPrivate()
 {
-    m_configuration->setState(m_private->configuration());
+    configurationChanged(m_private->configuration());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/html/track/VideoTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.cpp
@@ -35,14 +35,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackConfiguration);
 
-void VideoTrackConfiguration::setState(const VideoTrackConfigurationInit& state)
+auto VideoTrackConfiguration::updateState(const VideoTrackConfigurationInit& state) -> StateChanged
 {
     if (m_state == state && m_colorSpace->state() == m_state.colorSpace)
-        return;
+        return StateChanged::No;
 
     m_state = state;
     m_colorSpace->setState(m_state.colorSpace);
     notifyObservers();
+    return StateChanged::Yes;
 }
 
 void VideoTrackConfiguration::setCodec(String codec)

--- a/Source/WebCore/html/track/VideoTrackConfiguration.h
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.h
@@ -45,7 +45,8 @@ public:
     static Ref<VideoTrackConfiguration> create(VideoTrackConfigurationInit&& init) { return adoptRef(*new VideoTrackConfiguration(WTF::move(init))); }
     static Ref<VideoTrackConfiguration> create() { return adoptRef(*new VideoTrackConfiguration()); }
 
-    void setState(const VideoTrackConfigurationInit&);
+    enum class StateChanged : bool { No, Yes };
+    StateChanged updateState(const VideoTrackConfigurationInit&);
 
     String codec() const { return m_state.codec; }
     void setCodec(String);


### PR DESCRIPTION
#### f0c7215cac12ec83891cadbf034e8645927087f0
<pre>
Log when the VideoTrack or AudioTrack configurations change
<a href="https://rdar.apple.com/170828690">rdar://170828690</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308327">https://bugs.webkit.org/show_bug.cgi?id=308327</a>

Reviewed by Ryan Reno.

Notify clients when the track configuration changes; to do so
return a StateChanged enum from updateState().

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::videoTrackConfigurationChanged):
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::configurationChanged):
(WebCore::AudioTrack::updateConfigurationFromPrivate):
* Source/WebCore/html/track/AudioTrackConfiguration.cpp:
(WebCore::AudioTrackConfiguration::updateState):
* Source/WebCore/html/track/AudioTrackConfiguration.h:
(WebCore::AudioTrackConfiguration::setState): Deleted.
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::configurationChanged):
(WebCore::VideoTrack::updateConfigurationFromPrivate):
* Source/WebCore/html/track/VideoTrackConfiguration.cpp:
(WebCore::VideoTrackConfiguration::updateState):
(WebCore::VideoTrackConfiguration::setState): Deleted.
* Source/WebCore/html/track/VideoTrackConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/308156@main">https://commits.webkit.org/308156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03f652019079708ff5c192254a2ea01255744ed2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0624e906-d02f-40c0-b5c0-b534451f78f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112321 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80396 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61d76376-af67-4c0d-b7ad-48531f1744bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93213 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a91ec997-6ed3-427e-a32d-c1fa1639fe90) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13972 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11728 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2132 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156999 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120335 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31041 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74236 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7447 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81908 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17882 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17942 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->