### PR TITLE
Move shadow root out of ElementRareData and into Element

### DIFF
--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ElementRareData.h"
 #include "HTMLSlotElement.h"
 #include "PseudoElement.h"
 #include "ShadowRoot.h"

--- a/Source/WebCore/dom/ComposedTreeIterator.h
+++ b/Source/WebCore/dom/ComposedTreeIterator.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ElementAndTextDescendantIterator.h"
-#include "ElementRareData.h"
 #include "HTMLSlotElement.h"
 #include "ShadowRoot.h"
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -81,6 +81,7 @@ class PseudoElement;
 class RenderStyle;
 class RenderTreePosition;
 class Settings;
+class ShadowRoot;
 class SpaceSplitString;
 class StylePropertyMap;
 class StylePropertyMapReadOnly;
@@ -450,7 +451,7 @@ public:
     virtual bool rendererIsNeeded(const RenderStyle&);
     virtual bool isReplaced(const RenderStyle* = nullptr) const { return false; }
 
-    inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
+    inline ShadowRoot* shadowRoot() const;
     RefPtr<ShadowRoot> shadowRootForBindings(JSC::JSGlobalObject&) const;
     RefPtr<ShadowRoot> NODELETE openOrClosedShadowRoot() const;
     RefPtr<Element> resolveReferenceTarget() const;
@@ -1013,7 +1014,7 @@ private:
     void cloneShadowTreeIfPossible(Element& newHost) const;
     virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const;
 
-    inline void removeShadowRoot(); // Defined in ElementRareData.h.
+    inline void removeShadowRoot();
     void removeShadowRootSlow(ShadowRoot&);
 
     enum class ResolveComputedStyleMode : uint8_t { Normal, RenderedOnly, Editability };
@@ -1070,6 +1071,7 @@ private:
 
     QualifiedName m_tagName;
     RefPtr<ElementData> m_elementData;
+    RefPtr<ShadowRoot> m_shadowRoot;
 };
 
 inline void Element::setSavedLayerScrollPosition(const ScrollPosition& position)
@@ -1111,6 +1113,16 @@ void invalidateForSiblingCombinators(Element* sibling);
 inline bool isInTopLayerOrBackdrop(const RenderStyle&, const Element*);
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ContentRelevancy);
+
+inline ShadowRoot* Node::shadowRoot() const
+{
+    return is<Element>(*this) ? uncheckedDowncast<Element>(*this).shadowRoot() : nullptr;
+}
+
+inline ShadowRoot* Element::shadowRoot() const
+{
+    return m_shadowRoot.get();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -40,7 +40,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     IntPoint savedLayerScrollPosition;
     HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
     HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
-    void* pointers[18];
+    void* pointers[17];
     void* intersectionObserverData;
     void* resizeObserverData;
     void* largestContentfulPaintData;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -172,8 +172,6 @@ static ASCIILiteral stringForRareDataUseType(NodeRareData::UseType useType)
         return "Dataset"_s;
     case NodeRareData::UseType::ClassList:
         return "ClassList"_s;
-    case NodeRareData::UseType::ShadowRoot:
-        return "ShadowRoot"_s;
     case NodeRareData::UseType::CustomElementReactionQueue:
         return "CustomElementReactionQueue"_s;
     case NodeRareData::UseType::CustomElementDefaultARIA:

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -278,16 +278,13 @@ public:
     bool hasShadowRootContainingSlots() const { return hasEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots); }
     void setHasShadowRootContainingSlots(bool flag) { setEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots, flag); }
 
-    bool hasShadowRoot() const { return hasStateFlag(StateFlag::HasShadowRoot); }
-    void setHasShadowRoot(bool flag) { setStateFlag(StateFlag::HasShadowRoot, flag); }
-
     bool needsSVGRendererUpdate() const { return hasStateFlag(StateFlag::NeedsSVGRendererUpdate); }
     void setNeedsSVGRendererUpdate(bool flag) { setStateFlag(StateFlag::NeedsSVGRendererUpdate, flag); }
 
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* NODELETE shadowHost() const;
     ShadowRoot* NODELETE containingShadowRoot() const;
-    inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
+    inline ShadowRoot* shadowRoot() const; // Defined in Element.h.
     bool isClosedShadowHidden(const Node&) const;
 
     HTMLSlotElement* assignedSlot() const;
@@ -680,8 +677,7 @@ protected:
         InLargestContentfulPaintTextContentSet = 1 << 20,
         DidMutateSubtreeAfterSetInnerHTML = 1 << 21,
         WasParsedWithFastPath = 1 << 22,
-        HasShadowRoot = 1 << 23,
-        // 8 bits free.
+        // 9 bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -243,7 +243,6 @@ public:
         EffectiveLang = 1 << 7,
         Dataset = 1 << 8,
         ClassList = 1 << 9,
-        ShadowRoot = 1 << 10,
         CustomElementReactionQueue = 1 << 11,
         CustomElementDefaultARIA = 1 << 12,
         FormAssociatedCustomElement = 1 << 13,

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -66,6 +66,7 @@
 #include "ImageOverlay.h"
 #include "JSNode.h"
 #include "LocalFrame.h"
+#include "NodeList.h"
 #include "Page.h"
 #include "PlatformKeyboardEvent.h"
 #include "PlatformMouseEvent.h"

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -34,6 +34,7 @@
 #include "ContainerNodeInlines.h"
 #include "FontCascade.h"
 #include "HTMLFrameOwnerElement.h"
+#include "KeyframeEffectStack.h"
 #include "NodeRenderStyle.h"
 #include "PseudoElementIdentifier.h"
 #include "RenderBoxInlines.h"


### PR DESCRIPTION
#### ec977c8ae18ef88320387a697ba4231c5ac94820
<pre>
Move shadow root out of ElementRareData and into Element
<a href="https://bugs.webkit.org/show_bug.cgi?id=308341">https://bugs.webkit.org/show_bug.cgi?id=308341</a>
<a href="https://rdar.apple.com/170835643">rdar://170835643</a>

Reviewed by Ryosuke Niwa.

Store shadow root as a member of Element instead of in
ElementRareData, eliminating ElementRareData allocations.
Remove the redundant HasShadowRoot state flag and related
infrastructure.

There is no behavior change, correctness will be verified
with existing tests.

* Source/WebCore/dom/ComposedTreeAncestorIterator.h:
* Source/WebCore/dom/ComposedTreeIterator.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
(WebCore::Element::removeShadowRoot):
(WebCore::Element::removeShadowRootSlow):
* Source/WebCore/dom/Element.h:
(WebCore::Node::shadowRoot const):
(WebCore::Element::shadowRoot const):
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::useTypes const):
(WebCore::ElementRareData::~ElementRareData):
(WebCore::ElementRareData::clearShadowRoot): Deleted.
(WebCore::ElementRareData::shadowRoot const): Deleted.
(WebCore::ElementRareData::setShadowRoot): Deleted.
(WebCore::Node::shadowRoot const):
(WebCore::Element::shadowRoot const):
(WebCore::Element::removeShadowRoot): Deleted.
* Source/WebCore/dom/Node.cpp:
(WebCore::stringForRareDataUseType):
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasShadowRoot const): Deleted.
(WebCore::Node::setHasShadowRoot): Deleted.
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
* Source/WebCore/style/StyleExtractor.cpp:

Canonical link: <a href="https://commits.webkit.org/308069@main">https://commits.webkit.org/308069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2abcf5e30b28af6711f24e96b4807a83f0d6e0c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112640 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80544 "Exiting early after 60 failures. 15388 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12025 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157346 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/517 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120669 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120967 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30989 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131116 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74656 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8047 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82225 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->