### PR TITLE
Fix Memory64 overflow checks in BBQ

### DIFF
--- a/JSTests/wasm/spec-harness/wasm-module-builder.js
+++ b/JSTests/wasm/spec-harness/wasm-module-builder.js
@@ -162,6 +162,11 @@ class WasmModuleBuilder {
     return this;
   }
 
+  addMemory64(min, max, exp) {
+    this.memory = {min: min, max: max, exp: exp, is_memory64: true};
+    return this;
+  }
+
   addExplicitSection(bytes) {
     this.explicit.push(bytes);
     return this;
@@ -367,7 +372,9 @@ class WasmModuleBuilder {
       binary.emit_section(kMemorySectionCode, section => {
         section.emit_u8(1);  // one memory entry
         const has_max = wasm.memory.max !== undefined;
-        section.emit_u32v(has_max ? kResizableMaximumFlag : 0);
+        const is_memory64 = !!wasm.memory.is_memory64;
+        const flags = (is_memory64 ? 4 : 0) | (has_max ? kResizableMaximumFlag : 0);
+        section.emit_u32v(flags);
         section.emit_u32v(wasm.memory.min);
         if (has_max) section.emit_u32v(wasm.memory.max);
       });

--- a/JSTests/wasm/stress/memory64-bulk-memory.js
+++ b/JSTests/wasm/stress/memory64-bulk-memory.js
@@ -29,7 +29,7 @@ let wat = `
 `;
 
 const helloBytes = "hello";
-const instance = await instantiate(wat, {}, {reference_types: true});
+const instance = await instantiate(wat, {}, {memory64: true});
 const {testInit, testFill, testCopy, memory} = instance.exports;
 const len = helloBytes.length;
 const iterable = new DataView(memory.buffer);

--- a/JSTests/wasm/stress/memory64-grow-and-size.js
+++ b/JSTests/wasm/stress/memory64-grow-and-size.js
@@ -18,7 +18,7 @@ async function test() {
     )
     `;
 
-    const instance = await instantiate(wat, {}, {reference_types: true});
+    const instance = await instantiate(wat, {}, {memory64: true});
     const { getSize, grow, memory } = instance.exports;
 
     let size;

--- a/JSTests/wasm/stress/memory64-load-and-store.js
+++ b/JSTests/wasm/stress/memory64-load-and-store.js
@@ -54,7 +54,7 @@ let wat = `
     }
 )`;
 
-const instance = await instantiate(wat, {}, {reference_types: true});
+const instance = await instantiate(wat, {}, {memory64: true});
 const exports = instance.exports;
 
 function test() {

--- a/JSTests/wasm/stress/memory64-overflow.js
+++ b/JSTests/wasm/stress/memory64-overflow.js
@@ -1,39 +1,94 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
-import { instantiate } from "../wabt-wrapper.js";
-import * as assert from "../assert.js";
+//@ runDefaultWasm("--useWasmMemory64=1", "--useOMGJIT=0")
 
-async function test() {
-  const wat = `
-  (module
-      (memory i64 1)
-      (func (export "load") (param $addr i64) (result i32)
-          local.get $addr
-          i32.load offset=1
-      )
-      (func (export "store") (param $addr i64)
-          local.get $addr
-          i32.const 0
-          i32.store offset=1
-      )
-  )
-  `;
+load("../spec-harness.js", "caller relative");
 
-  const instance = await instantiate(wat, {}, { threads: false });
-  const { load, store } = instance.exports;
+// u64 LEB128 encoding of 0xffffffffffffffff
+const kU64MaxLEB128 = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01];
 
-  const outOfBoundsError = [
-    WebAssembly.RuntimeError,
-    "Out of bounds memory access (evaluating 'func(...args)')",
-  ];
-  // 0xFFFFFFFFFFFFFFFF + offset=1 wraps to 0x0, which is in bounds —
-  // without overflow detection this would incorrectly succeed.
-  assert.throws(() => load(0xffffffffffffffffn), ...outOfBoundsError);
-  assert.throws(() => store(0xffffffffffffffffn), ...outOfBoundsError);
+const builder = new WasmModuleBuilder();
+builder.addMemory64(1);
 
-  // 0xFFFFFFFFFFFFFFFE + offset=1 + size-1=3 wraps to 2, also falsely in bounds.
-  assert.throws(() => load(0xfffffffffffffffen), ...outOfBoundsError);
-  assert.throws(() => store(0xfffffffffffffffen), ...outOfBoundsError);
+builder.addFunction("testLoad", makeSig([kWasmI64], [kWasmI32]))
+    .addBody([
+        kExprGetLocal, 0,
+        kExprI32LoadMem, 0, 1,
+    ])
+    .exportAs("testLoad");
+
+builder.addFunction("testStore", makeSig([kWasmI64], []))
+    .addBody([
+        kExprGetLocal, 0,
+        kExprI32Const, 0,
+        kExprI32StoreMem, 0, 1,         
+    ])
+    .exportAs("testStore");
+
+builder.addFunction("constantLoad", makeSig([], [kWasmI32]))
+    .addBody([
+        kExprI64Const, 0x7F,  // -1 as signed LEB128 = 0xFFFFFFFFFFFFFFFF
+        kExprI32LoadMem, 0, 1,
+    ])
+    .exportAs("constantLoad");
+
+builder.addFunction("constantStore", makeSig([], []))
+    .addBody([
+        kExprI64Const, 0x7F,  // -1 as signed LEB128 = 0xFFFFFFFFFFFFFFFF
+        kExprI32Const, 0,
+        kExprI32StoreMem, 0, 1,
+    ])
+    .exportAs("constantStore");
+
+builder.addFunction("offsetLoad", makeSig([], [kWasmI32]))
+    .addBody([
+        kExprI64Const, 0,
+        kExprI32LoadMem, 0, ...kU64MaxLEB128,  
+    ])
+    .exportAs("offsetLoad");
+
+builder.addFunction("offsetStore", makeSig([], []))
+    .addBody([
+        kExprI64Const, 0,
+        kExprI32Const, 0,
+        kExprI32StoreMem, 0, ...kU64MaxLEB128,  
+    ])
+    .exportAs("offsetStore");
+
+const { testLoad, testStore, constantLoad, constantStore, offsetStore, offsetLoad } = builder.instantiate().exports;
+
+function testOverflow() {
+  assert.throws(() => testLoad(0xffffffffffffffffn), 
+      WebAssembly.RuntimeError, 
+      "Out of bounds memory access (evaluating 'testLoad(0xffffffffffffffffn)')");
+
+  assert.throws(() => testStore(0xffffffffffffffffn), 
+        WebAssembly.RuntimeError, 
+      "Out of bounds memory access (evaluating 'testStore(0xffffffffffffffffn)')");
+
+  assert.throws(() => testLoad(0xfffffffffffffffen), 
+      WebAssembly.RuntimeError, 
+      "Out of bounds memory access (evaluating 'testLoad(0xfffffffffffffffen)')");
+
+  assert.throws(() => testStore(0xfffffffffffffffen), 
+        WebAssembly.RuntimeError, 
+      "Out of bounds memory access (evaluating 'testStore(0xfffffffffffffffen)')");
+
+  assert.throws(() => constantLoad(), 
+        WebAssembly.RuntimeError, 
+        "Out of bounds memory access (evaluating 'constantLoad()')");
+
+  assert.throws(() => constantStore(), 
+        WebAssembly.RuntimeError, 
+        "Out of bounds memory access (evaluating 'constantStore()')");
+
+  assert.throws(() => offsetStore(), 
+        WebAssembly.RuntimeError, 
+        "Out of bounds memory access (evaluating 'offsetStore()')");
+
+    assert.throws(() => offsetLoad(), 
+        WebAssembly.RuntimeError, 
+        "Out of bounds memory access (evaluating 'offsetLoad()')");
 }
 
-await assert.asyncTest(test());
+for (let i = 0; i < wasmTestLoopCount; i++)
+    testOverflow();

--- a/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
+++ b/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
@@ -18,13 +18,15 @@ const instance = await instantiate(wat, {}, {reference_types: true});
 const {write, read} = instance.exports;
 
 const writeAddr = BigInt(Number.MAX_SAFE_INTEGER + 1);
+const outOfBoundsError = [
+    WebAssembly.RuntimeError,
+    "Out of bounds memory access (evaluating 'func(...args)')",
+];
+
 function test() {
-    const outOfBoundsError = [
-        WebAssembly.RuntimeError,
-        "Out of bounds memory access (evaluating 'func(...args)')",
-    ];
     assert.throws(() => write(42, writeAddr), ...outOfBoundsError);
     assert.throws(() => read(writeAddr), ...outOfBoundsError);
 }
 
-test();
+for (let i = 0; i < wasmTestLoopCount; i++)
+    test();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -342,7 +342,11 @@ Value BBQJIT::instanceValue()
 
 [[nodiscard]] PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint64_t uoffset)
 {
-    if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
+    bool offsetAndSizeOverflows = m_info.theOnlyMemory().isMemory64()
+        ? sumOverflows<uint64_t>(uoffset, sizeOfLoadOp(loadOp))
+        : sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp));
+
+    if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -435,7 +439,11 @@ Value BBQJIT::instanceValue()
 [[nodiscard]] PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint64_t uoffset)
 {
     Location valueLocation = locationOf(value);
-    if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
+    bool offsetAndSizeOverflows = m_info.theOnlyMemory().isMemory64()
+        ? sumOverflows<uint64_t>(uoffset, sizeOfStoreOp(storeOp))
+        : sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp));
+
+    if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -31,8 +31,10 @@
 #include "WasmBBQJIT.h"
 #include "WasmCallingConvention.h"
 #include "WasmCompilationContext.h"
+#include "WasmExceptionType.h"
 #include "WasmFunctionParser.h"
 #include "WasmLimits.h"
+#include <wtf/CheckedArithmetic.h>
 
 namespace JSC { namespace Wasm { namespace BBQJITImpl {
 
@@ -44,6 +46,11 @@ ALWAYS_INLINE bool BBQJIT::typeNeedsGPR2(TypeKind)
 template<typename Functor>
 auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64_t uoffset, uint32_t sizeOfOperation, Functor&& functor) -> decltype(auto)
 {
+    if (WTF::sumOverflows<uint64_t>(static_cast<uint64_t>(sizeOfOperation), uoffset)) {
+        recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
+        return functor(CCallHelpers::Address(wasmBaseMemoryPointer, 0));
+    }
+
     uint64_t boundary = static_cast<uint64_t>(sizeOfOperation) + uoffset - 1;
 
     ScratchScope<1, 0> scratches(*this);
@@ -51,25 +58,29 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
 
     if (pointer.isConst()) {
         uint64_t constantPointer = m_info.theOnlyMemory().isMemory64() ? pointer.asI64() : static_cast<uint32_t>(pointer.asI32());
-        uint64_t finalOffset = constantPointer + uoffset;
-        if (!(finalOffset > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) || !B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(finalOffset), Width::Width128))) {
-            switch (m_mode) {
-            case MemoryMode::BoundsChecking: {
-                m_jit.move(TrustedImmPtr(constantPointer + boundary), wasmScratchGPR);
-                recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchPtr(RelationalCondition::AboveOrEqual, wasmScratchGPR, wasmBoundsCheckingSizeRegister));
-                break;
-            }
-            case MemoryMode::Signaling: {
-                RELEASE_ASSERT(!m_info.theOnlyMemory().isMemory64());
-                if (uoffset >= Memory::fastMappedRedzoneBytes()) {
-                    uint64_t maximum = m_info.theOnlyMemory().maximum() ? m_info.theOnlyMemory().maximum().bytes() : std::numeric_limits<uint32_t>::max();
-                    if ((constantPointer + boundary) >= maximum)
-                        recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
+        if (WTF::sumOverflows<uint64_t>(constantPointer, boundary))
+            recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
+        else {
+            uint64_t finalOffset = constantPointer + uoffset;
+            if (finalOffset <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) && B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(finalOffset), Width::Width128)) {
+                switch (m_mode) {
+                case MemoryMode::BoundsChecking: {
+                    m_jit.move(TrustedImmPtr(constantPointer + boundary), wasmScratchGPR);
+                    recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchPtr(RelationalCondition::AboveOrEqual, wasmScratchGPR, wasmBoundsCheckingSizeRegister));
+                    break;
                 }
-                break;
+                case MemoryMode::Signaling: {
+                    // FIXME: it seems like this check is covered by the constantPointer + boundary >= maximum check below?
+                    if (uoffset >= Memory::fastMappedRedzoneBytes()) {
+                        uint64_t maximum = m_info.theOnlyMemory().maximum() ? m_info.theOnlyMemory().maximum().bytes() : std::numeric_limits<uint32_t>::max();
+                        if ((constantPointer + boundary) >= maximum)
+                            recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
+                    }
+                    break;
+                }
+                }
+                return functor(CCallHelpers::Address(wasmBaseMemoryPointer, static_cast<int32_t>(finalOffset)));
             }
-            }
-            return functor(CCallHelpers::Address(wasmBaseMemoryPointer, static_cast<int32_t>(finalOffset)));
         }
         pointerLocation = Location::fromGPR(scratches.gpr(0));
         emitMoveConst(pointer, pointerLocation);
@@ -81,13 +92,19 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
     case MemoryMode::BoundsChecking: {
         // We're not using signal handling only when the memory is not shared.
         // Regardless of signaling, we must check that no memory access exceeds the current memory size.
-        m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
-        if (boundary)
-            m_jit.addPtr(TrustedImmPtr(boundary), wasmScratchGPR);
+        if (m_info.theOnlyMemory().isMemory64() && boundary) {
+            m_jit.move(TrustedImmPtr(boundary), wasmScratchGPR);
+            Jump overflow = m_jit.branchAddPtr(ResultCondition::Carry, pointerLocation.asGPR(), wasmScratchGPR);
+            recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, overflow);
+        } else {
+            m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
+            if (boundary)
+                m_jit.addPtr(TrustedImmPtr(boundary), wasmScratchGPR);
+        }
+
         recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchPtr(RelationalCondition::AboveOrEqual, wasmScratchGPR, wasmBoundsCheckingSizeRegister));
         break;
     }
-
     case MemoryMode::Signaling: {
         RELEASE_ASSERT(!m_info.theOnlyMemory().isMemory64());
         // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
@@ -113,18 +130,29 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
 
     bool canUseOffsetForm = uoffset <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) && B3::Air::Arg::isValidAddrForm(B3::Air::Move, static_cast<int32_t>(uoffset), Width::Width128);
 #if CPU(ARM64)
-    if (canUseOffsetForm)
+    if (canUseOffsetForm) {
+        if (m_info.theOnlyMemory().isMemory64())
+            return functor(CCallHelpers::BaseIndex(wasmBaseMemoryPointer, pointerLocation.asGPR(), CCallHelpers::TimesOne, static_cast<int32_t>(uoffset)));
         return functor(CCallHelpers::BaseIndex(wasmBaseMemoryPointer, pointerLocation.asGPR(), CCallHelpers::TimesOne, static_cast<int32_t>(uoffset), CCallHelpers::Extend::ZExt32));
+    }
 
-    m_jit.addZeroExtend64(wasmBaseMemoryPointer, pointerLocation.asGPR(), wasmScratchGPR);
+    if (m_info.theOnlyMemory().isMemory64())
+        m_jit.addPtr(wasmBaseMemoryPointer, pointerLocation.asGPR(), wasmScratchGPR);
+    else
+        m_jit.addZeroExtend64(wasmBaseMemoryPointer, pointerLocation.asGPR(), wasmScratchGPR);
 #else
-    m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
-    m_jit.addPtr(wasmBaseMemoryPointer, wasmScratchGPR);
+    if (m_info.theOnlyMemory().isMemory64())
+        m_jit.addPtr(wasmBaseMemoryPointer, pointerLocation.asGPR(), wasmScratchGPR);
+    else {
+        m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
+        m_jit.addPtr(wasmBaseMemoryPointer, wasmScratchGPR);
+    }
 #endif
 
     if (canUseOffsetForm)
         return functor(Address(wasmScratchGPR, static_cast<int32_t>(uoffset)));
 
+    // FIXME: We (potentially) already computed this above before adding the boundary, we should preserve that add result and use it again here
     m_jit.addPtr(TrustedImmPtr(uoffset), wasmScratchGPR);
     return functor(Address(wasmScratchGPR));
 }


### PR DESCRIPTION
#### d8a913bd3feb8328bbe68664e5e33ef60f34d36c
<pre>
Fix Memory64 overflow checks in BBQ
<a href="https://rdar.apple.com/170851725">rdar://170851725</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308356">https://bugs.webkit.org/show_bug.cgi?id=308356</a>

Reviewed by Keith Miller.

Memory64 bounds checking was not correct. I also stopped zero-extending the 64 bit pointer.

* JSTests/wasm/stress/memory64-bulk-memory.js:
* JSTests/wasm/stress/memory64-grow-and-size.js:
(async test):
* JSTests/wasm/stress/memory64-load-and-store.js:
* JSTests/wasm/stress/memory64-overflow.js:
(test):
(async test): Deleted.
* JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js:
(test):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPrepareAndMaterializePointerApply):

Canonical link: <a href="https://commits.webkit.org/308634@main">https://commits.webkit.org/308634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c4467fc5b9a65ffd4e20858241992d7040fcc14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101395 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81351 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad07e0f9-466b-4ff0-b47a-97bbf5bfacb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16321 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89eea661-89ac-4324-a6f0-7124fbbc7d84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13267 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4102 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125073 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158998 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8769 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2132 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122110 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122316 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31373 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76617 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17791 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83842 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19812 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->