### PR TITLE
Reduce the amount of duplicated code around `scrollingThreadAddedPendingUpdate()`

### DIFF
--- a/LayoutTests/fast/scrolling/ios/non-invertible-transformed-over-scroller.html
+++ b/LayoutTests/fast/scrolling/ios/non-invertible-transformed-over-scroller.html
@@ -62,6 +62,8 @@
             // In case the previous scroll failed.
             document.scrollingElement.scrollTop = 0;
             scrollers[1].scrollTop = 0;
+            
+            await UIHelper.ensurePresentationUpdate();
 
             // Hit the scroller
             await UIHelper.immediateScrollElementAtContentPointToOffset(bounds.left + bounds.width / 2 + 10, bounds.top + 10, 0, 100);
@@ -95,5 +97,6 @@
         </div>
         <div class="overlay" style="transform: scale(0.5)"></div>
     </div>
+    <div id="console"></div>
 </body>
 </html>

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -933,7 +933,7 @@ RubberBandingBehavior ScrollingTree::clientAllowsMainFrameRubberBandingOnSide(Bo
     return m_swipeState.clientAllowedRubberBandableEdges.at(side);
 }
 
-void ScrollingTree::addPendingScrollUpdate(ScrollUpdate&& update)
+void ScrollingTree::addPendingScrollUpdateInternal(ScrollUpdate&& update)
 {
     Locker locker { m_pendingScrollUpdatesLock };
     for (auto& existingUpdate : m_pendingScrollUpdates) {
@@ -944,6 +944,12 @@ void ScrollingTree::addPendingScrollUpdate(ScrollUpdate&& update)
     }
 
     m_pendingScrollUpdates.append(WTF::move(update));
+}
+
+void ScrollingTree::addPendingScrollUpdate(ScrollUpdate&& update)
+{
+    addPendingScrollUpdateInternal(WTF::move(update));
+    didAddPendingScrollUpdate();
 }
 
 Vector<ScrollUpdate> ScrollingTree::takePendingScrollUpdates()

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -238,7 +238,6 @@ public:
 
     WEBCORE_EXPORT void willProcessWheelEvent();
 
-    WEBCORE_EXPORT void addPendingScrollUpdate(ScrollUpdate&&);
     WEBCORE_EXPORT Vector<ScrollUpdate> takePendingScrollUpdates();
     WEBCORE_EXPORT bool hasPendingScrollUpdates();
 
@@ -305,6 +304,10 @@ protected:
     HashSet<ScrollingNodeID> nodesWithActiveScrollAnimations();
     WEBCORE_EXPORT void serviceScrollAnimations(MonotonicTime) WTF_REQUIRES_LOCK(m_treeLock);
 
+    void addPendingScrollUpdateInternal(ScrollUpdate&&);
+    WEBCORE_EXPORT void addPendingScrollUpdate(ScrollUpdate&&);
+    virtual void didAddPendingScrollUpdate() { }
+
     mutable Lock m_treeLock; // Protects the scrolling tree.
 
 private:
@@ -316,7 +319,7 @@ private:
     void traverseScrollingTreeRecursive(ScrollingTreeNode&, NOESCAPE const VisitorFunction&) WTF_REQUIRES_LOCK(m_treeLock);
     
     void NODELETE setOverlayScrollbarsEnabled(bool);
-    
+
     virtual void didCommitTree() { }
 
     WEBCORE_EXPORT virtual RefPtr<ScrollingTreeNode> NODELETE scrollingNodeForPoint(FloatPoint);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -81,6 +81,8 @@ protected:
     bool scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) override WTF_REQUIRES_LOCK(m_treeLock);
     bool scrollingTreeNodeRequestsKeyboardScroll(ScrollingNodeID, const RequestedKeyboardScrollData&) override WTF_REQUIRES_LOCK(m_treeLock);
 
+    void addPendingScrollUpdateWithDeferReason(ScrollUpdate&&, WheelEventTestMonitor::DeferReason);
+
 #if PLATFORM(MAC)
     void handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase) override;
 #endif
@@ -126,6 +128,8 @@ private:
     void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
 
     void scrollingTreeNodeScrollUpdated(ScrollingTreeScrollingNode&, const ScrollUpdateType&);
+
+    void didAddPendingScrollUpdate() override;
 
     enum class SynchronizationState : uint8_t {
         Idle,

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -75,10 +75,6 @@ void RemoteScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&
 
     ScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);
 
-    CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get();
-    if (!scrollingCoordinatorProxy)
-        return;
-
     std::optional<FloatPoint> layoutViewportOrigin;
     if (auto* scrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(node))
         layoutViewportOrigin = scrollingNode->layoutViewport().location();
@@ -90,17 +86,11 @@ void RemoteScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&
         .updateLayerPositionAction = scrollingLayerPositionAction,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
-
-    scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
 }
 
 void RemoteScrollingTree::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode& node)
 {
     ASSERT(isMainRunLoop());
-
-    CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get();
-    if (!scrollingCoordinatorProxy)
-        return;
 
     auto scrollUpdate = ScrollUpdate {
         .nodeID = node.scrollingNodeID(),
@@ -109,17 +99,11 @@ void RemoteScrollingTree::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeSc
         .updateType = ScrollUpdateType::AnimatedScrollDidEnd,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
-
-    scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
 }
 
 void RemoteScrollingTree::scrollingTreeNodeDidStopWheelEventScroll(WebCore::ScrollingTreeScrollingNode& node)
 {
     ASSERT(isMainRunLoop());
-
-    CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get();
-    if (!scrollingCoordinatorProxy)
-        return;
 
     auto scrollUpdate = ScrollUpdate {
         .nodeID = node.scrollingNodeID(),
@@ -128,8 +112,6 @@ void RemoteScrollingTree::scrollingTreeNodeDidStopWheelEventScroll(WebCore::Scro
         .updateType = ScrollUpdateType::WheelEventScrollDidEnd,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
-
-    scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
 }
 
 bool RemoteScrollingTree::scrollingTreeNodeRequestsScroll(ScrollingNodeID nodeID, const RequestedScrollData& request)
@@ -171,10 +153,6 @@ void RemoteScrollingTree::scrollingTreeNodeDidStopProgrammaticScroll(ScrollingTr
 {
     ASSERT(isMainRunLoop());
 
-    CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get();
-    if (!scrollingCoordinatorProxy)
-        return;
-
     auto scrollUpdate = ScrollUpdate {
         .nodeID = node.scrollingNodeID(),
         .scrollPosition = { },
@@ -182,8 +160,12 @@ void RemoteScrollingTree::scrollingTreeNodeDidStopProgrammaticScroll(ScrollingTr
         .updateType = ScrollUpdateType::ProgrammaticScrollDidEnd,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
+}
 
-    scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
+void RemoteScrollingTree::didAddPendingScrollUpdate()
+{
+    if (CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get())
+        scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
 }
 
 void RemoteScrollingTree::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -138,6 +138,8 @@ protected:
     void updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
 
 private:
+    void didAddPendingScrollUpdate() override;
+
     std::unique_ptr<RemoteProgressBasedTimelineRegistry> m_progressBasedTimelineRegistry;
 #endif
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -100,6 +100,8 @@ private:
     void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;
 
+    void didAddPendingScrollUpdate() override;
+
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
 
     HashMap<WebCore::ScrollingNodeID, WebCore::RequestedScrollData> m_nodesWithPendingScrollAnimations; // Guarded by m_treeLock but used via call chains that can't be annotated.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -245,18 +245,6 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNo
         .updateLayerPositionAction = action,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
-
-    // Happens when the this is called as a result of the scrolling tree commmit.
-    if (RunLoop::isMain()) {
-        if (CheckedPtr scrollingCoordinatorProxy = this->scrollingCoordinatorProxy())
-            scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
-        return;
-    }
-
-    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }] {
-        if (CheckedPtr scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
-            scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
-    });
 }
 
 void RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode& node)
@@ -268,18 +256,6 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTre
         .updateType = ScrollUpdateType::AnimatedScrollDidEnd,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
-
-    // Happens when the this is called as a result of the scrolling tree commmit.
-    if (RunLoop::isMain()) {
-        if (CheckedPtr scrollingCoordinatorProxy = this->scrollingCoordinatorProxy())
-            scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
-        return;
-    }
-
-    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }] {
-        if (CheckedPtr scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
-            scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
-    });
 }
 
 void RemoteScrollingTreeMac::scrollingTreeNodeDidStopWheelEventScroll(WebCore::ScrollingTreeScrollingNode& node)
@@ -293,11 +269,6 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidStopWheelEventScroll(WebCore::S
         .updateType = ScrollUpdateType::WheelEventScrollDidEnd,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
-
-    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, nodeID = node.scrollingNodeID()] {
-        if (CheckedPtr scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
-            scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();
-    });
 }
 
 void RemoteScrollingTreeMac::scrollingTreeNodeDidStopProgrammaticScroll(WebCore::ScrollingTreeScrollingNode& node)
@@ -309,7 +280,10 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidStopProgrammaticScroll(WebCore:
         .updateType = ScrollUpdateType::ProgrammaticScrollDidEnd,
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
+}
 
+void RemoteScrollingTreeMac::didAddPendingScrollUpdate()
+{
     if (RunLoop::isMain()) {
         if (CheckedPtr scrollingCoordinatorProxy = this->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->scrollingThreadAddedPendingUpdate();


### PR DESCRIPTION
#### 52d8eb35f4f1cb7ecb0a1626ea6fa8c4227f9ab0
<pre>
Reduce the amount of duplicated code around `scrollingThreadAddedPendingUpdate()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308347">https://bugs.webkit.org/show_bug.cgi?id=308347</a>
<a href="https://rdar.apple.com/170839814">rdar://170839814</a>

Reviewed by Anne van Kesteren.

RemoteScrollingTree and RemoteScrollingTreeMac had lots of copies of the code that calls
`scrollingThreadAddedPendingUpdate()` on the scrolling coordinator, but in different ways
in each.

Fix by adding the virtual `ScrollingTree::didAddPendingScrollUpdate()`, calling that
in `ScrollingTree::addPendingScrollUpdate()`, and then overriding it in the derived
classes to do whatever they need to do.

A minor complication is `ThreadedScrollingTree` which needs to send a `WheelEventTestMonitor::DeferReason`
in one case, requiring `addPendingScrollUpdateInternal()` and a special `addPendingScrollUpdateWithDeferReason()`.

There&apos;s a minor behavior change, which is that `RemoteScrollingTreeMac::scrollingTreeNodeDidStopWheelEventScroll()`
now calls `scrollingThreadAddedPendingUpdate()` directly when on the main thread, but maybe it should
have done that all along.

* LayoutTests/fast/scrolling/ios/non-invertible-transformed-over-scroller.html: This test needs to wait between the
`scrollTop = 0` and `immediateScrollElementAtContentPointToOffset()` so the UI process has the zero top.
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::addPendingScrollUpdateInternal):
(WebCore::ScrollingTree::addPendingScrollUpdate):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::didAddPendingScrollUpdate):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeScrollUpdated):
(WebCore::ThreadedScrollingTree::didAddPendingScrollUpdate):
(WebCore::ThreadedScrollingTree::addPendingScrollUpdateWithDeferReason):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopWheelEventScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopProgrammaticScroll):
(WebKit::RemoteScrollingTree::didAddPendingScrollUpdate):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopWheelEventScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopProgrammaticScroll):
(WebKit::RemoteScrollingTreeMac::didAddPendingScrollUpdate):

Canonical link: <a href="https://commits.webkit.org/307990@main">https://commits.webkit.org/307990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/080a46fc56833ce3e9dcf798a513085c980e0e31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99627 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d884b411-c714-4eda-8dcc-07281e9a9275) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112458 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8564f604-ce0a-4c80-bcf4-79a4292d6e43) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14813 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93329 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51bc01d4-8694-41a6-9131-291cf6ad50b2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11835 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123645 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/8443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157146 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/317 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120482 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30943 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74371 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16463 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7642 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18273 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18007 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18173 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->