### PR TITLE
Remove NODELETE annotations from WebCore functions as mandated by bots

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -112,7 +112,7 @@ public:
 
     WebGPU::CommandEncoder& backing() { return m_backing; }
     const WebGPU::CommandEncoder& backing() const { return m_backing; }
-    void NODELETE setBacking(WebGPU::CommandEncoder&);
+    void setBacking(WebGPU::CommandEncoder&);
 
 private:
     GPUCommandEncoder(Ref<WebGPU::CommandEncoder>&&, WebGPU::Device&);

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -766,7 +766,7 @@ WGPUBufferUsageFlags ConvertToBackingContext::convertBufferUsageFlagsToBacking(B
     return static_cast<WGPUBufferUsageFlags>(bufferUsageFlags);
 }
 
-static constexpr bool NODELETE compare(auto a, auto b)
+static constexpr bool compare(auto a, auto b)
 {
     return static_cast<unsigned>(a) == static_cast<unsigned>(b);
 }

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -128,7 +128,7 @@ private:
     bool isOfflineContext() const final { return false; }
 
     // MediaProducer
-    MediaProducerMediaStateFlags NODELETE mediaState() const final;
+    MediaProducerMediaStateFlags mediaState() const final;
     void pageMutedStateDidChange() final;
 #if PLATFORM(IOS_FAMILY)
     void sceneIdentifierDidChange() final;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 bool isValidVideoFrameBufferInit(const WebCodecsVideoFrame::BufferInit&);
-bool NODELETE verifyRectOffsetAlignment(VideoPixelFormat, const DOMRectInit&);
+bool verifyRectOffsetAlignment(VideoPixelFormat, const DOMRectInit&);
 ExceptionOr<DOMRectInit> parseVisibleRect(const DOMRectInit&, const std::optional<DOMRectInit>&, size_t codedWidth, size_t codedHeight, VideoPixelFormat);
 size_t NODELETE videoPixelFormatToPlaneCount(VideoPixelFormat);
 size_t NODELETE videoPixelFormatToSampleByteSizePerPlane();
@@ -51,7 +51,7 @@ void initializeVisibleRectAndDisplaySize(WebCodecsVideoFrame&, const WebCodecsVi
 
 VideoColorSpaceInit NODELETE videoFramePickColorSpace(const std::optional<VideoColorSpaceInit>&, VideoPixelFormat);
 
-bool NODELETE validateVideoFrameInit(const WebCodecsVideoFrame::Init&, size_t codedWidth, size_t codedHeight, VideoPixelFormat);
+bool validateVideoFrameInit(const WebCodecsVideoFrame::Init&, size_t codedWidth, size_t codedHeight, VideoPixelFormat);
 
 }
 

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -54,8 +54,7 @@ DOMWindowExtension::~DOMWindowExtension()
 
 LocalFrame* DOMWindowExtension::frame() const
 {
-    RefPtr window = m_window.get();
-    return window ? window->localFrame() : nullptr;
+    return m_window ? m_window->localFrame() : nullptr;
 }
 
 void DOMWindowExtension::suspendForBackForwardCache()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -185,7 +185,7 @@ private:
     bool needsLayoutInternal() const;
 
     void performLayout(bool canDeferUpdateLayerPositions);
-    bool NODELETE canPerformLayout() const;
+    bool canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
     bool hasPendingUpdateLayerPositions() const { return !!m_pendingUpdateLayerPositions; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -771,7 +771,7 @@ Ref<DOMRectList> Page::passiveTouchEventListenerRectsForTesting()
     return DOMRectList::create(rects.map([](auto& rect) { return FloatQuad { FloatRect { rect } }; }));
 }
 
-void NODELETE Page::setConsoleMessageListenerForTesting(RefPtr<StringCallback>&& listener)
+void Page::setConsoleMessageListenerForTesting(RefPtr<StringCallback>&& listener)
 {
     m_consoleMessageListenerForTesting = listener;
 }
@@ -978,7 +978,7 @@ void Page::updateTopDocumentSyncData(Ref<DocumentSyncData>&& data)
     m_topDocumentSyncData = WTF::move(data);
 }
 
-void NODELETE Page::setMainFrameURLFragment(String&& fragment)
+void Page::setMainFrameURLFragment(String&& fragment)
 {
     if (!fragment.isEmpty())
         m_mainFrameURLFragment = WTF::move(fragment);

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -57,7 +57,7 @@ static inline void adjustViewportArgumentsToAvoidExcessiveZooming(ViewportArgume
     arguments.width = zoomedWidthFromArguments / arguments.zoom;
 }
 
-static inline void NODELETE ignoreViewportArgumentsToAvoidEnlargedView(ViewportArguments& arguments, FloatSize viewLayoutSize)
+static inline void ignoreViewportArgumentsToAvoidEnlargedView(ViewportArguments& arguments, FloatSize viewLayoutSize)
 {
     if (!viewportArgumentValueIsValid(arguments.width))
         return;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -228,7 +228,7 @@ public:
             m_containerMap.remove(renderer);
     }
     
-    TrackedRendererListHashSet* NODELETE positionedRenderers(const RenderBlock& containingBlock) const
+    TrackedRendererListHashSet* positionedRenderers(const RenderBlock& containingBlock) const
     {
         return m_descendantsMap.get(containingBlock);
     }

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -223,7 +223,7 @@ public:
 
     RenderFragmentedFlow* cachedEnclosingFragmentedFlow() const;
     void setCachedEnclosingFragmentedFlowNeedsUpdate();
-    virtual bool NODELETE cachedEnclosingFragmentedFlowNeedsUpdate() const;
+    virtual bool cachedEnclosingFragmentedFlowNeedsUpdate() const;
     void resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants(RenderFragmentedFlow* = nullptr) final;
 
     std::optional<LayoutUnit> availableLogicalHeightForPercentageComputation() const;

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -128,7 +128,7 @@ MarqueeDirection RenderMarquee::direction() const
     return result;
 }
 
-bool NODELETE RenderMarquee::isHorizontal() const
+bool RenderMarquee::isHorizontal() const
 {
     return direction() == MarqueeDirection::Left || direction() == MarqueeDirection::Right;
 }

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -75,7 +75,7 @@ private:
     int speed() const { return m_speed; }
     int marqueeSpeed() const;
 
-    MarqueeDirection NODELETE direction() const;
+    MarqueeDirection direction() const;
 
     int computePosition(MarqueeDirection, bool stopAtClientEdge);
 


### PR DESCRIPTION
#### 426a76f95544f3b396e5bd765202585fa36662df
<pre>
Remove NODELETE annotations from WebCore functions as mandated by bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=308383">https://bugs.webkit.org/show_bug.cgi?id=308383</a>

Reviewed by Anne van Kesteren.

Removed NODELETE annotations from WebCore functions for which NoDeleteChecker emits warnings
since we fixed the false negatives by rolling out a newer version of clang in 307871@main.

Some of these functions look &quot;trivial&quot;. We should investigate &amp; fix trivial function analysis
but that&apos;s for another time.

No new tests since there should be no behavioral changes.

* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::compare):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::frame const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setConsoleMessageListenerForTesting):
(WebCore::Page::setMainFrameURLFragment):
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ignoreViewportArgumentsToAvoidEnlargedView):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::OutOfFlowDescendantsMap::positionedRenderers const):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::isHorizontal const):
* Source/WebCore/rendering/RenderMarquee.h:

Canonical link: <a href="https://commits.webkit.org/307985@main">https://commits.webkit.org/307985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aee676013cfc10760bb3f0f80420a3c767fabe58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/194658fa-4b18-4217-8d44-292f50ef04a7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e21b41e-4eb8-43b5-8a62-edeb9f3924a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93307 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a995f03-664d-4a9c-9e47-decb4627120a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14052 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11809 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2248 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157120 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/291 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120459 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120760 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74326 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7586 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81999 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18147 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->