### PR TITLE
Reduce usage of protectedFoo() style in WebCore/dom, WebCore/xml, and WebCore/svg code

### DIFF
--- a/Source/WebCore/dom/ConstantPropertyMap.cpp
+++ b/Source/WebCore/dom/ConstantPropertyMap.cpp
@@ -128,11 +128,6 @@ static Ref<CSSVariableData> variableDataForPositiveDuration(Seconds durationInSe
     return CSSVariableData::create(tokenRange);
 }
 
-Ref<Document> ConstantPropertyMap::protectedDocument() const
-{
-    return m_document.get();
-}
-
 void ConstantPropertyMap::updateConstantsForSafeAreaInsets()
 {
     RefPtr page = m_document->page();
@@ -146,7 +141,7 @@ void ConstantPropertyMap::updateConstantsForSafeAreaInsets()
 void ConstantPropertyMap::didChangeSafeAreaInsets()
 {
     updateConstantsForSafeAreaInsets();
-    protectedDocument()->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
 void ConstantPropertyMap::updateConstantsForFullscreen()
@@ -165,13 +160,13 @@ void ConstantPropertyMap::updateConstantsForFullscreen()
 void ConstantPropertyMap::didChangeFullscreenInsets()
 {
     updateConstantsForFullscreen();
-    protectedDocument()->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
 void ConstantPropertyMap::setFullscreenAutoHideDuration(Seconds duration)
 {
     setValueForProperty(ConstantProperty::FullscreenAutoHideDuration, variableDataForPositiveDuration(duration));
-    protectedDocument()->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    protect(m_document)->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
 }

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -77,7 +77,6 @@ private:
     void updateConstantsForSafeAreaInsets();
     void updateConstantsForFullscreen();
 
-    Ref<Document> NODELETE protectedDocument() const;
 
     std::optional<Values> m_values;
 

--- a/Source/WebCore/dom/CurrentScriptIncrementer.h
+++ b/Source/WebCore/dom/CurrentScriptIncrementer.h
@@ -41,17 +41,15 @@ public:
         : m_document(document)
     {
         bool shouldPushNullForCurrentScript = scriptElement.element().isInShadowTree() || scriptElement.scriptType() != ScriptType::Classic;
-        protectedDocument()->pushCurrentScript(shouldPushNullForCurrentScript ? nullptr : &scriptElement.element());
+        protect(m_document)->pushCurrentScript(shouldPushNullForCurrentScript ? nullptr : &scriptElement.element());
     }
 
     ~CurrentScriptIncrementer()
     {
-        protectedDocument()->popCurrentScript();
+        protect(m_document)->popCurrentScript();
     }
 
 private:
-    Ref<Document> protectedDocument() const { return m_document.get(); }
-
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -71,11 +71,6 @@ using namespace HTMLNames;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMImplementation);
 
-Ref<Document> DOMImplementation::protectedDocument()
-{
-    return m_document.get();
-}
-
 DOMImplementation::DOMImplementation(Document& document)
     : m_document(document)
 {
@@ -86,7 +81,7 @@ ExceptionOr<Ref<DocumentType>> DOMImplementation::createDocumentType(const AtomS
     auto parseResult = Document::parseQualifiedName(qualifiedName);
     if (parseResult.hasException())
         return parseResult.releaseException();
-    return DocumentType::create(protectedDocument(), qualifiedName, publicId, systemId);
+    return DocumentType::create(protect(document()), qualifiedName, publicId, systemId);
 }
 
 static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, const Settings& settings)

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -47,8 +47,6 @@ public:
     static Ref<Document> createDocument(const String& contentType, LocalFrame*, const Settings&, const URL&, std::optional<ScriptExecutionContextIdentifier> = std::nullopt);
 
 private:
-    Ref<Document> NODELETE protectedDocument();
-
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2536,7 +2536,7 @@ void Document::setTitle(String&& title)
             m_titleElement = titleElement.copyRef();
             headElement->appendChild(titleElement);
         } else
-            oldTitle = protectedTitleElement()->textContent();
+            oldTitle = protect(m_titleElement)->textContent();
 
         // appendChild above may have run scripts which removed m_titleElement.
         if (!m_titleElement)
@@ -2587,18 +2587,13 @@ template<typename TitleElement> Element* selectNewTitleElement(Document& documen
     return newTitleElement.unsafeGet();
 }
 
-inline RefPtr<Element> Document::protectedTitleElement() const
-{
-    return m_titleElement;
-}
-
 void Document::updateTitleElement(Element& changingTitleElement)
 {
     // Most documents use HTML title rules.
     // Documents with SVG document elements use SVG title rules.
     auto selectTitleElement = is<SVGSVGElement>(documentElement())
         ? selectNewTitleElement<SVGTitleElement> : selectNewTitleElement<HTMLTitleElement>;
-    RefPtr newTitleElement = selectTitleElement(*this, protectedTitleElement().get(), changingTitleElement);
+    RefPtr newTitleElement = selectTitleElement(*this, protect(m_titleElement).get(), changingTitleElement);
     if (m_titleElement == newTitleElement)
         return;
     m_titleElement = WTF::move(newTitleElement);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2101,7 +2101,6 @@ private:
     friend class UnloadCountIncrementer;
 
     void updateTitleElement(Element& changingTitleElement);
-    RefPtr<Element> NODELETE protectedTitleElement() const;
     void willDetachPage() final;
     void frameDestroyed() final;
 

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -72,7 +72,7 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
 
     CachedResourceRequest request(ResourceRequest(WTF::move(url)), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-    return protect(protectedDocument()->cachedResourceLoader())->requestFont(WTF::move(request), isSVG).value_or(nullptr).get();
+    return protect(protect(m_document)->cachedResourceLoader())->requestFont(WTF::move(request), isSVG).value_or(nullptr).get();
 }
 
 void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
@@ -84,7 +84,7 @@ void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
     // Increment the request count now, in order to prevent didFinishLoad from being dispatched
     // after this font has been requested but before it began loading. Balanced by
     // decrementRequestCount() in fontLoadingTimerFired() and in stopLoadingAndClearFonts().
-    protect(protectedDocument()->cachedResourceLoader())->incrementRequestCount(font);
+    protect(protect(m_document)->cachedResourceLoader())->incrementRequestCount(font);
 
     if (!m_isFontLoadingSuspended && !m_fontLoadingTimer.isActive())
         m_fontLoadingTimer.startOneShot(0_s);
@@ -98,7 +98,7 @@ void DocumentFontLoader::loadPendingFonts()
     Vector<CachedResourceHandle<CachedFont>> fontsToBeginLoading;
     fontsToBeginLoading.swap(m_fontsToBeginLoading);
 
-    Ref cachedResourceLoader = protectedDocument()->cachedResourceLoader();
+    Ref cachedResourceLoader = protect(m_document)->cachedResourceLoader();
     for (auto& fontHandle : fontsToBeginLoading) {
         fontHandle->beginLoadIfNeeded(cachedResourceLoader);
         // Balances incrementRequestCount() in beginLoadingFontSoon().

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -58,7 +58,6 @@ public:
 
 private:
     void fontLoadingTimerFired();
-    Ref<Document> protectedDocument() const { return m_document.get(); }
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Timer m_fontLoadingTimer;

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -193,10 +193,6 @@ static void updateMainFrameLayoutIfNeeded(Document& document)
         mainFrameView->updateLayoutAndStyleIfNeededRecursive();
 }
 
-Ref<Document> DocumentMarkerController::protectedDocument() const
-{
-    return m_document.get();
-}
 
 void DocumentMarkerController::updateRectsForInvalidatedMarkersOfType(DocumentMarkerType type)
 {
@@ -210,7 +206,7 @@ void DocumentMarkerController::updateRectsForInvalidatedMarkersOfType(DocumentMa
             if (marker.type() != type || marker.isValid())
                 continue;
             if (!updatedLayout) {
-                updateMainFrameLayoutIfNeeded(protectedDocument());
+                updateMainFrameLayoutIfNeeded(protect(m_document));
                 updatedLayout = true;
             }
             updateRenderedRectsForMarker(marker, nodeMarkers.key);

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -130,7 +130,6 @@ private:
     void fadeAnimationTimerFired();
     void writingToolsTextSuggestionAnimationTimerFired();
 
-    Ref<Document> NODELETE protectedDocument() const;
 
     MarkerMap m_markers;
     // Provide a quick way to determine whether a particular marker type is absent without going through the map.

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -296,10 +296,6 @@ void DocumentStorageAccess::deref() const
     m_document->deref();
 }
 
-Ref<Document> DocumentStorageAccess::protectedDocument() const
-{
-    return m_document.get();
-}
 
 void DocumentStorageAccess::requestStorageAccessForDocumentQuirk(Document& document, CompletionHandler<void(StorageAccessWasGranted)>&& completionHandler)
 {
@@ -318,7 +314,7 @@ void DocumentStorageAccess::requestStorageAccessForDocumentQuirk(CompletionHandl
         *quickCheckResult == StorageAccessQuickResult::Grant ? completionHandler(StorageAccessWasGranted::Yes) : completionHandler(StorageAccessWasGranted::No);
         return;
     }
-    requestStorageAccessQuirk(RegistrableDomain::uncheckedCreateFromHost(protect(protectedDocument()->securityOrigin())->host()), WTF::move(completionHandler));
+    requestStorageAccessQuirk(RegistrableDomain::uncheckedCreateFromHost(protect(protect(m_document)->securityOrigin())->host()), WTF::move(completionHandler));
 }
 
 void DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(Document& hostingDocument, RegistrableDomain&& requestingDomain, CompletionHandler<void(StorageAccessWasGranted)>&& completionHandler)
@@ -358,7 +354,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         bool shouldPreserveUserGesture = result.wasGranted == StorageAccessWasGranted::Yes || result.promptWasShown == StorageAccessPromptWasShown::No;
 
         if (shouldPreserveUserGesture) {
-            protect(protectedThis->protectedDocument()->eventLoop())->queueMicrotask([weakThis] {
+            protect(protect(protectedThis->m_document)->eventLoop())->queueMicrotask([weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->enableTemporaryTimeUserGesture();
             });
@@ -376,7 +372,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         }
 
         if (shouldPreserveUserGesture) {
-            protect(protectedThis->protectedDocument()->eventLoop())->queueMicrotask([weakThis] {
+            protect(protect(protectedThis->m_document)->eventLoop())->queueMicrotask([weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->consumeTemporaryTimeUserGesture();
             });
@@ -386,7 +382,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
 
 void DocumentStorageAccess::enableTemporaryTimeUserGesture()
 {
-    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protectedDocument().ptr());
+    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protect(m_document).ptr());
 }
 
 void DocumentStorageAccess::consumeTemporaryTimeUserGesture()

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -99,7 +99,6 @@ private:
     void enableTemporaryTimeUserGesture();
     void consumeTemporaryTimeUserGesture();
 
-    Ref<Document> NODELETE protectedDocument() const;
 
     std::unique_ptr<UserGestureIndicator> m_temporaryUserGesture;
     

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -519,17 +519,12 @@ void EventLoopTaskGroup::resume()
         timer->resume();
 }
 
-RefPtr<EventLoop> EventLoopTaskGroup::protectedEventLoop() const
-{
-    return m_eventLoop.get();
-}
-
 void EventLoopTaskGroup::queueTask(std::unique_ptr<EventLoopTask>&& task)
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return;
     ASSERT(task->group() == this);
-    protectedEventLoop()->queueTask(WTF::move(task));
+    protect(m_eventLoop)->queueTask(WTF::move(task));
 }
 
 class EventLoopFunctionDispatchTask : public EventLoopTask {
@@ -597,7 +592,7 @@ void EventLoopTaskGroup::queueMicrotask(JSC::QueuedTask&& task)
     if (m_state == State::Stopped || !m_eventLoop)
         return;
 
-    protectedEventLoop()->queueMicrotask(WTF::move(task));
+    protect(m_eventLoop)->queueMicrotask(WTF::move(task));
 }
 
 void EventLoopTaskGroup::performMicrotaskCheckpoint()
@@ -618,14 +613,14 @@ EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TaskSourc
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleTask(timeout, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
+    return protect(m_eventLoop)->scheduleTask(timeout, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
 }
 
 EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TimerAlignment& alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, TaskSource source, EventLoop::TaskFunction&& function)
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleTask(timeout, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
+    return protect(m_eventLoop)->scheduleTask(timeout, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
 }
 
 void EventLoopTaskGroup::removeScheduledTimer(EventLoopTimer& timer)
@@ -640,14 +635,14 @@ EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeo
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleRepeatingTask(nextTimeout, interval, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
+    return protect(m_eventLoop)->scheduleRepeatingTask(nextTimeout, interval, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
 }
 
 EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment& alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, TaskSource source, EventLoop::TaskFunction&& function)
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleRepeatingTask(nextTimeout, interval, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
+    return protect(m_eventLoop)->scheduleRepeatingTask(nextTimeout, interval, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTF::move(function)));
 }
 
 void EventLoopTaskGroup::removeRepeatingTimer(EventLoopTimer& timer)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -204,7 +204,7 @@ public:
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
     WEBCORE_EXPORT void queueMicrotask(EventLoop::TaskFunction&&);
     WEBCORE_EXPORT void queueMicrotask(JSC::QueuedTask&&);
-    MicrotaskQueue& microtaskQueue() { return protectedEventLoop()->microtaskQueue(); }
+    MicrotaskQueue& microtaskQueue() { return protect(m_eventLoop)->microtaskQueue(); }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
     void performMicrotaskCheckpoint();
@@ -235,7 +235,6 @@ public:
 private:
     enum class State : uint8_t { Running, Suspended, ReadyToStop, Stopped };
 
-    RefPtr<EventLoop> NODELETE protectedEventLoop() const;
 
     WeakPtr<EventLoop> m_eventLoop;
     WeakHashSet<EventLoopTimer> m_timers;

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -91,7 +91,7 @@ private:
     void next(JSC::JSValue value) final
     {
         if (!m_amount) {
-            protectedSubscriber()->next(value);
+            protect(m_subscriber)->next(value);
             return;
         }
 
@@ -100,21 +100,19 @@ private:
 
     void error(JSC::JSValue value) final
     {
-        protectedSubscriber()->error(value);
+        protect(m_subscriber)->error(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        protectedSubscriber()->complete();
+        protect(m_subscriber)->complete();
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
         m_subscriber->visitAdditionalChildren(visitor);
     }
-
-    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
 
     InternalObserverDrop(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -105,11 +105,11 @@ private:
         JSC::Exception* previousException = nullptr;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            auto result = protectedPredicate()->invokeRethrowingException(value, m_idx);
+            auto result = protect(m_predicate)->invokeRethrowingException(value, m_idx);
             previousException = catchScope.exception();
             if (previousException) {
                 catchScope.clearException();
-                protectedSubscriber()->error(previousException->value());
+                protect(m_subscriber)->error(previousException->value());
                 return;
             }
 
@@ -120,18 +120,18 @@ private:
         m_idx += 1;
 
         if (matches)
-            protectedSubscriber()->next(value);
+            protect(m_subscriber)->next(value);
     }
 
     void error(JSC::JSValue value) final
     {
-        protectedSubscriber()->error(value);
+        protect(m_subscriber)->error(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        protectedSubscriber()->complete();
+        protect(m_subscriber)->complete();
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
@@ -139,9 +139,6 @@ private:
         m_subscriber->visitAdditionalChildren(visitor);
         m_predicate->visitJSFunction(visitor);
     }
-
-    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
-    Ref<PredicateCallback> NODELETE protectedPredicate() const { return m_predicate; }
 
     InternalObserverFilter(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<PredicateCallback> predicate)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -52,26 +52,24 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        protectedPromise()->resolve<IDLAny>(value);
+        protect(m_promise)->resolve<IDLAny>(value);
         Ref { m_signal }->signalAbort(JSC::jsUndefined());
     }
 
     void error(JSC::JSValue value) final
     {
-        protectedPromise()->reject<IDLAny>(value);
+        protect(m_promise)->reject<IDLAny>(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        protectedPromise()->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
+        protect(m_promise)->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final
     {
     }
-
-    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
 
     InternalObserverFirst(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -59,7 +59,7 @@ private:
 
     void error(JSC::JSValue value) final
     {
-        protectedPromise()->reject<IDLAny>(value);
+        protect(m_promise)->reject<IDLAny>(value);
     }
 
     void complete() final
@@ -67,17 +67,15 @@ private:
         InternalObserver::complete();
 
         if (!m_lastValue) [[unlikely]]
-            return protectedPromise()->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
+            return protect(m_promise)->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
 
-        protectedPromise()->resolve<IDLAny>(m_lastValue.getValue());
+        protect(m_promise)->resolve<IDLAny>(m_lastValue.getValue());
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
         m_lastValue.visit(visitor);
     }
-
-    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
 
     InternalObserverLast(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -103,30 +103,30 @@ private:
         JSC::Exception* previousException = nullptr;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            auto result = protectedMapper()->invokeRethrowingException(value, m_idx);
+            auto result = protect(m_mapper)->invokeRethrowingException(value, m_idx);
             previousException = catchScope.exception();
             if (previousException) {
                 catchScope.clearException();
-                protectedSubscriber()->error(previousException->value());
+                protect(m_subscriber)->error(previousException->value());
                 return;
             }
 
             m_idx += 1;
 
             if (result.type() == CallbackResultType::Success)
-                protectedSubscriber()->next(result.releaseReturnValue());
+                protect(m_subscriber)->next(result.releaseReturnValue());
         }
     }
 
     void error(JSC::JSValue value) final
     {
-        protectedSubscriber()->error(value);
+        protect(m_subscriber)->error(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        protectedSubscriber()->complete();
+        protect(m_subscriber)->complete();
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
@@ -134,9 +134,6 @@ private:
         m_subscriber->visitAdditionalChildren(visitor);
         m_mapper->visitJSFunction(visitor);
     }
-
-    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
-    Ref<MapperCallback> NODELETE protectedMapper() const { return m_mapper; }
 
     InternalObserverMap(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<MapperCallback> mapper)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -92,30 +92,28 @@ private:
     {
         if (!m_amount)
             return;
-
-        protectedSubscriber()->next(value);
+        Ref subscriber = m_subscriber;
+        subscriber->next(value);
         m_amount -= 1;
         if (!m_amount)
-            protectedSubscriber()->complete();
+            subscriber->complete();
     }
 
     void error(JSC::JSValue value) final
     {
-        protectedSubscriber()->error(value);
+        protect(m_subscriber)->error(value);
     }
 
     void complete() final
     {
         InternalObserver::complete();
-        protectedSubscriber()->complete();
+        protect(m_subscriber)->complete();
     }
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
     {
         m_subscriber->visitAdditionalChildren(visitor);
     }
-
-    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
 
     InternalObserverTake(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
         : InternalObserver(context)

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -170,7 +170,7 @@ LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const Atom
 void LoadableClassicScript::execute(ScriptElement& scriptElement)
 {
     ASSERT(!m_error);
-    scriptElement.executeClassicScript(ScriptSourceCode(protectedCachedScript().get(), JSC::SourceProviderSourceType::Program, *this));
+    scriptElement.executeClassicScript(ScriptSourceCode(protect(cachedScript()).get(), JSC::SourceProviderSourceType::Program, *this));
 }
 
 }

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -57,7 +57,6 @@ public:
 
     Document* document() { return m_weakDocument.get(); }
     CachedScript& cachedScript() { return *m_cachedScript; }
-    CachedResourceHandle<CachedScript> protectedCachedScript() { return cachedScript(); }
 
     bool load(Document&, const URL&);
     bool isAsync() const { return m_isAsync; }

--- a/Source/WebCore/dom/MessageChannel.cpp
+++ b/Source/WebCore/dom/MessageChannel.cpp
@@ -53,7 +53,7 @@ MessageChannel::MessageChannel(ScriptExecutionContext& context)
     if (!context.activeDOMObjectsAreStopped()) {
         ASSERT(!port1().isDetached());
         ASSERT(!port2().isDetached());
-        MessagePortChannelProvider::protectedFromContext(context)->createNewMessagePortChannel(port1().identifier(), port2().identifier(), context.settingsValues().siteIsolationEnabled);
+        protect(MessagePortChannelProvider::fromContext(context))->createNewMessagePortChannel(port1().identifier(), port2().identifier(), context.settingsValues().siteIsolationEnabled);
     } else {
         ASSERT(port1().isDetached());
         ASSERT(port2().isDetached());

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -145,7 +145,7 @@ MessagePort::~MessagePort()
 
 void MessagePort::entangle()
 {
-    MessagePortChannelProvider::protectedFromContext(*protect(scriptExecutionContext()))->entangleLocalPortInThisProcessToRemote(m_identifier, m_remoteIdentifier);
+    protect(MessagePortChannelProvider::fromContext(*protect(scriptExecutionContext())))->entangleLocalPortInThisProcessToRemote(m_identifier, m_remoteIdentifier);
 }
 
 ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
@@ -179,7 +179,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
 
     LOG(MessagePorts, "Actually posting message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
-    MessagePortChannelProvider::protectedFromContext(*protect(scriptExecutionContext()))->postMessageToRemote(WTF::move(message), m_remoteIdentifier);
+    protect(MessagePortChannelProvider::fromContext(*protect(scriptExecutionContext())))->postMessageToRemote(WTF::move(message), m_remoteIdentifier);
     return { };
 }
 
@@ -194,7 +194,7 @@ TransferredMessagePort MessagePort::disentangle()
     m_entangled = false;
 
     Ref context = *scriptExecutionContext();
-    MessagePortChannelProvider::protectedFromContext(context)->messagePortDisentangled(m_identifier);
+    protect(MessagePortChannelProvider::fromContext(context))->messagePortDisentangled(m_identifier);
 
     // We can't receive any messages or generate any events after this, so remove ourselves from the list of active ports.
     context->destroyedMessagePort(*this);
@@ -306,7 +306,7 @@ void MessagePort::dispatchMessages()
         }
     };
 
-    MessagePortChannelProvider::protectedFromContext(*context)->takeAllMessagesForPort(m_identifier, WTF::move(messagesTakenHandler));
+    protect(MessagePortChannelProvider::fromContext(*context))->takeAllMessagesForPort(m_identifier, WTF::move(messagesTakenHandler));
 }
 
 void MessagePort::dispatchEvent(Event& event)

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -125,7 +125,7 @@ void MutationObserver::disconnect()
     m_records.clear();
     WeakHashSet registrations { m_registrations };
     for (Ref registration : registrations)
-        registration->protectedNode()->unregisterMutationObserver(registration.get());
+        protect(registration->node())->unregisterMutationObserver(registration.get());
 }
 
 void MutationObserver::observationStarted(MutationObserverRegistration& registration)

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -64,7 +64,6 @@ public:
 
     MutationObserver& observer() { return m_observer.get(); }
     Node& node() { return m_node; }
-    Ref<Node> protectedNode() { return m_node; };
     MutationRecordDeliveryOptions deliveryOptions() const { return m_options & MutationObserver::AllDeliveryFlags; }
     MutationObserverOptions mutationTypes() const { return m_options & MutationObserver::AllMutationTypes; }
 

--- a/Source/WebCore/dom/NodeIterator.h
+++ b/Source/WebCore/dom/NodeIterator.h
@@ -59,7 +59,6 @@ private:
 
         NodePointer() = default;
         NodePointer(Node&, bool);
-        RefPtr<Node> protectedNode() const { return node; }
 
         void clear();
         bool moveToNext(Node& root);

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -132,7 +132,7 @@ void ScriptedAnimationController::cancelCallback(CallbackId callbackId)
     });
 
     if (cancelled && m_document)
-        InspectorInstrumentation::didCancelAnimationFrame(*protectedDocument(), callbackId);
+        InspectorInstrumentation::didCancelAnimationFrame(*protect(m_document), callbackId);
 }
 
 void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedResolutionSeconds timestamp)
@@ -193,9 +193,5 @@ void ScriptedAnimationController::scheduleAnimation()
         page->scheduleRenderingUpdate(RenderingUpdateStep::AnimationFrameCallbacks);
 }
 
-RefPtr<Document> ScriptedAnimationController::protectedDocument()
-{
-    return m_document.get();
-}
 
 }

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -76,7 +76,6 @@ private:
     bool isThrottledRelativeToPage() const;
     bool shouldRescheduleRequestAnimationFrame(ReducedResolutionSeconds) const;
     void scheduleAnimation();
-    RefPtr<Document> NODELETE protectedDocument();
 
     struct CallbackData {
         Ref<RequestAnimationFrameCallback> callback;

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
@@ -39,7 +39,6 @@ struct MessageWithMessagePorts;
 class MessagePortChannelProvider : public AbstractRefCountedAndCanMakeWeakPtr<MessagePortChannelProvider> {
 public:
     static MessagePortChannelProvider& fromContext(ScriptExecutionContext&);
-    static Ref<MessagePortChannelProvider> protectedFromContext(ScriptExecutionContext& context) { return fromContext(context); }
     static MessagePortChannelProvider& singleton();
     WEBCORE_EXPORT static void setSharedProvider(MessagePortChannelProvider&);
 

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -95,15 +95,10 @@ void SVGDocumentExtensions::pauseAnimations()
     m_areAnimationsPaused = true;
 }
 
-Ref<Document> SVGDocumentExtensions::protectedDocument() const
-{
-    return m_document.get();
-}
-
 void SVGDocumentExtensions::unpauseAnimations()
 {
     // If animations are paused at the document level, don't allow `this` to be unpaused.
-    if (animationsPausedForDocument(protectedDocument()))
+    if (animationsPausedForDocument(protect(m_document)))
         return;
 
     for (Ref container : m_timeContainers)
@@ -129,12 +124,12 @@ static void reportMessage(Document& document, MessageLevel level, const String& 
 
 void SVGDocumentExtensions::reportWarning(const String& message)
 {
-    reportMessage(protectedDocument(), MessageLevel::Warning, makeString("Warning: "_s, message));
+    reportMessage(protect(m_document), MessageLevel::Warning, makeString("Warning: "_s, message));
 }
 
 void SVGDocumentExtensions::reportError(const String& message)
 {
-    reportMessage(protectedDocument(), MessageLevel::Error, makeString("Error: "_s, message));
+    reportMessage(protect(m_document), MessageLevel::Error, makeString("Error: "_s, message));
 }
 
 void SVGDocumentExtensions::addElementToRebuild(SVGElement& element)

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -73,8 +73,6 @@ public:
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 
 private:
-    Ref<Document> NODELETE protectedDocument() const;
-
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_timeContainers; // For SVG 1.2 support this will need to be made more general.
     WeakHashSet<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_svgFontFaceElements;

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -378,14 +378,9 @@ std::optional<CSSToLengthConversionData> SVGLengthContext::cssConversionData() c
     };
 }
 
-RefPtr<const SVGElement> SVGLengthContext::protectedContext() const
-{
-    return m_context.get();
-}
-
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value) const
 {
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
+    auto* style = renderStyleForLengthResolving(protect(m_context).get());
     if (!style)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -400,7 +395,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value)
 
 ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value) const
 {
-    auto* style = renderStyleForLengthResolving(protectedContext().get());
+    auto* style = renderStyleForLengthResolving(protect(m_context).get());
     if (!style)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -433,7 +428,7 @@ std::optional<FloatSize> SVGLengthContext::computeViewportSize() const
     // applies zooming/panning for the whole SVG subtree as affine transform. Therefore
     // any length within the SVG subtree needs to exclude the 'zoom' information.
     if (m_context->isOutermostSVGSVGElement())
-        return downcast<SVGSVGElement>(*protectedContext()).currentViewportSizeExcludingZoom();
+        return downcast<SVGSVGElement>(*protect(m_context)).currentViewportSizeExcludingZoom();
 
     // Take size from nearest SVGSVGElement, skipping over <symbol> elements.
     RefPtr svg = dynamicDowncast<SVGSVGElement>(m_context->viewportElement(ViewportElementType::SVGSVGOnly));

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -93,7 +93,6 @@ private:
     float removeZoomFromFontOrRootFontRelativeLength(float value, CSS::LengthUnit) const;
 
     std::optional<CSSToLengthConversionData> cssConversionData() const;
-    RefPtr<const SVGElement> NODELETE protectedContext() const;
 
     template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomFactor usedZoom, SVGLengthMode = SVGLengthMode::Other) requires (SizeType::Fixed::zoomOptions == CSS::RangeZoomOptions::Unzoomed || SizeType::Calc::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed);
     template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -63,8 +63,6 @@ public:
 private:
     explicit SVGTRefTargetEventListener(SVGTRefElement& trefElement);
 
-    Ref<SVGTRefElement> protectedTRefElement() const { return m_trefElement.get(); }
-    RefPtr<Element> protectedTarget() const { return m_target; }
     void handleEvent(ScriptExecutionContext&, Event&) final;
     bool operator==(const EventListener&) const final;
 
@@ -113,9 +111,9 @@ void SVGTRefTargetEventListener::handleEvent(ScriptExecutionContext&, Event& eve
         return;
 
     if (event.type() == eventNames().DOMSubtreeModifiedEvent && m_trefElement.ptr() != event.target())
-        protectedTRefElement()->updateReferencedText(protectedTarget().get());
+        protect(m_trefElement)->updateReferencedText(protect(m_target).get());
     else if (event.type() == eventNames().DOMNodeRemovedFromDocumentEvent)
-        protectedTRefElement()->detachTarget();
+        protect(m_trefElement)->detachTarget();
 }
 
 inline SVGTRefElement::SVGTRefElement(const QualifiedName& tagName, Document& document)
@@ -128,12 +126,7 @@ inline SVGTRefElement::SVGTRefElement(const QualifiedName& tagName, Document& do
 
 SVGTRefElement::~SVGTRefElement()
 {
-    protectedTargetListener()->detach();
-}
-
-Ref<SVGTRefTargetEventListener> SVGTRefElement::protectedTargetListener() const
-{
-    return m_targetListener;
+    protect(m_targetListener)->detach();
 }
 
 void SVGTRefElement::updateReferencedText(Element* target)
@@ -156,7 +149,7 @@ void SVGTRefElement::updateReferencedText(Element* target)
 void SVGTRefElement::detachTarget()
 {
     // Remove active listeners and clear the text content.
-    protectedTargetListener()->detach();
+    protect(m_targetListener)->detach();
 
     ASSERT(shadowRoot());
     RefPtr container = shadowRoot()->firstChild();
@@ -214,13 +207,13 @@ bool SVGTRefElement::rendererIsNeeded(const RenderStyle& style)
 
 void SVGTRefElement::clearTarget()
 {
-    protectedTargetListener()->detach();
+    protect(m_targetListener)->detach();
 }
 
 void SVGTRefElement::buildPendingResource()
 {
     // Remove any existing event listener.
-    protectedTargetListener()->detach();
+    protect(m_targetListener)->detach();
 
     // If we're not yet in a document, this function will be called again from insertedIntoAncestor().
     if (!isConnected())
@@ -241,7 +234,7 @@ void SVGTRefElement::buildPendingResource()
     // expects every element instance to have an associated shadow tree element - which is not the
     // case when we land here from SVGUseElement::buildShadowTree().
     if (!isInShadowTree())
-        protectedTargetListener()->attach(target.element.copyRef());
+        protect(m_targetListener)->attach(target.element.copyRef());
 
     updateReferencedText(target.element.get());
 }
@@ -264,7 +257,7 @@ void SVGTRefElement::removedFromAncestor(RemovalType removalType, ContainerNode&
 {
     SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
-        protectedTargetListener()->detach();
+        protect(m_targetListener)->detach();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -43,8 +43,6 @@ private:
     SVGTRefElement(const QualifiedName&, Document&);
     virtual ~SVGTRefElement();
 
-    Ref<SVGTRefTargetEventListener> protectedTargetListener() const;
-
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -119,11 +119,6 @@ void SVGTests::addSupportedAttributes(MemoryCompactLookupOnlyRobinHoodHashSet<Qu
     supportedAttributes.add(SVGNames::systemLanguageAttr);
 }
 
-Ref<SVGElement> SVGTests::protectedContextElement() const
-{
-    return m_contextElement;
-}
-
 SVGConditionalProcessingAttributes& SVGTests::conditionalProcessingAttributes()
 {
     Ref contextElement = m_contextElement;
@@ -132,7 +127,7 @@ SVGConditionalProcessingAttributes& SVGTests::conditionalProcessingAttributes()
 
 SVGConditionalProcessingAttributes* SVGTests::conditionalProcessingAttributesIfExists() const
 {
-    return protectedContextElement()->conditionalProcessingAttributesIfExists();
+    return protect(m_contextElement)->conditionalProcessingAttributesIfExists();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -75,8 +75,6 @@ protected:
     SVGTests(SVGElement* contextElement);
 
 private:
-    Ref<SVGElement> protectedContextElement() const;
-
     WeakRef<SVGElement, WeakPtrImplWithEventTargetData> m_contextElement;
 };
 

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -245,8 +245,6 @@ private:
         return value * s_outputUnitsPerEm / m_inputUnitsPerEm;
     }
 
-    Ref<const SVGFontElement> protectedFontElement() const { return m_fontElement.get(); }
-
     Vector<GlyphData> m_glyphs;
     HashMap<String, Glyph> m_glyphNameToIndexMap; // SVG 1.1: "It is recommended that glyph names be unique within a font."
     HashMap<String, Vector<Glyph, 1>> m_codepointsToIndicesMap;
@@ -1061,7 +1059,7 @@ void SVGToOTFFontConverter::addKerningPair(Vector<KerningData>& data, SVGKerning
 template<typename T> inline size_t SVGToOTFFontConverter::appendKERNSubtable(std::optional<SVGKerningPair> (T::*buildKerningPair)() const, uint16_t coverage)
 {
     Vector<KerningData> kerningData;
-    for (Ref element : childrenOfType<T>(protectedFontElement())) {
+    for (Ref element : childrenOfType<T>(protect(m_fontElement))) {
         if (auto kerningPair = (element.get().*buildKerningPair)())
             addKerningPair(kerningData, WTF::move(*kerningPair));
     }
@@ -1414,7 +1412,7 @@ SVGToOTFFontConverter::SVGToOTFFontConverter(const SVGFontElement& fontElement)
         boundingBox = FloatRect(0, 0, s_outputUnitsPerEm, s_outputUnitsPerEm);
     }
 
-    for (Ref glyphElement : childrenOfType<SVGGlyphElement>(protectedFontElement())) {
+    for (Ref glyphElement : childrenOfType<SVGGlyphElement>(protect(m_fontElement))) {
         auto& unicodeAttribute = glyphElement->attributeWithoutSynchronization(SVGNames::unicodeAttr);
         if (!unicodeAttribute.isEmpty()) // If we can never actually trigger this glyph, ignore it completely
             processGlyphElement(glyphElement.get(), glyphElement.ptr(), defaultHorizontalAdvance, defaultVerticalAdvance, unicodeAttribute, boundingBox);

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -64,17 +64,12 @@ void SVGImageCache::setContainerContextForClient(const CachedImageClient& client
     FloatSize containerSizeWithoutZoom(containerSize);
     containerSizeWithoutZoom.scale(1 / containerZoom);
 
-    m_imageForContainerMap.set(&client, SVGImageForContainer::create(protectedSVGImage().get(), containerSizeWithoutZoom, containerZoom, imageURL));
+    m_imageForContainerMap.set(&client, SVGImageForContainer::create(protect(m_svgImage).get(), containerSizeWithoutZoom, containerZoom, imageURL));
 }
 
 Image* SVGImageCache::findImageForRenderer(const RenderObject* renderer) const
 {
     return renderer ? m_imageForContainerMap.get(&renderer->cachedImageClient()) : nullptr;
-}
-
-RefPtr<SVGImage> SVGImageCache::protectedSVGImage() const
-{
-    return m_svgImage.get();
 }
 
 FloatSize SVGImageCache::imageSizeForRenderer(const RenderObject* renderer) const

--- a/Source/WebCore/svg/graphics/SVGImageCache.h
+++ b/Source/WebCore/svg/graphics/SVGImageCache.h
@@ -50,7 +50,6 @@ public:
 
 private:
     Image* findImageForRenderer(const RenderObject*) const;
-    RefPtr<SVGImage> protectedSVGImage() const;
 
     using ImageForContainerMap = HashMap<const CachedImageClient*, Ref<SVGImageForContainer>>;
 

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
@@ -36,11 +36,6 @@ SVGImageForContainer::SVGImageForContainer(SVGImage* image, const FloatSize& con
 {
 }
 
-RefPtr<SVGImage> SVGImageForContainer::protectedImage() const
-{
-    return m_image.get();
-}
-
 FloatSize SVGImageForContainer::size(ImageOrientation) const
 {
     FloatSize scaledContainerSize(m_containerSize);
@@ -50,18 +45,18 @@ FloatSize SVGImageForContainer::size(ImageOrientation) const
 
 ImageDrawResult SVGImageForContainer::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    return protectedImage()->drawForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, dstRect, srcRect, options);
+    return protect(m_image)->drawForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, dstRect, srcRect, options);
 }
 
 void SVGImageForContainer::drawPattern(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, const AffineTransform& patternTransform,
     const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    protectedImage()->drawPatternForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, srcRect, patternTransform, phase, spacing, dstRect, options);
+    protect(m_image)->drawPatternForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, srcRect, patternTransform, phase, spacing, dstRect, options);
 }
 
 RefPtr<NativeImage> SVGImageForContainer::currentNativeImage()
 {
-    return protectedImage()->currentNativeImage();
+    return protect(m_image)->currentNativeImage();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.h
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.h
@@ -50,7 +50,7 @@ public:
     bool hasRelativeHeight() const final { return m_image->hasRelativeHeight(); }
     void computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio) final
     {
-        protectedImage()->computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, intrinsicRatio);
+        protect(m_image)->computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, intrinsicRatio);
     }
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect&, const FloatRect&, ImagePaintingOptions = { }) final;
@@ -65,7 +65,6 @@ public:
 
 private:
     WEBCORE_EXPORT SVGImageForContainer(SVGImage*, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL);
-    RefPtr<SVGImage> protectedImage() const;
 
     WeakPtr<SVGImage> m_image;
     const FloatSize m_containerSize;

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -46,7 +46,7 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
 
 ExceptionOr<Ref<Document>> DOMParser::parseFromString(Variant<Ref<TrustedHTML>, String>&& string, const AtomString& contentType)
 {
-    auto stringValueHolder = trustedTypeCompliantString(protect(protectedContextDocument()->contextDocument()), WTF::move(string), "DOMParser parseFromString"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(protect(m_contextDocument)->contextDocument()), WTF::move(string), "DOMParser parseFromString"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -40,8 +40,6 @@ public:
 private:
     explicit DOMParser(Document& contextDocument);
 
-    RefPtr<Document> protectedContextDocument() const { return m_contextDocument; }
-
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
     const Ref<const Settings> m_settings;
 };

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -107,7 +107,7 @@ void XMLHttpRequestProgressEventThrottle::dispatchProgressEvent(const AtomString
         m_total = 0;
     }
 
-    if (protectedTarget()->hasEventListeners(type))
+    if (protect(m_target)->hasEventListeners(type))
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(type, m_lengthComputable, m_loaded, m_total));
 }
 
@@ -115,7 +115,7 @@ void XMLHttpRequestProgressEventThrottle::dispatchErrorProgressEvent(const AtomS
 {
     ASSERT(type == eventNames().loadendEvent || type == eventNames().abortEvent || type == eventNames().errorEvent || type == eventNames().timeoutEvent);
 
-    if (protectedTarget()->hasEventListeners(type))
+    if (protect(m_target)->hasEventListeners(type))
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(type, false, 0, 0));
 }
 
@@ -149,7 +149,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
     m_shouldDeferEventsDueToSuspension = true;
 
     if (m_hasPendingThrottledProgressEvent) {
-        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedTarget().get(), TaskSource::Networking, [this](auto&) {
+        ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_target).get(), TaskSource::Networking, [this](auto&) {
             flushProgressEvent();
         });
     }
@@ -157,14 +157,9 @@ void XMLHttpRequestProgressEventThrottle::suspend()
 
 void XMLHttpRequestProgressEventThrottle::resume()
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedTarget().get(), TaskSource::Networking, [this](auto&) {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_target).get(), TaskSource::Networking, [this](auto&) {
         m_shouldDeferEventsDueToSuspension = false;
     });
-}
-
-Ref<XMLHttpRequest> XMLHttpRequestProgressEventThrottle::protectedTarget()
-{
-    return m_target.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -70,8 +70,6 @@ private:
     void flushProgressEvent();
     void dispatchEventWhenPossible(Event&);
 
-    Ref<XMLHttpRequest> protectedTarget();
-
     // Weak reference to our XMLHttpRequest object as it is the one holding us.
     WeakRef<XMLHttpRequest, WeakPtrImplWithEventTargetData> m_target;
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -151,7 +151,7 @@ void XMLDocumentParser::createLeafTextNode()
     ASSERT(!m_leafTextNode);
     m_leafTextNode = Text::create(protect(m_currentNode->document()), String { emptyString() });
     if (RefPtr currentNode = m_currentNode.get())
-        currentNode->parserAppendChild(*protectedLeafTextNode());
+        currentNode->parserAppendChild(*protect(m_leafTextNode));
 }
 
 bool XMLDocumentParser::updateLeafTextNode()
@@ -163,10 +163,10 @@ bool XMLDocumentParser::updateLeafTextNode()
         return true;
 
     if (isXHTMLDocument())
-        protectedLeafTextNode()->parserAppendData(String::fromUTF8(m_bufferedText.span()));
+        protect(m_leafTextNode)->parserAppendData(String::fromUTF8(m_bufferedText.span()));
     else {
         // This operation might fire mutation event, see below.
-        protectedLeafTextNode()->appendData(String::fromUTF8(m_bufferedText.span()));
+        protect(m_leafTextNode)->appendData(String::fromUTF8(m_bufferedText.span()));
     }
     m_bufferedText = { };
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -154,8 +154,6 @@ private:
     void doWrite(const String&);
     void doEnd();
 
-    RefPtr<Text> protectedLeafTextNode() const { return m_leafTextNode; }
-
     xmlParserCtxtPtr context() const { return m_context ? m_context->context() : nullptr; };
 
     IsInFrameView m_isInFrameView { IsInFrameView::No };


### PR DESCRIPTION
#### 30dd3a9c941fa5e1fc1a285d2b31b5eea1ebf50b
<pre>
Reduce usage of protectedFoo() style in WebCore/dom, WebCore/xml, and WebCore/svg code
<a href="https://bugs.webkit.org/show_bug.cgi?id=308379">https://bugs.webkit.org/show_bug.cgi?id=308379</a>
<a href="https://rdar.apple.com/170870938">rdar://170870938</a>

Reviewed by Chris Dumez.

Replace protectedFoo() one-off wrapper methods with the protect()
free function throughout dom/, xml/, and svg/ code

No new tests, as no change in functionality.

* Source/WebCore/dom/ConstantPropertyMap.cpp:
(WebCore::ConstantPropertyMap::didChangeSafeAreaInsets):
(WebCore::ConstantPropertyMap::didChangeFullscreenInsets):
(WebCore::ConstantPropertyMap::setFullscreenAutoHideDuration):
(WebCore::ConstantPropertyMap::protectedDocument const): Deleted.
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/CurrentScriptIncrementer.h:
(WebCore::CurrentScriptIncrementer::CurrentScriptIncrementer):
(WebCore::CurrentScriptIncrementer::~CurrentScriptIncrementer):
(WebCore::CurrentScriptIncrementer::protectedDocument const): Deleted.
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createDocumentType):
(WebCore::DOMImplementation::protectedDocument): Deleted.
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setTitle):
(WebCore::Document::updateTitleElement):
(WebCore::Document::protectedTitleElement const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
(WebCore::DocumentFontLoader::beginLoadingFontSoon):
(WebCore::DocumentFontLoader::loadPendingFonts):
* Source/WebCore/dom/DocumentFontLoader.h:
(WebCore::DocumentFontLoader::protectedDocument const): Deleted.
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::updateRectsForInvalidatedMarkersOfType):
(WebCore::DocumentMarkerController::protectedDocument const): Deleted.
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccessForDocumentQuirk):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
(WebCore::DocumentStorageAccess::enableTemporaryTimeUserGesture):
(WebCore::DocumentStorageAccess::protectedDocument const): Deleted.
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTaskGroup::queueTask):
(WebCore::EventLoopTaskGroup::queueMicrotask):
(WebCore::EventLoopTaskGroup::scheduleTask):
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::protectedEventLoop const): Deleted.
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFirst.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableClassicScript::execute):
* Source/WebCore/dom/LoadableClassicScript.h:
(WebCore::LoadableNonModuleScriptBase::cachedScript):
(WebCore::LoadableNonModuleScriptBase::protectedCachedScript): Deleted.
* Source/WebCore/dom/MessageChannel.cpp:
(WebCore::MessageChannel::MessageChannel):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::entangle):
(WebCore::MessagePort::postMessage):
(WebCore::MessagePort::disentangle):
(WebCore::MessagePort::dispatchMessages):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::disconnect):
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/NodeIterator.h:
* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::cancelCallback):
(WebCore::ScriptedAnimationController::protectedDocument): Deleted.
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/dom/messageports/MessagePortChannelProvider.h:
(WebCore::MessagePortChannelProvider::protectedFromContext): Deleted.
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::unpauseAnimations):
(WebCore::SVGDocumentExtensions::reportWarning):
(WebCore::SVGDocumentExtensions::reportError):
(WebCore::SVGDocumentExtensions::protectedDocument const): Deleted.
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueFromUserUnitsToEXS const):
(WebCore::SVGLengthContext::convertValueFromEXSToUserUnits const):
(WebCore::SVGLengthContext::computeViewportSize const):
(WebCore::SVGLengthContext::protectedContext const): Deleted.
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefTargetEventListener::handleEvent):
(WebCore::SVGTRefElement::~SVGTRefElement):
(WebCore::SVGTRefElement::detachTarget):
(WebCore::SVGTRefElement::clearTarget):
(WebCore::SVGTRefElement::buildPendingResource):
(WebCore::SVGTRefElement::removedFromAncestor):
(WebCore::SVGTRefElement::protectedTargetListener const): Deleted.
* Source/WebCore/svg/SVGTRefElement.h:
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::conditionalProcessingAttributesIfExists const):
(WebCore::SVGTests::protectedContextElement const): Deleted.
* Source/WebCore/svg/SVGTests.h:
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::appendKERNSubtable):
(WebCore::SVGToOTFFontConverter::SVGToOTFFontConverter):
(WebCore::SVGToOTFFontConverter::protectedFontElement const): Deleted.
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
(WebCore::SVGImageCache::setContainerContextForClient):
(WebCore::SVGImageCache::protectedSVGImage const): Deleted.
* Source/WebCore/svg/graphics/SVGImageCache.h:
* Source/WebCore/svg/graphics/SVGImageForContainer.cpp:
(WebCore::SVGImageForContainer::draw):
(WebCore::SVGImageForContainer::drawPattern):
(WebCore::SVGImageForContainer::currentNativeImage):
(WebCore::SVGImageForContainer::protectedImage const): Deleted.
* Source/WebCore/svg/graphics/SVGImageForContainer.h:
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):
* Source/WebCore/xml/DOMParser.h:
(WebCore::DOMParser::protectedContextDocument const): Deleted.
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchProgressEvent):
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchErrorProgressEvent):
(WebCore::XMLHttpRequestProgressEventThrottle::suspend):
(WebCore::XMLHttpRequestProgressEventThrottle::resume):
(WebCore::XMLHttpRequestProgressEventThrottle::protectedTarget): Deleted.
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::createLeafTextNode):
(WebCore::XMLDocumentParser::updateLeafTextNode):
* Source/WebCore/xml/parser/XMLDocumentParser.h:

Canonical link: <a href="https://commits.webkit.org/308161@main">https://commits.webkit.org/308161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ff575bacc2e19dd46f5991e888c5b7e44b8ec39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155310 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f1c7de7-5667-43b8-a924-26e3c2775428) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112990 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87f1f89e-ee1f-4adc-8584-fbd8838235ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15229 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93736 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/394e75c0-2025-41e2-8d50-13c76ffee1af) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/2754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157638 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11062 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31040 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131380 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18741 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18471 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->