### PR TITLE
Move AttrStyleEnabled from DeprecatedGlobalSettings to UnifiedWebPreferences

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2169,6 +2169,20 @@ CustomPasteboardDataEnabled:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)": true
       default: false
 
+DOMAttrStyleEnabled:
+  type: bool
+  status: internal
+  category: dom
+  humanReadableName: "Attr.style"
+  humanReadableDescription: "Expose style property on Attr nodes"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DOMAudioSessionEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/dom/Attr.idl
+++ b/Source/WebCore/dom/Attr.idl
@@ -33,5 +33,5 @@
 
     readonly attribute boolean specified; // Useless; always returns true.
 
-    [EnabledByDeprecatedGlobalSetting=AttrStyleEnabled] readonly attribute CSSStyleProperties? style;
+    [EnabledBySetting=DOMAttrStyleEnabled] readonly attribute CSSStyleProperties? style;
 };

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -81,9 +81,6 @@ public:
     static void setCustomPasteboardDataEnabled(bool isEnabled) { singleton().m_isCustomPasteboardDataEnabled = isEnabled; }
     static bool customPasteboardDataEnabled() { return singleton().m_isCustomPasteboardDataEnabled; }
 
-    static void setAttrStyleEnabled(bool isEnabled) { singleton().m_attrStyleEnabled = isEnabled; }
-    static bool attrStyleEnabled() { return singleton().m_attrStyleEnabled; }
-
     static void setWebSQLEnabled(bool isEnabled) { singleton().m_webSQLEnabled = isEnabled; }
     static bool webSQLEnabled() { return singleton().m_webSQLEnabled; }
 
@@ -154,7 +151,6 @@ private:
     bool m_allowsAnySSLCertificate { false };
 
     bool m_isCustomPasteboardDataEnabled { false };
-    bool m_attrStyleEnabled { false };
     bool m_webSQLEnabled { false };
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -129,7 +129,6 @@ struct WebProcessCreationParameters {
     bool hasStylusDevice { false };
 #endif
     bool memoryCacheDisabled { false };
-    bool attrStyleEnabled { false };
     bool shouldThrowExceptionForGlobalConstantRedeclaration { true };
     WebCore::CrossOriginMode crossOriginMode { WebCore::CrossOriginMode::Shared }; // Cross-origin isolation via COOP+COEP headers.
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -73,7 +73,6 @@
     bool hasStylusDevice;
 #endif
     bool memoryCacheDisabled;
-    bool attrStyleEnabled;
     bool shouldThrowExceptionForGlobalConstantRedeclaration;
     WebCore::CrossOriginMode crossOriginMode;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -876,6 +876,7 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 
     // For SharedPreferencesForWebProcess
     preferences->setAllowTestOnlyIPC(!![_configuration _allowTestOnlyIPC]);
+    preferences->setDOMAttrStyleEnabled(pool.configuration().attrStyleEnabled());
     preferences->setUsesSingleWebProcess(pool.usesSingleWebProcess());
 
     preferences->endBatchingUpdates();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1052,7 +1052,6 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
 #endif
 
     parameters.memoryCacheDisabled = m_memoryCacheDisabled;
-    parameters.attrStyleEnabled = m_configuration->attrStyleEnabled();
     parameters.shouldThrowExceptionForGlobalConstantRedeclaration = m_configuration->shouldThrowExceptionForGlobalConstantRedeclaration();
     parameters.crossOriginMode = process.crossOriginMode();
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -686,8 +686,6 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
     setMemoryCacheDisabled(parameters.memoryCacheDisabled);
 
-    WebCore::DeprecatedGlobalSettings::setAttrStyleEnabled(parameters.attrStyleEnabled);
-    
     commonVM().setGlobalConstRedeclarationShouldThrow(parameters.shouldThrowExceptionForGlobalConstantRedeclaration);
 
     ScriptExecutionContext::setCrossOriginMode(parameters.crossOriginMode);


### PR DESCRIPTION
#### 4f91536a0559463c8cf9c68b3c42498931bb115a
<pre>
Move AttrStyleEnabled from DeprecatedGlobalSettings to UnifiedWebPreferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=308388">https://bugs.webkit.org/show_bug.cgi?id=308388</a>

Reviewed by NOBODY (OOPS!).

I believe the hope is still to have a single preference system in the
end.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f91536a0559463c8cf9c68b3c42498931bb115a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e133b4da-0aa2-4582-8142-1c0dbcca8d4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112440 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80445 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ede1ecd4-a9d6-44d7-bb27-386934a8f86c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07f98e3b-3ac0-4615-be14-5c9e71047caa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14056 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11814 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2252 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138107 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157124 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6928 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/295 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120463 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74333 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7599 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82003 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45534 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->