### PR TITLE
[CMake] Add -Wno-missing-field-initializers compiler flag

### DIFF
--- a/Source/JavaScriptCore/disassembler/ARM64/Binja.c
+++ b/Source/JavaScriptCore/disassembler/ARM64/Binja.c
@@ -38,7 +38,6 @@ IGNORE_WARNINGS_BEGIN("cast-align")
 IGNORE_WARNINGS_BEGIN("sign-compare")
 IGNORE_WARNINGS_BEGIN("documentation")
 IGNORE_WARNINGS_BEGIN("unused-parameter")
-IGNORE_WARNINGS_BEGIN("missing-field-initializers")
 IGNORE_WARNINGS_BEGIN("implicit-fallthrough")
 IGNORE_WARNINGS_BEGIN("incompatible-pointer-types-discards-qualifiers")
 
@@ -289,7 +288,6 @@ const char* arm64Disassemble(uint32_t* pc, char* buffer, size_t size)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END

--- a/Source/ThirdParty/capstone/CMakeLists.txt
+++ b/Source/ThirdParty/capstone/CMakeLists.txt
@@ -191,7 +191,6 @@ if (COMPILER_IS_GCC_OR_CLANG)
         -Wno-unused-parameter
         -Wno-ignored-qualifiers
         -Wno-implicit-fallthrough
-        -Wno-missing-field-initializers
         -Wno-missing-format-attribute
         -Wno-discarded-qualifiers
         -Wno-cast-align

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -662,7 +662,6 @@ endif ()
 
 set(bmalloc_COMPILE_OPTIONS
     -Wno-cast-align
-    -Wno-missing-field-initializers
 )
 
 set(bmalloc_INTERFACE_LIBRARIES bmalloc)
@@ -704,5 +703,4 @@ if (DEVELOPER_MODE AND (APPLE OR HAVE_MALLOC_TRIM))
     target_include_directories(mbmalloc PRIVATE ${bmalloc_PRIVATE_INCLUDE_DIRECTORIES})
     target_link_libraries(mbmalloc Threads::Threads bmalloc)
     set_target_properties(mbmalloc PROPERTIES COMPILE_DEFINITIONS "BUILDING_mbmalloc")
-    WEBKIT_ADD_TARGET_CXX_FLAGS(mbmalloc -Wno-missing-field-initializers)
 endif ()

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -30,8 +30,6 @@
 
 #if LIBPAS_ENABLED
 
-PAS_IGNORE_WARNINGS_BEGIN("missing-field-initializers")
-
 #include "bmalloc_heap.h"
 #include "bmalloc_heap_config.h"
 #include "bmalloc_heap_innards.h"
@@ -409,8 +407,6 @@ static PAS_ALWAYS_INLINE void bmalloc_deallocate_inline(void* ptr)
 PAS_END_EXTERN_C;
 
 #endif /* PAS_ENABLE_BMALLOC */
-
-PAS_IGNORE_WARNINGS_END
 
 #endif /* LIBPAS_ENABLED */
 #endif /* BMALLOC_HEAP_INLINES_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h
@@ -83,7 +83,6 @@ static inline void pas_page_sharing_participant_set_index(pas_page_sharing_parti
     pas_page_sharing_participant_get_payload(*ptr)->index_in_sharing_pool_min_heap = (unsigned)index;
 }
 
-PAS_IGNORE_WARNINGS_BEGIN("missing-field-initializers")
 PAS_CREATE_MIN_HEAP(
     pas_page_sharing_pool_min_heap,
     pas_page_sharing_participant,
@@ -91,7 +90,6 @@ PAS_CREATE_MIN_HEAP(
     .compare = pas_page_sharing_participant_compare,
     .get_index = pas_page_sharing_participant_get_index,
     .set_index = pas_page_sharing_participant_set_index);
-PAS_IGNORE_WARNINGS_END
 
 struct PAS_ALIGNED(sizeof(pas_versioned_field)) pas_page_sharing_pool {
     pas_versioned_field first_delta;

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -214,6 +214,7 @@ if (COMPILER_IS_GCC_OR_CLANG)
       endif ()
     endif ()
 
+    WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-missing-field-initializers)
     WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-noexcept-type)
 
     # These GCC warnings produce too many false positives to be useful. We'll


### PR DESCRIPTION
#### 69d8903b4cbe4df3f4d72a0b3a090a5092a84867
<pre>
[CMake] Add -Wno-missing-field-initializers compiler flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=308272">https://bugs.webkit.org/show_bug.cgi?id=308272</a>

Reviewed by NOBODY (OOPS!).

Added -Wno-missing-field-initializers compiler flag to CMake to align to Mac
port. Removed the flag from bmalloc, capstone and JSC.

* Source/JavaScriptCore/disassembler/ARM64/Binja.c:
* Source/ThirdParty/capstone/CMakeLists.txt:
* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h:
* Source/cmake/WebKitCompilerFlags.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69d8903b4cbe4df3f4d72a0b3a090a5092a84867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146129 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18806 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99601 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19278 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18701 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112435 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80441 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149092 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/19278 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93306 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/19278 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2245 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138100 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/19278 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157117 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6921 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/289 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120458 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18624 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/18701 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120759 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18644 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74324 "Built successfully") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/11132 "Hash 69d8903b for PR 59157 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177430 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18244 "Hash 69d8903b for PR 59157 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81997 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45533 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17978 "Hash 69d8903b for PR 59157 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18145 "Hash 69d8903b for PR 59157 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18035 "Hash 69d8903b for PR 59157 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->