### PR TITLE
Support user agent part pseudo-elements in getComputedStyle()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/file-selector-button-inherit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/file-selector-button-inherit-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL ::file-selector-button should inherit from its originating element assert_equals: Check that ::file-selector-button is supported via color expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS ::file-selector-button should inherit from its originating element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/placeholder-inherit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/placeholder-inherit-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL ::placeholder should inherit from its originating element assert_equals: Check that ::placeholder is supported via color expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS ::placeholder should inherit from its originating element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shadow-parts/interaction-with-pseudo-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shadow-parts/interaction-with-pseudo-elements-expected.txt
@@ -1,7 +1,7 @@
 
 PASS ::before in selected host is styled
 PASS ::after in selected host is styled
-FAIL ::placeholder in selected host is styled assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS ::placeholder in selected host is styled
 PASS ::selection in selected host is styled
 PASS ::first-line in selected host is styled
 PASS ::first-letter in selected host is styled

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
@@ -1,5 +1,6 @@
 Item
 
+
 PASS Resolution of width is correct when pseudo-element argument is ignored (due to no colon)
 PASS Resolution of width is correct when pseudo-element argument is invalid (due to a trailing token)
 PASS Resolution of width is correct for ::before and ::after pseudo-elements (single-colon)
@@ -15,15 +16,17 @@ PASS Dynamically change to display: contents on pseudo-elements
 PASS Unknown pseudo-elements
 PASS CSSStyleDeclaration is immutable
 PASS Unknown pseudo-element with a known identifier: backdrop
-FAIL Unknown pseudo-element with a known identifier: file-selector-button assert_equals: Should return the ::file-selector-button style expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Unknown pseudo-element with a known identifier: file-selector-button
 PASS Unknown pseudo-element with a known identifier: grammar-error
 PASS Unknown pseudo-element with a known identifier: highlight(name)
 PASS Unknown pseudo-element with a known identifier: marker
-FAIL Unknown pseudo-element with a known identifier: placeholder assert_equals: Should return the ::placeholder style expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Unknown pseudo-element with a known identifier: placeholder
 PASS Unknown pseudo-element with a known identifier: spelling-error
 PASS Unknown pseudo-element with a known identifier: view-transition
 PASS Unknown pseudo-element with a known identifier: view-transition-image-pair(name)
 PASS Unknown pseudo-element with a known identifier: view-transition-group(name)
 PASS Unknown pseudo-element with a known identifier: view-transition-old(name)
 PASS Unknown pseudo-element with a known identifier: view-transition-new(name)
+PASS ::file-selector-button resolves to the file input button element
+PASS Prefixed ::-webkit-file-upload-button does not resolve in getComputedStyle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker-expected.txt
@@ -1,0 +1,11 @@
+
+
+PASS ::picker(select) returns picker element style
+PASS ::picker(select) on non-select element returns empty style
+PASS Invalid pseudo-element should return empty style: ::picker
+PASS Invalid pseudo-element should return empty style: ::picker()
+PASS Invalid pseudo-element should return empty style: ::picker(div)
+PASS Invalid pseudo-element should return empty style: :picker(select)
+PASS Invalid pseudo-element should return empty style: ::picker(select)a
+PASS Invalid pseudo-element should return empty style: ::picker( )
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: getComputedStyle with ::picker(select)</title>
+
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values">
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<style>
+select,
+select::picker(select) {
+  appearance: base-select;
+}
+
+#test-select::picker(select) {
+  background-color: rgb(0, 128, 0);
+}
+</style>
+
+<select id="test-select">
+  <option>The only option</option>
+</select>
+
+<div id="test-div"></div>
+
+<script>
+test(() => {
+  const select = document.getElementById('test-select');
+  const style = getComputedStyle(select, '::picker(select)');
+  assert_equals(style.backgroundColor, 'rgb(0, 128, 0)');
+}, '::picker(select) returns picker element style');
+
+test(() => {
+  const div = document.getElementById('test-div');
+  const style = getComputedStyle(div, '::picker(select)');
+  assert_equals(style.length, 0);
+}, '::picker(select) on non-select element returns empty style');
+
+[
+  "::picker",
+  "::picker()",
+  "::picker(div)",
+  ":picker(select)",
+  "::picker(select)a",
+  "::picker( )",
+].forEach(pseudo => {
+  test(() => {
+    const select = document.getElementById('test-select');
+    const style = getComputedStyle(select, pseudo);
+    assert_equals(style.length, 0);
+  }, `Invalid pseudo-element should return empty style: ${pseudo}`);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
@@ -94,6 +94,9 @@
 #pseudo-invalid {
   color: rgb(255, 0, 0)
 }
+#test-file-input::file-selector-button {
+  color: rgb(0, 128, 0);
+}
 </style>
 <div id="test">
   <div id="contents"></div>
@@ -103,6 +106,7 @@
   <div id="contents-pseudos"></div>
   <div id="contents-pseudos-dynamic"></div>
   <ul><li id="pseudo-invalid">Item</li></ul>
+  <input type="file" id="test-file-input">
 </div>
 <script>
 test(() => {
@@ -291,4 +295,18 @@ test(() => {
     `Should return the ::${pseudoIdentifier} style`);
   }, `Unknown pseudo-element with a known identifier: ${pseudoIdentifier}`);
 });
+
+test(() => {
+  const fileInput = document.getElementById('test-file-input');
+  const style = getComputedStyle(fileInput, '::file-selector-button');
+  assert_equals(style.color, 'rgb(0, 128, 0)',
+    '::file-selector-button should resolve to the backing element style');
+}, '::file-selector-button resolves to the file input button element');
+
+test(() => {
+  const fileInput = document.getElementById('test-file-input');
+  const style = getComputedStyle(fileInput, '::-webkit-file-upload-button');
+  assert_equals(style.length, 0,
+    '::-webkit-file-upload-button should return empty style');
+}, 'Prefixed ::-webkit-file-upload-button does not resolve in getComputedStyle');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -3,7 +3,7 @@ SIBLING
 
 FAIL UA styles of base appearance <select>. assert_equals: min-inline-size expected "calc-size(auto, max(size, 24px))" but got "0px"
 FAIL UA styles of base appearance select::picker-icon. assert_equals: content expected "counter(fake-counter-name, disclosure-open)" but got "\"▼\" / \"\""
-FAIL UA styles of base appearance ::picker(select) assert_equals: box-sizing expected "border-box" but got ""
+FAIL UA styles of base appearance ::picker(select) assert_equals: position-try-fallbacks expected "start span-end, end span-start, start span-start" but got "block-start span-inline-end, block-end span-inline-start, block-start span-inline-start"
 PASS UA styles of base appearance <option>.
 PASS UA styles of base appearance option::checkmark.
 FAIL UA styles of base appearance <optgroup>. assert_equals: display expected "block" but got "inline"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
@@ -3,11 +3,11 @@ option one
 option two
 option three
 
-FAIL Basic functionality of select picker and appearance assert_equals: expected "none" but got ""
-FAIL Basic functionality of select picker with appearance:auto assert_equals: expected "none" but got ""
-FAIL Basic functionality of select picker with appearance:none assert_equals: expected "none" but got ""
-FAIL Switching appearance in :open should close the picker assert_equals: expected "none" but got ""
-FAIL Switching appearance in JS after picker is open should close the picker assert_equals: expected "none" but got ""
+PASS Basic functionality of select picker and appearance
+FAIL Basic functionality of select picker with appearance:auto assert_equals: appearance:auto picker is never open expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
+FAIL Basic functionality of select picker with appearance:none assert_equals: appearance:none picker is never open expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
+FAIL Switching appearance in :open should close the picker assert_equals: expected "base-select" but got "auto"
+PASS Switching appearance in JS after picker is open should close the picker
 PASS Test of the test harness
 PASS The select picker is closed if the <select> appearance value is changed via CSS while the picker is open
 FAIL The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open assert_false: picker should get closed when the appearance value changes expected false got true

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3118,6 +3118,7 @@ style/PageRuleCollector.cpp
 style/PropertyAllowlist.cpp
 style/PropertyCascade.cpp
 style/PseudoClassChangeInvalidation.cpp
+style/PseudoElementUtilities.cpp
 style/ResolvedScopedName.cpp
 style/RuleData.cpp
 style/RuleFeature.cpp

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -832,6 +832,7 @@ KeyframeEffect::KeyframeEffect(Element* target, const std::optional<Style::Pseud
     : m_target(target)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)
 {
+    ASSERT(!pseudoElementIdentifier || pseudoElementIdentifier->type != PseudoElementType::UserAgentPartFallback);
     if (m_target)
         m_document = m_target->document();
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Overflow.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Overflow.cpp
@@ -26,6 +26,7 @@
 #include "CSSPropertyParserConsumer+Overflow.h"
 
 #include "CSSParserTokenRange.h"
+#include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserState.h"
 #include "CSSPropertyParsing.h"
 #include "CSSValueKeywords.h"

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -35,6 +35,7 @@
 #include <WebCore/CSSSelectorList.h>
 #include <WebCore/CSSSelectorParserContext.h>
 #include <WebCore/MutableCSSSelector.h>
+#include <WebCore/PseudoElementIdentifier.h>
 #include <WebCore/StyleSheetContents.h>
 
 namespace WebCore {
@@ -43,10 +44,6 @@ class CSSParserTokenRange;
 class CSSSelectorList;
 class StyleSheetContents;
 class StyleRule;
-
-namespace Style {
-struct PseudoElementIdentifier;
-}
 
 class CSSSelectorParser {
 public:
@@ -62,7 +59,7 @@ public:
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
-    static std::pair<bool, std::optional<Style::PseudoElementIdentifier>> parsePseudoElement(const String&, const CSSSelectorParserContext&);
+    static std::optional<Style::PseudoElementIdentifier> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 
 private:
     template<typename ConsumeSelector> MutableCSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -1019,7 +1019,7 @@ private:
 
     enum class ResolveComputedStyleMode : uint8_t { Normal, RenderedOnly, Editability };
     const RenderStyle* resolveComputedStyle(ResolveComputedStyleMode = ResolveComputedStyleMode::Normal);
-    const RenderStyle& resolvePseudoElementStyle(const Style::PseudoElementIdentifier&);
+    const RenderStyle* resolvePseudoElementStyle(const Style::PseudoElementIdentifier&);
 
     unsigned NODELETE rareDataChildIndex() const;
 

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -218,6 +218,7 @@ std::optional<Style::PseudoElementIdentifier> HitTestResult::pseudoElementIdenti
 
 void HitTestResult::setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier)
 {
+    ASSERT(!pseudoElementIdentifier || pseudoElementIdentifier->type != PseudoElementType::UserAgentPartFallback);
     m_pseudoElementIdentifier = pseudoElementIdentifier;
 }
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -71,6 +71,11 @@ enum class PseudoElementType : uint8_t {
     ViewTransitionOld,
     ViewTransitionNew,
 
+    // Special: This is only used for getComputedStyle(), and primarily in the event there's no
+    // concrete backing element and we have to look up the matching style rules. It is also limited
+    // to non-prefixed parts.
+    UserAgentPartFallback,
+
     // Internal:
     WebKitScrollbarThumb,
     WebKitScrollbarButton,

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -248,8 +248,12 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
             collectMatchingRulesForList(rules, matchRequest);
     }
 
-    if (m_pseudoElementRequest && m_pseudoElementRequest->nameArgument() != nullAtom())
-        collectMatchingRulesForList(ruleSet.namedPseudoElementRules(m_pseudoElementRequest->nameArgument()), matchRequest);
+    if (m_pseudoElementRequest) {
+        if (m_pseudoElementRequest->type() == PseudoElementType::UserAgentPartFallback)
+            collectMatchingRulesForList(ruleSet.userAgentPartRules(m_pseudoElementRequest->nameOrPart()), matchRequest);
+        else if (!m_pseudoElementRequest->nameOrPart().isNull())
+            collectMatchingRulesForList(ruleSet.namedPseudoElementRules(m_pseudoElementRequest->nameOrPart()), matchRequest);
+    }
 
     if (element.isLink())
         collectMatchingRulesForList(ruleSet.linkPseudoClassRules(), matchRequest);
@@ -601,7 +605,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
         context.setRequestedPseudoElement(pseudoElementIdentifier);
         context.scrollbarState = m_pseudoElementRequest->scrollbarState();
         if (isNamedViewTransitionPseudoElement(pseudoElementIdentifier))
-            context.classList = classListForNamedViewTransitionPseudoElement(element().document(), pseudoElementIdentifier.nameArgument);
+            context.classList = classListForNamedViewTransitionPseudoElement(element().document(), pseudoElementIdentifier.nameOrPart);
     }
     context.styleScopeOrdinal = styleScopeOrdinal;
     context.selectorMatchingState = m_selectorMatchingState;

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -35,22 +35,23 @@ namespace WebCore::Style {
 struct PseudoElementIdentifier {
     PseudoElementType type;
 
-    // highlight name for ::highlight or view transition name for view transition pseudo elements.
-    AtomString nameArgument { nullAtom() };
+    // Highlight name for ::highlight, view transition name for view transition pseudo-elements,
+    // or user agent part name for UserAgentPartFallback (e.g., "file-selector-button", "picker(select)").
+    AtomString nameOrPart { nullAtom() };
 
     friend bool operator==(const PseudoElementIdentifier& a, const PseudoElementIdentifier& b) = default;
 };
 
 inline void add(Hasher& hasher, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
-    add(hasher, pseudoElementIdentifier.type, pseudoElementIdentifier.nameArgument);
+    add(hasher, pseudoElementIdentifier.type, pseudoElementIdentifier.nameOrPart);
 }
 
 inline WTF::TextStream& operator<<(WTF::TextStream& ts, const PseudoElementIdentifier& pseudoElementIdentifier)
 {
     ts << "::"_s << pseudoElementIdentifier.type;
-    if (!pseudoElementIdentifier.nameArgument.isNull())
-        ts << '(' << pseudoElementIdentifier.nameArgument << ')';
+    if (!pseudoElementIdentifier.nameOrPart.isNull())
+        ts << '(' << pseudoElementIdentifier.nameOrPart << ')';
     return ts;
 }
 
@@ -81,8 +82,8 @@ struct HashTraits<WebCore::Style::PseudoElementIdentifier> : GenericHashTraits<W
     static constexpr bool emptyValueIsZero = false;
     static EmptyValueType emptyValue() { return WebCore::Style::PseudoElementIdentifier { { }, emptyAtom() }; }
 
-    static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& identifer) { new (NotNull, &identifer.nameArgument) AtomString { HashTableDeletedValue }; }
-    static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return identifer.nameArgument.isHashTableDeletedValue(); }
+    static void constructDeletedValue(WebCore::Style::PseudoElementIdentifier& identifer) { new (NotNull, &identifer.nameOrPart) AtomString { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebCore::Style::PseudoElementIdentifier& identifer) { return identifer.nameOrPart.isHashTableDeletedValue(); }
 };
 
 template<>

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -40,8 +40,8 @@ public:
     {
     }
 
-    PseudoElementRequest(PseudoElementType type, const AtomString& nameArgument)
-        : m_identifier({ type, nameArgument })
+    PseudoElementRequest(PseudoElementType type, const AtomString& nameOrPart)
+        : m_identifier({ type, nameOrPart })
     {
         ASSERT(type == PseudoElementType::Highlight || type == PseudoElementType::ViewTransitionGroup || type == PseudoElementType::ViewTransitionImagePair || type == PseudoElementType::ViewTransitionOld || type == PseudoElementType::ViewTransitionNew);
     }
@@ -53,7 +53,7 @@ public:
 
     const PseudoElementIdentifier& identifier() const { return m_identifier; }
     PseudoElementType type() const { return m_identifier.type; }
-    const AtomString& nameArgument() const { return m_identifier.nameArgument; }
+    const AtomString& nameOrPart() const { return m_identifier.nameOrPart; }
     const std::optional<StyleScrollbarState>& scrollbarState() const { return m_scrollbarState; }
 
 private:

--- a/Source/WebCore/style/PseudoElementUtilities.cpp
+++ b/Source/WebCore/style/PseudoElementUtilities.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PseudoElementUtilities.h"
+
+#include "CSSSelectorParser.h"
+#include "Document.h"
+#include "Element.h"
+#include "ShadowRoot.h"
+#include "TypedElementDescendantIteratorInlines.h"
+
+namespace WebCore::Style {
+
+static RefPtr<Element> findElementForUserAgentPart(Element& host, const AtomString& userAgentPartName)
+{
+    RefPtr shadowRoot = host.userAgentShadowRoot();
+    if (!shadowRoot)
+        return nullptr;
+    for (Ref descendant : descendantsOfType<Element>(*shadowRoot)) {
+        if (descendant->userAgentPart() == userAgentPartName)
+            return descendant.ptr();
+    }
+    return nullptr;
+}
+
+ResolvedComputedPseudoElement resolveComputedPseudoElement(Element& element, const String& pseudoElement)
+{
+    auto identifier = CSSSelectorParser::parsePseudoElement(pseudoElement, CSSSelectorParserContext { protect(element.document()) });
+    if (!identifier)
+        return { nullptr, { } };
+    if (identifier->type == PseudoElementType::UserAgentPartFallback) {
+        if (RefPtr backingElement = findElementForUserAgentPart(element, identifier->nameOrPart))
+            return { WTF::move(backingElement), { } };
+    }
+    return { &element, *identifier };
+}
+
+} // namespace WebCore::Style

--- a/Source/WebCore/style/PseudoElementUtilities.h
+++ b/Source/WebCore/style/PseudoElementUtilities.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PseudoElementIdentifier.h"
+#include <wtf/Forward.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class Element;
+
+namespace Style {
+
+struct ResolvedComputedPseudoElement {
+    RefPtr<Element> element;
+    std::optional<PseudoElementIdentifier> identifier;
+};
+
+ResolvedComputedPseudoElement resolveComputedPseudoElement(Element&, const String& pseudoElement);
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleDifference.h"
 
+#include "CSSValuePool.h"
 #include "InlineTextBoxStyle.h"
 #include "RenderStyleConstants.h"
 #include "RenderStyle+GettersInlines.h"

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -450,6 +450,8 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
 
 std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element, const PseudoElementIdentifier& pseudoElementIdentifier, const ElementUpdate& elementUpdate, IsInDisplayNoneTree isInDisplayNoneTree, const RenderStyle* existingStyle)
 {
+    ASSERT(pseudoElementIdentifier.type != PseudoElementType::UserAgentPartFallback);
+
     if (elementUpdate.style->display() == DisplayType::None)
         return { };
 
@@ -715,7 +717,7 @@ ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const Elem
 {
     auto parentStyle = [&]() -> const RenderStyle* {
         if (auto parentPseudoId = parentPseudoElement(pseudoElementIdentifier.type)) {
-            if (auto* parentPseudoStyle = elementUpdate.style->getCachedPseudoStyle({ *parentPseudoId, (*parentPseudoId == PseudoElementType::ViewTransitionGroup || *parentPseudoId == PseudoElementType::ViewTransitionImagePair) ? pseudoElementIdentifier.nameArgument : nullAtom() }))
+            if (auto* parentPseudoStyle = elementUpdate.style->getCachedPseudoStyle({ *parentPseudoId, (*parentPseudoId == PseudoElementType::ViewTransitionGroup || *parentPseudoId == PseudoElementType::ViewTransitionImagePair) ? pseudoElementIdentifier.nameOrPart : nullAtom() }))
                 return parentPseudoStyle;
         }
         return elementUpdate.style.get();

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -170,7 +170,7 @@ RenderElement* Styleable::renderer() const
             return nullptr;
 
         // Find the right ::view-transition-group().
-        WeakPtr correctGroup = element.renderer()->view().viewTransitionGroupForName(pseudoElementIdentifier->nameArgument);
+        WeakPtr correctGroup = element.renderer()->view().viewTransitionGroupForName(pseudoElementIdentifier->nameOrPart);
         if (!correctGroup)
             return nullptr;
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -202,7 +202,7 @@ public:
     {
         m_element = nullptr;
         m_pseudoElementIdentifier = Style::PseudoElementIdentifier();
-        m_pseudoElementIdentifier->nameArgument = name;
+        m_pseudoElementIdentifier->nameOrPart = name;
     }
 
     explicit operator bool() const { return !!m_element; }
@@ -242,7 +242,7 @@ struct WeakStyleableHashTraits : HashTraits<WeakStyleable> {
     static constexpr bool hasIsWeakNullValueFunction = true;
     static bool isWeakNullValue(const WeakStyleable& value) { return !value; }
     static void constructDeletedValue(WeakStyleable& slot) { slot = { AtomString { WTF::HashTableDeletedValue } }; }
-    static bool isDeletedValue(const WeakStyleable& value) { return !value.element() && value.pseudoElementIdentifier() && value.pseudoElementIdentifier()->nameArgument.isHashTableDeletedValue(); }
+    static bool isDeletedValue(const WeakStyleable& value) { return !value.element() && value.pseudoElementIdentifier() && value.pseudoElementIdentifier()->nameOrPart.isHashTableDeletedValue(); }
 };
 
 struct WeakStyleableHash {

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -228,7 +228,7 @@ inline void ComputedStyleBase::setPseudoElementIdentifier(std::optional<PseudoEl
 {
     if (identifier) {
         m_nonInheritedFlags.pseudoElementType = std::to_underlying(identifier->type) + 1;
-        SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, WTF::move(identifier->nameArgument));
+        SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, WTF::move(identifier->nameOrPart));
     } else {
         m_nonInheritedFlags.pseudoElementType = 0;
         SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, nullAtom());


### PR DESCRIPTION
#### f2441fbb57d8bc69d7c21c18f9e0dbb19d4627b0
<pre>
Support user agent part pseudo-elements in getComputedStyle()
<a href="https://bugs.webkit.org/show_bug.cgi?id=308380">https://bugs.webkit.org/show_bug.cgi?id=308380</a>

Reviewed by Antti Koivisto.

This enables support for ::picker(select) and ::file-selector-button
and the like, while not adding support for non-standard
pseudo-elements.

We do this by eagerly looking up the relevant element in the shadow
tree before creating a CSSComputedStyleDeclaration instance, but when
there is no such element we make use of the new StandardUserAgentPart
to pick up author-defined styles which need to be reflected as shown in
the various tests.

New test:

    <a href="https://github.com/web-platform-tests/wpt/pull/57959">https://github.com/web-platform-tests/wpt/pull/57959</a>
    <a href="https://github.com/web-platform-tests/wpt/pull/58009">https://github.com/web-platform-tests/wpt/pull/58009</a>

Canonical link: <a href="https://commits.webkit.org/308118@main">https://commits.webkit.org/308118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8714896f9f5f635a8ec60dea4807758bdb7fe77e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146492 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/697939a4-bcec-4f95-b350-78c007cfc6d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112795 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f7fb18d-a3f0-4814-8f81-b20cd63b08b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1962ec91-6a8b-45d6-ba23-eb84bc1d571f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14357 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2600 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157480 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10931 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121076 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131252 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74772 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22604 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8161 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82340 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18319 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18475 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->