### PR TITLE
Deploy more smart pointers in Source/WebKit/NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -171,7 +171,7 @@ void NetworkLoad::setSuggestedFilename(const String& suggestedName)
     if (!m_task)
         return;
 
-    m_task->setSuggestedFilename(suggestedName);
+    protect(m_task)->setSuggestedFilename(suggestedName);
 }
 
 void NetworkLoad::setPendingDownload(PendingDownload& pendingDownload)
@@ -352,8 +352,8 @@ void NetworkLoad::didNegotiateModernTLS(const URL& url)
 
 String NetworkLoad::description() const
 {
-    if (m_task.get())
-        return m_task->description();
+    if (RefPtr task = m_task.get())
+        return task->description();
     return emptyString();
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -571,9 +571,10 @@ ContentSecurityPolicy* NetworkLoadChecker::contentSecurityPolicy()
     if (!m_contentSecurityPolicy && m_cspResponseHeaders) {
         // FIXME: Pass the URL of the protected resource instead of its origin.
         m_contentSecurityPolicy = makeUnique<ContentSecurityPolicy>(URL { protect(origin())->toRawString() }, nullptr, m_networkResourceLoader.get());
-        CheckedPtr { m_contentSecurityPolicy.get() }->didReceiveHeaders(*m_cspResponseHeaders, String { m_referrer }, ContentSecurityPolicy::ReportParsingErrors::No);
+        CheckedPtr checkedContentSecurityPolicy = m_contentSecurityPolicy.get();
+        checkedContentSecurityPolicy->didReceiveHeaders(*m_cspResponseHeaders, String { m_referrer }, ContentSecurityPolicy::ReportParsingErrors::No);
         if (!m_documentURL.isEmpty())
-            m_contentSecurityPolicy->setDocumentURL(m_documentURL);
+            checkedContentSecurityPolicy->setDocumentURL(m_documentURL);
     }
     return m_contentSecurityPolicy.get();
 }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
@@ -63,7 +63,7 @@ void NetworkRTCSharedMonitor::addListener(NetworkRTCMonitor& monitor)
         return;
 
 #if PLATFORM(COCOA)
-    if (monitor.rtcProvider().webRTCInterfaceMonitoringViaNWEnabled()) {
+    if (protect(monitor.rtcProvider())->webRTCInterfaceMonitoringViaNWEnabled()) {
         setupNWPathMonitor();
         return;
     }

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,5 +1,3 @@
-[ Mac ] NetworkProcess/NetworkLoadChecker.cpp
-[ Mac ] NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
 [ Mac ] UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
 [ Mac ] UIProcess/Cocoa/VideoPresentationManagerProxy.mm
 [ Mac ] WebProcess/Network/WebLoaderStrategy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,5 +1,3 @@
-[ Mac ] NetworkProcess/NetworkLoad.cpp
-[ Mac ] NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
 [ Mac ] Shared/API/Cocoa/_WKFrameHandle.mm
 [ Mac ] Shared/API/Cocoa/_WKHitTestResult.mm
 [ Mac ] Shared/Cocoa/WKNSArray.mm


### PR DESCRIPTION
#### 20dd6598353a34cb2e528b6381fe9cbe5758a86e
<pre>
Deploy more smart pointers in Source/WebKit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=308343">https://bugs.webkit.org/show_bug.cgi?id=308343</a>

Reviewed by Wenson Hsieh.

Deployed more smart pointers to fix new warnings after clang rollout in 307871@main.

No new tests since there should be no behavioral changes.

* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::setSuggestedFilename):
(WebKit::NetworkLoad::description const):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::contentSecurityPolicy):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp:
(WebKit::NetworkRTCSharedMonitor::addListener):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/307955@main">https://commits.webkit.org/307955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/665ed2cb2532732cde6bb39cdeab2e61a0cc0bb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154716 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bcf0af7-eac6-4c4b-bd47-ce1763a2cb81) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112351 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe48a834-a186-4977-b588-497628c7c630) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a36faa62-33c5-4f8c-acd3-3c2b9f667d32) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13989 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2161 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123550 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157032 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/225 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120364 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120685 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74257 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16378 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7482 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81929 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->