### PR TITLE
Add API Test For Null MACaptionActiveProfile

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -709,5 +709,17 @@ TEST_F(CaptionPreferenceTests, ReceievedDidOpenWhenHighlighted)
 }
 #endif
 
+TEST_F(CaptionPreferenceTests, NullProfileNameShouldYieldEmptyStyleSheet)
+{
+    if (!canLoad_MediaAccessibility_MACaptionAppearanceIsCustomized())
+        return;
+
+    MediaAccessibilityShim shim;
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
+    auto preferences = CaptionUserPreferencesMediaAF::create(group);
+
+    SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyActiveProfileID, CFSTR(""));
+    EXPECT_STREQ(preferences->captionsStyleSheetOverride().utf8().data(), "");
+}
 
 }


### PR DESCRIPTION
#### 0ef677f42b09042cab75f967db847f2b6e85c875
<pre>
Add API Test For Null MACaptionActiveProfile
<a href="https://bugs.webkit.org/show_bug.cgi?id=308346">https://bugs.webkit.org/show_bug.cgi?id=308346</a>
<a href="https://rdar.apple.com/170838909">rdar://170838909</a>

Reviewed by Eric Carlson.

Add API test that checks that when Media Accessibility&apos;s MACaptionActiveProfile
ss the empty string, we produce an empty CSS style sheet.

We set MACaptionActiveProfile to &quot;&quot; when running our WebVTT WPT bot, so that
media accessibility styles do not interfere with tests.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, NullProfileNameShouldYieldEmptyStyleSheet)):

Canonical link: <a href="https://commits.webkit.org/308048@main">https://commits.webkit.org/308048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ff684ee9e9460d86e006bc952fdef143603563

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99554 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1388e0de-c4c7-44d2-a57b-b3631c615684) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112358 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80405 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3eb85be6-f0c2-40ca-83cd-eaa0a525ac3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93239 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bc6f81a-b402-411f-b3b1-51e182260efd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13991 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11751 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2169 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157040 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120371 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120690 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74263 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7489 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18176 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17911 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->