### PR TITLE
Suppress safer C++ warnings in Source/WebKit/Shared

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,7 +1,3 @@
-[ Mac ] Shared/API/Cocoa/_WKFrameHandle.mm
-[ Mac ] Shared/API/Cocoa/_WKHitTestResult.mm
-[ Mac ] Shared/Cocoa/WKNSArray.mm
-[ Mac ] Shared/Cocoa/WKNSNumber.mm
 [ Mac ] UIProcess/API/C/WKContext.cpp
 [ Mac ] UIProcess/API/C/WKContextConfigurationRef.cpp
 [ Mac ] UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,1 +1,0 @@
-[ Mac ] Shared/Cocoa/WKObject.h

--- a/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
@@ -37,7 +37,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKFrameHandle.class, self))
         return;
 
-    _frameHandle->~FrameHandle();
+    SUPPRESS_UNCOUNTED_ARG _frameHandle->~FrameHandle();
 
     [super dealloc];
 }

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -41,7 +41,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKHitTestResult.class, self))
         return;
 
-    _hitTestResult->~HitTestResult();
+    SUPPRESS_UNCOUNTED_ARG _hitTestResult->~HitTestResult();
 
     [super dealloc];
 }

--- a/Source/WebKit/Shared/Cocoa/WKNSArray.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSArray.mm
@@ -38,7 +38,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNSArray.class, self))
         return;
 
-    _array->~Array();
+    SUPPRESS_UNCOUNTED_ARG _array->~Array();
 
     [super dealloc];
 }

--- a/Source/WebKit/Shared/Cocoa/WKNSNumber.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSNumber.mm
@@ -43,19 +43,19 @@ using namespace WebKit;
 {
     switch (_type) {
     case API::Object::Type::Boolean:
-        _number._boolean->~Boolean();
+        SUPPRESS_UNCOUNTED_ARG _number._boolean->~Boolean();
         break;
 
     case API::Object::Type::Double:
-        _number._double->~Double();
+        SUPPRESS_UNCOUNTED_ARG _number._double->~Double();
         break;
 
     case API::Object::Type::UInt64:
-        _number._uint64->~UInt64();
+        SUPPRESS_UNCOUNTED_ARG _number._uint64->~UInt64();
         break;
 
     case API::Object::Type::Int64:
-        _number._int64->~Int64();
+        SUPPRESS_UNCOUNTED_ARG _number._int64->~Int64();
         break;
 
     default:

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -51,37 +51,37 @@ namespace WebKit {
 
 template<typename WrappedObjectClass> struct WrapperTraits;
 
-template<typename DestinationClass, typename SourceClass> inline DestinationClass *checkedObjCCast(SourceClass *source)
+template<typename DestinationClass, typename SourceClass> inline CLANG_POINTER_CONVERSION DestinationClass *checkedObjCCast(SourceClass *source)
 {
     return checked_objc_cast<DestinationClass>(source);
 }
 
-template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass& object)
+template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass& object)
 {
     return checkedObjCCast<typename WrapperTraits<ObjectClass>::WrapperClass>(object.wrapper());
 }
 
-template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass* object)
+template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass* object)
 {
     return object ? wrapper(*object) : nil;
 }
 
-template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const Ref<ObjectClass>& object)
+template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const Ref<ObjectClass>& object)
 {
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const RefPtr<ObjectClass>& object)
+template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const RefPtr<ObjectClass>& object)
 {
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(Ref<ObjectClass>&& object)
+template<typename ObjectClass> inline CLANG_POINTER_CONVERSION RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(Ref<ObjectClass>&& object)
 {
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(RefPtr<ObjectClass>&& object)
+template<typename ObjectClass> inline CLANG_POINTER_CONVERSION RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(RefPtr<ObjectClass>&& object)
 {
     return object ? wrapper(object.releaseNonNull()) : nil;
 }


### PR DESCRIPTION
#### 51175caa041c4d256d43bd7b87dba8ad713da238
<pre>
Suppress safer C++ warnings in Source/WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=308354">https://bugs.webkit.org/show_bug.cgi?id=308354</a>

Reviewed by Anne van Kesteren.

Suppressed new safer C++ warnings found after clang rollout in 307871@main.

No new tests since there should be no behavioral changes.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm:
(-[_WKFrameHandle dealloc]):
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult dealloc]):
* Source/WebKit/Shared/Cocoa/WKNSArray.mm:
(-[WKNSArray dealloc]):
* Source/WebKit/Shared/Cocoa/WKNSNumber.mm:
(-[WKNSNumber dealloc]):
* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::checkedObjCCast):
(WebKit::wrapper):

Canonical link: <a href="https://commits.webkit.org/307969@main">https://commits.webkit.org/307969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf0ea01a2ab67d6fbb75ff8e0a9af7fe328b0301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154755 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/836b2c10-b942-44ae-b061-84fa1368387c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e301d9dc-6066-4e81-8b11-88370195a6b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93270 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c5d9c26-a06d-48be-97a9-e7a562dcf64e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11772 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2201 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123580 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157073 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120412 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120721 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74285 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7518 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81958 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17939 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->