### PR TITLE
Remote snapshotting may flip part of the page

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -575,10 +575,12 @@ void GraphicsContext::drawDisplayList(const DisplayList::DisplayList& displayLis
 
 void GraphicsContext::drawDisplayList(const DisplayList::DisplayList& displayList, ControlFactory& controlFactory)
 {
+    AffineTransform baseTransform = getCTM();
+
     // FIXME: ControlFactory should be property of the context and not passed this way here.
     // Currently this mutates each ControlPart which is unsuitable for display lists.
     for (auto& item : displayList.items())
-        applyItem(*this, controlFactory, item);
+        applyItem(*this, baseTransform, controlFactory, item);
 }
 
 FloatRect GraphicsContext::computeUnderlineBoundsForText(const FloatRect& rect, bool printing)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -34,11 +34,13 @@
 namespace WebCore {
 namespace DisplayList {
 
-void applyItem(GraphicsContext& context, ControlFactory& controlFactory, const Item& item)
+void applyItem(GraphicsContext& context, const AffineTransform& baseTransform, ControlFactory& controlFactory, const Item& item)
 {
     WTF::switchOn(item,
         [&](const DrawControlPart& item) {
             item.apply(context, controlFactory);
+        }, [&](const SetCTM& item) {
+            item.apply(context, baseTransform);
         }, [&](const auto& item) {
             item.apply(context);
         }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -34,6 +34,7 @@ class TextStream;
 
 namespace WebCore {
 
+class AffineTransform;
 class ControlFactory;
 class GraphicsContext;
 
@@ -182,7 +183,7 @@ enum class AsTextFlag : uint8_t {
     IncludeResourceIdentifiers     = 1 << 1,
 };
 
-void applyItem(GraphicsContext&, ControlFactory&, const Item&);
+void applyItem(GraphicsContext&, const AffineTransform& baseTransform, ControlFactory&, const Item&);
 
 bool shouldDumpItem(const Item&, OptionSet<AsTextFlag>);
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -83,9 +83,9 @@ void Scale::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("size"_s, amount());
 }
 
-void SetCTM::apply(GraphicsContext& context) const
+void SetCTM::apply(GraphicsContext& context, const AffineTransform& baseTransform) const
 {
-    context.setCTM(m_transform);
+    context.setCTM(baseTransform * m_transform);
 }
 
 void SetCTM::dump(TextStream& ts, OptionSet<AsTextFlag>) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -139,7 +139,7 @@ public:
 
     const AffineTransform& transform() const LIFETIME_BOUND { return m_transform; }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, const AffineTransform& baseTransform = AffineTransform()) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -33,8 +33,10 @@
 #import "TestWKWebView.h"
 #import <WebCore/Color.h>
 #import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKSnapshotConfigurationPrivate.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKJSHandle.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
@@ -806,5 +808,70 @@ TEST(WKWebView, SnapshotNodeByJSHandle)
         EXPECT_NULL(image);
     }
 }
+
+// FIXME: Make this test work on iOS.
+#if PLATFORM(MAC)
+static void enableRemoteSnapshotting(WKWebViewConfiguration *configuration)
+{
+    auto preferences = [configuration preferences];
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"RemoteSnapshottingEnabled"]) {
+            [preferences _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+}
+
+TEST(WKWebView, RemoteSnapshotWithTransform)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableRemoteSnapshotting(configuration.get());
+
+    NSInteger viewWidth = 800;
+    NSInteger viewHeight = 600;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, viewHeight) configuration:configuration.get()]);
+
+    [webView synchronouslyLoadHTMLString:@"<style> body { margin: 0; } .box { position: relative; width: 100px; height: 50px; } .top { top: 50px; transform: translateY(-100%); border-radius: 50px 50px 0 0; background-color: green; } .bottom { border-radius: 0 0 50px 50px; overflow: hidden; } </style> <body><div class='top box'></div> <div class='bottom box'> <img height='50' width='100' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVR4AQEEAPv/AACAAAEEAIEu/TP9AAAAAElFTkSuQmCC'> </div></body>"];
+
+    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    [snapshotConfiguration setRect:NSMakeRect(0, 0, viewWidth, viewHeight)];
+    [snapshotConfiguration setSnapshotWidth:@(viewWidth)];
+
+    isDone = false;
+    [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:^(Util::PlatformImage *snapshotImage, NSError *error) {
+        EXPECT_NULL(error);
+
+        EXPECT_EQ(viewWidth, snapshotImage.size.width);
+
+        auto cgImage = Util::convertToCGImage(snapshotImage);
+        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+
+        uint8_t *rgba = (unsigned char *)calloc(viewWidth * viewHeight * 4, sizeof(unsigned char));
+        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidth, viewHeight, 8, 4 * viewWidth, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidth, viewHeight), cgImage.get());
+
+        void (^verifyPixel)(NSPoint) = ^(NSPoint point) {
+            NSInteger pixelIndex = getPixelIndex(point.x, point.y, viewWidth);
+            EXPECT_EQ(0, rgba[pixelIndex]);
+            EXPECT_EQ(128, rgba[pixelIndex + 1]);
+            EXPECT_EQ(0, rgba[pixelIndex + 2]);
+        };
+
+        void (^verifyPixels)(NSRect) = ^(NSRect rect) {
+            verifyPixel(NSMakePoint(NSMinX(rect), NSMaxY(rect)));
+            verifyPixel(NSMakePoint(NSMaxX(rect), NSMaxY(rect)));
+            verifyPixel(NSMakePoint(NSMinX(rect), NSMinY(rect)));
+            verifyPixel(NSMakePoint(NSMaxX(rect), NSMinY(rect)));
+        };
+
+        verifyPixels(NSMakeRect(30, 30, 40, 40));
+
+        free(rgba);
+        isDone = true;
+    }];
+
+    TestWebKitAPI::Util::run(&isDone);
+}
+#endif
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 286c709225989fd38e69c4917db4be57129670f8
<pre>
Remote snapshotting may flip part of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=308365">https://bugs.webkit.org/show_bug.cgi?id=308365</a>
<a href="https://rdar.apple.com/170868383">rdar://170868383</a>

Reviewed by Kimmo Kinnunen.

The remote snapshotting relies on first recording the drawing of the Frame to a
DisplayList in GPUProcess. Then the DisplayList is replayed back to the destination
GraphicsContext.

Parts of the rendering code like RenderLayer::paintLayerByApplyingTransform() may
use the following pattern to change the CTM and restore it at the end:

    oldCTM = context.getCTM();
    context.setCTM(newCTM);
    ...
    context.setCTM(oldCTM);

If the context is a DisplayListRecorder, getCTM() does not include the flipping
transformation. Calling setCTM(), in this case, will add SetCTM to DisplayList.
When replaying back SetCTM, it sets the CTM to the `oldCTM`, so the flipping
transformation will be lost.

To fix this issue, setCTM::apply() will take a new argument called `baseTransform`.
This argument is eqaul to the destination context CTM before replaying back the
DisplayList.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawDisplayList):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::SetCTM::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(TestWebKitAPI::enableRemoteSnapshotting):
(TestWebKitAPI::TEST(WKWebView, RemoteSnapshotWithTransform)):

Canonical link: <a href="https://commits.webkit.org/309441@main">https://commits.webkit.org/309441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc0bead091471717ce73ef35d033132b065700be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154871 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99663 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (exception)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9d4710a-f05d-4f02-af23-79e9f2b66a92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112497 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99663 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/157e3f8f-8856-45ef-a576-ee5000b70fed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ce43b7c-fb38-4b5b-90a0-e4d0b777cf0b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14114 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11873 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2317 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157190 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120520 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33789 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130137 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74446 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7717 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82069 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18107 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->