### PR TITLE
Web Inspector: InspectorDOMAgent event listener lookups use linear scan instead of keyed index

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1092,30 +1092,12 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::E
     auto listeners = JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>::create();
 
     auto addListener = [&](RegisteredEventListener& listener, const EventListenerInfo& info) {
-        Inspector::Protocol::DOM::EventListenerId identifier = 0;
-        bool disabled = false;
-        RefPtr<JSC::Breakpoint> breakpoint;
+        auto result = m_eventListenerEntries.ensure({ info.eventTarget.get(), info.eventType, &listener.callback(), listener.useCapture() }, [&] {
+            return InspectorEventListener { m_lastEventListenerId++ };
+        });
+        auto& entry = result.iterator->value;
 
-        for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
-            if (inspectorEventListener.matches(*info.eventTarget, info.eventType, listener.callback(), listener.useCapture())) {
-                identifier = inspectorEventListener.identifier;
-                disabled = inspectorEventListener.disabled;
-                breakpoint = inspectorEventListener.breakpoint;
-                break;
-            }
-        }
-
-        if (!identifier) {
-            InspectorEventListener inspectorEventListener(m_lastEventListenerId++, *info.eventTarget, info.eventType, listener.callback(), listener.useCapture());
-
-            identifier = inspectorEventListener.identifier;
-            disabled = inspectorEventListener.disabled;
-            breakpoint = inspectorEventListener.breakpoint;
-
-            m_eventListenerEntries.add(identifier, inspectorEventListener);
-        }
-
-        listeners->addItem(buildObjectForEventListener(listener, identifier, *info.eventTarget, info.eventType, disabled, breakpoint));
+        listeners->addItem(buildObjectForEventListener(listener, entry.identifier, *info.eventTarget, info.eventType, entry.disabled, entry.breakpoint));
     };
 
     // Get Capturing Listeners (in this order)
@@ -1144,45 +1126,49 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::E
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setEventListenerDisabled(Inspector::Protocol::DOM::EventListenerId eventListenerId, bool disabled)
 {
-    auto it = m_eventListenerEntries.find(eventListenerId);
-    if (it == m_eventListenerEntries.end())
-        return makeUnexpected("Missing event listener for given eventListenerId"_s);
+    for (auto& entry : m_eventListenerEntries.values()) {
+        if (entry.identifier != eventListenerId)
+            continue;
 
-    it->value.disabled = disabled;
-
-    return { };
+        entry.disabled = disabled;
+        return { };
+    }
+    return makeUnexpected("Missing event listener for given eventListenerId"_s);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setBreakpointForEventListener(Inspector::Protocol::DOM::EventListenerId eventListenerId, RefPtr<JSON::Object>&& options)
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto it = m_eventListenerEntries.find(eventListenerId);
-    if (it == m_eventListenerEntries.end())
-        return makeUnexpected("Missing event listener for given eventListenerId"_s);
+    for (auto& entry : m_eventListenerEntries.values()) {
+        if (entry.identifier != eventListenerId)
+            continue;
 
-    if (it->value.breakpoint)
-        return makeUnexpected("Breakpoint for given eventListenerId already exists"_s);
+        if (entry.breakpoint)
+            return makeUnexpected("Breakpoint for given eventListenerId already exists"_s);
 
-    it->value.breakpoint = InspectorDebuggerAgent::debuggerBreakpointFromPayload(errorString, WTF::move(options));
-    if (!it->value.breakpoint)
-        return makeUnexpected(errorString);
+        entry.breakpoint = InspectorDebuggerAgent::debuggerBreakpointFromPayload(errorString, WTF::move(options));
+        if (!entry.breakpoint)
+            return makeUnexpected(errorString);
 
-    return { };
+        return { };
+    }
+    return makeUnexpected("Missing event listener for given eventListenerId"_s);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::removeBreakpointForEventListener(Inspector::Protocol::DOM::EventListenerId eventListenerId)
 {
-    auto it = m_eventListenerEntries.find(eventListenerId);
-    if (it == m_eventListenerEntries.end())
-        return makeUnexpected("Missing event listener for given eventListenerId"_s);
+    for (auto& entry : m_eventListenerEntries.values()) {
+        if (entry.identifier != eventListenerId)
+            continue;
 
-    if (!it->value.breakpoint)
-        return makeUnexpected("Breakpoint for given eventListenerId missing"_s);
+        if (!entry.breakpoint)
+            return makeUnexpected("Breakpoint for given eventListenerId missing"_s);
 
-    it->value.breakpoint = nullptr;
-
-    return { };
+        entry.breakpoint = nullptr;
+        return { };
+    }
+    return makeUnexpected("Missing event listener for given eventListenerId"_s);
 }
 
 Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> InspectorDOMAgent::getAccessibilityPropertiesForNode(Inspector::Protocol::DOM::NodeId nodeId)
@@ -2973,9 +2959,7 @@ void InspectorDOMAgent::willRemoveEventListener(EventTarget& target, const AtomS
     if (!listenerExists)
         return;
 
-    m_eventListenerEntries.removeIf([&] (auto& entry) {
-        return entry.value.matches(target, eventType, listener, capture);
-    });
+    m_eventListenerEntries.remove({ &target, eventType, &listener, capture });
 
     if (m_suppressEventListenerChangedEvent)
         return;
@@ -2987,11 +2971,10 @@ void InspectorDOMAgent::willRemoveEventListener(EventTarget& target, const AtomS
 
 bool InspectorDOMAgent::isEventListenerDisabled(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
-    for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
-        if (inspectorEventListener.matches(target, eventType, listener, capture))
-            return inspectorEventListener.disabled;
-    }
-    return false;
+    auto it = m_eventListenerEntries.find({ &target, eventType, &listener, capture });
+    if (it == m_eventListenerEntries.end())
+        return false;
+    return it->value.disabled;
 }
 
 void InspectorDOMAgent::eventDidResetAfterDispatch(const Event& event)
@@ -3018,20 +3001,18 @@ Vector<size_t> InspectorDOMAgent::flexibleBoxRendererCachedItemsAtStartOfLine(co
 
 RefPtr<JSC::Breakpoint> InspectorDOMAgent::breakpointForEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
-    for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
-        if (inspectorEventListener.matches(target, eventType, listener, capture))
-            return inspectorEventListener.breakpoint;
-    }
-    return nullptr;
+    auto it = m_eventListenerEntries.find({ &target, eventType, &listener, capture });
+    if (it == m_eventListenerEntries.end())
+        return nullptr;
+    return it->value.breakpoint;
 }
 
 Inspector::Protocol::DOM::EventListenerId InspectorDOMAgent::idForEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
-    for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
-        if (inspectorEventListener.matches(target, eventType, listener, capture))
-            return inspectorEventListener.identifier;
-    }
-    return 0;
+    auto it = m_eventListenerEntries.find({ &target, eventType, &listener, capture });
+    if (it == m_eventListenerEntries.end())
+        return 0;
+    return it->value.identifier;
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -48,6 +48,7 @@
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace Inspector {
 class InjectedScriptManager;
@@ -326,43 +327,20 @@ private:
 #endif
 
     struct InspectorEventListener {
-        Inspector::Protocol::DOM::EventListenerId identifier { 1 };
-        RefPtr<EventTarget> eventTarget;
-        RefPtr<EventListener> eventListener;
-        AtomString eventType;
-        bool useCapture { false };
+        Inspector::Protocol::DOM::EventListenerId identifier { 0 };
         bool disabled { false };
         RefPtr<JSC::Breakpoint> breakpoint;
-
-        InspectorEventListener() { }
-
-        InspectorEventListener(Inspector::Protocol::DOM::EventListenerId identifier, EventTarget& target, const AtomString& type, EventListener& listener, bool capture)
-            : identifier(identifier)
-            , eventTarget(&target)
-            , eventListener(&listener)
-            , eventType(type)
-            , useCapture(capture)
-        {
-        }
-
-        bool matches(EventTarget& target, const AtomString& type, EventListener& listener, bool capture)
-        {
-            if (eventTarget.get() != &target)
-                return false;
-            if (eventListener.get() != &listener)
-                return false;
-            if (eventType != type)
-                return false;
-            if (useCapture != capture)
-                return false;
-            return true;
-        }
     };
 
     friend class EventFiredCallback;
 
     HashSet<const Event*> m_dispatchedEvents;
-    HashMap<Inspector::Protocol::DOM::EventListenerId, InspectorEventListener> m_eventListenerEntries;
+    // Keyed by listener identity (target, type, callback, capture) for O(1)
+    // lookup in the hot path. Raw pointers are safe because entries are removed
+    // in willRemoveEventListener before the target/listener are destroyed, and
+    // the entire map is cleared in discardBindings.
+    using EventListenerKey = std::tuple<EventTarget*, AtomString, EventListener*, bool>;
+    HashMap<EventListenerKey, InspectorEventListener> m_eventListenerEntries;
     Inspector::Protocol::DOM::EventListenerId m_lastEventListenerId { 1 };
 
     bool m_searchingForNode { false };


### PR DESCRIPTION
#### 5b00613b50f6cc3742fa831dfc50e6d820442797
<pre>
Web Inspector: InspectorDOMAgent event listener lookups use linear scan instead of keyed index
<a href="https://bugs.webkit.org/show_bug.cgi?id=308339">https://bugs.webkit.org/show_bug.cgi?id=308339</a>
<a href="https://rdar.apple.com/170834187">rdar://170834187</a>

Reviewed by NOBODY (OOPS!).

Add secondary HashMap for O(1) event listener lookup by identity.

Replace linear scans of m_eventListenerEntries with a secondary
index keyed by (EventTarget*, eventType, callback, useCapture).
This eliminates removeIf over the full hash table in
willRemoveEventListener and avoids repeated linear searches in
isEventListenerDisabled, breakpointForEventListener, and
idForEventListener. Both maps are kept in sync.

* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::getEventListenersForNode):
(WebCore::InspectorDOMAgent::setEventListenerDisabled):
(WebCore::InspectorDOMAgent::setBreakpointForEventListener):
(WebCore::InspectorDOMAgent::removeBreakpointForEventListener):
(WebCore::InspectorDOMAgent::willRemoveEventListener):
(WebCore::InspectorDOMAgent::isEventListenerDisabled):
(WebCore::InspectorDOMAgent::breakpointForEventListener):
(WebCore::InspectorDOMAgent::idForEventListener):
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b00613b50f6cc3742fa831dfc50e6d820442797

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146883 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19563 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155565 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100271 "Hash 5b00613b for PR 59122 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148757 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20022 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19464 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/155565 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/100271 "Hash 5b00613b for PR 59122 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/293b7baa-c3dd-49d3-9430-9788ab725493) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149845 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/20022 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/155565 "Hash 5b00613b for PR 59122 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13a6af54-b82f-4b04-8e5c-97cd15ef26fe) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/20022 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3007 "Hash 5b00613b for PR 59122 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/20022 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157896 "Hash 5b00613b for PR 59122 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1027 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/157896 "Hash 5b00613b for PR 59122 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19365 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/19464 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/157896 "Hash 5b00613b for PR 59122 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19374 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75331 "Hash 5b00613b for PR 59122 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/13117 "Hash 5b00613b for PR 59122 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18980 "Hash 5b00613b for PR 59122 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82735 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18710 "Hash 5b00613b for PR 59122 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18861 "Hash 5b00613b for PR 59122 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18769 "Hash 5b00613b for PR 59122 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->