### PR TITLE
Remove scheduleToRunIfNeeded from normal MicrotaskQueue enqueueing

### DIFF
--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -256,7 +256,6 @@ void EventLoop::removeRepeatingTimer(EventLoopTimer& timer)
 void EventLoop::queueMicrotask(JSC::QueuedTask&& microtask)
 {
     microtaskQueue().append(WTF::move(microtask));
-    scheduleToRunIfNeeded(); // FIXME: Remove this once everything is integrated with the event loop.
 }
 
 void EventLoop::performMicrotaskCheckpoint()
@@ -590,6 +589,11 @@ void EventLoopTaskGroup::queueMicrotask(EventLoop::TaskFunction&& function)
     JSC::JSLockHolder locker(vm);
     auto* cell = JSC::JSMicrotaskDispatcher::create(vm, EventLoopFunctionMicrotaskDispatcher::create(*this, WTF::move(function)));
     queueMicrotask(JSC::QueuedTask { cell });
+    // C++ callers of this function may not have a JSExecState on the stack,
+    // so there is no guarantee that ~JSExecState will drain the microtask queue.
+    // Schedule the event loop to run so these microtasks are not left stranded.
+    if (RefPtr eventLoop = m_eventLoop.get())
+        eventLoop->scheduleToRunIfNeeded();
 }
 
 void EventLoopTaskGroup::queueMicrotask(JSC::QueuedTask&& task)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -141,9 +141,10 @@ public:
     void invalidateNextTimerFireTimeCache() { m_nextTimerFireTimeCache = std::nullopt; }
     Markable<MonotonicTime> nextTimerFireTime() const;
 
+    void scheduleToRunIfNeeded();
+
 protected:
     EventLoop();
-    void scheduleToRunIfNeeded();
     void run(std::optional<ApproximateTime> deadline = std::nullopt);
     void clearAllTasks();
 


### PR DESCRIPTION
#### 100be3a3fccda89c70091fef14c715e95db3f635
<pre>
Remove scheduleToRunIfNeeded from normal MicrotaskQueue enqueueing
<a href="https://bugs.webkit.org/show_bug.cgi?id=308381">https://bugs.webkit.org/show_bug.cgi?id=308381</a>
<a href="https://rdar.apple.com/170871858">rdar://170871858</a>

Reviewed by NOBODY (OOPS!).

scheduleToRunIfNeeded call is not necessary when enqueueing microtask
from JS world.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::queueMicrotask):
(WebCore::EventLoopTaskGroup::queueMicrotask):
* Source/WebCore/dom/EventLoop.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/100be3a3fccda89c70091fef14c715e95db3f635

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18805 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12452 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99600 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b9a16d6-c067-4808-9788-c56a607fb05d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18700 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112432 "Failure limit exceed. At least found 493 new test failures: compositing/geometry/fixed-position-composited-page-scale-down.html compositing/geometry/fixed-position-composited-page-scale-scroll.html compositing/geometry/fixed-position-composited-page-scale.html compositing/geometry/fixed-position-iframe-composited-page-scale-down.html compositing/geometry/fixed-position-iframe-composited-page-scale.html compositing/geometry/fixed-position-transform-composited-page-scale-down.html compositing/geometry/fixed-position-transform-composited-page-scale.html compositing/geometry/foreground-offset-change.html compositing/iframes/become-composited-nested-iframes.html compositing/iframes/iframe-scrolling-change.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80437 "Exiting early after 60 failures. 8541 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09acd57f-ebed-45e3-ac79-afe4b752e633) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149091 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14785 "Found 60 new test failures: applicationmanifest/multiple-links.html compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html compositing/clip-change.html compositing/geometry/fixed-position-composited-page-scale-down.html compositing/geometry/fixed-position-composited-page-scale-scroll.html compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html compositing/geometry/fixed-position-composited-page-scale.html compositing/geometry/fixed-position-iframe-composited-page-scale-down.html compositing/geometry/fixed-position-iframe-composited-page-scale.html compositing/geometry/fixed-position-transform-composited-page-scale-down.html ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131473 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93303 "Found 6 new API test failures: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/hit-test, WPE/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request, WPE/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-with-reply-received, WPE/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, WPE/TestWebKitWebView:/webkit/WebKitWebView/run-async-js-functions (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1408d0bc-2442-48d5-9993-8de495ed41ae) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14050 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-in-worker.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-stream.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-text.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-text.any.worker.html ... (failure)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11984 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2244 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123790 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157116 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/288 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10727 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120455 "Failure limit exceed. At least found 483 new test failures: compositing/clip-change.html compositing/geometry/fixed-position-composited-page-scale-down.html compositing/geometry/fixed-position-composited-page-scale-scroll.html compositing/geometry/fixed-position-composited-page-scale.html compositing/geometry/fixed-position-iframe-composited-page-scale-down.html compositing/geometry/fixed-position-iframe-composited-page-scale.html compositing/geometry/fixed-position-transform-composited-page-scale-down.html compositing/geometry/fixed-position-transform-composited-page-scale.html compositing/geometry/foreground-offset-change.html compositing/geometry/limit-layer-bounds-transformed-overflow.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18623 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15592 "Found 60 new test failures: applicationmanifest/developer-warnings.html compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html compositing/clip-change.html compositing/fixed-with-fixed-layout.html compositing/geometry/fixed-position-composited-page-scale-down.html compositing/geometry/fixed-position-composited-page-scale-scroll.html compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html compositing/geometry/fixed-position-composited-page-scale.html compositing/iframes/become-composited-nested-iframes.html compositing/iframes/become-overlapped-iframe.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120756 "Found 11 new API test failures: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-with-reply-received, WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-permission-requests, WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/clipboard/permission-request, WebKitGTK/TestUIClient:/webkit/WebKitWebView/query-permission-requests, WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/permission-request, WebKitGTK/TestUIClient:/webkit/WebKitWebView/audio-usermedia-permission-request ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18643 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131047 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74323 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16435 "Found 15 new test failures: http/tests/iframe-monitor/blob-resource.html http/tests/iframe-monitor/cached-resource.html http/tests/iframe-monitor/compressed-resource.html http/tests/iframe-monitor/dark-mode.html http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/eligibility.html http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/just-use-eligible-subresource.html http/tests/iframe-monitor/throttler.html http/tests/iframe-monitor/workers/service-worker-not-count-twice.html ... (failure)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8007 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18243 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17977 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18144 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18034 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->