### PR TITLE
Always provide a CSSSelectorParserContext to pseudoElementIdentifierFromString in WebCore/animation

### DIFF
--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -32,8 +32,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSAnimationEvent);
 
-CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement))
+CSSAnimationEvent::CSSAnimationEvent(Document& document, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement), document)
     , m_animationName(WTF::move(initializer.animationName))
 {
 }

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+class Document;
+
 class CSSAnimationEvent final : public StyleOriginatedAnimationEvent {
     WTF_MAKE_TZONE_ALLOCATED(CSSAnimationEvent);
 public:
@@ -43,9 +45,9 @@ public:
         String pseudoElement { emptyString() };
     };
 
-    static Ref<CSSAnimationEvent> create(const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<CSSAnimationEvent> create(Document& document, const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new CSSAnimationEvent(type, WTF::move(initializer), isTrusted));
+        return adoptRef(*new CSSAnimationEvent(document, type, WTF::move(initializer), isTrusted));
     }
 
     virtual ~CSSAnimationEvent();
@@ -54,7 +56,7 @@ public:
 
 private:
     CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String& animationName);
-    CSSAnimationEvent(const AtomString&, Init&&, IsTrusted);
+    CSSAnimationEvent(Document&, const AtomString&, Init&&, IsTrusted);
 
     String m_animationName;
 };

--- a/Source/WebCore/animation/CSSAnimationEvent.idl
+++ b/Source/WebCore/animation/CSSAnimationEvent.idl
@@ -28,7 +28,7 @@
     Exposed=Window,
     InterfaceName=AnimationEvent
 ] interface CSSAnimationEvent : Event {
-    constructor([AtomString] DOMString type, optional AnimationEventInit animationEventInitDict = {});
+    [CallWith=CurrentDocument] constructor([AtomString] DOMString type, optional AnimationEventInit animationEventInitDict = {});
 
     readonly attribute DOMString animationName;
     readonly attribute double elapsedTime;

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -39,8 +39,8 @@ CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* ani
 {
 }
 
-CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement))
+CSSTransitionEvent::CSSTransitionEvent(Document& document, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, WTF::move(initializer), isTrusted, initializer.elapsedTime, WTF::move(initializer.pseudoElement), document)
     , m_propertyName(WTF::move(initializer.propertyName))
 {
 }

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+class Document;
+
 class CSSTransitionEvent final : public StyleOriginatedAnimationEvent {
     WTF_MAKE_TZONE_ALLOCATED(CSSTransitionEvent);
 public:
@@ -44,9 +46,9 @@ public:
         String pseudoElement { emptyString() };
     };
 
-    static Ref<CSSTransitionEvent> create(const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<CSSTransitionEvent> create(Document& document, const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new CSSTransitionEvent(type, WTF::move(initializer), isTrusted));
+        return adoptRef(*new CSSTransitionEvent(document, type, WTF::move(initializer), isTrusted));
     }
 
     virtual ~CSSTransitionEvent();
@@ -55,7 +57,7 @@ public:
 
 private:
     CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String propertyName);
-    CSSTransitionEvent(const AtomString& type, Init&&, IsTrusted);
+    CSSTransitionEvent(Document&, const AtomString& type, Init&&, IsTrusted);
 
     String m_propertyName;
 };

--- a/Source/WebCore/animation/CSSTransitionEvent.idl
+++ b/Source/WebCore/animation/CSSTransitionEvent.idl
@@ -29,7 +29,7 @@
     Exposed=Window,
     InterfaceName=TransitionEvent
 ] interface CSSTransitionEvent : Event {
-    constructor([AtomString] DOMString type, optional TransitionEventInit transitionEventInitDict = {});
+    [CallWith=CurrentDocument] constructor([AtomString] DOMString type, optional TransitionEventInit transitionEventInitDict = {});
 
     readonly attribute DOMString propertyName;
     readonly attribute double elapsedTime;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -146,7 +146,7 @@ public:
 
     void willChangeRenderer();
 
-    Document* document() const final;
+    Document& document() const final { return m_document; }
     RenderElement* renderer() const final;
     const RenderStyle& currentStyle() const final;
     bool triggersStackingContext() const { return m_triggersStackingContext; }
@@ -198,7 +198,7 @@ public:
 #endif
 
 private:
-    KeyframeEffect(Element*, const std::optional<Style::PseudoElementIdentifier>&);
+    KeyframeEffect(Document&, Element*, const std::optional<Style::PseudoElementIdentifier>&);
     ~KeyframeEffect();
 
     enum class AcceleratedAction : uint8_t { Play, Pause, UpdateProperties, TransformChange, Stop };
@@ -299,7 +299,7 @@ private:
     const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
     bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     BlendingKeyframes m_blendingKeyframes { };
     HashSet<AnimatableCSSProperty> m_animatedProperties;

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -26,9 +26,7 @@
 #include "config.h"
 #include "StyleOriginatedAnimationEvent.h"
 
-#include "Node.h"
-#include "NodeDocument.h"
-#include "NodeInlines.h"
+#include "CSSSelectorParserContext.h"
 #include "WebAnimationUtilities.h"
 
 #include <wtf/TZoneMallocInlines.h>
@@ -44,13 +42,13 @@ StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterface
 {
 }
 
-StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, EventInit&& init, IsTrusted isTrusted, double elapsedTime, String&& pseudoElement)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, EventInit&& init, IsTrusted isTrusted, double elapsedTime, String&& pseudoElement, Document& document)
     : AnimationEventBase(eventInterface, type, WTF::move(init), isTrusted)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(WTF::move(pseudoElement))
 {
     RefPtr node = dynamicDowncast<Node>(target());
-    auto [parsed, pseudoElementIdentifier] = pseudoElementIdentifierFromString(m_pseudoElement, node ? protect(node->document()).ptr() : nullptr);
+    auto [parsed, pseudoElementIdentifier] = pseudoElementIdentifierFromString(m_pseudoElement, CSSSelectorParserContext { node ? protect(node->document()).get() : document });
     m_pseudoElementIdentifier = parsed ? pseudoElementIdentifier : std::nullopt;
 }
 

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+class Document;
+
 class StyleOriginatedAnimationEvent : public AnimationEventBase {
     WTF_MAKE_TZONE_ALLOCATED(StyleOriginatedAnimationEvent);
 public:
@@ -41,7 +43,7 @@ public:
 
 protected:
     StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const std::optional<Style::PseudoElementIdentifier>&);
-    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted, double, String&&);
+    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString&, EventInit&&, IsTrusted, double, String&&, Document&);
 
 private:
     double m_elapsedTime;

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -380,15 +380,13 @@ String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementI
 }
 
 // bool represents whether parsing was successful, std::optional<Style::PseudoElementIdentifier> is the result of the parsing when successful.
-std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String& pseudoElement, Document* document)
+std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String& pseudoElement, const CSSSelectorParserContext& context)
 {
     // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudoelement
     if (pseudoElement.isNull())
         return { true, { } };
 
-    // FIXME: We should always have a document for accurate settings.
-    auto parserContext = document ? CSSSelectorParserContext { *document } : CSSSelectorParserContext { CSSParserContext { HTMLStandardMode } };
-    auto identifier = CSSSelectorParser::parsePseudoElement(pseudoElement, parserContext);
+    auto identifier = CSSSelectorParser::parsePseudoElement(pseudoElement, context);
     // FIXME: Add API support for UserAgentPartFallback pseudo-elements like ::picker(select).
     if (identifier && identifier->type == PseudoElementType::UserAgentPartFallback)
         return { true, std::nullopt };

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -36,10 +36,10 @@ namespace WebCore {
 enum class PseudoId : uint8_t;
 
 class AnimationEventBase;
-class Document;
 class Element;
 class RenderStyle;
 class WebAnimation;
+struct CSSSelectorParserContext;
 
 namespace Style {
 struct PseudoElementIdentifier;
@@ -64,7 +64,7 @@ const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
 String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementIdentifier>&);
-std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String&, Document*);
+std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String&, const CSSSelectorParserContext&);
 AtomString animatablePropertyAsString(AnimatableCSSProperty);
 bool animatablePropertiesContainTransformRelatedProperty(const HashSet<AnimatableCSSProperty>&);
 

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -238,8 +238,7 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const IntRect
         }
     }
 
-    ASSERT(effect.document());
-    auto& settings = effect.document()->settings();
+    auto& settings = effect.document().settings();
     CheckedPtr renderLayerModelObject = dynamicDowncast<RenderLayerModelObject>(effect.renderer());
 
     OptionSet<AcceleratedEffectProperty> propertiesReplacedByZeroKeyframe;

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -187,7 +187,7 @@ static void interpolateCustomProperty(const AtomString& customProperty, RenderSt
     if (!fromValue || !toValue)
         return;
 
-    bool isInherited = client.document()->customPropertyRegistry().isInherited(customProperty);
+    bool isInherited = client.document().customPropertyRegistry().isInherited(customProperty);
     destination.setCustomPropertyValue(interpolatedCustomProperty(from, to, *fromValue, *toValue, context), isInherited);
 }
 

--- a/Source/WebCore/style/StyleInterpolationClient.h
+++ b/Source/WebCore/style/StyleInterpolationClient.h
@@ -37,7 +37,7 @@ namespace Style::Interpolation {
 
 class Client {
 public:
-    virtual Document* document() const = 0;
+    virtual Document& document() const = 0;
     virtual RenderElement* renderer() const = 0;
     virtual const RenderStyle& currentStyle() const = 0;
     virtual std::optional<unsigned> transformFunctionListPrefix() const = 0;

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -93,9 +93,7 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
 auto Blending<LineWidth>::blend(const LineWidth& a, const LineWidth& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const Interpolation::Context& context) -> LineWidth
 {
     auto blendedValue = Style::blend(a.value, b.value, aStyle, bStyle, context);
-    if (RefPtr document = context.client.document())
-        return LineWidth::snapLengthAsBorderWidth(blendedValue, document->deviceScaleFactor());
-    return blendedValue;
+    return LineWidth::snapLengthAsBorderWidth(blendedValue, protect(context.client.document())->deviceScaleFactor());
 }
 
 // MARK: - Evaluate


### PR DESCRIPTION
#### 7663646655fa3e0e1b1c45c9351fe1cbf0360a5c
<pre>
Always provide a CSSSelectorParserContext to pseudoElementIdentifierFromString in WebCore/animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=308385">https://bugs.webkit.org/show_bug.cgi?id=308385</a>

Reviewed by Antoine Quint and Tim Nguyen.

For KeyframeEffect the document can in fact not be null and for
synthetic animation events we can forward a document from JavaScript.

Canonical link: <a href="https://commits.webkit.org/308181@main">https://commits.webkit.org/308181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1a72225fce44bac87ef18c7cbe87d65fe16f87d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99941 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d82f654b-aa3d-40bd-8cb6-b5414b403832) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112928 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80642 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4864d649-715c-4ca4-a3a9-c14c4f5339d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93652 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d823e334-47af-42db-9ae5-f3115637ffc5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14396 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12165 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2650 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157530 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120923 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121122 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131292 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74818 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16765 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->