### PR TITLE
[AppKit Gestures] Selection does not show context menu when a secondary click is performed

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -224,21 +224,8 @@ typedef void (^NSWindowSnapshotReadinessHandler) (void);
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-@protocol NSTextSelectionManagerDelegateForWebKit_Staging <NSObject>
-
-- (BOOL)isTextSelectedAtPoint:(NSPoint)point;
-- (void)moveInsertionCursorToPoint:(NSPoint)point;
-- (void)handleClickAtPoint:(NSPoint)point clickCount:(NSUInteger)clickCount;
-- (void)showContextMenuAtPoint:(NSPoint)point;
-- (void)dragSelectionWithGesture:(NSGestureRecognizer *)gesture completionHandler:(void(^)(NSDraggingSession*))completionHandler;
-- (void)beginRangeSelectionAtPoint:(NSPoint)point withGranularity:(NSTextSelectionGranularity)granularity;
-- (void)continueRangeSelectionAtPoint:(NSPoint)point;
-- (void)endRangeSelectionAtPoint:(NSPoint)point;
-
-@end
-
 @interface NSTextSelectionManager (WebKit_SPI)
-@property (weak) id <NSTextSelectionManagerDelegateForWebKit_Staging> _webkitDelegate;
+@property (weak) id /* <NSTextSelectionManagerDelegate> */ _webkitDelegate;
 @end
 
 NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -657,7 +657,7 @@ struct PerWebProcessState {
 - (NakedPtr<WebKit::WebPageProxy>)_page;
 - (RefPtr<WebKit::WebPageProxy>)_protectedPage;
 #if PLATFORM(MAC)
-- (WebKit::WebViewImpl * _Null_unspecified)_impl;
+- (nullable WebKit::WebViewImpl *)_impl;
 #endif
 #if ENABLE(SCREEN_TIME)
 - (nullable STWebpageController *)_screenTimeWebpageController;

--- a/Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift
@@ -39,29 +39,3 @@ extension Comparable {
         min(max(self, limits.lowerBound), limits.upperBound)
     }
 }
-
-extension CGPoint {
-    /// Returns the euclidean distance between this point and `point`.
-    ///
-    /// - Parameter point: A point to compute the distance to.
-    /// - Returns: The distance between this point and `point`.
-    func distance(to point: CGPoint) -> Double {
-        let distanceSquared = (x - point.x) * (x - point.x) + (y - point.y) * (y - point.y)
-        return distanceSquared.squareRoot()
-    }
-}
-
-extension CGRect {
-    /// Determines the closest distance between this rect and `point` using whichever edge is nearest.
-    ///
-    /// - Parameter point: A point to compute the distance to.
-    /// - Returns: The closest distance between this rect and `point`. If `point` is contained within this rect, `0` is returned.
-    func distance(to point: CGPoint) -> Double {
-        // Clamp the point coordinates to the rectangle's bounds
-        let closestX = point.x.clamped(to: minX...maxX)
-        let closestY = point.y.clamped(to: minY...maxY)
-
-        let closestPoint = CGPoint(x: closestX, y: closestY)
-        return point.distance(to: closestPoint)
-    }
-}

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
@@ -29,7 +29,7 @@
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
 
-#import "AppKitSPI.h"
+#import <AppKit/AppKit.h>
 
 @class WKWebView;
 
@@ -46,17 +46,21 @@ NS_SWIFT_UI_ACTOR
 
 @end
 
-@interface WKTextSelectionController (NSTextSelectionManagerDelegate) <NSTextSelectionManagerDelegateForWebKit_Staging>
+@interface WKTextSelectionController (NSTextSelectionManagerDelegate)
+
+@property (nonatomic, readonly) NSRect insertionCursorRect;
+@property (nonatomic, readonly) BOOL selectionIsInsertionPoint;
 
 - (BOOL)isTextSelectedAtPoint:(NSPoint)point;
-- (void)moveInsertionCursorToPoint:(NSPoint)point;
-- (void)handleClickAtPoint:(NSPoint)point; // FIXME: Remove this declaration and its definition when possible.
-- (void)handleClickAtPoint:(NSPoint)point clickCount:(NSUInteger)clickCount;
 - (void)showContextMenuAtPoint:(NSPoint)point;
-- (void)dragSelectionWithGesture:(NSGestureRecognizer *)gesture completionHandler:(void(^)(NSDraggingSession*))completionHandler;
+
+- (void)dragSelectionWithGesture:(NSGestureRecognizer *)gesture completionHandler:(void(^)(NSDraggingSession *))completionHandler;
+
 - (void)beginRangeSelectionAtPoint:(NSPoint)point withGranularity:(NSTextSelectionGranularity)granularity;
 - (void)continueRangeSelectionAtPoint:(NSPoint)point;
 - (void)endRangeSelectionAtPoint:(NSPoint)point;
+
+- (void)moveInsertionCursorToPoint:(NSPoint)point placeAtWordBoundary:(BOOL)wordBoundary completionHandler:(void(^)(BOOL))completionHandler;
 
 @end
 


### PR DESCRIPTION
#### ac7381b615e8d93d872f1edd5fd230e1a8100a6c
<pre>
[AppKit Gestures] Selection does not show context menu when a secondary click is performed
<a href="https://bugs.webkit.org/show_bug.cgi?id=308350">https://bugs.webkit.org/show_bug.cgi?id=308350</a>
<a href="https://rdar.apple.com/170844266">rdar://170844266</a>

Reviewed by Abrar Rahman Protyasha.

Fix by adopting the updated system delegate interface.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:

- Remove the forward declaration since it was literally doing nothing and was just a burden to maintain

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

- Properly annotate the nullability of the WebViewImpl accessor

* Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift:
(CGPoint.distance(to:)): Deleted.
(CGRect.distance(to:)): Deleted.

- Delete some now-unused functions

* Source/WebKit/UIProcess/mac/WKTextSelectionController.h:
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.addTextSelectionManager):
(WKTextSelectionController.selectionDidChange):
(WKTextSelectionController.insertionCursorRect):
(WKTextSelectionController.selectionIsInsertionPoint):
(WKTextSelectionController.isTextSelected(at:)):
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
(WKTextSelectionController.showContextMenu(at:)):
(WKTextSelectionController.dragSelection(withGesture:completionHandler:)):
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.continueRangeSelection(at:)):
(WKTextSelectionController.endRangeSelection(at:)):
(WKTextSelectionController.moveInsertionCursor(to:)): Deleted.
(WKTextSelectionController.handleDoubleClick(at:)): Deleted.
(WKTextSelectionController.handleSingleClick(at:)): Deleted.
(WKTextSelectionController.handleClick(at:)): Deleted.
(WKTextSelectionController.handleClick(at:clickCount:)): Deleted.

- Switch to `unowned` from `weak` since the WKWebView will never actually be nil
- Remove some duplicate logic now that the system takes care of it
- Adopt and replace a few delegate methods

Canonical link: <a href="https://commits.webkit.org/308084@main">https://commits.webkit.org/308084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e9fae68e32a82ae473ae4efa25fa2716eb62ebf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155058 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13981474-7f22-4af3-8f8c-4ffe5d4c06a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18970 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4605679-8c76-4739-81ad-1bcd4df91b90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93530 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d761d28e-0f62-4dbb-9244-3bb30e9d74ce) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12052 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123859 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157380 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120698 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120992 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74694 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22584 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16662 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18399 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->