### PR TITLE
Use an enum to represent the selection type for `EditorState` instead of two booleans

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1474,6 +1474,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/SecurityPolicyViolationEvent.h
     dom/SecurityPolicyViolationEventDisposition.h
     dom/SelectionRestorationMode.h
+    dom/SelectionType.h
     dom/SerializedNode.h
     dom/ShadowRoot.h
     dom/ShadowRootMode.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1358,6 +1358,7 @@ dom/ScriptedAnimationController.cpp
 dom/SecurityContext.cpp
 dom/SecurityOriginPolicy.cpp
 dom/SecurityPolicyViolationEvent.cpp
+dom/SelectionType.cpp
 dom/SelectorQuery.cpp
 dom/SerializedNode.cpp
 dom/ShadowRoot.cpp

--- a/Source/WebCore/dom/SelectionType.cpp
+++ b/Source/WebCore/dom/SelectionType.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SelectionType.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const SelectionType& type)
+{
+    switch (type) {
+    case SelectionType::None:
+        ts << "None";
+        break;
+
+    case SelectionType::Caret:
+        ts << "Caret";
+        break;
+
+    case SelectionType::Range:
+        ts << "Range";
+        break;
+    }
+
+    return ts;
+}
+
+}

--- a/Source/WebCore/dom/SelectionType.h
+++ b/Source/WebCore/dom/SelectionType.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/PlatformExportMacros.h>
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+enum class SelectionType : uint8_t {
+    None,
+    Caret,
+    Range,
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const SelectionType&);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -29,6 +29,7 @@
 #include "ElementInlines.h"
 #include "HTMLSlotElement.h"
 #include "InspectorInstrumentation.h"
+#include "RenderStyle+GettersInlines.h"
 #include "RenderTreeUpdater.h"
 #include "ShadowRoot.h"
 #include "TypedElementDescendantIteratorInlines.h"

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -402,12 +402,12 @@ void VisibleSelection::updateSelectionType()
 {
     if (m_start.isNull()) {
         ASSERT(m_end.isNull());
-        m_type = Type::None;
+        m_type = SelectionType::None;
         m_affinity = Affinity::Downstream;
     } else if (m_start == m_end || m_start.upstream() == m_end.upstream())
-        m_type = Type::Caret;
+        m_type = SelectionType::Caret;
     else {
-        m_type = Type::Range;
+        m_type = SelectionType::Range;
         m_affinity = Affinity::Downstream;
     }
 }
@@ -475,7 +475,7 @@ void VisibleSelection::setWithoutValidation(const Position& anchor, const Positi
     m_extent = focus;
     m_start = m_anchorIsFirst ? anchor : focus;
     m_end = m_anchorIsFirst ? focus : anchor;
-    m_type = anchor == focus ? Type::Caret : Type::Range;
+    m_type = anchor == focus ? SelectionType::Caret : SelectionType::Range;
 }
 
 Position VisibleSelection::adjustPositionForEnd(const Position& currentPosition, Node* startContainerNode)

--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/SelectionType.h>
 #include <WebCore/TextGranularity.h>
 #include <WebCore/VisiblePosition.h>
 
@@ -88,13 +89,17 @@ public:
 
     operator VisiblePositionRange() const { return { visibleStart(), visibleEnd() }; }
 
-    bool isNone() const { return m_type == Type::None; }
-    bool isCaret() const { return m_type == Type::Caret; }
-    bool isRange() const { return m_type == Type::Range; }
+    SelectionType type() const { return m_type; }
+
+    bool isNone() const { return type() == SelectionType::None; }
+    bool isCaret() const { return type() == SelectionType::Caret; }
+    bool isRange() const { return type() == SelectionType::Range; }
+
     bool isCaretOrRange() const { return !isNone(); }
     bool isNonOrphanedRange() const { return isRange() && !start().isOrphan() && !end().isOrphan(); }
     bool isNoneOrOrphaned() const { return isNone() || start().isOrphan() || end().isOrphan(); }
     bool isOrphan() const;
+
     RefPtr<Document> document() const;
 
     bool isBaseFirst() const { return m_anchorIsFirst; }
@@ -168,8 +173,7 @@ private:
     Affinity m_affinity { defaultAffinity };
 
     // These are cached, can be recalculated by validate()
-    enum class Type : uint8_t { None, Caret, Range };
-    Type m_type { Type::None };
+    SelectionType m_type { SelectionType::None };
     bool m_anchorIsFirst { true }; // True if the anchor is before the focus. FIXME: Rename to m_anchorIsBeforeFocus since that's what the comment says.
     Directionality m_directionality { Directionality::None };
 };

--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -35,10 +35,8 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
 {
     if (editorState.shouldIgnoreSelectionChanges)
         ts.dumpProperty("shouldIgnoreSelectionChanges"_s, editorState.shouldIgnoreSelectionChanges);
-    if (!editorState.selectionIsNone)
-        ts.dumpProperty("selectionIsNone"_s, editorState.selectionIsNone);
-    if (editorState.selectionIsRange)
-        ts.dumpProperty("selectionIsRange"_s, editorState.selectionIsRange);
+    if (editorState.selectionType != WebCore::SelectionType::None)
+        ts.dumpProperty("selectionType"_s, editorState.selectionType);
     if (editorState.isContentEditable)
         ts.dumpProperty("isContentEditable"_s, editorState.isContentEditable);
     if (editorState.isContentRichlyEditable)

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -32,6 +32,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/ScrollTypes.h>
+#include <WebCore/SelectionType.h>
 #include <WebCore/WritingDirection.h>
 #include <wtf/text/WTFString.h>
 
@@ -72,9 +73,8 @@ struct EditorState {
     void move(float x, float y);
 
     EditorStateIdentifier identifier;
+    WebCore::SelectionType selectionType { WebCore::SelectionType::None };
     bool shouldIgnoreSelectionChanges { false };
-    bool selectionIsNone { true }; // This will be false when there is a caret selection.
-    bool selectionIsRange { false };
     bool selectionIsRangeInsideImageOverlay { false };
     bool selectionIsRangeInAutoFilledAndViewableField { false };
     bool isContentEditable { false };

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -43,9 +43,8 @@ enum class WebKit::TextAlignment : uint8_t {
 
 struct WebKit::EditorState {
     WebKit::EditorStateIdentifier identifier;
+    WebCore::SelectionType selectionType;
     bool shouldIgnoreSelectionChanges;
-    bool selectionIsNone;
-    bool selectionIsRange;
     bool selectionIsRangeInsideImageOverlay;
     bool selectionIsRangeInAutoFilledAndViewableField;
     bool isContentEditable;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9318,6 +9318,12 @@ enum class WebCore::SelectionRestorationMode : uint8_t {
     PlaceCaretAtStart,
 };
 
+enum class WebCore::SelectionType : uint8_t {
+    None,
+    Caret,
+    Range,
+};
+
 header: <WebCore/FocusOptions.h>
 [CustomHeader] enum class WebCore::FocusRemovalEventsMode : bool;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2364,16 +2364,14 @@ static NSTextAlignment NODELETE nsTextAlignment(WebKit::TextAlignment alignment)
 
 static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorState& editorState, _WKSelectionAttributes previousAttributes)
 {
-    _WKSelectionAttributes attributes = _WKSelectionAttributeNoSelection;
-    if (editorState.selectionIsNone)
-        return attributes;
-
-    if (editorState.selectionIsRange)
-        attributes |= _WKSelectionAttributeIsRange;
-    else
-        attributes |= _WKSelectionAttributeIsCaret;
-
-    return attributes;
+    switch (editorState.selectionType) {
+    case WebCore::SelectionType::None:
+        return _WKSelectionAttributeNoSelection;
+    case WebCore::SelectionType::Caret:
+        return _WKSelectionAttributeIsCaret;
+    case WebCore::SelectionType::Range:
+        return _WKSelectionAttributeIsRange;
+    }
 }
 
 - (void)_didChangeEditorState

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1393,7 +1393,7 @@ WebCore::WritingTools::Behavior WebPageProxy::writingToolsBehavior() const
     auto& editorState = this->editorState();
     auto& configuration = this->configuration();
 
-    if (configuration.writingToolsBehavior() == WebCore::WritingTools::Behavior::None || editorState.selectionIsNone || editorState.isInPasswordField || editorState.isInPlugin)
+    if (configuration.writingToolsBehavior() == WebCore::WritingTools::Behavior::None || editorState.selectionType == WebCore::SelectionType::None || editorState.isInPasswordField || editorState.isInPlugin)
         return WebCore::WritingTools::Behavior::None;
 
     if (configuration.writingToolsBehavior() == WebCore::WritingTools::Behavior::Complete && editorState.isContentEditable)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3541,7 +3541,7 @@ const EditorState& WebPageProxy::editorState() const
 
 bool WebPageProxy::hasSelectedRange() const
 {
-    return internals().editorState.selectionIsRange;
+    return internals().editorState.selectionType == WebCore::SelectionType::Range;
 }
 
 bool WebPageProxy::isContentEditable() const

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -42,6 +42,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/PlatformEvent.h>
+#include <WebCore/SelectionType.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/glib/Sandbox.h>
@@ -74,7 +75,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState&, const EditorState& n
 {
     if (newEditorState.shouldIgnoreSelectionChanges)
         return;
-    if (newEditorState.selectionIsRange)
+    if (newEditorState.selectionType == WebCore::SelectionType::Range)
         WebPasteboardProxy::singleton().setPrimarySelectionOwner(focusedFrame());
     if (RefPtr pageClient = this->pageClient())
         pageClient->selectionDidChange();

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -72,6 +72,7 @@
 #import <WebCore/FloatQuad.h>
 #import <WebCore/MediaControlsContextMenuItem.h>
 #import <WebCore/PointerID.h>
+#import <WebCore/SelectionType.h>
 #import <WebCore/TextGranularity.h>
 #import <pal/spi/cocoa/WritingToolsSPI.h>
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
@@ -278,10 +279,9 @@ enum class TargetedPreviewPositioning : uint8_t {
 using InputViewUpdateDeferralSources = OptionSet<InputViewUpdateDeferralSource>;
 
 struct WKSelectionDrawingInfo {
-    enum class SelectionType : bool { None, Range };
     WKSelectionDrawingInfo();
     explicit WKSelectionDrawingInfo(const EditorState&);
-    SelectionType type { SelectionType::None };
+    WebCore::SelectionType type { WebCore::SelectionType::None };
     WebCore::IntRect caretRect;
     WebCore::Color caretColor;
     Vector<WebCore::SelectionGeometry> selectionGeometries;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1142,10 +1142,10 @@ void WebPageProxy::generateSyntheticEditingCommand(WebKit::SyntheticEditingComma
 
 void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const EditorState& newEditorState)
 {
-    bool couldChangeSecureInputState = newEditorState.isInPasswordField != oldEditorState.isInPasswordField || oldEditorState.selectionIsNone;
-    
+    bool couldChangeSecureInputState = newEditorState.isInPasswordField != oldEditorState.isInPasswordField || oldEditorState.selectionType == WebCore::SelectionType::None;
+
     // Selection being none is a temporary state when editing. Flipping secure input state too quickly was causing trouble (not fully understood).
-    if (couldChangeSecureInputState && !newEditorState.selectionIsNone) {
+    if (couldChangeSecureInputState && newEditorState.selectionType != WebCore::SelectionType::None) {
         if (RefPtr pageClient = this->pageClient())
             pageClient->updateSecureInputState();
     }
@@ -1234,7 +1234,7 @@ void WebPageProxy::updateSelectionWithDelta(int64_t locationDelta, int64_t lengt
 
 WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() const
 {
-    if (editorState().selectionIsNone)
+    if (editorState().selectionType == WebCore::SelectionType::None)
         return { };
 
     if (!editorState().hasVisualData())
@@ -1242,7 +1242,7 @@ WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() co
 
     WebCore::FloatRect bounds;
     auto& visualData = *editorState().visualData;
-    if (editorState().selectionIsRange) {
+    if (editorState().selectionType == WebCore::SelectionType::Range) {
         for (auto& geometry : visualData.selectionGeometries)
             bounds.unite(geometry.rect());
     } else

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -91,7 +91,7 @@ extension WKTextSelectionController {
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
         let editorState = unsafe page.editorState
-        let hasSelection = unsafe !editorState.selectionIsNone
+        let hasSelection = unsafe editorState.selectionType != .None
 
         if unsafe !hasSelection || !editorState.hasPostLayoutAndVisualData() {
             Logger.viewGestures.log(
@@ -100,7 +100,7 @@ extension WKTextSelectionController {
             return false
         }
 
-        let isRange = unsafe editorState.selectionIsRange
+        let isRange = unsafe editorState.selectionType == .Range
         let isContentEditable = unsafe editorState.isContentEditable
 
         if !isContentEditable && !isRange {
@@ -191,7 +191,7 @@ extension WKTextSelectionController {
         // FIXME: Reduce duplication of this logic.
 
         let distance = unsafe CGRect(previousVisualData.caretRectAtStart).distance(to: point)
-        let clickLocationIsNearCaret = unsafe !previousState.selectionIsRange && distance < Self.nearCaretDistance
+        let clickLocationIsNearCaret = unsafe previousState.selectionType != .Range && distance < Self.nearCaretDistance
         let caretLocationIsSame = unsafe previousVisualData.caretRectAtStart == newVisualData.caretRectAtStart
 
         Logger.viewGestures.log(

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1429,8 +1429,7 @@ bool PDFPluginBase::populateEditorStateIfNeeded(EditorState& state) const
     if (selectionString().isNull())
         return false;
 
-    state.selectionIsNone = false;
-    state.selectionIsRange = true;
+    state.selectionType = WebCore::SelectionType::Range;
     state.isInPlugin = true;
     return true;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4583,8 +4583,7 @@ bool UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded(EditorState& state) c
     }
 
     state.isInPlugin = true;
-    state.selectionIsNone = false;
-    state.selectionIsRange = selectionGeometries.size();
+    state.selectionType = selectionGeometries.isEmpty() ? WebCore::SelectionType::Caret : WebCore::SelectionType::Range;
 
     auto selectedString = String { [selection string] };
     state.postLayoutData = EditorState::PostLayoutData { };

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -827,7 +827,7 @@ void WebPage::getPlatformEditorStateCommon(LocalFrame& frame, EditorState& resul
 #if PLATFORM(IOS_FAMILY)
         result.visualData->editableRootBounds = rootViewInteractionBounds(Ref { *editableRootOrFormControl });
 #endif
-    } else if (result.selectionIsRange)
+    } else if (result.selectionType == WebCore::SelectionType::Range)
         postLayoutData.selectionIsTransparentOrFullyClipped = selectionIsTransparentOrFullyClipped(selection);
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1669,8 +1669,7 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
     const VisibleSelection& selection = frame->selection().selection();
     Ref editor = frame->editor();
 
-    result.selectionIsNone = selection.isNone();
-    result.selectionIsRange = selection.isRange();
+    result.selectionType = selection.type();
     result.isContentEditable = selection.hasEditableStyle();
     result.isContentRichlyEditable = selection.isContentRichlyEditable();
     result.isInPasswordField = selection.isInPasswordField();
@@ -1680,7 +1679,7 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
 
     Ref<Document> document = *frame->document();
 
-    if (result.selectionIsRange) {
+    if (result.selectionType == WebCore::SelectionType::Range) {
         auto selectionRange = selection.range();
         result.selectionIsRangeInsideImageOverlay = selectionRange && ImageOverlay::isInsideOverlay(*selectionRange);
         result.selectionIsRangeInAutoFilledAndViewableField = selection.isInAutoFilledAndViewableField();


### PR DESCRIPTION
#### 16bd64e97b30b4da2c557b424e6f3205bc6642a8
<pre>
Use an enum to represent the selection type for `EditorState` instead of two booleans
<a href="https://bugs.webkit.org/show_bug.cgi?id=308369">https://bugs.webkit.org/show_bug.cgi?id=308369</a>
<a href="https://rdar.apple.com/170868905">rdar://170868905</a>

Reviewed by Abrar Rahman Protyasha and Ryosuke Niwa.

Introduce `WebCore::SelectionType` and use it instead of the existing pair of boolean fields on EditorState.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/SelectionType.cpp: Added.
(operator&lt;&lt;):
* Source/WebCore/dom/SelectionType.h: Added.
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::updateSelectionType):
(WebCore::VisibleSelection::setWithoutValidation):
* Source/WebCore/editing/VisibleSelection.h:
(WebCore::VisibleSelection::type const):
(WebCore::VisibleSelection::isNone const):
(WebCore::VisibleSelection::isCaret const):
(WebCore::VisibleSelection::isRange const):
* Source/WebKit/Shared/EditorState.cpp:
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(selectionAttributes):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::writingToolsBehavior const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hasSelectedRange const):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::WKSelectionDrawingInfo):
(WebKit::WKSelectionDrawingInfo::compare const):
(WebKit::operator&lt;&lt;):
(-[WKContentView observeValueForKeyPath:ofObject:change:context:]):
(-[WKContentView shouldHideSelectionInFixedPositionWhenScrolling]):
(-[WKContentView canShowNonEmptySelectionView]):
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
(-[WKContentView webSelectionRects]):
(-[WKContentView supportedPasteboardTypesForCurrentSelection]):
(-[WKContentView lookupForWebView:]):
(-[WKContentView shouldAllowHighlightLinkCreation]):
(-[WKContentView canPerformAction:withSender:]):
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _characterInRelationToCaretSelection:]):
(-[WKContentView textInRange:]):
(-[WKContentView selectedTextRange]):
(-[WKContentView _hasContent]):
(-[WKContentView _updateInitialWritingDirectionIfNecessary]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):
(-[WKContentView appHighlightMenu]):
(-[WKContentView _simulateSelectionStart]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::selectionBoundingRectInRootViewCoordinates const):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::stringSelectionForPasteboard):
(WebKit::WebPageProxy::dataSelectionForPasteboard):
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::selectionBoundingRectInRootViewCoordinates const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::mightBeginDragWhileInactive):
(WebKit::WebViewImpl::validRequestorForSendAndReturnTypes):
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::unionRectInVisibleSelectedRangeInScreen const):
(WebKit::WebViewImpl::changeFontColorFromSender):
(WebKit::WebViewImpl::changeFontAttributesFromSender):
(WebKit::WebViewImpl::changeFontFromFontManager):
(WebKit::WebViewImpl::validateUserInterfaceItem):
(WebKit::WebViewImpl::showWritingTools):
(WebKit::WebViewImpl::inputContextIncludingNonEditable):
(WebKit::WebViewImpl::updateTextTouchBar):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::populateEditorStateIfNeeded const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):

Canonical link: <a href="https://commits.webkit.org/308024@main">https://commits.webkit.org/308024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933edd7143bc6f40a8465435ef5f734c8b3ad70d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99738 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fb09285-d96e-438c-9d2f-1bec8690fc38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112567 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80519 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13f9ab0f-0ae3-44f4-87a0-1f6ebd6e1963) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14925 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93437 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/725a5a57-5f69-4633-8d29-c38e8f2b669e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14192 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2395 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123760 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157270 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120595 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120894 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30961 "Found 1 new test failure: fast/images/mac/play-pause-individual-animation-context-menu-items.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130766 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74547 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16576 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82149 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18127 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18293 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->