### PR TITLE
Fix places where NODELETE was incorrectly added to implementation instead of declaration

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
@@ -74,7 +74,7 @@ void ComputePassEncoderImpl::setBindGroup(Index32 index, const BindGroup* bindGr
     wgpuComputePassEncoderSetBindGroup(m_backing.get(), index, bindGroup ? m_convertToBackingContext->convertToBacking(*bindGroup) : nullptr, WTF::move(offsets));
 }
 
-void NODELETE ComputePassEncoderImpl::setBindGroup(Index32, const BindGroup*, std::span<const uint32_t>, Size64, Size32)
+void ComputePassEncoderImpl::setBindGroup(Index32, const BindGroup*, std::span<const uint32_t>, Size64, Size32)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
@@ -68,7 +68,7 @@ private:
     void setBindGroup(Index32, const BindGroup*,
         std::optional<Vector<BufferDynamicOffset>>&&) final;
 
-    void setBindGroup(Index32, const BindGroup*,
+    void NODELETE setBindGroup(Index32, const BindGroup*,
         std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) final;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -72,7 +72,7 @@ void QueueImpl::onSubmittedWorkDone(CompletionHandler<void()>&& callback)
     wgpuQueueOnSubmittedWorkDone(m_backing.get(), &onSubmittedWorkDoneCallback, Block_copy(blockPtr.get())); // Block_copy is matched with Block_release above in onSubmittedWorkDoneCallback().
 }
 
-void NODELETE QueueImpl::writeBuffer(
+void QueueImpl::writeBuffer(
     const Buffer&,
     Size64,
     std::span<const uint8_t>,
@@ -82,7 +82,7 @@ void NODELETE QueueImpl::writeBuffer(
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void NODELETE QueueImpl::writeTexture(
+void QueueImpl::writeTexture(
     const ImageCopyTexture&,
     std::span<const uint8_t>,
     const ImageDataLayout&,
@@ -127,7 +127,7 @@ void QueueImpl::writeTexture(
     wgpuQueueWriteTexture(m_backing.get(), &backingDestination, source, &backingDataLayout, &backingSize);
 }
 
-void NODELETE QueueImpl::copyExternalImageToTexture(
+void QueueImpl::copyExternalImageToTexture(
     const ImageCopyExternalImage& source,
     const ImageCopyTextureTagged& destination,
     const Extent3D& copySize)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -64,14 +64,14 @@ private:
 
     void onSubmittedWorkDone(CompletionHandler<void()>&&) final;
 
-    void writeBuffer(
+    void NODELETE writeBuffer(
         const Buffer&,
         Size64 bufferOffset,
         std::span<const uint8_t> source,
         Size64 dataOffset,
         std::optional<Size64>) final;
 
-    void writeTexture(
+    void NODELETE writeTexture(
         const ImageCopyTexture& destination,
         std::span<const uint8_t> source,
         const ImageDataLayout&,
@@ -90,7 +90,7 @@ private:
         const ImageDataLayout&,
         const Extent3D& size) final;
 
-    void copyExternalImageToTexture(
+    void NODELETE copyExternalImageToTexture(
         const ImageCopyExternalImage& source,
         const ImageCopyTextureTagged& destination,
         const Extent3D& copySize) final;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
@@ -94,7 +94,7 @@ void RenderBundleEncoderImpl::setBindGroup(Index32 index, const BindGroup* bindG
     wgpuRenderBundleEncoderSetBindGroupWithDynamicOffsets(m_backing.get(), index, bindGroup ? m_convertToBackingContext->convertToBacking(*bindGroup) : nullptr, WTF::move(dynamicOffsets));
 }
 
-void NODELETE RenderBundleEncoderImpl::setBindGroup(Index32, const BindGroup*,
+void RenderBundleEncoderImpl::setBindGroup(Index32, const BindGroup*,
     std::span<const uint32_t>,
     Size64,
     Size32)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
@@ -77,7 +77,7 @@ private:
     void setBindGroup(Index32, const BindGroup*,
         std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets) final;
 
-    void setBindGroup(Index32, const BindGroup*,
+    void NODELETE setBindGroup(Index32, const BindGroup*,
         std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) final;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
@@ -94,7 +94,7 @@ void RenderPassEncoderImpl::setBindGroup(Index32 index, const BindGroup* bindGro
     wgpuRenderPassEncoderSetBindGroup(m_backing.get(), index, bindGroup ? m_convertToBackingContext->convertToBacking(*bindGroup) : nullptr, WTF::move(dynamicOffsets));
 }
 
-void NODELETE RenderPassEncoderImpl::setBindGroup(Index32, const BindGroup*, std::span<const uint32_t>, Size64, Size32)
+void RenderPassEncoderImpl::setBindGroup(Index32, const BindGroup*, std::span<const uint32_t>, Size64, Size32)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
@@ -77,7 +77,7 @@ private:
     void setBindGroup(Index32, const BindGroup*,
         std::optional<Vector<BufferDynamicOffset>>&& dynamicOffsets) final;
 
-    void setBindGroup(Index32, const BindGroup*,
+    void NODELETE setBindGroup(Index32, const BindGroup*,
         std::span<const uint32_t> dynamicOffsetsArrayBuffer,
         Size64 dynamicOffsetsDataStart,
         Size32 dynamicOffsetsDataLength) final;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
@@ -87,7 +87,7 @@ private:
     ExceptionOr<Vector<uint8_t>> encryptData(std::span<const uint8_t>, const Vector<uint8_t>& iv, const Vector<uint8_t>& key);
     ExceptionOr<Vector<uint8_t>> decryptData(std::span<const uint8_t>, const Vector<uint8_t>& iv, const Vector<uint8_t>& key);
     Vector<uint8_t> computeEncryptedDataSignature(const Vector<uint8_t>& nonce, std::span<const uint8_t> header, std::span<const uint8_t> data, const Vector<uint8_t>& key);
-    void updateAuthenticationSize();
+    void NODELETE updateAuthenticationSize();
 
     mutable Lock m_keyLock;
     bool m_hasKey { false };

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
@@ -91,7 +91,7 @@ Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vec
     return result;
 }
 
-void NODELETE RTCRtpSFrameTransformer::updateAuthenticationSize()
+void RTCRtpSFrameTransformer::updateAuthenticationSize()
 {
     if (m_authenticationSize > CC_SHA256_DIGEST_LENGTH)
         m_authenticationSize = CC_SHA256_DIGEST_LENGTH;

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -272,7 +272,7 @@ WebSocketHandshake::Mode WebSocketHandshake::mode() const
     return m_mode;
 }
 
-String NODELETE WebSocketHandshake::failureReason() const
+String WebSocketHandshake::failureReason() const
 {
     return m_failureReason;
 }

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -73,7 +73,7 @@ public:
 
     WEBCORE_EXPORT int readServerHandshake(std::span<const uint8_t> header);
     WEBCORE_EXPORT Mode NODELETE mode() const;
-    WEBCORE_EXPORT String failureReason() const; // Returns a string indicating the reason of failure if mode() == Failed.
+    WEBCORE_EXPORT String NODELETE failureReason() const; // Returns a string indicating the reason of failure if mode() == Failed.
 
     WEBCORE_EXPORT String serverWebSocketProtocol() const;
     WEBCORE_EXPORT String serverSetCookie() const;

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -667,19 +667,19 @@ RefPtr<Icon> EmptyChromeClient::createIconForFiles(const Vector<String>& /* file
 
 // MARK: -
 
-void NODELETE EmptyFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&)
+void EmptyFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse&, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, NavigationUpgradeToHTTPSBehavior, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&)
+void EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse&, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, NavigationUpgradeToHTTPSBehavior, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::updateSandboxFlags(SandboxFlags)
+void EmptyFrameLoaderClient::updateSandboxFlags(SandboxFlags)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::updateOpener(std::optional<FrameIdentifier>)
+void EmptyFrameLoaderClient::updateOpener(std::optional<FrameIdentifier>)
 {
 }
 
@@ -687,7 +687,7 @@ void EmptyFrameLoaderClient::setPrinting(bool, FloatSize, FloatSize, float, Adju
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<FormState>&&)
+void EmptyFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<FormState>&&)
 {
 }
 
@@ -716,12 +716,12 @@ RefPtr<Widget> EmptyFrameLoaderClient::createPlugin(HTMLPlugInElement&, const UR
     return nullptr;
 }
 
-bool NODELETE EmptyFrameLoaderClient::hasWebView() const
+bool EmptyFrameLoaderClient::hasWebView() const
 {
     return true; // mainly for assertions
 }
 
-void NODELETE EmptyFrameLoaderClient::makeRepresentation(DocumentLoader*)
+void EmptyFrameLoaderClient::makeRepresentation(DocumentLoader*)
 {
 }
 
@@ -734,46 +734,46 @@ bool EmptyFrameLoaderClient::forceLayoutOnRestoreFromBackForwardCache()
 
 #endif
 
-void NODELETE EmptyFrameLoaderClient::forceLayoutForNonHTML()
+void EmptyFrameLoaderClient::forceLayoutForNonHTML()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::setCopiesOnScroll()
+void EmptyFrameLoaderClient::setCopiesOnScroll()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::detachedFromParent2()
+void EmptyFrameLoaderClient::detachedFromParent2()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::detachedFromParent3()
+void EmptyFrameLoaderClient::detachedFromParent3()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&)
+void EmptyFrameLoaderClient::convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&)
+void EmptyFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&)
 {
 }
 
-bool NODELETE EmptyFrameLoaderClient::shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier)
+bool EmptyFrameLoaderClient::shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier)
 {
     return false;
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse&)
+void EmptyFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge(DocumentLoader*, ResourceLoaderIdentifier, const AuthenticationChallenge&)
+void EmptyFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge(DocumentLoader*, ResourceLoaderIdentifier, const AuthenticationChallenge&)
 {
 }
 
 #if USE(PROTECTION_SPACE_AUTH_CALLBACK)
 
-bool NODELETE EmptyFrameLoaderClient::canAuthenticateAgainstProtectionSpace(DocumentLoader*, ResourceLoaderIdentifier, const ProtectionSpace&)
+bool EmptyFrameLoaderClient::canAuthenticateAgainstProtectionSpace(DocumentLoader*, ResourceLoaderIdentifier, const ProtectionSpace&)
 {
     return false;
 }
@@ -789,44 +789,44 @@ RetainPtr<CFDictionaryRef> EmptyFrameLoaderClient::connectionProperties(Document
 
 #endif
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&)
+void EmptyFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier, int)
+void EmptyFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier, int)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier)
+void EmptyFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier)
 {
 }
 
 #if ENABLE(DATA_DETECTION)
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *)
+void EmptyFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *)
 {
 }
 
 #endif
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&)
+void EmptyFrameLoaderClient::dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&)
 {
 }
 
-bool NODELETE EmptyFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int)
+bool EmptyFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int)
 {
     return false;
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidDispatchOnloadEvents()
+void EmptyFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
+void EmptyFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidCancelClientRedirect()
+void EmptyFrameLoaderClient::dispatchDidCancelClientRedirect()
 {
 }
 
@@ -834,195 +834,195 @@ void EmptyFrameLoaderClient::dispatchWillPerformClientRedirect(const URL&, doubl
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidChangeLocationWithinPage()
+void EmptyFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidPushStateWithinPage()
+void EmptyFrameLoaderClient::dispatchDidPushStateWithinPage()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReplaceStateWithinPage()
+void EmptyFrameLoaderClient::dispatchDidReplaceStateWithinPage()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidPopStateWithinPage()
+void EmptyFrameLoaderClient::dispatchDidPopStateWithinPage()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchWillClose()
+void EmptyFrameLoaderClient::dispatchWillClose()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidStartProvisionalLoad()
+void EmptyFrameLoaderClient::dispatchDidStartProvisionalLoad()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirection&)
+void EmptyFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirection&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureContent>, std::optional<UsedLegacyTLS>, std::optional<WasPrivateRelayed>)
+void EmptyFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureContent>, std::optional<UsedLegacyTLS>, std::optional<WasPrivateRelayed>)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceError&, WillContinueLoading, WillInternallyHandleFailure)
+void EmptyFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceError&, WillContinueLoading, WillInternallyHandleFailure)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFailLoad(const ResourceError&)
+void EmptyFrameLoaderClient::dispatchDidFailLoad(const ResourceError&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFinishDocumentLoad()
+void EmptyFrameLoaderClient::dispatchDidFinishDocumentLoad()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidFinishLoad()
+void EmptyFrameLoaderClient::dispatchDidFinishLoad()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>)
+void EmptyFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState()
+void EmptyFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState()
 {
 }
 
-LocalFrame* NODELETE EmptyFrameLoaderClient::dispatchCreatePage(const NavigationAction&, NewFrameOpenerPolicy)
+LocalFrame* EmptyFrameLoaderClient::dispatchCreatePage(const NavigationAction&, NewFrameOpenerPolicy)
 {
     return nullptr;
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchShow()
+void EmptyFrameLoaderClient::dispatchShow()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&)
+void EmptyFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::cancelPolicyCheck()
+void EmptyFrameLoaderClient::cancelPolicyCheck()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchUnableToImplementPolicy(const ResourceError&)
+void EmptyFrameLoaderClient::dispatchUnableToImplementPolicy(const ResourceError&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::revertToProvisionalState(DocumentLoader*)
+void EmptyFrameLoaderClient::revertToProvisionalState(DocumentLoader*)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::setMainDocumentError(DocumentLoader*, const ResourceError&)
+void EmptyFrameLoaderClient::setMainDocumentError(DocumentLoader*, const ResourceError&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::setMainFrameDocumentReady(bool)
+void EmptyFrameLoaderClient::setMainFrameDocumentReady(bool)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::startDownload(const ResourceRequest&, const String&, FromDownloadAttribute)
+void EmptyFrameLoaderClient::startDownload(const ResourceRequest&, const String&, FromDownloadAttribute)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::willChangeTitle(DocumentLoader*)
+void EmptyFrameLoaderClient::willChangeTitle(DocumentLoader*)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::didChangeTitle(DocumentLoader*)
+void EmptyFrameLoaderClient::didChangeTitle(DocumentLoader*)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::willReplaceMultipartContent()
+void EmptyFrameLoaderClient::willReplaceMultipartContent()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::didReplaceMultipartContent()
+void EmptyFrameLoaderClient::didReplaceMultipartContent()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::committedLoad(DocumentLoader*, const SharedBuffer&)
+void EmptyFrameLoaderClient::committedLoad(DocumentLoader*, const SharedBuffer&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::finishedLoading(DocumentLoader*)
+void EmptyFrameLoaderClient::finishedLoading(DocumentLoader*)
 {
 }
 
-bool NODELETE EmptyFrameLoaderClient::shouldFallBack(const ResourceError&) const
-{
-    return false;
-}
-
-void NODELETE EmptyFrameLoaderClient::loadStorageAccessQuirksIfNeeded()
-{
-}
-
-bool NODELETE EmptyFrameLoaderClient::canHandleRequest(const ResourceRequest&) const
+bool EmptyFrameLoaderClient::shouldFallBack(const ResourceError&) const
 {
     return false;
 }
 
-bool NODELETE EmptyFrameLoaderClient::canShowMIMEType(const String&) const
+void EmptyFrameLoaderClient::loadStorageAccessQuirksIfNeeded()
+{
+}
+
+bool EmptyFrameLoaderClient::canHandleRequest(const ResourceRequest&) const
 {
     return false;
 }
 
-bool NODELETE EmptyFrameLoaderClient::canShowMIMETypeAsHTML(const String&) const
+bool EmptyFrameLoaderClient::canShowMIMEType(const String&) const
 {
     return false;
 }
 
-bool NODELETE EmptyFrameLoaderClient::representationExistsForURLScheme(StringView) const
+bool EmptyFrameLoaderClient::canShowMIMETypeAsHTML(const String&) const
 {
     return false;
 }
 
-String NODELETE EmptyFrameLoaderClient::generatedMIMETypeForURLScheme(StringView) const
+bool EmptyFrameLoaderClient::representationExistsForURLScheme(StringView) const
+{
+    return false;
+}
+
+String EmptyFrameLoaderClient::generatedMIMETypeForURLScheme(StringView) const
 {
     return emptyString();
 }
 
-void NODELETE EmptyFrameLoaderClient::frameLoadCompleted()
+void EmptyFrameLoaderClient::frameLoadCompleted()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::restoreViewState()
+void EmptyFrameLoaderClient::restoreViewState()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::provisionalLoadStarted()
+void EmptyFrameLoaderClient::provisionalLoadStarted()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::didFinishLoad()
+void EmptyFrameLoaderClient::didFinishLoad()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::prepareForDataSourceReplacement()
+void EmptyFrameLoaderClient::prepareForDataSourceReplacement()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::updateCachedDocumentLoader(DocumentLoader&)
+void EmptyFrameLoaderClient::updateCachedDocumentLoader(DocumentLoader&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::setTitle(const StringWithDirection&, const URL&)
+void EmptyFrameLoaderClient::setTitle(const StringWithDirection&, const URL&)
 {
 }
 
-String NODELETE EmptyFrameLoaderClient::userAgent(const URL&) const
+String EmptyFrameLoaderClient::userAgent(const URL&) const
 {
     return emptyString();
 }
 
-void NODELETE EmptyFrameLoaderClient::savePlatformDataToCachedFrame(CachedFrame*)
+void EmptyFrameLoaderClient::savePlatformDataToCachedFrame(CachedFrame*)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame*)
+void EmptyFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame*)
 {
 }
 
@@ -1034,78 +1034,78 @@ void EmptyFrameLoaderClient::didRestoreFrameHierarchyForCachedFrame()
 
 #endif
 
-void NODELETE EmptyFrameLoaderClient::transitionToCommittedForNewPage(InitializingIframe)
+void EmptyFrameLoaderClient::transitionToCommittedForNewPage(InitializingIframe)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::didRestoreFromBackForwardCache()
+void EmptyFrameLoaderClient::didRestoreFromBackForwardCache()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::updateGlobalHistory()
+void EmptyFrameLoaderClient::updateGlobalHistory()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::updateGlobalHistoryRedirectLinks()
+void EmptyFrameLoaderClient::updateGlobalHistoryRedirectLinks()
 {
 }
 
-ShouldGoToHistoryItem NODELETE EmptyFrameLoaderClient::shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const
+ShouldGoToHistoryItem EmptyFrameLoaderClient::shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const
 {
     return ShouldGoToHistoryItem::No;
 }
 
-bool NODELETE EmptyFrameLoaderClient::supportsAsyncShouldGoToHistoryItem() const
+bool EmptyFrameLoaderClient::supportsAsyncShouldGoToHistoryItem() const
 {
     return false;
 }
 
-void NODELETE EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const
+void EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void NODELETE EmptyFrameLoaderClient::saveViewStateToItem(HistoryItem&)
+void EmptyFrameLoaderClient::saveViewStateToItem(HistoryItem&)
 {
 }
 
-bool NODELETE EmptyFrameLoaderClient::canCachePage() const
+bool EmptyFrameLoaderClient::canCachePage() const
 {
     return false;
 }
 
-ObjectContentType NODELETE EmptyFrameLoaderClient::objectContentType(const URL&, const String&)
+ObjectContentType EmptyFrameLoaderClient::objectContentType(const URL&, const String&)
 {
     return ObjectContentType::None;
 }
 
-AtomString NODELETE EmptyFrameLoaderClient::overrideMediaType() const
+AtomString EmptyFrameLoaderClient::overrideMediaType() const
 {
     return nullAtom();
 }
 
-void NODELETE EmptyFrameLoaderClient::redirectDataToPlugin(Widget&)
+void EmptyFrameLoaderClient::redirectDataToPlugin(Widget&)
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&)
+void EmptyFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&)
 {
 }
 
 #if PLATFORM(COCOA)
 
-RemoteAXObjectRef NODELETE EmptyFrameLoaderClient::accessibilityRemoteObject()
+RemoteAXObjectRef EmptyFrameLoaderClient::accessibilityRemoteObject()
 {
     return nullptr;
 }
 
-IntPoint NODELETE EmptyFrameLoaderClient::accessibilityRemoteFrameOffset()
+IntPoint EmptyFrameLoaderClient::accessibilityRemoteFrameOffset()
 {
     return { };
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-void NODELETE EmptyFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&)
+void EmptyFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&)
 {
 }
 
@@ -1122,12 +1122,12 @@ void EmptyFrameLoaderClient::willCacheResponse(DocumentLoader*, ResourceLoaderId
 
 #endif
 
-bool NODELETE EmptyFrameLoaderClient::isEmptyFrameLoaderClient() const
+bool EmptyFrameLoaderClient::isEmptyFrameLoaderClient() const
 {
     return true;
 }
 
-void NODELETE EmptyFrameLoaderClient::prefetchDNS(const String&)
+void EmptyFrameLoaderClient::prefetchDNS(const String&)
 {
 }
 
@@ -1145,16 +1145,16 @@ RefPtr<LegacyPreviewLoaderClient> EmptyFrameLoaderClient::createPreviewLoaderCli
 
 #endif
 
-bool NODELETE EmptyFrameLoaderClient::hasFrameSpecificStorageAccess()
+bool EmptyFrameLoaderClient::hasFrameSpecificStorageAccess()
 {
     return false;
 }
 
-void NODELETE EmptyFrameLoaderClient::revokeFrameSpecificStorageAccess()
+void EmptyFrameLoaderClient::revokeFrameSpecificStorageAccess()
 {
 }
 
-void NODELETE EmptyFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess()
+void EmptyFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess()
 {
 }
 

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -40,147 +40,147 @@ private:
     Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&, ResourceRequest&&) override;
     Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&) override;
 
-    bool hasWebView() const final;
+    bool NODELETE hasWebView() const final;
 
-    void makeRepresentation(DocumentLoader*) final;
+    void NODELETE makeRepresentation(DocumentLoader*) final;
 
 #if PLATFORM(IOS_FAMILY)
     bool forceLayoutOnRestoreFromBackForwardCache() final;
 #endif
 
-    void forceLayoutForNonHTML() final;
+    void NODELETE forceLayoutForNonHTML() final;
 
-    void setCopiesOnScroll() final;
+    void NODELETE setCopiesOnScroll() final;
 
-    void detachedFromParent2() final;
-    void detachedFromParent3() final;
+    void NODELETE detachedFromParent2() final;
+    void NODELETE detachedFromParent3() final;
 
-    void convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&) final;
+    void NODELETE convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&) final;
 
-    void assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&) final;
-    bool shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier) override;
-    void dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse&) final;
-    void dispatchDidReceiveAuthenticationChallenge(DocumentLoader*, ResourceLoaderIdentifier, const AuthenticationChallenge&) final;
+    void NODELETE assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&) final;
+    bool NODELETE shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier) override;
+    void NODELETE dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse&) final;
+    void NODELETE dispatchDidReceiveAuthenticationChallenge(DocumentLoader*, ResourceLoaderIdentifier, const AuthenticationChallenge&) final;
 #if USE(PROTECTION_SPACE_AUTH_CALLBACK)
-    bool canAuthenticateAgainstProtectionSpace(DocumentLoader*, ResourceLoaderIdentifier, const ProtectionSpace&) final;
+    bool NODELETE canAuthenticateAgainstProtectionSpace(DocumentLoader*, ResourceLoaderIdentifier, const ProtectionSpace&) final;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<CFDictionaryRef> connectionProperties(DocumentLoader*, ResourceLoaderIdentifier) final;
 #endif
 
-    void dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&) final;
-    void dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier, int) final;
-    void dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier) final;
+    void NODELETE dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&) final;
+    void NODELETE dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier, int) final;
+    void NODELETE dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier) final;
 #if ENABLE(DATA_DETECTION)
-    void dispatchDidFinishDataDetection(NSArray *) final;
+    void NODELETE dispatchDidFinishDataDetection(NSArray *) final;
 #endif
-    void dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&) final;
-    bool dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int) final;
+    void NODELETE dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&) final;
+    bool NODELETE dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int) final;
 
-    void dispatchDidDispatchOnloadEvents() final;
-    void dispatchDidReceiveServerRedirectForProvisionalLoad() final;
-    void dispatchDidCancelClientRedirect() final;
+    void NODELETE dispatchDidDispatchOnloadEvents() final;
+    void NODELETE dispatchDidReceiveServerRedirectForProvisionalLoad() final;
+    void NODELETE dispatchDidCancelClientRedirect() final;
     void dispatchWillPerformClientRedirect(const URL&, double, WallTime, LockBackForwardList) final;
-    void dispatchDidChangeLocationWithinPage() final;
-    void dispatchDidPushStateWithinPage() final;
-    void dispatchDidReplaceStateWithinPage() final;
-    void dispatchDidPopStateWithinPage() final;
-    void dispatchWillClose() final;
-    void dispatchDidStartProvisionalLoad() final;
-    void dispatchDidReceiveTitle(const StringWithDirection&) final;
-    void dispatchDidCommitLoad(std::optional<HasInsecureContent>, std::optional<UsedLegacyTLS>, std::optional<WasPrivateRelayed>) final;
-    void dispatchDidFailProvisionalLoad(const ResourceError&, WillContinueLoading, WillInternallyHandleFailure) final;
-    void dispatchDidFailLoad(const ResourceError&) final;
-    void dispatchDidFinishDocumentLoad() final;
-    void dispatchDidFinishLoad() final;
-    void dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>) final;
-    void dispatchDidReachVisuallyNonEmptyState() final;
+    void NODELETE dispatchDidChangeLocationWithinPage() final;
+    void NODELETE dispatchDidPushStateWithinPage() final;
+    void NODELETE dispatchDidReplaceStateWithinPage() final;
+    void NODELETE dispatchDidPopStateWithinPage() final;
+    void NODELETE dispatchWillClose() final;
+    void NODELETE dispatchDidStartProvisionalLoad() final;
+    void NODELETE dispatchDidReceiveTitle(const StringWithDirection&) final;
+    void NODELETE dispatchDidCommitLoad(std::optional<HasInsecureContent>, std::optional<UsedLegacyTLS>, std::optional<WasPrivateRelayed>) final;
+    void NODELETE dispatchDidFailProvisionalLoad(const ResourceError&, WillContinueLoading, WillInternallyHandleFailure) final;
+    void NODELETE dispatchDidFailLoad(const ResourceError&) final;
+    void NODELETE dispatchDidFinishDocumentLoad() final;
+    void NODELETE dispatchDidFinishLoad() final;
+    void NODELETE dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>) final;
+    void NODELETE dispatchDidReachVisuallyNonEmptyState() final;
 
-    LocalFrame* dispatchCreatePage(const NavigationAction&, NewFrameOpenerPolicy) final;
-    void dispatchShow() final;
+    LocalFrame* NODELETE dispatchCreatePage(const NavigationAction&, NewFrameOpenerPolicy) final;
+    void NODELETE dispatchShow() final;
 
-    void dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&) final;
-    void dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&) final;
-    void dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse& redirectResponse, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, NavigationUpgradeToHTTPSBehavior, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&) final;
-    void updateSandboxFlags(SandboxFlags) final;
-    void updateOpener(std::optional<FrameIdentifier>) final;
+    void NODELETE dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&) final;
+    void NODELETE dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&) final;
+    void NODELETE dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse& redirectResponse, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, NavigationUpgradeToHTTPSBehavior, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&) final;
+    void NODELETE updateSandboxFlags(SandboxFlags) final;
+    void NODELETE updateOpener(std::optional<FrameIdentifier>) final;
     void setPrinting(bool, FloatSize, FloatSize, float, AdjustViewSize) final;
-    void cancelPolicyCheck() final;
+    void NODELETE cancelPolicyCheck() final;
 
-    void dispatchUnableToImplementPolicy(const ResourceError&) final;
+    void NODELETE dispatchUnableToImplementPolicy(const ResourceError&) final;
 
-    void dispatchWillSendSubmitEvent(Ref<FormState>&&) final;
+    void NODELETE dispatchWillSendSubmitEvent(Ref<FormState>&&) final;
     void dispatchWillSubmitForm(FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) final;
 
-    void revertToProvisionalState(DocumentLoader*) final;
-    void setMainDocumentError(DocumentLoader*, const ResourceError&) final;
+    void NODELETE revertToProvisionalState(DocumentLoader*) final;
+    void NODELETE setMainDocumentError(DocumentLoader*, const ResourceError&) final;
 
-    void setMainFrameDocumentReady(bool) final;
+    void NODELETE setMainFrameDocumentReady(bool) final;
 
-    void startDownload(const ResourceRequest&, const String&, FromDownloadAttribute = FromDownloadAttribute::No) final;
+    void NODELETE startDownload(const ResourceRequest&, const String&, FromDownloadAttribute = FromDownloadAttribute::No) final;
 
-    void willChangeTitle(DocumentLoader*) final;
-    void didChangeTitle(DocumentLoader*) final;
+    void NODELETE willChangeTitle(DocumentLoader*) final;
+    void NODELETE didChangeTitle(DocumentLoader*) final;
 
-    void willReplaceMultipartContent() final;
-    void didReplaceMultipartContent() final;
+    void NODELETE willReplaceMultipartContent() final;
+    void NODELETE didReplaceMultipartContent() final;
 
-    void committedLoad(DocumentLoader*, const SharedBuffer&) final;
-    void finishedLoading(DocumentLoader*) final;
+    void NODELETE committedLoad(DocumentLoader*, const SharedBuffer&) final;
+    void NODELETE finishedLoading(DocumentLoader*) final;
 
-    void loadStorageAccessQuirksIfNeeded() final;
+    void NODELETE loadStorageAccessQuirksIfNeeded() final;
 
-    bool shouldFallBack(const ResourceError&) const final;
+    bool NODELETE shouldFallBack(const ResourceError&) const final;
 
-    bool canHandleRequest(const ResourceRequest&) const final;
-    bool canShowMIMEType(const String&) const final;
-    bool canShowMIMETypeAsHTML(const String&) const final;
-    bool representationExistsForURLScheme(StringView) const final;
-    String generatedMIMETypeForURLScheme(StringView) const final;
+    bool NODELETE canHandleRequest(const ResourceRequest&) const final;
+    bool NODELETE canShowMIMEType(const String&) const final;
+    bool NODELETE canShowMIMETypeAsHTML(const String&) const final;
+    bool NODELETE representationExistsForURLScheme(StringView) const final;
+    String NODELETE generatedMIMETypeForURLScheme(StringView) const final;
 
-    void frameLoadCompleted() final;
-    void restoreViewState() final;
-    void provisionalLoadStarted() final;
-    void didFinishLoad() final;
-    void prepareForDataSourceReplacement() final;
+    void NODELETE frameLoadCompleted() final;
+    void NODELETE restoreViewState() final;
+    void NODELETE provisionalLoadStarted() final;
+    void NODELETE didFinishLoad() final;
+    void NODELETE prepareForDataSourceReplacement() final;
 
-    void updateCachedDocumentLoader(DocumentLoader&) final;
-    void setTitle(const StringWithDirection&, const URL&) final;
+    void NODELETE updateCachedDocumentLoader(DocumentLoader&) final;
+    void NODELETE setTitle(const StringWithDirection&, const URL&) final;
 
-    String userAgent(const URL&) const override;
+    String NODELETE userAgent(const URL&) const override;
 
-    void savePlatformDataToCachedFrame(CachedFrame*) final;
-    void transitionToCommittedFromCachedFrame(CachedFrame*) final;
+    void NODELETE savePlatformDataToCachedFrame(CachedFrame*) final;
+    void NODELETE transitionToCommittedFromCachedFrame(CachedFrame*) final;
 #if PLATFORM(IOS_FAMILY)
     void didRestoreFrameHierarchyForCachedFrame() final;
 #endif
-    void transitionToCommittedForNewPage(InitializingIframe) final;
+    void NODELETE transitionToCommittedForNewPage(InitializingIframe) final;
 
-    void didRestoreFromBackForwardCache() final;
+    void NODELETE didRestoreFromBackForwardCache() final;
 
-    void updateGlobalHistory() final;
-    void updateGlobalHistoryRedirectLinks() final;
-    ShouldGoToHistoryItem shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const final;
-    bool supportsAsyncShouldGoToHistoryItem() const final;
-    void shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const final;
+    void NODELETE updateGlobalHistory() final;
+    void NODELETE updateGlobalHistoryRedirectLinks() final;
+    ShouldGoToHistoryItem NODELETE shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const final;
+    bool NODELETE supportsAsyncShouldGoToHistoryItem() const final;
+    void NODELETE shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const final;
 
-    void saveViewStateToItem(HistoryItem&) final;
-    bool canCachePage() const final;
+    void NODELETE saveViewStateToItem(HistoryItem&) final;
+    bool NODELETE canCachePage() const final;
     RefPtr<LocalFrame> createFrame(const AtomString&, HTMLFrameOwnerElement&) final;
     RefPtr<Widget> createPlugin(HTMLPlugInElement&, const URL&, const Vector<AtomString>&, const Vector<AtomString>&, const String&, bool) final;
 
-    ObjectContentType objectContentType(const URL&, const String&) final;
-    AtomString overrideMediaType() const final;
+    ObjectContentType NODELETE objectContentType(const URL&, const String&) final;
+    AtomString NODELETE overrideMediaType() const final;
 
-    void redirectDataToPlugin(Widget&) final;
-    void dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&) final;
+    void NODELETE redirectDataToPlugin(Widget&) final;
+    void NODELETE dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&) final;
 
 #if PLATFORM(COCOA)
-    RemoteAXObjectRef accessibilityRemoteObject() final;
-    IntPoint accessibilityRemoteFrameOffset() final;
+    RemoteAXObjectRef NODELETE accessibilityRemoteObject() final;
+    IntPoint NODELETE accessibilityRemoteFrameOffset() final;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final;
+    void NODELETE setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final;
     RefPtr<WebCore::AXIsolatedTree> isolatedTree() const final;
 #endif
     void willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse *, CompletionHandler<void(NSCachedURLResponse *)>&&) const final;
@@ -188,18 +188,18 @@ private:
 
     Ref<FrameNetworkingContext> createNetworkingContext() final;
 
-    bool isEmptyFrameLoaderClient() const override;
-    void prefetchDNS(const String&) final;
+    bool NODELETE isEmptyFrameLoaderClient() const override;
+    void NODELETE prefetchDNS(const String&) final;
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&&) final;
 
 #if USE(QUICK_LOOK)
     RefPtr<LegacyPreviewLoaderClient> createPreviewLoaderClient(const String&, const String&) final;
 #endif
 
-    bool hasFrameSpecificStorageAccess() final;
-    void revokeFrameSpecificStorageAccess() final;
+    bool NODELETE hasFrameSpecificStorageAccess() final;
+    void NODELETE revokeFrameSpecificStorageAccess() final;
 
-    void dispatchLoadEventToOwnerElementInAnotherProcess() final;
+    void NODELETE dispatchLoadEventToOwnerElementInAnotherProcess() final;
 
     RefPtr<HistoryItem> createHistoryItemTree(bool, BackForwardItemIdentifier) const final;
 };


### PR DESCRIPTION
#### cf6ce317a961aa714b5ea4357ed53bb66258a918
<pre>
Fix places where NODELETE was incorrectly added to implementation instead of declaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=308357">https://bugs.webkit.org/show_bug.cgi?id=308357</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp:
(WebCore::WebGPU::ComputePassEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::writeBuffer):
(WebCore::WebGPU::QueueImpl::writeTexture):
(WebCore::WebGPU::QueueImpl::copyExternalImageToTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp:
(WebCore::WebGPU::RenderBundleEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp:
(WebCore::WebGPU::RenderPassEncoderImpl::setBindGroup):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp:
(WebCore::RTCRtpSFrameTransformer::updateAuthenticationSize):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::failureReason const):
* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebCore::EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
(WebCore::EmptyFrameLoaderClient::updateSandboxFlags):
(WebCore::EmptyFrameLoaderClient::updateOpener):
(WebCore::EmptyFrameLoaderClient::dispatchWillSendSubmitEvent):
(WebCore::EmptyFrameLoaderClient::hasWebView const):
(WebCore::EmptyFrameLoaderClient::makeRepresentation):
(WebCore::EmptyFrameLoaderClient::forceLayoutForNonHTML):
(WebCore::EmptyFrameLoaderClient::setCopiesOnScroll):
(WebCore::EmptyFrameLoaderClient::detachedFromParent2):
(WebCore::EmptyFrameLoaderClient::detachedFromParent3):
(WebCore::EmptyFrameLoaderClient::convertMainResourceLoadToDownload):
(WebCore::EmptyFrameLoaderClient::assignIdentifierToInitialRequest):
(WebCore::EmptyFrameLoaderClient::shouldUseCredentialStorage):
(WebCore::EmptyFrameLoaderClient::dispatchWillSendRequest):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge):
(WebCore::EmptyFrameLoaderClient::canAuthenticateAgainstProtectionSpace):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveResponse):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveContentLength):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishLoading):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishDataDetection):
(WebCore::EmptyFrameLoaderClient::dispatchDidFailLoading):
(WebCore::EmptyFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache):
(WebCore::EmptyFrameLoaderClient::dispatchDidDispatchOnloadEvents):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidCancelClientRedirect):
(WebCore::EmptyFrameLoaderClient::dispatchDidChangeLocationWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchDidPushStateWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchDidReplaceStateWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchDidPopStateWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchWillClose):
(WebCore::EmptyFrameLoaderClient::dispatchDidStartProvisionalLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveTitle):
(WebCore::EmptyFrameLoaderClient::dispatchDidCommitLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFailProvisionalLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFailLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishDocumentLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidReachLayoutMilestone):
(WebCore::EmptyFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState):
(WebCore::EmptyFrameLoaderClient::dispatchCreatePage):
(WebCore::EmptyFrameLoaderClient::dispatchShow):
(WebCore::EmptyFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebCore::EmptyFrameLoaderClient::cancelPolicyCheck):
(WebCore::EmptyFrameLoaderClient::dispatchUnableToImplementPolicy):
(WebCore::EmptyFrameLoaderClient::revertToProvisionalState):
(WebCore::EmptyFrameLoaderClient::setMainDocumentError):
(WebCore::EmptyFrameLoaderClient::setMainFrameDocumentReady):
(WebCore::EmptyFrameLoaderClient::startDownload):
(WebCore::EmptyFrameLoaderClient::willChangeTitle):
(WebCore::EmptyFrameLoaderClient::didChangeTitle):
(WebCore::EmptyFrameLoaderClient::willReplaceMultipartContent):
(WebCore::EmptyFrameLoaderClient::didReplaceMultipartContent):
(WebCore::EmptyFrameLoaderClient::committedLoad):
(WebCore::EmptyFrameLoaderClient::finishedLoading):
(WebCore::EmptyFrameLoaderClient::shouldFallBack const):
(WebCore::EmptyFrameLoaderClient::loadStorageAccessQuirksIfNeeded):
(WebCore::EmptyFrameLoaderClient::canHandleRequest const):
(WebCore::EmptyFrameLoaderClient::canShowMIMEType const):
(WebCore::EmptyFrameLoaderClient::canShowMIMETypeAsHTML const):
(WebCore::EmptyFrameLoaderClient::representationExistsForURLScheme const):
(WebCore::EmptyFrameLoaderClient::generatedMIMETypeForURLScheme const):
(WebCore::EmptyFrameLoaderClient::frameLoadCompleted):
(WebCore::EmptyFrameLoaderClient::restoreViewState):
(WebCore::EmptyFrameLoaderClient::provisionalLoadStarted):
(WebCore::EmptyFrameLoaderClient::didFinishLoad):
(WebCore::EmptyFrameLoaderClient::prepareForDataSourceReplacement):
(WebCore::EmptyFrameLoaderClient::updateCachedDocumentLoader):
(WebCore::EmptyFrameLoaderClient::setTitle):
(WebCore::EmptyFrameLoaderClient::userAgent const):
(WebCore::EmptyFrameLoaderClient::savePlatformDataToCachedFrame):
(WebCore::EmptyFrameLoaderClient::transitionToCommittedFromCachedFrame):
(WebCore::EmptyFrameLoaderClient::transitionToCommittedForNewPage):
(WebCore::EmptyFrameLoaderClient::didRestoreFromBackForwardCache):
(WebCore::EmptyFrameLoaderClient::updateGlobalHistory):
(WebCore::EmptyFrameLoaderClient::updateGlobalHistoryRedirectLinks):
(WebCore::EmptyFrameLoaderClient::shouldGoToHistoryItem const):
(WebCore::EmptyFrameLoaderClient::supportsAsyncShouldGoToHistoryItem const):
(WebCore::EmptyFrameLoaderClient::shouldGoToHistoryItemAsync const):
(WebCore::EmptyFrameLoaderClient::saveViewStateToItem):
(WebCore::EmptyFrameLoaderClient::canCachePage const):
(WebCore::EmptyFrameLoaderClient::objectContentType):
(WebCore::EmptyFrameLoaderClient::overrideMediaType const):
(WebCore::EmptyFrameLoaderClient::redirectDataToPlugin):
(WebCore::EmptyFrameLoaderClient::dispatchDidClearWindowObjectInWorld):
(WebCore::EmptyFrameLoaderClient::accessibilityRemoteObject):
(WebCore::EmptyFrameLoaderClient::accessibilityRemoteFrameOffset):
(WebCore::EmptyFrameLoaderClient::setIsolatedTree):
(WebCore::EmptyFrameLoaderClient::isEmptyFrameLoaderClient const):
(WebCore::EmptyFrameLoaderClient::prefetchDNS):
(WebCore::EmptyFrameLoaderClient::hasFrameSpecificStorageAccess):
(WebCore::EmptyFrameLoaderClient::revokeFrameSpecificStorageAccess):
(WebCore::EmptyFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/307970@main">https://commits.webkit.org/307970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56b75c1a48d4eff05f100c330558f675ecbf465a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99574 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/786ee3a0-88d8-4162-9cc3-a969c07915ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93274 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd334093-1dc5-4173-b155-850e496e0fad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14022 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2207 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157079 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/255 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120418 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30936 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74290 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7531 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18209 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17945 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->