### PR TITLE
Reduce use of `checked*()` functions in Source/WebCore

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -113,7 +113,7 @@ void CookieStore::MainThreadBridge::ensureOnMainThread(Function<void(ScriptExecu
         return;
     }
 
-    downcast<WorkerGlobalScope>(*context).thread()->checkedWorkerLoaderProxy()->postTaskToLoader(WTF::move(task));
+    protect(downcast<WorkerGlobalScope>(*context).thread()->workerLoaderProxy())->postTaskToLoader(WTF::move(task));
 }
 
 void CookieStore::MainThreadBridge::ensureOnContextThread(Function<void(CookieStore&)>&& task)

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -79,7 +79,6 @@ public:
 
     void setAsFormData(Ref<FormData>&& data) { m_data = WTF::move(data); }
     FetchBodyConsumer& consumer();
-    CheckedRef<FetchBodyConsumer> checkedConsumer() { return consumer(); }
 
     void consumeOnceLoadingFinished(FetchBodyConsumer::Type, Ref<DeferredPromise>&&);
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -163,8 +163,6 @@ private:
     enum class DidCreateIndexInBackingStore : bool { No, Yes };
     void didCreateIndexAsyncForTransaction(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&, const IDBError&, DidCreateIndexInBackingStore = DidCreateIndexInBackingStore::Yes);
 
-    CheckedPtr<IDBBackingStore> NODELETE checkedBackingStore() const;
-
     WeakPtr<UniqueIDBDatabaseManager> m_manager;
     IDBDatabaseIdentifier m_identifier;
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -53,7 +53,6 @@ public:
 
     const IDBResourceIdentifier& openRequestIdentifier() { return m_openRequestIdentifier; }
     UniqueIDBDatabase* database() { return m_database.get(); }
-    CheckedPtr<UniqueIDBDatabase> NODELETE checkedDatabase();
     UniqueIDBDatabaseManager* NODELETE manager();
     IDBConnectionToClient& connectionToClient() { return m_connectionToClient; }
     Ref<IDBConnectionToClient> NODELETE protectedConnectionToClient();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -50,7 +50,7 @@ UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConn
     ASSERT(database());
 
     if (m_transactionInfo.mode() == IDBTransactionMode::Versionchange)
-        m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(checkedDatabase()->info());
+        m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(protect(database())->info());
 
     RefPtr databaseConnection = m_databaseConnection.get();
     if (!databaseConnection)
@@ -111,11 +111,6 @@ void UniqueIDBDatabaseTransaction::abortWithoutCallback()
 UniqueIDBDatabase* UniqueIDBDatabaseTransaction::database() const
 {
     return m_databaseConnection ? m_databaseConnection->database() : nullptr;
-}
-
-CheckedPtr<UniqueIDBDatabase> UniqueIDBDatabaseTransaction::checkedDatabase() const
-{
-    return database();
 }
 
 bool UniqueIDBDatabaseTransaction::isVersionChange() const

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -64,7 +64,6 @@ public:
 
     UniqueIDBDatabaseConnection* NODELETE databaseConnection() const;
     UniqueIDBDatabase* NODELETE database() const;
-    CheckedPtr<UniqueIDBDatabase> NODELETE checkedDatabase() const;
     const IDBTransactionInfo& info() const { return m_transactionInfo; }
     WEBCORE_EXPORT bool NODELETE isVersionChange() const;
     bool NODELETE isReadOnly() const;

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
@@ -109,7 +109,7 @@ IDBResultData IDBResultData::openDatabaseSuccess(const IDBResourceIdentifier& re
     IDBResultData result { requestIdentifier };
     result.m_type = IDBResultType::OpenDatabaseSuccess;
     result.m_databaseConnectionIdentifier = connection.identifier();
-    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(connection.checkedDatabase()->info());
+    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(protect(connection.database())->info());
     return result;
 }
 
@@ -119,7 +119,7 @@ IDBResultData IDBResultData::openDatabaseUpgradeNeeded(const IDBResourceIdentifi
     IDBResultData result { requestIdentifier };
     result.m_type = IDBResultType::OpenDatabaseUpgradeNeeded;
     result.m_databaseConnectionIdentifier = connection.identifier();
-    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(connection.checkedDatabase()->info());
+    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(protect(connection.database())->info());
     result.m_transactionInfo = makeUnique<IDBTransactionInfo>(transaction.info());
     return result;
 }

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -127,8 +127,6 @@ private:
     void computeBitRates(const MediaStreamPrivate*);
     void timeSlicerTimerFired();
 
-    CheckedPtr<MediaRecorderPrivate> NODELETE checkedPrivate();
-
     static CreatorFunction m_customCreator;
 
     Options m_options;

--- a/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
@@ -76,14 +76,14 @@ AnalyserNode::~AnalyserNode()
 
 void AnalyserNode::process(size_t framesToProcess)
 {
-    Ref outputBus = checkedOutput(0)->bus();
+    Ref outputBus = protect(output(0))->bus();
 
     if (!isInitialized()) {
         outputBus->zero();
         return;
     }
 
-    Ref inputBus = checkedInput(0)->bus();
+    Ref inputBus = protect(input(0))->bus();
 
     // Give the analyser the audio which is passing through this AudioNode. This must always
     // be done so that the state of the Analyser reflects the current input.
@@ -154,7 +154,7 @@ void AnalyserNode::updatePullStatus()
 {
     ASSERT(context().isGraphOwner());
 
-    if (checkedOutput(0)->isConnected()) {
+    if (protect(output(0))->isConnected()) {
         // When an AudioBasicInspectorNode is connected to a downstream node, it
         // will get pulled by the downstream node, thus remove it from the context's
         // automatic pull list.

--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
@@ -49,7 +49,7 @@ void AudioBasicInspectorNode::pullInputs(size_t framesToProcess)
 {
     // Render input stream - try to render directly into output bus for pass-through processing where process() doesn't need to do anything...
     CheckedPtr output = this->output(0);
-    checkedInput(0)->pull(output ? &output->bus() : nullptr, framesToProcess);
+    protect(input(0))->pull(output ? &output->bus() : nullptr, framesToProcess);
 }
 
 void AudioBasicInspectorNode::checkNumberOfChannelsForInput(AudioNodeInput* input)

--- a/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp
@@ -103,7 +103,7 @@ void AudioBasicProcessorNode::processOnlyAudioParams(size_t framesToProcess)
 void AudioBasicProcessorNode::pullInputs(size_t framesToProcess)
 {
     // Render input stream - suggest to the input to render directly into output bus for in-place processing in process() if possible.
-    checkedInput(0)->pull(protect(checkedOutput(0)->bus()).ptr(), framesToProcess);
+    protect(input(0))->pull(protect(protect(output(0))->bus()).ptr(), framesToProcess);
 }
 
 // As soon as we know the channel count of our input, we can lazily initialize.
@@ -130,7 +130,7 @@ void AudioBasicProcessorNode::checkNumberOfChannelsForInput(AudioNodeInput* inpu
     
     if (!isInitialized()) {
         // This will propagate the channel count to any nodes connected further down the chain...
-        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
+        protect(output(0))->setNumberOfChannels(numberOfChannels);
 
         // Re-initialize the processor with the new channel count.
         processor()->setNumberOfChannels(numberOfChannels);

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -460,7 +460,7 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
         unsigned numberOfChannels = buffer->numberOfChannels();
         ASSERT(numberOfChannels <= AudioContext::maxNumberOfChannels);
 
-        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
+        protect(output(0))->setNumberOfChannels(numberOfChannels);
 
         m_sourceChannels = FixedVector<std::span<const float>>(numberOfChannels);
         m_destinationChannels = FixedVector<std::span<float>>(numberOfChannels);

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -96,7 +96,7 @@ void AudioDestinationNode::renderQuantum(AudioBus& destinationBus, size_t number
 
     // This will cause the node(s) connected to us to process, which in turn will pull on their input(s),
     // all the way backwards through the rendering graph.
-    AudioBus& renderedBus = checkedInput(0)->pull(&destinationBus, numberOfFrames);
+    AudioBus& renderedBus = protect(input(0))->pull(&destinationBus, numberOfFrames);
 
     if (&renderedBus != &destinationBus) {
         // in-place processing was not possible - so copy

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -176,21 +176,11 @@ AudioNodeInput* AudioNode::input(unsigned i)
     return nullptr;
 }
 
-CheckedPtr<AudioNodeInput> AudioNode::checkedInput(unsigned i)
-{
-    return input(i);
-}
-
 AudioNodeOutput* AudioNode::output(unsigned i)
 {
     if (i < m_outputs.size())
         return m_outputs[i].get();
     return nullptr;
-}
-
-CheckedPtr<AudioNodeOutput> AudioNode::checkedOutput(unsigned i)
-{
-    return output(i);
 }
 
 ExceptionOr<void> AudioNode::connect(AudioNode& destination, unsigned outputIndex, unsigned inputIndex)

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -127,9 +127,7 @@ public:
     unsigned numberOfOutputs() const { return m_outputs.size(); }
 
     AudioNodeInput* NODELETE input(unsigned);
-    CheckedPtr<AudioNodeInput> NODELETE checkedInput(unsigned);
     AudioNodeOutput* NODELETE output(unsigned);
-    CheckedPtr<AudioNodeOutput> NODELETE checkedOutput(unsigned);
 
     // Called from main thread by corresponding JavaScript methods.
     ExceptionOr<void> connect(AudioNode&, unsigned outputIndex, unsigned inputIndex);
@@ -327,6 +325,11 @@ namespace WTF {
 template<> struct LogArgument<WebCore::AudioNode::NodeType> {
     static String toString(WebCore::AudioNode::NodeType type) { return convertEnumerationToString(type); }
 };
+
+// Make sure `protect()` returns a CheckedPtr/CheckedRef for AudioNodes instead of a RefPtr/Ref
+// since AudioNode's ref-counting is not thread-safe and protect() gets called from the AudioThread.
+inline CheckedRef<WebCore::AudioNode> protect(WebCore::AudioNode& node) { return node; }
+inline CheckedPtr<WebCore::AudioNode> protect(WebCore::AudioNode* node) { return node; }
 
 } // namespace WTF
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -115,7 +115,7 @@ void AudioNodeInput::disable(AudioNodeOutput* output)
     }
 
     // Propagate disabled state to outputs.
-    checkedNode()->disableOutputsIfNecessary();
+    protect(node())->disableOutputsIfNecessary();
 }
 
 void AudioNodeInput::enable(AudioNodeOutput* output)
@@ -139,12 +139,12 @@ void AudioNodeInput::enable(AudioNodeOutput* output)
     m_disabledOutputs.remove(output);
 
     // Propagate enabled state to outputs.
-    checkedNode()->enableOutputsIfNecessary();
+    protect(node())->enableOutputsIfNecessary();
 }
 
 void AudioNodeInput::didUpdate()
 {
-    checkedNode()->checkNumberOfChannelsForInput(this);
+    protect(node())->checkNumberOfChannelsForInput(this);
 }
 
 void AudioNodeInput::updateInternalBus()

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.h
@@ -54,7 +54,6 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
-    CheckedPtr<AudioNode> checkedNode() const { return m_node.get(); }
 
     // Must be called with the context's graph lock.
     void connect(AudioNodeOutput*);

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -102,7 +102,7 @@ void AudioNodeOutput::propagateChannelCount()
     if (isChannelCountKnown()) {
         // Announce to any nodes we're connected to that we changed our channel count for its input.
         for (auto& input : m_inputs.keys())
-            input->checkedNode()->checkNumberOfChannelsForInput(input);
+            protect(input->node())->checkNumberOfChannelsForInput(input);
     }
 }
 
@@ -121,7 +121,7 @@ AudioBus& AudioNodeOutput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
 
     m_inPlaceBus = isInPlace ? inPlaceBus : nullptr;
 
-    checkedNode()->processIfNecessary(framesToProcess);
+    protect(node())->processIfNecessary(framesToProcess);
     return bus();
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -51,8 +51,7 @@ public:
 
     // Can be called from any thread.
     AudioNode* node() const { return m_node.get(); }
-    CheckedPtr<AudioNode> checkedNode() const { return m_node.get(); }
-    BaseAudioContext& context() { return checkedNode()->context(); }
+    BaseAudioContext& context() { return protect(node())->context(); }
     
     // Causes our AudioNode to process if it hasn't already for this render quantum.
     // It returns the bus containing the processed audio for this output, returning inPlaceBus if in-place processing was possible.

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -204,7 +204,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
 
     auto zeroOutput = [&] {
         for (unsigned i = 0; i < numberOfOutputs(); ++i)
-            checkedOutput(i)->bus().zero();
+            protect(output(i))->bus().zero();
     };
 
     if (!m_processLock.tryLock()) {
@@ -224,7 +224,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
         m_inputs[i] = currentInput->isConnected() ? &currentInput->bus() : nullptr;
     }
     for (unsigned i = 0; i < numberOfOutputs(); ++i)
-        m_outputs[i] = checkedOutput(i)->bus();
+        m_outputs[i] = protect(output(i))->bus();
 
     if (noiseInjectionPolicies().contains(NoiseInjectionPolicy::Minimal)) {
         for (unsigned inputIndex = 0; inputIndex < numberOfInputs(); ++inputIndex) {
@@ -270,7 +270,7 @@ void AudioWorkletNode::updatePullStatus()
 
     bool hasConnectedOutput = false;
     for (unsigned i = 0; i < numberOfOutputs(); ++i) {
-        if (checkedOutput(i)->isConnected()) {
+        if (protect(output(i))->isConnected()) {
             hasConnectedOutput = true;
             break;
         }
@@ -295,7 +295,7 @@ void AudioWorkletNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
         unsigned numberOfInputChannels = input->numberOfChannels();
         if (numberOfInputChannels != output(0)->numberOfChannels()) {
             // This will propagate the channel count to any nodes connected further downstream in the graph.
-            checkedOutput(0)->setNumberOfChannels(numberOfInputChannels);
+            protect(output(0))->setNumberOfChannels(numberOfInputChannels);
         }
     }
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -333,8 +333,8 @@ private:
         }
         TailProcessingNode& operator=(const TailProcessingNode&) = delete;
         TailProcessingNode& operator=(TailProcessingNode&&) = delete;
-        CheckedPtr<AudioNode> checkedNode() const { return m_node.get(); }
         AudioNode* operator->() const { return m_node.get(); }
+        AudioNode* node() const { return m_node.get(); }
         friend bool operator==(const TailProcessingNode&, const TailProcessingNode&) = default;
         bool operator==(const AudioNode& node) const { return m_node == &node; }
     private:

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -70,7 +70,7 @@ BiquadFilterType BiquadFilterNode::type() const
 
 void BiquadFilterNode::setType(BiquadFilterType type)
 {
-    checkedBiquadProcessor()->setType(type);
+    protect(biquadProcessor())->setType(type);
 }
 
 ExceptionOr<void> BiquadFilterNode::getFrequencyResponse(const Ref<Float32Array>& frequencyHz, const Ref<Float32Array>& magResponse, const Ref<Float32Array>& phaseResponse)
@@ -80,7 +80,7 @@ ExceptionOr<void> BiquadFilterNode::getFrequencyResponse(const Ref<Float32Array>
         return Exception { ExceptionCode::InvalidAccessError, "The arrays passed as arguments must have the same length"_s };
 
     if (length)
-        checkedBiquadProcessor()->getFrequencyResponse(length, frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
+        protect(biquadProcessor())->getFrequencyResponse(length, frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
     return { };
 }
 

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
@@ -54,7 +54,6 @@ private:
     explicit BiquadFilterNode(BaseAudioContext&);
 
     BiquadProcessor* biquadProcessor() { return downcast<BiquadProcessor>(processor()); }
-    CheckedPtr<BiquadProcessor> checkedBiquadProcessor() { return biquadProcessor(); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -109,7 +109,7 @@ void ConvolverNode::process(size_t framesToProcess)
         // Note that we can handle the case where nothing is connected to the input, in which case we'll just feed silence into the convolver.
         // FIXME: If we wanted to get fancy we could try to factor in the 'tail time' and stop processing once the tail dies down if
         // we keep getting fed silence.
-        m_reverb->process(checkedInput(0)->bus(), outputBus, framesToProcess);
+        m_reverb->process(protect(input(0))->bus(), outputBus, framesToProcess);
     }
 }
 
@@ -156,7 +156,7 @@ ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buff
         m_buffer = WTF::move(buffer);
         if (m_buffer) {
             // This will propagate the channel count to any nodes connected further downstream in the graph.
-            checkedOutput(0)->setNumberOfChannels(computeNumberOfOutputChannels(checkedInput(0)->numberOfChannels(), m_buffer->numberOfChannels()));
+            protect(output(0))->setNumberOfChannels(computeNumberOfOutputChannels(protect(input(0))->numberOfChannels(), m_buffer->numberOfChannels()));
         }
     }
 
@@ -234,7 +234,7 @@ void ConvolverNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
         if (!isInitialized()) {
             // This will propagate the channel count to any nodes connected further
             // downstream in the graph.
-            checkedOutput(0)->setNumberOfChannels(numberOfOutputChannels);
+            protect(output(0))->setNumberOfChannels(numberOfOutputChannels);
             initialize();
         }
     }

--- a/Source/WebCore/Modules/webaudio/DelayNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayNode.cpp
@@ -63,7 +63,7 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
     if (result.hasException())
         return result.releaseException();
 
-    delayNode->checkedDelayTime()->setValue(options.delayTime);
+    protect(delayNode->delayTime())->setValue(options.delayTime);
 
     return delayNode;
 }
@@ -71,11 +71,6 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
 AudioParam& DelayNode::delayTime()
 {
     return downcast<DelayProcessor>(*m_processor).delayTime();
-}
-
-CheckedRef<AudioParam> DelayNode::checkedDelayTime()
-{
-    return delayTime();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/DelayNode.h
+++ b/Source/WebCore/Modules/webaudio/DelayNode.h
@@ -37,7 +37,6 @@ public:
     static ExceptionOr<Ref<DelayNode>> create(BaseAudioContext&, const DelayOptions&);
 
     AudioParam& NODELETE delayTime();
-    CheckedRef<AudioParam> NODELETE checkedDelayTime();
 
 private:
     DelayNode(BaseAudioContext&, double maxDelayTime);

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
@@ -91,7 +91,7 @@ void DynamicsCompressorNode::process(size_t framesToProcess)
     m_dynamicsCompressor->setParameterValue(DynamicsCompressor::ParamAttack, attack);
     m_dynamicsCompressor->setParameterValue(DynamicsCompressor::ParamRelease, release);
 
-    m_dynamicsCompressor->process(checkedInput(0)->bus(), outputBus, framesToProcess);
+    m_dynamicsCompressor->process(protect(input(0))->bus(), outputBus, framesToProcess);
 
     setReduction(m_dynamicsCompressor->parameterValue(DynamicsCompressor::ParamReduction));
 }

--- a/Source/WebCore/Modules/webaudio/GainNode.cpp
+++ b/Source/WebCore/Modules/webaudio/GainNode.cpp
@@ -128,7 +128,7 @@ void GainNode::checkNumberOfChannelsForInput(AudioNodeInput* input)
 
     if (!isInitialized()) {
         // This will propagate the channel count to any nodes connected further downstream in the graph.
-        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
+        protect(output(0))->setNumberOfChannels(numberOfChannels);
         initialize();
     }
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -116,7 +116,7 @@ void MediaElementAudioSourceNode::setFormat(size_t numberOfChannels, float sourc
             Locker contextLocker { context().graphLock() };
 
             // Do any necesssary re-configuration to the output's number of channels.
-            checkedOutput(0)->setNumberOfChannels(numberOfChannels);
+            protect(output(0))->setNumberOfChannels(numberOfChannels);
         }
     }
 }
@@ -142,7 +142,7 @@ bool MediaElementAudioSourceNode::wouldTaintOrigin()
 
 void MediaElementAudioSourceNode::process(size_t numberOfFrames)
 {
-    Ref outputBus = checkedOutput(0)->bus();
+    Ref outputBus = protect(output(0))->bus();
 
     // Use tryLock() to avoid contention in the real-time audio thread.
     // If we fail to acquire the lock then the HTMLMediaElement must be in the middle of

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
@@ -121,7 +121,7 @@ void MediaStreamAudioSourceNode::setFormat(size_t numberOfChannels, float source
         Locker contextLocker { context().graphLock() };
 
         // Do any necesssary re-configuration to the output's number of channels.
-        checkedOutput(0)->setNumberOfChannels(numberOfChannels);
+        protect(output(0))->setNumberOfChannels(numberOfChannels);
     }
 }
 
@@ -132,7 +132,7 @@ void MediaStreamAudioSourceNode::provideInput(AudioBus& bus, size_t framesToProc
 
 void MediaStreamAudioSourceNode::process(size_t numberOfFrames)
 {
-    Ref outputBus = checkedOutput(0)->bus();
+    Ref outputBus = protect(output(0))->bus();
 
     // Use tryLock() to avoid contention in the real-time audio thread.
     // If we fail to acquire the lock then the MediaStream must be in the middle of

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2665,7 +2665,7 @@ AccessibilityObject* AccessibilityNodeObject::parentTable() const
         // https://bugs.webkit.org/show_bug.cgi?id=42652
         RefPtr<AccessibilityObject> tableFromRenderTree;
         if (CheckedPtr renderTableCell = dynamicDowncast<RenderTableCell>(renderer()))
-            tableFromRenderTree = cache->get(renderTableCell->checkedTable().get());
+            tableFromRenderTree = cache->get(protect(renderTableCell->table()).get());
 
         if (!tableFromRenderTree || !tableFromRenderTree->isTable()) {
             if (node()) {

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -81,7 +81,6 @@ public:
     bool canSetSelectedAttribute() const override;
 
     Node* node() const final { return m_node.get(); }
-    CheckedPtr<Node> checkedNode() const { return node(); }
     Document* document() const override;
     LocalFrameView* documentFrameView() const override;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -470,7 +470,6 @@ public:
     String ariaRoleDescription() const final { return getAttributeTrimmed(HTMLNames::aria_roledescriptionAttr); };
 
     inline AXObjectCache* axObjectCache() const;
-    CheckedPtr<AXObjectCache> checkedAxObjectCache() const;
 
     static AccessibilityObject* anchorElementForNode(Node&);
     static AccessibilityObject* headingElementForNode(Node*);

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -57,11 +57,6 @@ inline AXObjectCache* AccessibilityObject::axObjectCache() const
     return m_axObjectCache.get();
 }
 
-inline CheckedPtr<AXObjectCache> AccessibilityObject::checkedAxObjectCache() const
-{
-    return axObjectCache();
-}
-
 inline bool AccessibilityObject::isDetached() const
 {
     return !wrapper();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1097,7 +1097,7 @@ AccessibilityObject* AccessibilityRenderObject::titleUIElement() const
 
         // Table cells that are th cannot have title ui elements, since by definition
         // they are title ui elements
-        if (WebCore::elementName(checkedNode().get()) == ElementName::HTML_th)
+        if (WebCore::elementName(protect(node()).get()) == ElementName::HTML_th)
             return nullptr;
 
         CheckedRef renderCell = downcast<RenderTableCell>(*m_renderer);

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -110,7 +110,6 @@ public:
     LayoutRect boundingBoxRect() const final;
 
     RenderObject* renderer() const final { return m_renderer.get(); }
-    CheckedPtr<RenderObject> checkedRenderer() const { return renderer(); }
     Document* document() const final;
 
     URL url() const final;

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
@@ -83,7 +83,7 @@ float AccessibilityScrollbar::valueForRange() const
 bool AccessibilityScrollbar::setValue(float value)
 {
     float newValue = value * m_scrollbar->maximum();
-    m_scrollbar->checkedScrollableArea()->scrollToOffsetWithoutAnimation(m_scrollbar->orientation(), newValue);
+    protect(m_scrollbar->scrollableArea())->scrollToOffsetWithoutAnimation(m_scrollbar->orientation(), newValue);
     return true;
 }
 

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -116,7 +116,7 @@ RefPtr<AccessibilityObject> AccessibilitySlider::elementAccessibilityHitTest(con
             return downcast<AccessibilityObject>(m_children[0].get());
     }
 
-    return checkedAxObjectCache()->getOrCreate(checkedRenderer().get());
+    return protect(axObjectCache())->getOrCreate(protect(renderer()).get());
 }
 
 float AccessibilitySlider::valueForRange() const

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -118,7 +118,7 @@ static const Style::CustomProperty* propertyValueForVariableName(const AtomStrin
     // Apply this variable first, in case it is still unresolved
     builder.applyCustomProperty(variableName);
 
-    return builder.state().checkedStyle()->customPropertyValue(variableName);
+    return protect(builder.state().style())->customPropertyValue(variableName);
 }
 
 bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, Style::Builder& builder) const

--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -70,12 +70,12 @@ void DeviceMotionController::didChangeDeviceMotion(DeviceMotionData* deviceMotio
 
 bool DeviceMotionController::hasLastData()
 {
-    return checkedClient()->lastMotion();
+    return protect(m_client)->lastMotion();
 }
 
 RefPtr<Event> DeviceMotionController::getLastEvent()
 {
-    RefPtr lastMotion = checkedClient()->lastMotion();
+    RefPtr lastMotion = protect(m_client)->lastMotion();
     return DeviceMotionEvent::create(eventNames().devicemotionEvent, lastMotion.get());
 }
 
@@ -92,11 +92,6 @@ bool DeviceMotionController::isActiveAt(Page* page)
 }
 
 DeviceClient& DeviceMotionController::client()
-{
-    return m_client.get();
-}
-
-CheckedRef<DeviceMotionClient> DeviceMotionController::checkedClient()
 {
     return m_client.get();
 }

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -63,8 +63,6 @@ private:
     static ASCIILiteral supplementName() { return "DeviceMotionController"_s; }
     bool isDeviceMotionController() const final { return true; }
 
-    CheckedRef<DeviceMotionClient> NODELETE checkedClient();
-
     WeakRef<DeviceMotionClient> m_client;
 };
 

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -71,12 +71,12 @@ void DeviceOrientationController::resumeUpdates()
 
 bool DeviceOrientationController::hasLastData()
 {
-    return checkedClient()->lastOrientation();
+    return protect(m_client)->lastOrientation();
 }
 
 RefPtr<Event> DeviceOrientationController::getLastEvent()
 {
-    RefPtr orientation = checkedClient()->lastOrientation();
+    RefPtr orientation = protect(m_client)->lastOrientation();
     return DeviceOrientationEvent::create(eventNames().deviceorientationEvent, orientation.get());
 }
 
@@ -95,11 +95,6 @@ bool DeviceOrientationController::isActiveAt(Page* page)
 }
 
 DeviceClient& DeviceOrientationController::client()
-{
-    return m_client.get();
-}
-
-CheckedRef<DeviceOrientationClient> DeviceOrientationController::checkedClient()
 {
     return m_client.get();
 }

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -64,8 +64,6 @@ private:
     static ASCIILiteral supplementName() { return "DeviceOrientationController"_s; }
     bool isDeviceOrientationController() const final { return true; }
 
-    CheckedRef<DeviceOrientationClient> NODELETE checkedClient();
-
     WeakRef<DeviceOrientationClient> m_client;
 };
 

--- a/Source/WebCore/dom/messageports/MessagePortChannel.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.cpp
@@ -51,17 +51,12 @@ MessagePortChannel::MessagePortChannel(MessagePortChannelRegistry& registry, con
     m_processes[1] = port2.processIdentifier;
     m_entangledToProcessProtectors[1] = this;
 
-    checkedRegistry()->messagePortChannelCreated(*this);
+    protect(m_registry)->messagePortChannelCreated(*this);
 }
 
 MessagePortChannel::~MessagePortChannel()
 {
-    checkedRegistry()->messagePortChannelDestroyed(*this);
-}
-
-CheckedRef<MessagePortChannelRegistry> MessagePortChannel::checkedRegistry() const
-{
-    return m_registry;
+    protect(m_registry)->messagePortChannelDestroyed(*this);
 }
 
 std::optional<ProcessIdentifier> MessagePortChannel::processForPort(const MessagePortIdentifier& port)

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -68,8 +68,6 @@ public:
 private:
     MessagePortChannel(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
 
-    CheckedRef<MessagePortChannelRegistry> NODELETE checkedRegistry() const;
-
     std::array<MessagePortIdentifier, 2> m_ports;
     std::array<bool, 2> m_isClosed { false, false };
     std::array<std::optional<ProcessIdentifier>, 2> m_processes;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -363,11 +363,6 @@ EditorClient* Editor::client() const
     return m_client.get();
 }
 
-CheckedPtr<EditorClient> Editor::checkedClient() const
-{
-    return client();
-}
-
 TextCheckerClient* Editor::textChecker() const
 {
     if (CheckedPtr owner = client())

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -209,7 +209,6 @@ public:
     };
 
     WEBCORE_EXPORT EditorClient* client() const;
-    WEBCORE_EXPORT CheckedPtr<EditorClient> checkedClient() const;
     WEBCORE_EXPORT TextCheckerClient* textChecker() const;
 
     CompositeEditCommand* lastEditCommand() { return m_lastEditCommand.get(); }

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -243,7 +243,7 @@ auto TextCheckingHelper::findMisspelledWords(Operation operation) const -> std::
 
         int misspellingLocation = -1;
         int misspellingLength = 0;
-        checkedClient()->textChecker()->checkSpellingOfString(text, &misspellingLocation, &misspellingLength);
+        protect(m_client)->textChecker()->checkSpellingOfString(text, &misspellingLocation, &misspellingLength);
 
         int textLength = text.length();
 
@@ -339,7 +339,7 @@ auto TextCheckingHelper::findFirstMisspelledWordOrUngrammaticalPhrase(bool check
                 VisibleSelection currentSelection;
                 if (auto* frame = paragraphRange.start.document().frame())
                     currentSelection = frame->selection().selection();
-                checkTextOfParagraph(*checkedClient()->textChecker(), paragraphString, checkingTypes, results, currentSelection);
+                checkTextOfParagraph(*protect(m_client)->textChecker(), paragraphString, checkingTypes, results, currentSelection);
 
                 for (auto& result : results) {
                     if (result.type == TextCheckingType::Spelling && result.range.location >= currentStartOffset && result.range.location + result.range.length <= currentEndOffset) {
@@ -459,7 +459,7 @@ auto TextCheckingHelper::findUngrammaticalPhrases(Operation operation) const -> 
         Vector<GrammarDetail> grammarDetails;
         int badGrammarPhraseLocation = -1;
         int badGrammarPhraseLength = 0;
-        checkedClient()->textChecker()->checkGrammarOfString(paragraph.text().substring(startOffset), grammarDetails, &badGrammarPhraseLocation, &badGrammarPhraseLength);
+        protect(m_client)->textChecker()->checkGrammarOfString(paragraph.text().substring(startOffset), grammarDetails, &badGrammarPhraseLocation, &badGrammarPhraseLength);
         
         if (!badGrammarPhraseLength) {
             ASSERT(badGrammarPhraseLocation == -1);
@@ -565,11 +565,6 @@ void TextCheckingHelper::markAllUngrammaticalPhrases() const
 bool TextCheckingHelper::unifiedTextCheckerEnabled() const
 {
     return WebCore::unifiedTextCheckerEnabled(m_range.start.document().frame());
-}
-
-CheckedRef<EditorClient> TextCheckingHelper::checkedClient() const
-{
-    return m_client.get();
 }
 
 void checkTextOfParagraph(TextCheckerClient& client, StringView text, OptionSet<TextCheckingType> checkingTypes, Vector<TextCheckingResult>& results, const VisibleSelection& currentSelection)

--- a/Source/WebCore/editing/TextCheckingHelper.h
+++ b/Source/WebCore/editing/TextCheckingHelper.h
@@ -109,8 +109,6 @@ private:
     bool unifiedTextCheckerEnabled() const;
     int findUngrammaticalPhrases(Operation, const Vector<GrammarDetail>&, uint64_t badGrammarPhraseLocation, uint64_t startOffset, uint64_t endOffset) const;
 
-    CheckedRef<EditorClient> checkedClient() const;
-
     WeakRef<EditorClient> m_client;
     SimpleRange m_range;
 };

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -484,7 +484,7 @@ static AttributedString editingAttributedStringInternal(const SimpleRange& range
         CheckedPtr renderer = node->renderer();
 
         if (renderer)
-            updateAttributes(node.get(), renderer->checkedStyle(), includedElements, elementQualifiesForWritingToolsPreservationCache, enclosingLinkCache, enclosingListCache, attributes.get(), textListsForListElements);
+            updateAttributes(node.get(), protect(renderer->style()), includedElements, elementQualifiesForWritingToolsPreservationCache, enclosingLinkCache, enclosingListCache, attributes.get(), textListsForListElements);
         else if (!includedElements.contains(IncludedElement::NonRenderedContent))
             continue;
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -186,7 +186,7 @@ void HTMLLinkElement::setDisabledState(bool disabled)
     if (!m_sheet && m_disabledState == EnabledViaScript)
         process();
     else {
-        checkedStyleScope()->didChangeActiveStyleSheetCandidates();
+        protect(m_styleScope)->didChangeActiveStyleSheetCandidates();
         if (m_sheet)
             clearSheet();
     }
@@ -418,7 +418,7 @@ void HTMLLinkElement::process()
     if (m_sheet) {
         // we no longer contain a stylesheet, e.g. perhaps rel or type was changed
         clearSheet();
-        checkedStyleScope()->didChangeActiveStyleSheetCandidates();
+        protect(m_styleScope)->didChangeActiveStyleSheetCandidates();
         return;
     }
 
@@ -521,7 +521,7 @@ Node::InsertedIntoAncestorResult HTMLLinkElement::insertedIntoAncestor(Insertion
         return InsertedIntoAncestorResult::Done;
 
     m_styleScope = &Style::Scope::forNode(*this);
-    checkedStyleScope()->addStyleSheetCandidateNode(*this, m_createdByParser);
+    protect(m_styleScope)->addStyleSheetCandidateNode(*this, m_createdByParser);
 
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
@@ -821,7 +821,7 @@ void HTMLLinkElement::addPendingSheet(PendingSheetType type)
 
     if (m_pendingSheetType == PendingSheetType::Inactive)
         return;
-    checkedStyleScope()->addPendingSheet(*this);
+    protect(m_styleScope)->addPendingSheet(*this);
 }
 
 void HTMLLinkElement::removePendingSheet()
@@ -865,11 +865,6 @@ String HTMLLinkElement::fetchPriorityForBindings() const
 RequestPriority HTMLLinkElement::fetchPriority() const
 {
     return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto);
-}
-
-CheckedPtr<Style::Scope> HTMLLinkElement::checkedStyleScope()
-{
-    return m_styleScope;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -154,8 +154,6 @@ private:
 
     void removePendingSheet();
 
-    CheckedPtr<Style::Scope> NODELETE checkedStyleScope();
-
     const Ref<LinkLoader> m_linkLoader;
     CheckedPtr<Style::Scope> m_styleScope;
     CachedResourceHandle<CachedCSSStyleSheet> m_cachedSheet;

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -215,7 +215,7 @@ RenderMarquee* HTMLMarqueeElement::renderMarquee() const
     CheckedPtr renderer = this->renderer();
     if (!renderer || !renderer->hasLayer())
         return nullptr;
-    CheckedPtr scrollableArea = downcast<RenderBoxModelObject>(*renderer).checkedLayer()->scrollableArea();
+    CheckedPtr scrollableArea = protect(downcast<RenderBoxModelObject>(*renderer).layer())->scrollableArea();
     if (!scrollableArea)
         return nullptr;
     return scrollableArea->marquee();

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -2141,7 +2141,7 @@ String HTMLSelectElement::itemText(unsigned listIndex) const
         itemString = optionElement->textIndentedToRespectGroupLabel();
 
     if (CheckedPtr renderer = this->renderer())
-        return applyTextTransform(renderer->checkedStyle().get(), itemString);
+        return applyTextTransform(protect(renderer->style()).get(), itemString);
     return itemString;
 }
 

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -202,7 +202,7 @@ HTMLTableCellElement* HTMLTableCellElement::cellAbove() const
     if (!tableCellRenderer)
         return nullptr;
 
-    CheckedPtr cellAboveRenderer = tableCellRenderer->checkedTable()->cellAbove(tableCellRenderer.get());
+    CheckedPtr cellAboveRenderer = protect(tableCellRenderer->table())->cellAbove(tableCellRenderer.get());
     if (!cellAboveRenderer)
         return nullptr;
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -172,7 +172,7 @@ void HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer()
     bool isInFullScreen = false;
 #endif
     CheckedPtr renderer = this->renderer();
-    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (renderer && renderer->checkedView()->compositor().hasAcceleratedCompositing()));
+    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
     if (canBeAccelerated == m_renderingCanBeAccelerated)
         return;
     m_renderingCanBeAccelerated = canBeAccelerated;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -296,10 +296,10 @@ RefPtr<WebGLBuffer> WebGL2RenderingContext::validateBufferDataTarget(ASCIILitera
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "no buffer"_s);
         return nullptr;
     }
-    if (protect(m_boundTransformFeedback.get())->hasBoundIndexedTransformFeedbackBuffer(buffer.get())) {
+    if (protect(m_boundTransformFeedback)->hasBoundIndexedTransformFeedbackBuffer(buffer.get())) {
         ASSERT(buffer != m_boundVertexArrayObject->getElementArrayBuffer());
         if (m_boundIndexedUniformBuffers.contains(buffer)
-            || protect(m_boundVertexArrayObject.get())->hasArrayBuffer(buffer.get())
+            || protect(m_boundVertexArrayObject)->hasArrayBuffer(buffer.get())
             || buffer == m_boundArrayBuffer
             || buffer == m_boundCopyReadBuffer
             || buffer == m_boundCopyWriteBuffer
@@ -332,7 +332,7 @@ bool WebGL2RenderingContext::validateAndCacheBufferBinding(const AbstractLocker&
         m_boundCopyWriteBuffer = buffer;
         break;
     case GraphicsContextGL::ELEMENT_ARRAY_BUFFER:
-        protect(m_boundVertexArrayObject.get())->setElementArrayBuffer(locker, buffer);
+        protect(m_boundVertexArrayObject)->setElementArrayBuffer(locker, buffer);
         break;
     case GraphicsContextGL::PIXEL_PACK_BUFFER:
         m_boundPixelPackBuffer = buffer;
@@ -1558,7 +1558,7 @@ void WebGL2RenderingContext::vertexAttribIPointer(GCGLuint index, GCGLint size, 
     }
     GCGLsizei bytesPerElement = size * typeSize;
 
-    protect(m_boundVertexArrayObject.get())->setVertexAttribState(locker, index, bytesPerElement, size, type, false, stride, static_cast<GCGLintptr>(offset), true, RefPtr { m_boundArrayBuffer.get() }.get());
+    protect(m_boundVertexArrayObject)->setVertexAttribState(locker, index, bytesPerElement, size, type, false, stride, static_cast<GCGLintptr>(offset), true, RefPtr { m_boundArrayBuffer.get() }.get());
     graphicsContextGL()->vertexAttribIPointer(index, size, type, stride, offset);
 }
 
@@ -1652,7 +1652,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
                 return;
             }
         }
-        protect(m_framebufferBinding.get())->drawBuffers(buffers);
+        protect(m_framebufferBinding)->drawBuffers(buffers);
     }
 }
 
@@ -2286,7 +2286,7 @@ void WebGL2RenderingContext::resumeTransformFeedback()
     if (isContextLost())
         return;
 
-    if (!protect(m_boundTransformFeedback.get())->validateProgramForResume(m_currentProgram.get())) {
+    if (!protect(m_boundTransformFeedback)->validateProgramForResume(m_currentProgram.get())) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "resumeTransformFeedback"_s, "the current program is not the same as when beginTransformFeedback was called"_s);
         return;
     }
@@ -2339,7 +2339,7 @@ bool WebGL2RenderingContext::setIndexedBufferBinding(ASCIILiteral functionName, 
 
     switch (target) {
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER:
-        protect(m_boundTransformFeedback.get())->setBoundIndexedTransformFeedbackBuffer(locker, index, buffer);
+        protect(m_boundTransformFeedback)->setBoundIndexedTransformFeedbackBuffer(locker, index, buffer);
         break;
     case GraphicsContextGL::UNIFORM_BUFFER:
         m_boundIndexedUniformBuffers[index] = buffer;
@@ -2379,7 +2379,7 @@ WebGLAny WebGL2RenderingContext::getIndexedParameter(GCGLenum target, GCGLuint i
     switch (target) {
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER_BINDING: {
         WebGLBuffer* buffer;
-        bool success = protect(m_boundTransformFeedback.get())->getBoundIndexedTransformFeedbackBuffer(index, &buffer);
+        bool success = protect(m_boundTransformFeedback)->getBoundIndexedTransformFeedbackBuffer(index, &buffer);
         if (!success) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getIndexedParameter"_s, "index out of range"_s);
             return nullptr;
@@ -3532,7 +3532,7 @@ void WebGL2RenderingContext::uncacheDeletedBuffer(const AbstractLocker& locker, 
     REMOVE_BUFFER_FROM_BINDING(m_boundPixelUnpackBuffer);
     REMOVE_BUFFER_FROM_BINDING(m_boundTransformFeedbackBuffer);
     REMOVE_BUFFER_FROM_BINDING(m_boundUniformBuffer);
-    protect(m_boundTransformFeedback.get())->unbindBuffer(locker, *buffer);
+    protect(m_boundTransformFeedback)->unbindBuffer(locker, *buffer);
 
     for (auto& boundBuffer : m_boundIndexedUniformBuffers) {
         if (boundBuffer == buffer)

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
@@ -78,7 +78,7 @@ void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
                 return;
             }
         }
-        protect(context->m_framebufferBinding.get())->drawBuffers(buffers);
+        protect(context->m_framebufferBinding)->drawBuffers(buffers);
     }
 }
 

--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -82,6 +82,20 @@ private:
     RefPtr<T> m_object;
 };
 
+} // namespace WebCore
+
+namespace WTF {
+
+template<typename T, unsigned target>
+ALWAYS_INLINE RefPtr<T> protect(const WebCore::WebGLBindingPoint<T, target>& bindingPoint)
+{
+    return bindingPoint.get();
+}
+
+} // namespace WTF
+
+namespace WebCore {
+
 class WebGLObject : public RefCounted<WebGLObject> {
 public:
     virtual ~WebGLObject();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1053,7 +1053,7 @@ bool WebGLRenderingContextBase::validateAndCacheBufferBinding(const AbstractLock
         m_boundArrayBuffer = buffer;
     else {
         ASSERT(target == GraphicsContextGL::ELEMENT_ARRAY_BUFFER);
-        protect(m_boundVertexArrayObject.get())->setElementArrayBuffer(locker, buffer);
+        protect(m_boundVertexArrayObject)->setElementArrayBuffer(locker, buffer);
     }
 
     return true;
@@ -1446,7 +1446,7 @@ void WebGLRenderingContextBase::uncacheDeletedBuffer(const AbstractLocker& locke
 {
     REMOVE_BUFFER_FROM_BINDING(m_boundArrayBuffer);
 
-    protect(m_boundVertexArrayObject.get())->unbindBuffer(locker, *buffer);
+    protect(m_boundVertexArrayObject)->unbindBuffer(locker, *buffer);
 }
 
 void WebGLRenderingContextBase::setBoundVertexArrayObject(const AbstractLocker&, WebGLVertexArrayObjectBase* arrayObject)
@@ -1508,7 +1508,7 @@ void WebGLRenderingContextBase::deleteRenderbuffer(WebGLRenderbuffer* renderbuff
     if (renderbuffer == m_renderbufferBinding)
         m_renderbufferBinding = nullptr;
     if (m_framebufferBinding)
-        protect(m_framebufferBinding.get())->removeAttachmentFromBoundFramebuffer(locker, GraphicsContextGL::FRAMEBUFFER, renderbuffer);
+        protect(m_framebufferBinding)->removeAttachmentFromBoundFramebuffer(locker, GraphicsContextGL::FRAMEBUFFER, renderbuffer);
     if (RefPtr readFramebufferBinding = getFramebufferBinding(GraphicsContextGL::READ_FRAMEBUFFER))
         readFramebufferBinding->removeAttachmentFromBoundFramebuffer(locker, GraphicsContextGL::READ_FRAMEBUFFER, renderbuffer);
 }
@@ -1539,7 +1539,7 @@ void WebGLRenderingContextBase::deleteTexture(WebGLTexture* texture)
         }
     }
     if (m_framebufferBinding)
-        protect(m_framebufferBinding.get())->removeAttachmentFromBoundFramebuffer(locker, GraphicsContextGL::FRAMEBUFFER, texture);
+        protect(m_framebufferBinding)->removeAttachmentFromBoundFramebuffer(locker, GraphicsContextGL::FRAMEBUFFER, texture);
     if (RefPtr readFramebufferBinding = getFramebufferBinding(GraphicsContextGL::READ_FRAMEBUFFER))
         readFramebufferBinding->removeAttachmentFromBoundFramebuffer(locker, GraphicsContextGL::READ_FRAMEBUFFER, texture);
 }
@@ -1600,13 +1600,13 @@ void WebGLRenderingContextBase::disableVertexAttribArray(GCGLuint index)
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "disableVertexAttribArray"_s, "index out of range"_s);
         return;
     }
-    protect(m_boundVertexArrayObject.get())->setVertexAttribEnabled(index, false);
+    protect(m_boundVertexArrayObject)->setVertexAttribEnabled(index, false);
     graphicsContextGL()->disableVertexAttribArray(index);
 }
 
 bool WebGLRenderingContextBase::validateVertexArrayObject(ASCIILiteral functionName)
 {
-    if (!protect(m_boundVertexArrayObject.get())->areAllEnabledAttribBuffersBound()) {
+    if (!protect(m_boundVertexArrayObject)->areAllEnabledAttribBuffersBound()) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "no buffer is bound to enabled attribute"_s);
         return false;
     }
@@ -1671,7 +1671,7 @@ void WebGLRenderingContextBase::enableVertexAttribArray(GCGLuint index)
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "enableVertexAttribArray"_s, "index out of range"_s);
         return;
     }
-    protect(m_boundVertexArrayObject.get())->setVertexAttribEnabled(index, true);
+    protect(m_boundVertexArrayObject)->setVertexAttribEnabled(index, true);
     graphicsContextGL()->enableVertexAttribArray(index);
 }
 
@@ -2183,7 +2183,7 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
             && pname < static_cast<GCGLenum>(GraphicsContextGL::DRAW_BUFFER0_EXT + maxDrawBuffers())) {
             GCGLint value = GraphicsContextGL::NONE;
             if (m_framebufferBinding)
-                value = protect(m_framebufferBinding.get())->getDrawBuffer(pname);
+                value = protect(m_framebufferBinding)->getDrawBuffer(pname);
             else // emulated backbuffer
                 value = m_backDrawBuffer;
             return value;
@@ -2658,7 +2658,7 @@ WebGLAny WebGLRenderingContextBase::getVertexAttrib(GCGLuint index, GCGLenum pna
         return nullptr;
     }
 
-    const WebGLVertexArrayObjectBase::VertexAttribState& state = protect(m_boundVertexArrayObject.get())->getVertexAttribState(index);
+    const WebGLVertexArrayObjectBase::VertexAttribState& state = protect(m_boundVertexArrayObject)->getVertexAttribState(index);
 
     if ((isWebGL2() || m_angleInstancedArrays) && pname == GraphicsContextGL::VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE)
         return state.divisor;
@@ -4630,7 +4630,7 @@ void WebGLRenderingContextBase::vertexAttribPointer(GCGLuint index, GCGLint size
         return;
     }
     GCGLsizei bytesPerElement = size * typeSize;
-    protect(m_boundVertexArrayObject.get())->setVertexAttribState(locker, index, bytesPerElement, size, type, normalized, stride, static_cast<GCGLintptr>(offset), false, RefPtr { m_boundArrayBuffer.get() }.get());
+    protect(m_boundVertexArrayObject)->setVertexAttribState(locker, index, bytesPerElement, size, type, normalized, stride, static_cast<GCGLintptr>(offset), false, RefPtr { m_boundArrayBuffer.get() }.get());
     graphicsContextGL()->vertexAttribPointer(index, size, type, normalized, stride, static_cast<GCGLintptr>(offset));
 }
 
@@ -5460,7 +5460,7 @@ void WebGLRenderingContextBase::vertexAttribDivisor(GCGLuint index, GCGLuint div
         return;
     }
 
-    protect(m_boundVertexArrayObject.get())->setVertexAttribDivisor(index, divisor);
+    protect(m_boundVertexArrayObject)->setVertexAttribDivisor(index, divisor);
     graphicsContextGL()->vertexAttribDivisor(index, divisor);
 }
 

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -86,7 +86,7 @@ protected:
     {
     }
 
-    CheckedRef<Inspector::InspectorEnvironment> checkedEnvironment() { return m_environment.get(); }
+    Inspector::InspectorEnvironment& environment() { return m_environment.get(); }
 
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
 

--- a/Source/WebCore/inspector/InstrumentingAgents.cpp
+++ b/Source/WebCore/inspector/InstrumentingAgents.cpp
@@ -57,7 +57,7 @@ InstrumentingAgents::InstrumentingAgents(InspectorEnvironment& environment, Inst
 
 bool InstrumentingAgents::developerExtrasEnabled() const
 {
-    return checkedEnvironment()->developerExtrasEnabled();
+    return protect(m_environment)->developerExtrasEnabled();
 }
 
 void InstrumentingAgents::reset()

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -161,8 +161,6 @@ FOR_EACH_INSPECTOR_AGENT(DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT)
 private:
     InstrumentingAgents(Inspector::InspectorEnvironment&, InstrumentingAgents* fallbackAgents);
 
-    CheckedRef<const Inspector::InspectorEnvironment> checkedEnvironment() const { return m_environment.get(); }
-
     WeakRef<Inspector::InspectorEnvironment> m_environment;
     const WeakPtr<InstrumentingAgents> m_fallbackAgents;
 

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -400,7 +400,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking(
 
     ASSERT(m_trackedStyleOriginatedAnimationData.isEmpty());
 
-    m_frontendDispatcher->trackingStart(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingStart(protect(environment())->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -415,7 +415,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::stopTracking()
 
     m_trackedStyleOriginatedAnimationData.clear();
 
-    m_frontendDispatcher->trackingComplete(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingComplete(protect(environment())->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -490,7 +490,7 @@ void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, K
             ASSERT_NOT_REACHED();
     }
 
-    m_frontendDispatcher->trackingUpdate(checkedEnvironment()->executionStopwatch().elapsedTime().seconds(), WTF::move(event));
+    m_frontendDispatcher->trackingUpdate(protect(environment())->executionStopwatch().elapsedTime().seconds(), WTF::move(event));
 }
 
 void InspectorAnimationAgent::didChangeWebAnimationName(WebAnimation& animation)
@@ -690,7 +690,7 @@ void InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation(StyleOriginat
             .setTrackingAnimationId(data->trackingAnimationId)
             .setAnimationState(Inspector::Protocol::Animation::AnimationState::Canceled)
             .release();
-        m_frontendDispatcher->trackingUpdate(checkedEnvironment()->executionStopwatch().elapsedTime().seconds(), WTF::move(event));
+        m_frontendDispatcher->trackingUpdate(protect(environment())->executionStopwatch().elapsedTime().seconds(), WTF::move(event));
     }
 }
 

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -72,7 +72,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTrackin
 
     m_tracking = true;
 
-    m_frontendDispatcher->trackingStart(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingStart(protect(environment())->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -86,7 +86,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::stopTracking
 
     m_tracking = false;
 
-    m_frontendDispatcher->trackingComplete(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingComplete(protect(environment())->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -114,7 +114,7 @@ static Ref<Inspector::Protocol::CPUProfiler::ThreadInfo> buildThreadInfo(const T
 void InspectorCPUProfilerAgent::collectSample(const ResourceUsageData& data)
 {
     auto event = Inspector::Protocol::CPUProfiler::Event::create()
-        .setTimestamp(checkedEnvironment()->executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
+        .setTimestamp(protect(environment())->executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
         .setUsage(data.cpuExcludingDebuggerThreads)
         .release();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -285,7 +285,7 @@ public:
             data->setBoolean("enabled"_s, !!node->document().fullscreen().fullscreenElement());
 #endif // ENABLE(FULLSCREEN_API)
 
-        auto timestamp = domAgent->checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+        auto timestamp = protect(domAgent->environment())->executionStopwatch().elapsedTime().seconds();
         domAgent->m_frontendDispatcher->didFireEvent(nodeId, event.type(), timestamp, data->size() ? WTF::move(data) : nullptr);
     }
 
@@ -3070,7 +3070,7 @@ void InspectorDOMAgent::mediaMetricsTimerFired()
             iterator->value.isPowerEfficient = isPowerEfficient;
 
             if (auto nodeId = pushNodePathToFrontend(mediaElement.ptr())) {
-                auto timestamp = checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+                auto timestamp = protect(environment())->executionStopwatch().elapsedTime().seconds();
                 m_frontendDispatcher->powerEfficientPlaybackStateChanged(nodeId, timestamp, iterator->value.isPowerEfficient);
             }
         }

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -99,7 +99,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::startTracking()
 
     m_tracking = true;
 
-    m_frontendDispatcher->trackingStart(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingStart(protect(environment())->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -113,7 +113,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
 
     m_tracking = false;
 
-    m_frontendDispatcher->trackingComplete(checkedEnvironment()->executionStopwatch().elapsedTime().seconds());
+    m_frontendDispatcher->trackingComplete(protect(environment())->executionStopwatch().elapsedTime().seconds());
 
     return { };
 }
@@ -121,7 +121,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
 void InspectorMemoryAgent::didHandleMemoryPressure(Critical critical)
 {
     MemoryFrontendDispatcher::Severity severity = critical == Critical::Yes ? MemoryFrontendDispatcher::Severity::Critical : MemoryFrontendDispatcher::Severity::NonCritical;
-    m_frontendDispatcher->memoryPressure(checkedEnvironment()->executionStopwatch().elapsedTime().seconds(), Inspector::Protocol::Helpers::getEnumConstantValue(severity));
+    m_frontendDispatcher->memoryPressure(protect(environment())->executionStopwatch().elapsedTime().seconds(), Inspector::Protocol::Helpers::getEnumConstantValue(severity));
 }
 
 void InspectorMemoryAgent::collectSample(const ResourceUsageData& data)
@@ -165,7 +165,7 @@ void InspectorMemoryAgent::collectSample(const ResourceUsageData& data)
     categories->addItem(WTF::move(otherCategory));
 
     auto event = Inspector::Protocol::Memory::Event::create()
-        .setTimestamp(checkedEnvironment()->executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
+        .setTimestamp(protect(environment())->executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
         .setCategories(WTF::move(categories))
         .release();
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -154,7 +154,7 @@ static Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const HT
 Ref<Inspector::Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTiming(const NetworkLoadMetrics& timing, ResourceLoader& resourceLoader)
 {
     auto elapsedTimeSince = [&] (const MonotonicTime& time) {
-        return checkedEnvironment()->executionStopwatch().elapsedTimeSince(time).seconds();
+        return protect(environment())->executionStopwatch().elapsedTimeSince(time).seconds();
     };
     auto millisecondsSinceFetchStart = [&] (const MonotonicTime& time) {
         if (!time)
@@ -390,7 +390,7 @@ Ref<Inspector::Protocol::Network::CachedResource> InspectorNetworkAgent::buildOb
 
 double InspectorNetworkAgent::timestamp()
 {
-    return checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+    return protect(environment())->executionStopwatch().elapsedTime().seconds();
 }
 
 void InspectorNetworkAgent::willSendRequest(ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, Inspector::ResourceType type, ResourceLoader* resourceLoader)
@@ -580,7 +580,7 @@ void InspectorNetworkAgent::didFinishLoading(ResourceLoaderIdentifier identifier
 
     double elapsedFinishTime;
     if (networkLoadMetrics.responseEnd)
-        elapsedFinishTime = checkedEnvironment()->executionStopwatch().elapsedTimeSince(networkLoadMetrics.responseEnd).seconds();
+        elapsedFinishTime = protect(environment())->executionStopwatch().elapsedTimeSince(networkLoadMetrics.responseEnd).seconds();
     else
         elapsedFinishTime = timestamp();
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -133,7 +133,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 
     agents->setEnabledPageAgent(this);
 
-    auto& stopwatch = checkedEnvironment()->executionStopwatch();
+    auto& stopwatch = protect(environment())->executionStopwatch();
     stopwatch.reset();
     stopwatch.start();
 
@@ -178,7 +178,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
 
 double InspectorPageAgent::timestamp()
 {
-    return checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+    return protect(environment())->executionStopwatch().elapsedTime().seconds();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& ignoreCache, std::optional<bool>&& revalidateAllResources)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -178,7 +178,7 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
 
     Ref { m_instrumentingAgents.get() }->setTrackingTimelineAgent(this);
 
-    checkedEnvironment()->debugger()->addObserver(*this);
+    protect(environment())->debugger()->addObserver(*this);
 
     m_frontendDispatcher->recordingStarted(timestamp());
 }
@@ -187,7 +187,7 @@ void InspectorTimelineAgent::internalStop()
 {
     Ref { m_instrumentingAgents.get() }->setTrackingTimelineAgent(nullptr);
 
-    checkedEnvironment()->debugger()->removeObserver(*this, true);
+    protect(environment())->debugger()->removeObserver(*this, true);
 
     // Complete all pending records to prevent discarding events that are currently in progress.
     while (!m_recordStack.isEmpty())
@@ -205,12 +205,12 @@ void InspectorTimelineAgent::autoCaptureStarted() const
 
 double InspectorTimelineAgent::timestamp()
 {
-    return checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+    return protect(environment())->executionStopwatch().elapsedTime().seconds();
 }
 
 std::optional<double> InspectorTimelineAgent::timestampFromMonotonicTime(MonotonicTime time)
 {
-    auto stopwatchTime = checkedEnvironment()->executionStopwatch().fromMonotonicTime(time);
+    auto stopwatchTime = protect(environment())->executionStopwatch().fromMonotonicTime(time);
     if (!stopwatchTime)
         return std::nullopt;
     return stopwatchTime->seconds();

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -116,7 +116,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
         CheckedPtr checkedThis = weakThis.get();
         if (!checkedThis)
             return;
-        if (!checkedThis->tracking() || checkedThis->checkedEnvironment()->debugger()->isPaused())
+        if (!checkedThis->tracking() || protect(checkedThis->environment())->debugger()->isPaused())
             return;
         if (!checkedThis->m_runLoopNestingLevel) {
             checkedThis->pushCurrentRecord(JSON::Object::create(), TimelineRecordType::RenderingFrame, false);
@@ -136,7 +136,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
         CheckedPtr checkedThis = weakThis.get();
         if (!checkedThis)
             return;
-        if (!checkedThis->tracking() || checkedThis->checkedEnvironment()->debugger()->isPaused())
+        if (!checkedThis->tracking() || protect(checkedThis->environment())->debugger()->isPaused())
             return;
 
         switch (event) {
@@ -299,7 +299,7 @@ void PageTimelineAgent::mainFrameNavigated()
 void PageTimelineAgent::didCompleteRenderingFrame()
 {
 #if PLATFORM(COCOA)
-    if (!tracking() || checkedEnvironment()->debugger()->isPaused())
+    if (!tracking() || protect(environment())->debugger()->isPaused())
         return;
 
     ASSERT(m_runLoopNestingLevel > 0);

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -281,7 +281,7 @@ FloatRect LargestContentfulPaintData::computeViewportIntersectionRect(Element& e
     auto localTargetBounds = LayoutRect { localRect };
     auto absoluteRects = targetRenderer->computeVisibleRectsInContainer(
         { localTargetBounds },
-        &targetRenderer->checkedView().get(),
+        &protect(targetRenderer->view()).get(),
         {
             .hasPositionFixedDescendant = false,
             .dirtyRectIsFlipped = false,

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3638,7 +3638,7 @@ void Page::setUnderPageBackgroundColorOverride(Color&& underPageBackgroundColorO
     if (RefPtr frameView = localMainFrame ? localMainFrame->view() : nullptr) {
         if (CheckedPtr renderView = frameView->renderView()) {
             if (renderView->usesCompositing())
-                renderView->checkedCompositor()->updateLayerForOverhangAreasBackgroundColor();
+                protect(renderView->compositor())->updateLayerForOverhangAreasBackgroundColor();
         }
     }
 #endif // HAVE(RUBBER_BANDING)
@@ -3702,7 +3702,7 @@ void Page::addRelevantRepaintedObject(const RenderObject& object, const LayoutRe
     if (&object.frame() != &mainFrame())
         return;
 
-    LayoutRect relevantRect = relevantViewRect(object.checkedView().ptr());
+    LayoutRect relevantRect = relevantViewRect(protect(object.view()).ptr());
 
     // The objects are only relevant if they are being painted within the viewRect().
     if (!objectPaintRect.intersects(snappedIntRect(relevantRect)))
@@ -3760,7 +3760,7 @@ void Page::addRelevantUnpaintedObject(const RenderObject& object, const LayoutRe
         return;
 
     // The objects are only relevant if they are being painted within the relevantViewRect().
-    if (!objectPaintRect.intersects(snappedIntRect(relevantViewRect(object.checkedView().ptr()))))
+    if (!objectPaintRect.intersects(snappedIntRect(relevantViewRect(protect(object.view()).ptr()))))
         return;
 
     m_relevantUnpaintedRenderObjects.add(object);
@@ -5420,7 +5420,7 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
     if (RefPtr layer = frameView->setWantsLayerForTopOverhangColorExtension(topOverhangColor.isVisible())) {
         layer->setBackgroundColor(WTF::move(topOverhangColor));
         if (CheckedPtr renderView = frameView->renderView())
-            renderView->checkedCompositor()->updateSizeAndPositionForTopOverhangColorExtensionLayer();
+            protect(renderView->compositor())->updateSizeAndPositionForTopOverhangColorExtensionLayer();
     }
 #endif
 }

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -460,7 +460,7 @@ bool PageOverlayController::shouldDumpPropertyForLayer(const GraphicsLayer* laye
 void PageOverlayController::tiledBackingUsageChanged(const GraphicsLayer* graphicsLayer, bool usingTiledBacking)
 {
     if (usingTiledBacking)
-        graphicsLayer->checkedTiledBacking()->setIsInWindow(m_page->isInWindow());
+        protect(graphicsLayer->tiledBacking())->setIsInWindow(m_page->isInWindow());
 }
 
 } // namespace WebKit

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -81,7 +81,7 @@ RefPtr<TextIndicator> TextIndicator::createWithRange(const SimpleRange& range, O
             Ref indicatorNode = commonAncestor.releaseNonNull();
 
             for (Ref ancestorElement : ancestorsOfType<Element>(indicatorNode)) {
-                if (CheckedPtr renderer = ancestorElement->renderer(); renderer && renderer->checkedStyle()->usedUserSelect() == UserSelect::All)
+                if (CheckedPtr renderer = ancestorElement->renderer(); renderer && protect(renderer->style())->usedUserSelect() == UserSelect::All)
                     indicatorNode = ancestorElement;
             }
 
@@ -258,7 +258,7 @@ static HashSet<Color> estimatedTextColorsForRange(const SimpleRange& range)
         if (!node)
             continue;
         if (CheckedPtr renderText = dynamicDowncast<RenderText>(node->renderer()))
-            colors.add(renderText->checkedStyle()->color());
+            colors.add(protect(renderText->style())->color());
     }
     return colors;
 }

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -245,18 +245,13 @@ void KeyboardScrollingAnimator::handleKeyUpEvent()
 
     m_scrollTriggeringKeyIsPressed = false;
 
-    checkedScrollableArea()->endKeyboardScroll(false);
+    protect(m_scrollableArea)->endKeyboardScroll(false);
 }
 
 void KeyboardScrollingAnimator::stopScrollingImmediately()
 {
     m_scrollTriggeringKeyIsPressed = false;
-    checkedScrollableArea()->endKeyboardScroll(true);
-}
-
-CheckedRef<ScrollableArea> KeyboardScrollingAnimator::checkedScrollableArea() const
-{
-    return m_scrollableArea.get();
+    protect(m_scrollableArea)->endKeyboardScroll(true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -67,7 +67,6 @@ private:
     std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection, ScrollGranularity) const;
     float scrollDistance(ScrollDirection, ScrollGranularity) const;
     RectEdges<bool> scrollingDirections() const;
-    CheckedRef<ScrollableArea> checkedScrollableArea() const;
 
     WeakRef<ScrollableArea> m_scrollableArea;
     bool m_scrollTriggeringKeyIsPressed { false };

--- a/Source/WebCore/platform/PopupMenuStyle.h
+++ b/Source/WebCore/platform/PopupMenuStyle.h
@@ -60,7 +60,6 @@ public:
     const Color& foregroundColor() const { return m_foregroundColor; }
     const Color& backgroundColor() const { return m_backgroundColor; }
     const FontCascade& font() const { return m_font; }
-    CheckedRef<const FontCascade> checkedFont() const { return font(); }
     const String& language() const { return m_language; }
     bool isVisible() const { return m_visible; }
     bool isDisplayNone() const { return m_isDisplayNone; }

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -176,7 +176,7 @@ bool ScrollAnimator::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
     if (processWheelEventForScrollSnap(wheelEvent))
         return false;
 
-    if (checkedScrollableArea()->hasSteppedScrolling())
+    if (protect(scrollableArea())->hasSteppedScrolling())
         return handleSteppedScrolling(wheelEvent);
 
     return m_scrollController.handleWheelEvent(wheelEvent);
@@ -261,7 +261,7 @@ void ScrollAnimator::setCurrentPosition(const FloatPoint& position, NotifyScroll
     if (notify == NotifyScrollableArea::Yes)
         notifyPositionChanged(delta);
     else
-        notifyScrollAnchoringControllerOfScroll(checkedScrollableArea());
+        notifyScrollAnchoringControllerOfScroll(protect(scrollableArea()));
 
     updateActiveScrollSnapIndexForOffset();
 }
@@ -291,17 +291,17 @@ const LayoutScrollSnapOffsetsInfo* ScrollAnimator::snapOffsetsInfo() const
 
 FloatPoint ScrollAnimator::scrollOffset() const
 {
-    return checkedScrollableArea()->scrollOffsetFromPosition(roundedIntPoint(currentPosition()));
+    return protect(scrollableArea())->scrollOffsetFromPosition(roundedIntPoint(currentPosition()));
 }
 
 bool ScrollAnimator::allowsHorizontalScrolling() const
 {
-    return checkedScrollableArea()->allowsHorizontalScrolling();
+    return protect(scrollableArea())->allowsHorizontalScrolling();
 }
 
 bool ScrollAnimator::allowsVerticalScrolling() const
 {
-    return checkedScrollableArea()->allowsVerticalScrolling();
+    return protect(scrollableArea())->allowsVerticalScrolling();
 }
 
 void ScrollAnimator::willStartAnimatedScroll()
@@ -320,17 +320,17 @@ void ScrollAnimator::didStopAnimatedScroll()
 #if HAVE(RUBBER_BANDING)
 IntSize ScrollAnimator::stretchAmount() const
 {
-    return checkedScrollableArea()->overhangAmount();
+    return protect(scrollableArea())->overhangAmount();
 }
 
 RectEdges<bool> ScrollAnimator::edgePinnedState() const
 {
-    return checkedScrollableArea()->edgePinnedState();
+    return protect(scrollableArea())->edgePinnedState();
 }
 
 bool ScrollAnimator::isPinnedOnSide(BoxSide side) const
 {
-    return checkedScrollableArea()->isPinnedOnSide(side);
+    return protect(scrollableArea())->isPinnedOnSide(side);
 }
 
 #endif
@@ -381,7 +381,7 @@ ScrollExtents ScrollAnimator::scrollExtents() const
 
 float ScrollAnimator::pageScaleFactor() const
 {
-    return checkedScrollableArea()->pageScaleFactor();
+    return protect(scrollableArea())->pageScaleFactor();
 }
 
 std::unique_ptr<ScrollingEffectsControllerTimer> ScrollAnimator::createTimer(Function<void()>&& function)
@@ -397,7 +397,7 @@ void ScrollAnimator::startAnimationCallback(ScrollingEffectsController&)
 {
     if (!m_scrollAnimationScheduled) {
         m_scrollAnimationScheduled = true;
-        checkedScrollableArea()->didStartScrollAnimation();
+        protect(scrollableArea())->didStartScrollAnimation();
     }
 }
 
@@ -421,14 +421,14 @@ void ScrollAnimator::removeWheelEventTestCompletionDeferralForReason(ScrollingNo
 #if USE(COORDINATED_GRAPHICS)
 bool ScrollAnimator::scrollAnimationEnabled() const
 {
-    return checkedScrollableArea()->scrollAnimatorEnabled();
+    return protect(scrollableArea())->scrollAnimatorEnabled();
 }
 #endif
 
 void ScrollAnimator::cancelAnimations()
 {
     m_scrollController.stopAnimatedScroll();
-    checkedScrollableArea()->scrollbarsController().cancelAnimations();
+    protect(scrollableArea())->scrollbarsController().cancelAnimations();
 }
 
 void ScrollAnimator::contentsSizeChanged()
@@ -474,7 +474,7 @@ ScrollAnimationStatus ScrollAnimator::serviceScrollAnimation(MonotonicTime time)
 
 ScrollingNodeID ScrollAnimator::scrollingNodeIDForTesting() const
 {
-    return checkedScrollableArea()->scrollingNodeIDForTesting();
+    return protect(scrollableArea())->scrollingNodeIDForTesting();
 }
 
 

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -63,7 +63,6 @@ public:
     virtual ~ScrollAnimator();
 
     ScrollableArea& scrollableArea() const { return m_scrollableArea; }
-    CheckedRef<ScrollableArea> checkedScrollableArea() const { return scrollableArea(); }
 
     KeyboardScrollingAnimator *keyboardScrollingAnimator() const final { return m_keyboardScrollingAnimator.ptr(); }
 

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -122,7 +122,7 @@ int Scrollbar::occupiedHeight() const
 
 void Scrollbar::offsetDidChange()
 {
-    float position = static_cast<float>(offsetForOrientation(checkedScrollableArea()->scrollOffset(), m_orientation));
+    float position = static_cast<float>(offsetForOrientation(protect(scrollableArea())->scrollOffset(), m_orientation));
     if (position == m_currentPos)
         return;
 
@@ -173,7 +173,7 @@ void Scrollbar::updateThumbProportion()
 void Scrollbar::setFrameRect(const IntRect& rect)
 {
     Widget::setFrameRect(rect);
-    checkedScrollableArea()->scrollbarFrameRectChanged(*this);
+    protect(scrollableArea())->scrollbarFrameRectChanged(*this);
 }
 
 void Scrollbar::paint(GraphicsContext& context, const IntRect& damageRect, Widget::SecurityOriginPaintPolicy, RegionContext*)
@@ -216,7 +216,7 @@ void Scrollbar::autoscrollPressedPart(Seconds delay)
     }
 
     // Handle the arrows and track.
-    if (checkedScrollableArea()->scroll(pressedPartScrollDirection(), pressedPartScrollGranularity()))
+    if (protect(scrollableArea())->scroll(pressedPartScrollDirection(), pressedPartScrollGranularity()))
         startTimerIfNeeded(delay);
 }
 
@@ -310,7 +310,7 @@ void Scrollbar::moveThumb(int pos, bool draggingDocument)
     
     if (delta) {
         float newOffset = static_cast<float>(thumbPos + delta) * maximum() / (trackLen - thumbLen);
-        checkedScrollableArea()->scrollToOffsetWithoutAnimation(m_orientation, newOffset);
+        protect(scrollableArea())->scrollToOffsetWithoutAnimation(m_orientation, newOffset);
     }
 }
 
@@ -327,7 +327,7 @@ void Scrollbar::setHoveredPart(ScrollbarPart part)
     }
     m_hoveredPart = part;
 #if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    checkedScrollableArea()->scrollbarsController().hoveredPartChanged(*this);
+    protect(scrollableArea())->scrollbarsController().hoveredPartChanged(*this);
 #endif
 }
 
@@ -341,7 +341,7 @@ void Scrollbar::setPressedPart(ScrollbarPart part)
     else if (m_hoveredPart != NoPart)  // When we no longer have a pressed part, we can start drawing a hovered state on the hovered part.
         theme().invalidatePart(*this, m_hoveredPart);
 #if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    checkedScrollableArea()->scrollbarsController().pressedPartChanged(*this);
+    protect(scrollableArea())->scrollbarsController().pressedPartChanged(*this);
 #endif
 }
 
@@ -350,7 +350,7 @@ bool Scrollbar::mouseMoved(const PlatformMouseEvent& evt)
 {
     if (m_pressedPart == ThumbPart) {
         if (theme().shouldSnapBackToDragOrigin(*this, evt))
-            checkedScrollableArea()->scrollToOffsetWithoutAnimation(m_orientation, m_dragOrigin);
+            protect(scrollableArea())->scrollToOffsetWithoutAnimation(m_orientation, m_dragOrigin);
         else
             moveThumb(m_orientation == ScrollbarOrientation::Horizontal ? convertFromContainingWindow(evt.position()).x() : convertFromContainingWindow(evt.position()).y(), theme().shouldDragDocumentInsteadOfThumb(*this, evt));
 
@@ -385,12 +385,12 @@ bool Scrollbar::mouseMoved(const PlatformMouseEvent& evt)
 
 void Scrollbar::mouseEntered()
 {
-    checkedScrollableArea()->mouseEnteredScrollbar(this);
+    protect(scrollableArea())->mouseEnteredScrollbar(this);
 }
 
 bool Scrollbar::mouseExited()
 {
-    checkedScrollableArea()->mouseExitedScrollbar(this);
+    protect(scrollableArea())->mouseExitedScrollbar(this);
     setHoveredPart(NoPart);
     return true;
 }
@@ -425,7 +425,7 @@ bool Scrollbar::mouseDown(const PlatformMouseEvent& evt)
     if (action == ScrollbarButtonPressAction::None)
         return true;
 
-    checkedScrollableArea()->mouseIsDownInScrollbar(this, true);
+    protect(scrollableArea())->mouseIsDownInScrollbar(this, true);
     setPressedPart(pressedPart);
 
     int pressedPosition = (orientation() == ScrollbarOrientation::Horizontal ? convertFromContainingWindow(evt.position()).x() : convertFromContainingWindow(evt.position()).y());
@@ -457,7 +457,7 @@ void Scrollbar::setEnabled(bool e)
         return;
     m_enabled = e;
     theme().updateEnabledState(*this);
-    checkedScrollableArea()->scrollbarsController().updateScrollbarEnabledState(*this);
+    protect(scrollableArea())->scrollbarsController().updateScrollbarEnabledState(*this);
     invalidate();
 }
 
@@ -476,12 +476,12 @@ bool Scrollbar::shouldParticipateInHitTesting()
     // Non-overlay scrollbars should always participate in hit testing.
     if (!isOverlayScrollbar())
         return true;
-    return checkedScrollableArea()->scrollbarsController().shouldScrollbarParticipateInHitTesting(this);
+    return protect(scrollableArea())->scrollbarsController().shouldScrollbarParticipateInHitTesting(this);
 }
 
 bool Scrollbar::isWindowActive() const
 {
-    return checkedScrollableArea()->isActive();
+    return protect(scrollableArea())->isActive();
 }
 
 void Scrollbar::invalidateRect(const IntRect& rect)
@@ -489,27 +489,27 @@ void Scrollbar::invalidateRect(const IntRect& rect)
     if (suppressInvalidation())
         return;
 
-    checkedScrollableArea()->invalidateScrollbar(*this, rect);
+    protect(scrollableArea())->invalidateScrollbar(*this, rect);
 }
 
 IntRect Scrollbar::convertToContainingView(const IntRect& localRect) const
 {
-    return checkedScrollableArea()->convertFromScrollbarToContainingView(*this, localRect);
+    return protect(scrollableArea())->convertFromScrollbarToContainingView(*this, localRect);
 }
 
 IntRect Scrollbar::convertFromContainingView(const IntRect& parentRect) const
 {
-    return checkedScrollableArea()->convertFromContainingViewToScrollbar(*this, parentRect);
+    return protect(scrollableArea())->convertFromContainingViewToScrollbar(*this, parentRect);
 }
 
 IntPoint Scrollbar::convertToContainingView(IntPoint localPoint) const
 {
-    return checkedScrollableArea()->convertFromScrollbarToContainingView(*this, localPoint);
+    return protect(scrollableArea())->convertFromScrollbarToContainingView(*this, localPoint);
 }
 
 IntPoint Scrollbar::convertFromContainingView(IntPoint parentPoint) const
 {
-    return checkedScrollableArea()->convertFromContainingViewToScrollbar(*this, parentPoint);
+    return protect(scrollableArea())->convertFromContainingViewToScrollbar(*this, parentPoint);
 }
 
 bool Scrollbar::supportsUpdateOnSecondaryThread() const
@@ -542,22 +542,22 @@ bool Scrollbar::isHiddenByStyle() const
 
 float Scrollbar::deviceScaleFactor() const
 {
-    return checkedScrollableArea()->deviceScaleFactor();
+    return protect(scrollableArea())->deviceScaleFactor();
 }
 
 bool Scrollbar::shouldRegisterScrollbar() const
 {
-    return checkedScrollableArea()->scrollbarsController().shouldRegisterScrollbars();
+    return protect(scrollableArea())->scrollbarsController().shouldRegisterScrollbars();
 }
 
 int Scrollbar::minimumThumbLength() const
 {
-    return checkedScrollableArea()->scrollbarsController().minimumThumbLength(m_orientation);
+    return protect(scrollableArea())->scrollbarsController().minimumThumbLength(m_orientation);
 }
 
 void Scrollbar::updateScrollbarThickness()
 {
-    m_widthStyle = checkedScrollableArea()->scrollbarWidthStyle();
+    m_widthStyle = protect(scrollableArea())->scrollbarWidthStyle();
     if (!isCustomScrollbar() || isMockScrollbar()) {
         int thickness = ScrollbarTheme::theme().scrollbarThickness(widthStyle());
         setFrameRect(IntRect(0, 0, thickness, thickness));

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -60,7 +60,6 @@ public:
     static float pageStepDelta(int widthOrHeight) { return std::max(std::max(static_cast<float>(widthOrHeight) * Scrollbar::minFractionToStepWhenPaging(), static_cast<float>(widthOrHeight) - Scrollbar::maxOverlapBetweenPages()), 1.0f); }
 
     inline ScrollableArea& scrollableArea() const; // Defined in ScrollbarInlines.h.
-    inline CheckedRef<ScrollableArea> checkedScrollableArea() const; // Defined in ScrollbarInlines.h.
 
     bool isCustomScrollbar() const { return m_isCustomScrollbar; }
     WEBCORE_EXPORT bool isMockScrollbar() const;

--- a/Source/WebCore/platform/ScrollbarInlines.h
+++ b/Source/WebCore/platform/ScrollbarInlines.h
@@ -35,9 +35,4 @@ ScrollableArea& Scrollbar::scrollableArea() const
     return m_scrollableArea.get();
 }
 
-CheckedRef<ScrollableArea> Scrollbar::checkedScrollableArea() const
-{
-    return scrollableArea();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollbarsController.cpp
+++ b/Source/WebCore/platform/ScrollbarsController.cpp
@@ -51,7 +51,7 @@ ScrollbarsController::~ScrollbarsController() = default;
 
 bool ScrollbarsController::shouldSuspendScrollbarAnimations() const
 {
-    return checkedScrollableArea()->shouldSuspendScrollAnimations();
+    return protect(scrollableArea())->shouldSuspendScrollAnimations();
 }
 
 void ScrollbarsController::cancelAnimations()

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -51,7 +51,6 @@ public:
     WEBCORE_EXPORT virtual ~ScrollbarsController();
     
     inline ScrollableArea& scrollableArea() const; // Defined in ScrollbarsControllerInlines.h
-    inline CheckedRef<ScrollableArea> checkedScrollableArea() const; // Defined in ScrollbarsControllerInlines.h
 
     bool scrollbarAnimationsUnsuspendedByUserInteraction() const { return m_scrollbarAnimationsUnsuspendedByUserInteraction; }
     void setScrollbarAnimationsUnsuspendedByUserInteraction(bool unsuspended) { m_scrollbarAnimationsUnsuspendedByUserInteraction = unsuspended; }

--- a/Source/WebCore/platform/ScrollbarsControllerInlines.h
+++ b/Source/WebCore/platform/ScrollbarsControllerInlines.h
@@ -35,9 +35,4 @@ ScrollableArea& ScrollbarsController::scrollableArea() const
     return m_scrollableArea.get();
 }
 
-CheckedRef<ScrollableArea> ScrollbarsController::checkedScrollableArea() const
-{
-    return scrollableArea();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/ThreadTimers.cpp
+++ b/Source/WebCore/platform/ThreadTimers.cpp
@@ -44,11 +44,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadTimers);
 
-inline CheckedPtr<SharedTimer> ThreadTimers::checkedSharedTimer()
-{
-    return m_sharedTimer.get();
-}
-
 // Timers are created, started and fired on the same thread, and each thread has its own ThreadTimers
 // copy to keep the heap and a set of currently firing timers.
 
@@ -89,7 +84,7 @@ void ThreadTimers::updateSharedTimer()
 
     if (m_firingTimers || m_timerHeap.isEmpty()) {
         m_pendingSharedTimerFireTime = MonotonicTime { };
-        checkedSharedTimer()->stop();
+        protect(m_sharedTimer)->stop();
     } else {
         MonotonicTime nextFireTime = m_timerHeap.first()->time;
         MonotonicTime currentMonotonicTime = MonotonicTime::now();
@@ -97,9 +92,9 @@ void ThreadTimers::updateSharedTimer()
             // No need to restart the timer if both the pending fire time and the new fire time are in the past.
             if (m_pendingSharedTimerFireTime <= currentMonotonicTime && nextFireTime <= currentMonotonicTime)
                 return;
-        } 
+        }
         m_pendingSharedTimerFireTime = nextFireTime;
-        checkedSharedTimer()->setFireInterval(std::max(nextFireTime - currentMonotonicTime, 0_s));
+        protect(m_sharedTimer)->setFireInterval(std::max(nextFireTime - currentMonotonicTime, 0_s));
     }
 }
 

--- a/Source/WebCore/platform/ThreadTimers.h
+++ b/Source/WebCore/platform/ThreadTimers.h
@@ -66,8 +66,6 @@ public:
     unsigned nextHeapInsertionCount() { return m_currentHeapInsertionOrder++; }
 
 private:
-    inline CheckedPtr<SharedTimer> checkedSharedTimer();
-
     void sharedTimerFiredInternal();
     void fireTimersInNestedEventLoopInternal();
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -140,8 +140,8 @@ public:
     virtual void setActive(bool) = 0;
 
     using MediaType = PlatformMediaSessionMediaType;
-    virtual MediaType mediaType() const { return checkedClient()->mediaType(); }
-    virtual MediaType presentationType() const { return checkedClient()->presentationType(); }
+    virtual MediaType mediaType() const { return protect(client())->mediaType(); }
+    virtual MediaType presentationType() const { return protect(client())->presentationType(); }
 
     using State = PlatformMediaSessionState;
     virtual State state() const = 0;
@@ -171,20 +171,20 @@ public:
 
     using RemoteCommandArgument = PlatformMediaSessionRemoteCommandArgument;
     using RemoteControlCommandType = PlatformMediaSessionRemoteControlCommandType;
-    bool canReceiveRemoteControlCommands() const { return checkedClient()->canReceiveRemoteControlCommands(); }
+    bool canReceiveRemoteControlCommands() const { return protect(client())->canReceiveRemoteControlCommands(); }
     virtual void didReceiveRemoteControlCommand(RemoteControlCommandType, const RemoteCommandArgument&) = 0;
 
     using DisplayType = PlatformMediaSessionDisplayType;
-    virtual DisplayType displayType() const { return checkedClient()->displayType(); }
+    virtual DisplayType displayType() const { return protect(client())->displayType(); }
 
-    virtual bool supportsSeeking() const { return checkedClient()->supportsSeeking(); }
-    virtual bool isSuspended() const { return checkedClient()->isSuspended(); }
-    virtual bool isPlaying() const { return checkedClient()->isPlaying(); }
-    virtual bool isAudible() const { return checkedClient()->isAudible(); }
-    virtual bool isEnded() const { return checkedClient()->isEnded(); }
-    virtual MediaTime duration() const { return checkedClient()->mediaSessionDuration(); }
+    virtual bool supportsSeeking() const { return protect(client())->supportsSeeking(); }
+    virtual bool isSuspended() const { return protect(client())->isSuspended(); }
+    virtual bool isPlaying() const { return protect(client())->isPlaying(); }
+    virtual bool isAudible() const { return protect(client())->isAudible(); }
+    virtual bool isEnded() const { return protect(client())->isEnded(); }
+    virtual MediaTime duration() const { return protect(client())->mediaSessionDuration(); }
 
-    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return checkedClient()->shouldOverrideBackgroundLoadingRestriction(); }
+    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return protect(client())->shouldOverrideBackgroundLoadingRestriction(); }
 
     virtual bool isPlayingToWirelessPlaybackTarget() const { return false; }
     virtual void isPlayingToWirelessPlaybackTargetChanged(bool) = 0;
@@ -203,8 +203,8 @@ public:
 
     virtual bool blockedBySystemInterruption() const = 0;
     virtual bool activeAudioSessionRequired() const = 0;
-    virtual bool canProduceAudio() const { return checkedClient()->canProduceAudio(); }
-    virtual bool hasMediaStreamSource() const { return checkedClient()->hasMediaStreamSource(); }
+    virtual bool canProduceAudio() const { return protect(client())->canProduceAudio(); }
+    virtual bool hasMediaStreamSource() const { return protect(client())->hasMediaStreamSource(); }
     virtual void canProduceAudioChanged() = 0;
 
     virtual void resetPlaybackSessionState() { }
@@ -215,10 +215,10 @@ public:
     virtual bool preparingToPlay() const = 0;
 
     virtual bool canPlayConcurrently(const PlatformMediaSessionInterface&) const = 0;
-    virtual bool shouldOverridePauseDuringRouteChange() const { return checkedClient()->shouldOverridePauseDuringRouteChange(); }
+    virtual bool shouldOverridePauseDuringRouteChange() const { return protect(client())->shouldOverridePauseDuringRouteChange(); }
 
-    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return checkedClient()->nowPlayingInfo(); }
-    virtual bool isNowPlayingEligible() const { return checkedClient()->isNowPlayingEligible(); }
+    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return protect(client())->nowPlayingInfo(); }
+    virtual bool isNowPlayingEligible() const { return protect(client())->isNowPlayingEligible(); }
 
     using PlaybackControlsPurpose = PlatformMediaSessionPlaybackControlsPurpose;
     virtual WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlaybackControlsPurpose) = 0;
@@ -239,14 +239,13 @@ public:
     virtual String description() const = 0;
 #endif
 
-    virtual std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const { return checkedClient()->mediaSessionGroupIdentifier(); }
-    virtual bool isPlayingOnSecondScreen() const { return checkedClient()->isPlayingOnSecondScreen(); }
+    virtual std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const { return protect(client())->mediaSessionGroupIdentifier(); }
+    virtual bool isPlayingOnSecondScreen() const { return protect(client())->isPlayingOnSecondScreen(); }
 
     virtual bool isRemoteSessionProxy() const;
 
     void invalidateClient() { m_client = emptyPlatformMediaSessionClient(); }
     PlatformMediaSessionClient& client() const;
-    CheckedRef<PlatformMediaSessionClient> checkedClient() const;
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
@@ -263,7 +262,7 @@ protected:
     {
     }
 
-    RefPtr<MediaSessionManagerInterface> sessionManager() const { return checkedClient()->sessionManager(); }
+    RefPtr<MediaSessionManagerInterface> sessionManager() const { return protect(client())->sessionManager(); }
 
 private:
     CheckedRef<PlatformMediaSessionClient> m_client;
@@ -273,7 +272,6 @@ private:
 
 inline void PlatformMediaSessionInterface::setMediaSessionIdentifier(MediaSessionIdentifier identifier) { m_mediaSessionIdentifier = identifier; }
 inline PlatformMediaSessionClient& PlatformMediaSessionInterface::client() const { return m_client; }
-inline CheckedRef<PlatformMediaSessionClient> PlatformMediaSessionInterface::checkedClient() const { return m_client; }
 inline bool PlatformMediaSessionInterface::isRemoteSessionProxy() const { return false; }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -87,14 +87,14 @@ private:
             m_connectTime = wrapped->connectTime();
         }
 
-        MonotonicTime lastUpdateTime() const final { return checkedPlatformGamepad()->lastUpdateTime(); }
-        const Vector<SharedGamepadValue>& axisValues() const final { return checkedPlatformGamepad()->axisValues(); }
-        const Vector<SharedGamepadValue>& buttonValues() const final { return checkedPlatformGamepad()->buttonValues(); }
+        MonotonicTime lastUpdateTime() const final { return protect(platformGamepad())->lastUpdateTime(); }
+        const Vector<SharedGamepadValue>& axisValues() const final { return protect(platformGamepad())->axisValues(); }
+        const Vector<SharedGamepadValue>& buttonValues() const final { return protect(platformGamepad())->buttonValues(); }
 
-        ASCIILiteral source() const final { return checkedPlatformGamepad()->source(); }
+        ASCIILiteral source() const final { return protect(platformGamepad())->source(); }
 
     private:
-        CheckedRef<PlatformGamepad> checkedPlatformGamepad() const { return *m_platformGamepad; }
+        PlatformGamepad& platformGamepad() const { return *m_platformGamepad; }
 
         WeakPtr<PlatformGamepad> m_platformGamepad;
     };

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -513,7 +513,6 @@ public:
     virtual bool backingStoreAttachedForTesting() const { return backingStoreAttached(); }
 
     virtual TiledBacking* tiledBacking() const { return 0; }
-    CheckedPtr<TiledBacking> checkedTiledBacking() const { return tiledBacking(); }
     WEBCORE_EXPORT virtual void setTileCoverage(TileCoverage);
 
     void resetTrackedRepaints();

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
@@ -65,16 +65,16 @@ void ScrollAnimatorMac::handleWheelEventPhase(PlatformWheelEventPhase phase)
 
     // FIXME: Need to ensure we get PlatformWheelEventPhase::Ended.
     if (phase == PlatformWheelEventPhase::Began)
-        checkedScrollableArea()->scrollbarsController().didBeginScrollGesture();
+        protect(scrollableArea())->scrollbarsController().didBeginScrollGesture();
     else if (phase == PlatformWheelEventPhase::Ended || phase == PlatformWheelEventPhase::Cancelled)
-        checkedScrollableArea()->scrollbarsController().didEndScrollGesture();
+        protect(scrollableArea())->scrollbarsController().didEndScrollGesture();
     else if (phase == PlatformWheelEventPhase::MayBegin)
-        checkedScrollableArea()->scrollbarsController().mayBeginScrollGesture();
+        protect(scrollableArea())->scrollbarsController().mayBeginScrollGesture();
 }
 
 bool ScrollAnimatorMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 {
-    checkedScrollableArea()->scrollbarsController().setScrollbarAnimationsUnsuspendedByUserInteraction(true);
+    protect(scrollableArea())->scrollbarsController().setScrollbarAnimationsUnsuspendedByUserInteraction(true);
     m_scrollController.updateGestureInProgressState(wheelEvent);
 
     // Events in the PlatformWheelEventPhase::MayBegin phase have no deltas, and therefore never passes through the scroll handling logic below.

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -145,7 +145,7 @@ void ScrollbarThemeMac::didCreateScrollerImp(Scrollbar& scrollbar)
 #if PLATFORM(MAC)
     RetainPtr scrollerImp = scrollerImpForScrollbar(scrollbar);
     ASSERT(scrollerImp);
-    scrollerImp.get().userInterfaceLayoutDirection = scrollbar.checkedScrollableArea()->shouldPlaceVerticalScrollbarOnLeft() ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
+    scrollerImp.get().userInterfaceLayoutDirection = protect(scrollbar.scrollableArea())->shouldPlaceVerticalScrollbarOnLeft() ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
 #else
     UNUSED_PARAM(scrollbar);
 #endif
@@ -182,7 +182,7 @@ bool ScrollbarThemeMac::isLayoutDirectionRTL(Scrollbar& scrollbar)
     RetainPtr scrollerImp = scrollerImpForScrollbar(scrollbar);
     if (!scrollerImp) {
         if (!scrollbar.shouldRegisterScrollbar())
-            return scrollbar.checkedScrollableArea()->shouldPlaceVerticalScrollbarOnLeft() ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
+            return protect(scrollbar.scrollableArea())->shouldPlaceVerticalScrollbarOnLeft() ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
         return false;
     }
     return scrollerImp.get().userInterfaceLayoutDirection == NSUserInterfaceLayoutDirectionRightToLeft;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -69,7 +69,6 @@ public:
     PlaybackSessionInterfaceMac& playbackSessionInterface() const { return m_playbackSessionInterface; }
     RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
-    CheckedPtr<PlaybackSessionModel> checkedPlaybackSessionModel() const { return playbackSessionModel(); }
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
 
 #if HAVE(PIP_SKIP_PREROLL)

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -509,7 +509,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
     CheckedPtr videoPresentationInterfaceMac = _videoPresentationInterfaceMac;
     if (videoPresentationInterfaceMac && videoPresentationInterfaceMac->playbackSessionModel())
-        videoPresentationInterfaceMac->checkedPlaybackSessionModel()->play();
+        protect(videoPresentationInterfaceMac->playbackSessionModel())->play();
 }
 
 - (void)pipActionPause:(PIPViewController *)pip
@@ -518,7 +518,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
     CheckedPtr videoPresentationInterfaceMac = _videoPresentationInterfaceMac;
     if (videoPresentationInterfaceMac && videoPresentationInterfaceMac->playbackSessionModel())
-        videoPresentationInterfaceMac->checkedPlaybackSessionModel()->pause();
+        protect(videoPresentationInterfaceMac->playbackSessionModel())->pause();
 }
 
 - (void)pipActionStop:(PIPViewController *)pip

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -66,7 +66,6 @@ public:
     SCStream* stream() const { return m_stream.get(); }
     SCContentFilter* contentFilter() const { return m_contentFilter.get(); }
     ScreenCaptureSessionSourceObserver* observer() const { return m_observer.get(); }
-    CheckedPtr<ScreenCaptureSessionSourceObserver> checkedObserver() const { return m_observer.get(); }
 
     void updateContentFilter(SCContentFilter*);
     void streamDidEnd();

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -172,7 +172,6 @@ public:
     CFURLStorageSessionRef platformSession() { return m_platformSession.get(); }
     WEBCORE_EXPORT RetainPtr<CFHTTPCookieStorageRef> cookieStorage() const;
     CookieStorageObserver& cookieStorageObserver() const;
-    CheckedRef<CookieStorageObserver> checkedCookieStorageObserver() const;
 #elif USE(SOUP)
     WEBCORE_EXPORT explicit NetworkStorageSession(PAL::SessionID, IsInMemoryCookieStore = IsInMemoryCookieStore::No);
     ~NetworkStorageSession();

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -146,7 +146,7 @@ void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, Completi
 
     // FIXME: rdar://168454473 (Remove workaround in CookieStorageObserver once CFNetwork bug is resolved)
     if (m_cookieStorageObserver && cookieStorage().get())
-        checkedCookieStorageObserver()->registerInternalsForNotifications(true);
+        protect(cookieStorageObserver())->registerInternalsForNotifications(true);
 
     completionHandler(hasCookieForDomain);
 }
@@ -199,11 +199,6 @@ CookieStorageObserver& NetworkStorageSession::cookieStorageObserver() const
         m_cookieStorageObserver = makeUnique<CookieStorageObserver>(nsCookieStorage().get());
 
     return *m_cookieStorageObserver;
-}
-
-CheckedRef<CookieStorageObserver> NetworkStorageSession::checkedCookieStorageObserver() const
-{
-    return cookieStorageObserver();
 }
 
 RetainPtr<CFURLStorageSessionRef> createPrivateStorageSession(CFStringRef identifier, std::optional<HTTPCookieAcceptPolicy> cookieAcceptPolicy, NetworkStorageSession::ShouldDisableCFURLCache shouldDisableCFURLCache)

--- a/Source/WebCore/platform/network/mac/CookieStorageMac.mm
+++ b/Source/WebCore/platform/network/mac/CookieStorageMac.mm
@@ -33,12 +33,12 @@ namespace WebCore {
 
 void startObservingCookieChanges(NetworkStorageSession& storageSession, WTF::Function<void()>&& callback)
 {
-    storageSession.checkedCookieStorageObserver()->startObserving(WTF::move(callback));
+    protect(storageSession.cookieStorageObserver())->startObserving(WTF::move(callback));
 }
 
 void stopObservingCookieChanges(NetworkStorageSession& storageSession)
 {
-    storageSession.checkedCookieStorageObserver()->stopObserving();
+    protect(storageSession.cookieStorageObserver())->stopObserving();
 }
 
 }

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -244,7 +244,7 @@ GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& i
     LayoutUnit toleranceValue = tolerance.switchOn(
         [&](const CSS::Keyword::Normal&) -> LayoutUnit {
             // Normal resolves to 1em
-            return LayoutUnit { m_renderGrid->checkedStyle()->computedFontSize() };
+            return LayoutUnit { protect(m_renderGrid->style())->computedFontSize() };
         },
         [&](const typename Style::FlowTolerance::Fixed& fixed) -> LayoutUnit {
             return LayoutUnit { fixed.resolveZoom(m_renderGrid->style().usedZoomForLength()) };

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -953,7 +953,7 @@ void RenderBlock::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         CheckedPtr layer = this->layer();
         if (hasNonVisibleOverflow() && layer && layer->scrollableArea() && style().usedVisibility() == Visibility::Visible
             && paintInfo.shouldPaintWithinRoot(*this) && !paintInfo.paintRootBackgroundOnly()) {
-            layer->checkedScrollableArea()->paintOverflowControls(paintInfo.context(), paintInfo.paintBehavior, roundedIntPoint(adjustedPaintOffset), snappedIntRect(paintInfo.rect));
+            protect(layer->scrollableArea())->paintOverflowControls(paintInfo.context(), paintInfo.paintBehavior, roundedIntPoint(adjustedPaintOffset), snappedIntRect(paintInfo.rect));
         }
     }
 }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4034,7 +4034,7 @@ static void setFullRepaintOnParentInlineBoxLayerIfNeeded(const RenderText& rende
     }
     if (!parent->isInline() || !parent->hasLayer())
         return;
-    downcast<RenderLayerModelObject>(*parent).checkedLayer()->setRepaintStatus(RepaintStatus::NeedsFullRepaint);
+    protect(downcast<RenderLayerModelObject>(*parent).layer())->setRepaintStatus(RepaintStatus::NeedsFullRepaint);
 }
 
 std::pair<float, float> RenderBlockFlow::inlineContentTopAndBottomIncludingInkOverflow() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -74,8 +74,6 @@ public:
     bool hasInitializedStyle() const { return m_hasInitializedStyle; }
 
     const RenderStyle& style() const { return m_style; }
-    // FIXME: Remove checkedStyle once https://github.com/llvm/llvm-project/pull/142485 lands. This is a false positive.
-    const CheckedRef<const RenderStyle> checkedStyle() const { return m_style; }
     const RenderStyle* parentStyle() const { return !m_parent ? nullptr : &m_parent->style(); }
     const RenderStyle& firstLineStyle() const;
 
@@ -514,11 +512,6 @@ inline RenderObject* RenderElement::lastInFlowChild() const
 }
 
 inline RenderElement* RenderObject::parent() const
-{
-    return m_parent.get();
-}
-
-inline CheckedPtr<RenderElement> RenderObject::checkedParent() const
 {
     return m_parent.get();
 }

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -977,9 +977,4 @@ RenderBox* RenderImage::embeddedContentBox() const
     return nullptr;
 }
 
-CheckedRef<RenderImageResource> RenderImage::checkedImageResource() const
-{
-    return *m_imageResource;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -48,7 +48,6 @@ public:
 
     RenderImageResource& imageResource() { return *m_imageResource; }
     const RenderImageResource& imageResource() const { return *m_imageResource; }
-    CheckedRef<RenderImageResource> NODELETE checkedImageResource() const;
     CachedImage* cachedImage() const { return imageResource().cachedImage(); }
 
     ImageSizeChangeType setImageSizeForAltText(CachedImage* newImage = nullptr);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6575,11 +6575,6 @@ RenderLayerScrollableArea* RenderLayer::scrollableArea() const
     return m_scrollableArea.get();
 }
 
-CheckedPtr<RenderLayerScrollableArea> RenderLayer::checkedScrollableArea() const
-{
-    return scrollableArea();
-}
-
 #if ENABLE(ASYNC_SCROLLING) && !LOG_DISABLED
 static TextStream& operator<<(TextStream& ts, RenderLayer::EventRegionInvalidationReason reason)
 {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -181,7 +181,6 @@ public:
     WEBCORE_EXPORT ~RenderLayer();
 
     WEBCORE_EXPORT RenderLayerScrollableArea* NODELETE scrollableArea() const;
-    WEBCORE_EXPORT CheckedPtr<RenderLayerScrollableArea> NODELETE checkedScrollableArea() const;
     WEBCORE_EXPORT RenderLayerScrollableArea* ensureLayerScrollableArea();
 
     String name() const;
@@ -525,7 +524,7 @@ public:
     bool isForcedStackingContext() const { return m_forcedStackingContext; }
     bool isOpportunisticStackingContext() const { return m_isOpportunisticStackingContext; }
 
-    RenderLayerCompositor& compositor() const { return renderer().checkedView()->compositor(); }
+    RenderLayerCompositor& compositor() const { return protect(renderer().view())->compositor(); }
 
     // Notification from the renderer that its content changed (e.g. current frame of image changed).
     // Allows updates of layer content without repainting.

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -669,11 +669,6 @@ bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) con
     );
 }
 
-CheckedPtr<RenderLayer> RenderLayerModelObject::checkedLayer() const
-{
-    return m_layer.get();
-}
-
 void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -55,7 +55,6 @@ public:
 
     bool NODELETE hasSelfPaintingLayer() const;
     RenderLayer* layer() const { return m_layer.get(); }
-    CheckedPtr<RenderLayer> NODELETE checkedLayer() const;
 
     void styleWillChange(Style::Difference, const RenderStyle& newStyle) override;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -155,7 +155,7 @@ void RenderLineBreak::collectSelectionGeometries(Vector<SelectionGeometry>& rect
     auto absoluteQuad = localToAbsoluteQuad(FloatRect(rect), UseTransforms, &isFixed);
     bool boxIsHorizontal = !is<InlineIterator::SVGTextBoxIterator>(run) ? run->isHorizontal() : !writingMode().isVertical();
 
-    rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(WTF::protect(element())), run->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, run->isLineBreak(), isFirstOnLine, isLastOnLine, false, false, boxIsHorizontal, isFixed, checkedView()->pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
+    rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(WTF::protect(element())), run->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, run->isLineBreak(), isFirstOnLine, isLastOnLine, false, false, boxIsHorizontal, isFixed, protect(view())->pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -354,7 +354,6 @@ public:
     virtual ASCIILiteral renderName() const = 0;
 
     inline RenderElement* parent() const; // Defined in RenderElement.h.
-    inline CheckedPtr<RenderElement> checkedParent() const; // Defined in RenderElement.h.
     bool NODELETE isDescendantOf(const RenderObject*) const;
 
     RenderObject* previousSibling() const { return m_previous.get(); }
@@ -396,7 +395,6 @@ public:
 #endif
 
     WEBCORE_EXPORT RenderLayer* enclosingLayer() const;
-    WEBCORE_EXPORT CheckedPtr<RenderLayer> checkedEnclosingLayer() const;
 
     WEBCORE_EXPORT RenderBox& NODELETE enclosingBox() const;
     RenderBoxModelObject& NODELETE enclosingBoxModelObject() const;
@@ -732,7 +730,6 @@ public:
     bool effectiveCapturedInViewTransition() const;
 
     inline RenderView& view() const; // Defined in RenderObjectDocument.h
-    CheckedRef<RenderView> NODELETE checkedView() const;
     inline LocalFrameViewLayoutContext& layoutContext() const;
 
     HostWindow* hostWindow() const;
@@ -806,7 +803,6 @@ public:
 
     // Returns the containing block level element for this element.
     WEBCORE_EXPORT RenderBlock* containingBlock() const;
-    CheckedPtr<RenderBlock> checkedContainingBlock() const;
     static RenderBlock* containingBlockForPositionType(PositionType, const RenderObject&);
 
     // Convert the given local point to absolute coordinates. If OptionSet<MapCoordinatesMode> includes UseTransforms, take transforms into account.
@@ -864,7 +860,6 @@ public:
     WEBCORE_EXPORT LayoutRect paintingRootRect(LayoutRect& topLevelRect);
 
     inline const RenderStyle& style() const; // Defined in RenderObjectStyle.h.
-    inline CheckedRef<const RenderStyle> checkedStyle() const; // Defined in RenderObjectStyle.h.
     inline const RenderStyle& firstLineStyle() const;
     inline WritingMode writingMode() const; // Defined in RenderObjectStyle.h.
     // writingMode().isHorizontal() is cached by isHorizontalWritingMode() above.

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -66,7 +66,7 @@ inline TreeScope& RenderObject::treeScopeForSVGReferences() const
 inline const RenderStyle& RenderObject::firstLineStyle() const
 {
     if (isRenderText())
-        return checkedParent()->firstLineStyle();
+        return protect(parent())->firstLineStyle();
     return downcast<RenderElement>(*this).firstLineStyle();
 }
 

--- a/Source/WebCore/rendering/RenderObjectStyle.h
+++ b/Source/WebCore/rendering/RenderObjectStyle.h
@@ -39,9 +39,4 @@ inline const RenderStyle& RenderObject::style() const
     return downcast<RenderElement>(*this).style();
 }
 
-inline CheckedRef<const RenderStyle> RenderObject::checkedStyle() const
-{
-    return style();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -152,9 +152,9 @@ std::unique_ptr<RenderStyle> RenderScrollbar::getScrollbarPseudoStyle(ScrollbarP
     scrollbarState.orientation = orientation();
     scrollbarState.buttonsPlacement = theme().buttonsPlacement();
     scrollbarState.enabled = enabled();
-    scrollbarState.scrollCornerIsVisible = checkedScrollableArea()->isScrollCornerVisible();
+    scrollbarState.scrollCornerIsVisible = protect(scrollableArea())->isScrollCornerVisible();
     
-    std::unique_ptr<RenderStyle> result = renderer->getUncachedPseudoStyle({ pseudoElementType, scrollbarState }, renderer->checkedStyle().ptr());
+    std::unique_ptr<RenderStyle> result = renderer->getUncachedPseudoStyle({ pseudoElementType, scrollbarState }, protect(renderer->style()).ptr());
     // Scrollbars for root frames should always have background color 
     // unless explicitly specified as transparent. So we force it.
     // This is because WebKit assumes scrollbar to be always painted and missing background

--- a/Source/WebCore/rendering/RenderSelection.cpp
+++ b/Source/WebCore/rendering/RenderSelection.cpp
@@ -144,7 +144,7 @@ void RenderSelection::set(const RenderRange& selection, RepaintMode blockRepaint
 void RenderSelection::clear()
 {
     if (!m_selectionWasCaret)
-        m_renderView->checkedLayer()->repaintBlockSelectionGaps();
+        protect(m_renderView->layer())->repaintBlockSelectionGaps();
     set({ }, RenderSelection::RepaintMode::NewMinusOld);
 }
 
@@ -255,7 +255,7 @@ void RenderSelection::apply(const RenderRange& newSelection, RepaintMode blockRe
     }
 
     if (blockRepaintMode != RepaintMode::Nothing)
-        m_renderView->checkedLayer()->clearBlockSelectionGapsBounds();
+        protect(m_renderView->layer())->clearBlockSelectionGapsBounds();
 
     // Now that the selection state has been updated for the new objects, walk them again and
     // put them in the new objects list.
@@ -267,7 +267,7 @@ void RenderSelection::apply(const RenderRange& newSelection, RepaintMode blockRe
             auto selectionGeometry = makeUnique<RenderSelectionGeometry>(*currentRenderer, true);
 #if ENABLE(SERVICE_CONTROLS)
             for (auto& quad : selectionGeometry->collectedSelectionQuads())
-                m_selectionGeometryGatherer.addQuad(selectionGeometry->checkedRepaintContainer().get(), quad);
+                m_selectionGeometryGatherer.addQuad(protect(selectionGeometry->repaintContainer()).get(), quad);
             if (!currentRenderer->isRenderTextOrLineBreak())
                 m_selectionGeometryGatherer.setTextOnly(false);
 #endif
@@ -280,7 +280,7 @@ void RenderSelection::apply(const RenderRange& newSelection, RepaintMode blockRe
                 blockSelectionGeometry = makeUnique<RenderBlockSelectionGeometry>(*containingBlock);
                 containingBlock = containingBlock->containingBlock();
 #if ENABLE(SERVICE_CONTROLS)
-                m_selectionGeometryGatherer.addGapRects(blockSelectionGeometry->checkedRepaintContainer().get(), blockSelectionGeometry->rects());
+                m_selectionGeometryGatherer.addGapRects(protect(blockSelectionGeometry->repaintContainer()).get(), blockSelectionGeometry->rects());
 #endif
             }
         }

--- a/Source/WebCore/rendering/RenderSelectionGeometry.h
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.h
@@ -39,7 +39,6 @@ class RenderSelectionGeometryBase {
 public:
     explicit RenderSelectionGeometryBase(RenderObject& renderer);
     const RenderLayerModelObject* repaintContainer() const { return m_repaintContainer; }
-    CheckedPtr<const RenderLayerModelObject> checkedRepaintContainer() const { return m_repaintContainer; }
     RenderObject::HighlightState state() const { return m_state; }
 
 protected:

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -69,7 +69,7 @@ public:
     inline LayoutUnit borderTop() const final;
     inline LayoutUnit borderBottom() const final;
 
-    Color bgColor() const { return checkedStyle()->visitedDependentBackgroundColorApplyingColorFilter(); }
+    Color bgColor() const { return protect(style())->visitedDependentBackgroundColorApplyingColorFilter(); }
 
     LayoutUnit outerBorderBefore() const;
     LayoutUnit outerBorderAfter() const;

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -60,7 +60,6 @@ public:
     RenderTableRow* row() const { return downcast<RenderTableRow>(parent()); }
     RenderTableSection* section() const;
     RenderTable* table() const;
-    CheckedPtr<RenderTable> checkedTable() const;
     unsigned rowIndex() const;
     inline std::pair<Style::PreferredSize, Style::ZoomFactor> styleOrColLogicalWidth() const;
     LayoutUnit logicalHeightForRowSizing() const;
@@ -285,11 +284,6 @@ inline RenderTable* RenderTableCell::table() const
     if (!section)
         return nullptr;
     return downcast<RenderTable>(section->parent());
-}
-
-inline CheckedPtr<RenderTable> RenderTableCell::checkedTable() const
-{
-    return table();
 }
 
 inline unsigned RenderTableCell::rowIndex() const

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -75,7 +75,7 @@ void RenderTableCol::styleDidChange(Style::Difference diff, const RenderStyle* o
     // If border was changed, notify table.
     if (!oldStyle)
         return;
-    table->invalidateCollapsedBordersAfterStyleChangeIfNeeded(*oldStyle, checkedStyle());
+    table->invalidateCollapsedBordersAfterStyleChangeIfNeeded(*oldStyle, protect(style()));
     if (oldStyle->width() != style().width()) {
         table->recalcSectionsIfNeeded();
         for (CheckedRef section : childrenOfType<RenderTableSection>(*table)) {
@@ -113,7 +113,7 @@ void RenderTableCol::updateFromElement()
 void RenderTableCol::insertedIntoTree()
 {
     RenderBox::insertedIntoTree();
-    checkedTable()->addColumn(this);
+    protect(table())->addColumn(this);
 }
 
 void RenderTableCol::willBeRemovedFromTree()
@@ -182,11 +182,6 @@ RenderTable* RenderTableCol::table() const
     return dynamicDowncast<RenderTable>(table);
 }
 
-CheckedPtr<RenderTable> RenderTableCol::checkedTable() const
-{
-    return table();
-}
-
 RenderTableCol* RenderTableCol::enclosingColumnGroup() const
 {
     auto* parentColumnGroup = dynamicDowncast<RenderTableCol>(*parent());
@@ -209,7 +204,7 @@ RenderTableCol* RenderTableCol::nextColumn() const
 
     // Failing that, the child is the last column in a column-group, so the next column is the next column/column-group after its column-group.
     if (!next && is<RenderTableCol>(*parent()))
-        next = checkedParent()->nextSibling();
+        next = protect(parent())->nextSibling();
 
     for (; next; next = next->nextSibling()) {
         if (auto* column = dynamicDowncast<RenderTableCol>(*next))
@@ -221,46 +216,46 @@ RenderTableCol* RenderTableCol::nextColumn() const
 
 const BorderValue& RenderTableCol::borderAdjoiningCellStartBorder() const
 {
-    return checkedStyle()->borderStart(table()->writingMode());
+    return protect(style())->borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellEndBorder() const
 {
-    return checkedStyle()->borderEnd(table()->writingMode());
+    return protect(style())->borderEnd(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellBefore(const RenderTableCell& cell) const
 {
     CheckedPtr table = this->table();
     ASSERT_UNUSED(cell, table->colElement(cell.col() + cell.colSpan()) == this);
-    return checkedStyle()->borderStart(table->writingMode());
+    return protect(style())->borderStart(table->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellAfter(const RenderTableCell& cell) const
 {
     CheckedPtr table = this->table();
     ASSERT_UNUSED(cell, table->colElement(cell.col() - 1) == this);
-    return checkedStyle()->borderEnd(table->writingMode());
+    return protect(style())->borderEnd(table->writingMode());
 }
 
 LayoutUnit RenderTableCol::offsetLeft() const
 {
-    return checkedTable()->offsetLeftForColumn(*this);
+    return protect(table())->offsetLeftForColumn(*this);
 }
 
 LayoutUnit RenderTableCol::offsetTop() const
 {
-    return checkedTable()->offsetTopForColumn(*this);
+    return protect(table())->offsetTopForColumn(*this);
 }
 
 LayoutUnit RenderTableCol::offsetWidth() const
 {
-    return checkedTable()->offsetWidthForColumn(*this);
+    return protect(table())->offsetWidthForColumn(*this);
 }
 
 LayoutUnit RenderTableCol::offsetHeight() const
 {
-    return checkedTable()->offsetHeightForColumn(*this);
+    return protect(table())->offsetHeightForColumn(*this);
 }
 
 }

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -88,7 +88,6 @@ private:
     void paint(PaintInfo&, const LayoutPoint&) override { }
 
     RenderTable* NODELETE table() const;
-    CheckedPtr<RenderTable> NODELETE checkedTable() const;
 
     unsigned m_span { 1 };
 };

--- a/Source/WebCore/rendering/RenderTableRowInlines.h
+++ b/Source/WebCore/rendering/RenderTableRowInlines.h
@@ -24,7 +24,7 @@
 
 namespace WebCore {
 
-inline const BorderValue& RenderTableRow::borderAdjoiningTableStart() const { return checkedStyle()->borderStart(table()->writingMode()); }
-inline const BorderValue& RenderTableRow::borderAdjoiningTableEnd() const { return checkedStyle()->borderEnd(table()->writingMode()); }
+inline const BorderValue& RenderTableRow::borderAdjoiningTableStart() const { return protect(style())->borderStart(table()->writingMode()); }
+inline const BorderValue& RenderTableRow::borderAdjoiningTableEnd() const { return protect(style())->borderEnd(table()->writingMode()); }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTableSectionInlines.h
+++ b/Source/WebCore/rendering/RenderTableSectionInlines.h
@@ -24,8 +24,8 @@
 
 namespace WebCore {
 
-inline const BorderValue& RenderTableSection::borderAdjoiningTableEnd() const { return checkedStyle()->borderEnd(table()->writingMode()); }
-inline const BorderValue& RenderTableSection::borderAdjoiningTableStart() const { return checkedStyle()->borderStart(table()->writingMode()); }
+inline const BorderValue& RenderTableSection::borderAdjoiningTableEnd() const { return protect(style())->borderEnd(table()->writingMode()); }
+inline const BorderValue& RenderTableSection::borderAdjoiningTableStart() const { return protect(style())->borderStart(table()->writingMode()); }
 
 inline LayoutUnit RenderTableSection::outerBorderBottom(const WritingMode writingMode) const
 {

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -63,8 +63,7 @@ public:
     WEBCORE_EXPORT Text* NODELETE textNode() const;
 
     const RenderStyle& style() const;
-    // FIXME: Remove checkedStyle once https://github.com/llvm/llvm-project/pull/142485 lands. This is a false positive.
-    const CheckedRef<const RenderStyle> checkedStyle() const { return style(); }
+
     const RenderStyle& firstLineStyle() const;
     const RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&, const RenderStyle* parentStyle = nullptr) const;
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -880,7 +880,7 @@ bool RenderTheme::paint(const RenderBox& box, ControlPart& part, const PaintInfo
 
     float deviceScaleFactor = protect(box.document())->deviceScaleFactor();
     auto zoomedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
-    auto borderShape = BorderShape::shapeForBorderRect(box.checkedStyle().get(), LayoutRect(zoomedRect));
+    auto borderShape = BorderShape::shapeForBorderRect(protect(box.style()).get(), LayoutRect(zoomedRect));
     auto controlStyle = extractControlStyleForRenderer(box);
     auto& context = paintInfo.context();
 
@@ -1739,7 +1739,7 @@ void RenderTheme::adjustSwitchStyle(RenderStyle& style, const Element*) const
     // FIXME: This probably has the same flaw as
     // RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle() by not taking
     // min-width/min-height into account.
-    auto controlSize = this->controlSize(StyleAppearance::Switch, style.checkedFontCascade().get(), { style.logicalWidth(), style.logicalHeight() }, usedZoomForComputedStyle(style));
+    auto controlSize = this->controlSize(StyleAppearance::Switch, protect(style.fontCascade()).get(), { style.logicalWidth(), style.logicalHeight() }, usedZoomForComputedStyle(style));
     style.setLogicalWidth(Style::PreferredSize { controlSize.width() });
     style.setLogicalHeight(Style::PreferredSize { controlSize.height() });
 

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -229,7 +229,7 @@ bool RenderVideo::shouldDisplayVideo() const
 
 bool RenderVideo::failedToLoadPosterImage() const
 {
-    return checkedImageResource()->errorOccurred();
+    return protect(imageResource())->errorOccurred();
 }
 
 void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -404,7 +404,7 @@ bool RenderVideo::hasPosterFrameSize() const
     // so that contain: inline-size could affect the intrinsic size, which should be 0 x block-size.
     if (shouldApplyInlineSizeContainment())
         isEmpty = isHorizontalWritingMode() ? !m_cachedImageSize.height() : !m_cachedImageSize.width();
-    return protect(videoElement())->shouldDisplayPosterImage() && !isEmpty && !checkedImageResource()->errorOccurred();
+    return protect(videoElement())->shouldDisplayPosterImage() && !isEmpty && !protect(imageResource())->errorOccurred();
 }
 
 bool RenderVideo::hasDefaultObjectSize() const

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -908,11 +908,6 @@ RenderLayerCompositor& RenderView::compositor()
     return *m_compositor;
 }
 
-CheckedRef<RenderLayerCompositor> RenderView::checkedCompositor()
-{
-    return compositor();
-}
-
 void RenderView::setIsInWindow(bool isInWindow)
 {
     if (m_compositor)

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -138,7 +138,6 @@ public:
     void setIsInWindow(bool);
 
     WEBCORE_EXPORT RenderLayerCompositor& compositor();
-    WEBCORE_EXPORT CheckedRef<RenderLayerCompositor> checkedCompositor();
     WEBCORE_EXPORT bool NODELETE usesCompositing() const;
 
     WEBCORE_EXPORT IntRect unscaledDocumentRect() const;

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -125,7 +125,7 @@ TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderSty
             forceBackgroundToWhite = false;
 
         if (forceBackgroundToWhite) {
-            if (Style::hasAnyBackgroundClipText(renderer.checkedStyle()->backgroundLayers()))
+            if (Style::hasAnyBackgroundClipText(protect(renderer.style())->backgroundLayers()))
                 paintStyle.fillColor = Color::black;
         }
     }

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -294,7 +294,7 @@ void RenderThemeCocoa::paintFileUploadIconDecorations(const RenderElement&, cons
         thumbnailRect.contract(kMultipleThumbnailShrinkSize, kMultipleThumbnailShrinkSize);
 
         // Background picture frame and simple background icon with a gradient matching the button.
-        auto backgroundImageColor = buttonRenderer.checkedStyle()->visitedDependentBackgroundColor();
+        auto backgroundImageColor = protect(buttonRenderer.style())->visitedDependentBackgroundColor();
         paintInfo.context().fillRoundedRect(FloatRoundedRect(thumbnailPictureFrameRect, cornerSize, cornerSize, cornerSize, cornerSize), pictureFrameColor);
         paintInfo.context().fillRect(thumbnailRect, backgroundImageColor);
 

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -83,7 +83,6 @@ public:
     }
 
     RenderObject* currentObject() { return m_current.renderer(); }
-    CheckedPtr<RenderObject> checkedCurrentObject() { return currentObject(); }
     LegacyInlineIterator lineBreak() { return m_lineBreak; }
     LineWidth& lineWidth() { return m_width; }
     bool atEnd() { return m_atEnd; }

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -69,7 +69,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
                 return context.lineBreak();
             }
         } else if (context.currentObject()->isLineBreakOpportunity())
-            context.commitLineBreakAtCurrentWidth(*context.checkedCurrentObject());
+            context.commitLineBreakAtCurrentWidth(*protect(context.currentObject()));
         else
             ASSERT_NOT_REACHED();
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
@@ -57,7 +57,7 @@ inline LayoutUnit RenderMathMLBlock::mirrorIfNeeded(LayoutUnit horizontalOffset,
 // https://w3c.github.io/mathml-core/#dfn-default-rule-thickness
 inline LayoutUnit RenderMathMLBlock::ruleThicknessFallback() const
 {
-    return LayoutUnit(checkedStyle()->metricsOfPrimaryFont().underlineThickness().value_or(0.0f));
+    return LayoutUnit(protect(style())->metricsOfPrimaryFont().underlineThickness().value_or(0.0f));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -46,7 +46,7 @@ public:
     virtual ~RenderMathMLRoot();
 
     void updateStyle();
-    void resetRadicalOperator() { m_radicalOperator.reset(checkedStyle()); }
+    void resetRadicalOperator() { m_radicalOperator.reset(protect(style())); }
 
 private:
     bool isValid() const;

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -370,11 +370,6 @@ inline const FontCascade& RenderStyle::fontCascade() const
     return m_computedStyle.fontCascade();
 }
 
-inline CheckedRef<const FontCascade> RenderStyle::checkedFontCascade() const
-{
-    return m_computedStyle.checkedFontCascade();
-}
-
 inline FontCascade& RenderStyle::mutableFontCascadeWithoutUpdate()
 {
     return m_computedStyle.mutableFontCascadeWithoutUpdate();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -248,7 +248,6 @@ public:
     // MARK: - Fonts
 
     inline const FontCascade& fontCascade() const;
-    inline CheckedRef<const FontCascade> checkedFontCascade() const;
     inline FontCascade& mutableFontCascadeWithoutUpdate();
     inline void setFontCascade(FontCascade&&);
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -316,7 +316,7 @@ Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
 
     if (RefPtr useElement = dynamicDowncast<SVGUseElement>(protect(element()))) {
         if (CheckedPtr clipChildRenderer = useElement->rendererClipChild())
-            transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform());
+            transform.multiply(protect(downcast<RenderLayerModelObject>(*clipChildRenderer).layer())->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform());
         if (RefPtr clipChild = useElement->clipChild())
             return pathFromGraphicsElement(*clipChild);
     }

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -239,7 +239,7 @@ void RenderSVGPath::drawMarkers(PaintInfo& paintInfo)
 
             context.setLineDash(DashArray(), 0);
             auto contentTransform = marker->markerTransformation(markerPosition.origin, markerPosition.angle, strokeWidth);
-            marker->checkedLayer()->paintSVGResourceLayer(context, contentTransform);
+            protect(marker->layer())->paintSVGResourceLayer(context, contentTransform);
         }
     }
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -178,7 +178,7 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
         context.setCompositeOperation(CompositeOperator::SourceOver);
     }
 
-    checkedLayer()->paintSVGResourceLayer(context, contentTransform);
+    protect(layer())->paintSVGResourceLayer(context, contentTransform);
 
     if (pushTransparencyLayer)
         context.endTransparencyLayer();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -189,7 +189,7 @@ bool RenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& context, c
     }
 
     // Draw the content into the ImageBuffer.
-    checkedLayer()->paintSVGResourceLayer(context, maskContentTransformation);
+    protect(layer())->paintSVGResourceLayer(context, maskContentTransformation);
     return true;
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -205,7 +205,7 @@ RefPtr<ImageBuffer> RenderSVGResourcePattern::createTileImage(GraphicsContext& c
     GraphicsContextStateSaver stateSaver(tileImageContext);
 
     // Draw the content into the ImageBuffer.
-    patternRenderer->checkedLayer()->paintSVGResourceLayer(tileImageContext, tileImageTransform);
+    protect(patternRenderer->layer())->paintSVGResourceLayer(tileImageContext, tileImageTransform);
     return tileImage;
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -89,11 +89,6 @@ RenderSVGViewportContainer* RenderSVGRoot::viewportContainer() const
     return dynamicDowncast<RenderSVGViewportContainer>(child);
 }
 
-CheckedPtr<RenderSVGViewportContainer> RenderSVGRoot::checkedViewportContainer() const
-{
-    return viewportContainer();
-}
-
 bool RenderSVGRoot::hasIntrinsicAspectRatio() const
 {
     return computeIntrinsicAspectRatio();

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -76,7 +76,6 @@ public:
     void invalidateCachedVisualOverflowRect() final { m_cachedVisualOverflowRect = std::nullopt; }
 
     RenderSVGViewportContainer* viewportContainer() const;
-    CheckedPtr<RenderSVGViewportContainer> checkedViewportContainer() const;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -109,11 +109,9 @@ public:
 
     ComputedStyle& style() { return m_style.computedStyle(); }
     const ComputedStyle& style() const { return m_style.computedStyle(); }
-    CheckedRef<const ComputedStyle> checkedStyle() const { return style(); }
 
     RenderStyle& renderStyle() { return m_style; }
     const RenderStyle& renderStyle() const { return m_style; }
-    CheckedRef<const RenderStyle> checkedRenderStyle() const { return renderStyle(); }
 
     const ComputedStyle& parentStyle() const { return m_context.parentStyle->computedStyle(); }
     const RenderStyle& parentRenderStyle() const { return *m_context.parentStyle; }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -184,11 +184,6 @@ void ComputedStyleBase::addCustomPaintWatchProperty(const AtomString& name)
 
 // MARK: - FontCascade support.
 
-CheckedRef<const FontCascade> ComputedStyleBase::checkedFontCascade() const
-{
-    return fontCascade();
-}
-
 FontCascade& ComputedStyleBase::mutableFontCascadeWithoutUpdate()
 {
     return m_inheritedData.access().fontData.access().fontCascade;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -624,7 +624,6 @@ public:
     // MARK: - Fonts
 
     inline const FontCascade& fontCascade() const;
-    CheckedRef<const FontCascade> checkedFontCascade() const;
     WEBCORE_EXPORT FontCascade& mutableFontCascadeWithoutUpdate();
     void setFontCascade(FontCascade&&);
 

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -90,7 +90,7 @@ bool SVGFEDiffuseLightingElement::setFilterEffectAttribute(FilterEffect& filterE
 
     switch (attrName.nodeName()) {
     case AttributeNames::lighting_colorAttr:
-        return effect.setLightingColor(renderer()->checkedStyle()->lightingColorResolvingCurrentColorApplyingColorFilter());
+        return effect.setLightingColor(protect(renderer()->style())->lightingColorResolvingCurrentColorApplyingColorFilter());
     case AttributeNames::surfaceScaleAttr:
         return effect.setSurfaceScale(surfaceScale());
     case AttributeNames::diffuseConstantAttr:
@@ -163,7 +163,7 @@ RefPtr<FilterEffect> SVGFEDiffuseLightingElement::createFilterEffect(const Filte
         return nullptr;
 
     Ref lightSource = lightElement->lightSource();
-    return FEDiffuseLighting::create(renderer->checkedStyle()->lightingColorResolvingCurrentColorApplyingColorFilter(), surfaceScale(), diffuseConstant(), kernelUnitLengthX(), kernelUnitLengthY(), WTF::move(lightSource));
+    return FEDiffuseLighting::create(protect(renderer->style())->lightingColorResolvingCurrentColorApplyingColorFilter(), surfaceScale(), diffuseConstant(), kernelUnitLengthX(), kernelUnitLengthY(), WTF::move(lightSource));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -126,9 +126,9 @@ bool SVGFEDropShadowElement::setFilterEffectAttribute(FilterEffect& filterEffect
     case AttributeNames::dyAttr:
         return effect.setDy(dy());
     case AttributeNames::flood_colorAttr:
-        return effect.setShadowColor(renderer()->checkedStyle()->floodColorResolvingCurrentColor());
+        return effect.setShadowColor(protect(renderer()->style())->floodColorResolvingCurrentColor());
     case AttributeNames::flood_opacityAttr:
-        return effect.setShadowOpacity(renderer()->checkedStyle()->floodOpacity().value.value);
+        return effect.setShadowOpacity(protect(renderer()->style())->floodOpacity().value.value);
     default:
         break;
     }

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -96,7 +96,7 @@ bool SVGFESpecularLightingElement::setFilterEffectAttribute(FilterEffect& filter
 
     switch (attrName.nodeName()) {
     case AttributeNames::lighting_colorAttr:
-        return effect.setLightingColor(renderer()->checkedStyle()->lightingColorResolvingCurrentColorApplyingColorFilter());
+        return effect.setLightingColor(protect(renderer()->style())->lightingColorResolvingCurrentColorApplyingColorFilter());
     case AttributeNames::surfaceScaleAttr:
         return effect.setSurfaceScale(surfaceScale());
     case AttributeNames::specularConstantAttr:
@@ -164,7 +164,7 @@ RefPtr<FilterEffect> SVGFESpecularLightingElement::createFilterEffect(const Filt
         return nullptr;
 
     Ref lightSource = lightElement->lightSource();
-    return FESpecularLighting::create(renderer->checkedStyle()->lightingColorResolvingCurrentColorApplyingColorFilter(), surfaceScale(), specularConstant(), specularExponent(), kernelUnitLengthX(), kernelUnitLengthY(), WTF::move(lightSource));
+    return FESpecularLighting::create(protect(renderer->style())->lightingColorResolvingCurrentColorApplyingColorFilter(), surfaceScale(), specularConstant(), specularExponent(), kernelUnitLengthX(), kernelUnitLengthY(), WTF::move(lightSource));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -160,7 +160,7 @@ void SVGSVGElement::updateCurrentTranslate()
     if (document().settings().layerBasedSVGEngineEnabled()) {
         if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(*renderer)) {
             ASSERT(svgRoot->viewportContainer());
-            svgRoot->checkedViewportContainer()->updateHasSVGTransformFlags();
+            protect(svgRoot->viewportContainer())->updateHasSVGTransformFlags();
         }
 
         // TODO: [LBSE] Avoid relayout upon transform changes (not possible in legacy, but should be in LBSE).
@@ -245,7 +245,7 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
             // FIXME: try to get rid of this custom handling of embedded SVG invalidation, maybe through abstraction.
             if (CheckedPtr renderer = this->renderer()) {
                 if (isEmbeddedThroughFrameContainingSVGDocument(*renderer))
-                    renderer->checkedView()->setNeedsLayout(MarkOnlyThis);
+                    protect(renderer->view())->setNeedsLayout(MarkOnlyThis);
             }
         }
         invalidateResourceImageBuffersIfNeeded();
@@ -257,7 +257,7 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
         if (document().settings().layerBasedSVGEngineEnabled()) {
             if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(renderer())) {
                 ASSERT(svgRoot->viewportContainer());
-                svgRoot->checkedViewportContainer()->updateHasSVGTransformFlags();
+                protect(svgRoot->viewportContainer())->updateHasSVGTransformFlags();
                 svgRoot->setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
             } else if (CheckedPtr viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(renderer()))
                 viewportContainer->updateHasSVGTransformFlags();
@@ -717,7 +717,7 @@ bool SVGSVGElement::scrollToFragment(StringView fragmentIdentifier)
         if (renderer.document().settings().layerBasedSVGEngineEnabled()) {
             if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(renderer)) {
                 ASSERT(svgRoot->viewportContainer());
-                svgRoot->checkedViewportContainer()->updateHasSVGTransformFlags();
+                protect(svgRoot->viewportContainer())->updateHasSVGTransformFlags();
             }
             updateSVGRendererForElementChange();
             return;

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.cpp
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.cpp
@@ -56,7 +56,7 @@ public:
 Color SVGStyleColorResolutionDelegate::currentColor() const
 {
     if (CheckedPtr renderer = m_element->renderer())
-        return renderer->checkedStyle()->visitedDependentColor();
+        return protect(renderer->style())->visitedDependentColor();
     return { };
 }
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -360,9 +360,4 @@ void WorkerOrWorkletThread::removeChildThread(WorkerOrWorkletThread& childThread
         std::exchange(m_runWhenLastChildThreadIsGone, nullptr)();
 }
 
-CheckedPtr<WorkerLoaderProxy> WorkerOrWorkletThread::checkedWorkerLoaderProxy() const
-{
-    return workerLoaderProxy();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -60,7 +60,6 @@ public:
 
     virtual WorkerDebuggerProxy* workerDebuggerProxy() const = 0;
     virtual WorkerLoaderProxy* workerLoaderProxy() const = 0;
-    virtual CheckedPtr<WorkerLoaderProxy> checkedWorkerLoaderProxy() const;
 
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
     WorkerRunLoop& runLoop() { return m_runLoop; }

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -68,7 +68,6 @@ private:
     std::optional<uint64_t> recordsCount();
     std::optional<Vector<ServiceWorkerContextData>> importRegistrationsImpl();
     std::optional<Vector<ServiceWorkerScripts>> updateRegistrationsImpl(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
-    CheckedPtr<SQLiteDatabase> checkedDatabase() const;
 
     String m_directory;
     std::unique_ptr<SQLiteDatabase> m_database;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -358,8 +358,6 @@ private:
     enum class ShouldUpdateRegistrations : bool { No, Yes };
     void unregisterServiceWorkerClientInternal(const ClientOrigin&, ScriptExecutionContextIdentifier, ShouldUpdateRegistrations);
 
-    CheckedRef<SWServerDelegate> checkedDelegate() const;
-
     WeakPtr<SWServerDelegate> m_delegate;
 
     HashMap<SWServerConnectionIdentifier, Ref<Connection>> m_connections;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -55,7 +55,7 @@ RemoteMediaSessionProxy::~RemoteMediaSessionProxy()
 void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& remoteState)
 {
     m_sessionState = remoteState;
-    downcast<RemoteMediaSessionClientProxy>(checkedClient()).updateState(remoteState);
+    downcast<RemoteMediaSessionClientProxy>(protect(client())).updateState(remoteState);
 
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -419,7 +419,7 @@ bool InjectedBundleNodeHandle::isSelectElement() const
 bool InjectedBundleNodeHandle::isSelectableTextNode() const
 {
     if (CheckedPtr renderText = dynamicDowncast<RenderText>(m_node->renderer()))
-        return renderText->checkedStyle()->usedUserSelect() != UserSelect::None;
+        return protect(renderText->style())->usedUserSelect() != UserSelect::None;
     return false;
 }
 

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -162,31 +162,31 @@ RefPtr<WebCore::PlatformMediaSessionInterface> RemoteMediaSessionManager::sessio
 void RemoteMediaSessionManager::clientShouldResumeAutoplaying(WebCore::MediaSessionIdentifier identifier)
 {
     if (RefPtr session = sessionWithIdentifier(identifier))
-        session->checkedClient()->resumeAutoplaying();
+        protect(session->client())->resumeAutoplaying();
 }
 
 void RemoteMediaSessionManager::clientMayResumePlayback(WebCore::MediaSessionIdentifier identifier, bool shouldResume)
 {
     if (RefPtr session = sessionWithIdentifier(identifier))
-        session->checkedClient()->mayResumePlayback(shouldResume);
+        protect(session->client())->mayResumePlayback(shouldResume);
 }
 
 void RemoteMediaSessionManager::clientShouldSuspendPlayback(WebCore::MediaSessionIdentifier identifier)
 {
     if (RefPtr session = sessionWithIdentifier(identifier))
-        session->checkedClient()->suspendPlayback();
+        protect(session->client())->suspendPlayback();
 }
 
 void RemoteMediaSessionManager::clientSetShouldPlayToPlaybackTarget(WebCore::MediaSessionIdentifier identifier, bool shouldPlay)
 {
     if (RefPtr session = sessionWithIdentifier(identifier))
-        session->checkedClient()->setShouldPlayToPlaybackTarget(shouldPlay);
+        protect(session->client())->setShouldPlayToPlaybackTarget(shouldPlay);
 }
 
 void RemoteMediaSessionManager::clientDidReceiveRemoteControlCommand(WebCore::MediaSessionIdentifier identifier, WebCore::PlatformMediaSessionRemoteControlCommandType command, WebCore::PlatformMediaSessionRemoteCommandArgument argument)
 {
     if (RefPtr session = sessionWithIdentifier(identifier))
-        session->checkedClient()->didReceiveRemoteControlCommand(command, argument);
+        protect(session->client())->didReceiveRemoteControlCommand(command, argument);
 }
 
 void RemoteMediaSessionManager::setCurrentMediaSession(std::optional<WebCore::MediaSessionIdentifier> identifier)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1428,7 +1428,7 @@ bool PDFDiscretePresentationController::layerAllowsDynamicContentScaling(const G
 void PDFDiscretePresentationController::tiledBackingUsageChanged(const GraphicsLayer* layer, bool usingTiledBacking)
 {
     if (usingTiledBacking)
-        layer->checkedTiledBacking()->setIsInWindow(m_plugin->isInWindow());
+        protect(layer->tiledBacking())->setIsInWindow(m_plugin->isInWindow());
 }
 
 void PDFDiscretePresentationController::paintBackgroundLayerForRow(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, unsigned rowIndex)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -413,7 +413,7 @@ bool PDFScrollingPresentationController::layerAllowsDynamicContentScaling(const 
 void PDFScrollingPresentationController::tiledBackingUsageChanged(const GraphicsLayer* layer, bool usingTiledBacking)
 {
     if (usingTiledBacking)
-        layer->checkedTiledBacking()->setIsInWindow(m_plugin->isInWindow());
+        protect(layer->tiledBacking())->setIsInWindow(m_plugin->isInWindow());
 }
 
 void PDFScrollingPresentationController::paintContents(const GraphicsLayer& layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1744,7 +1744,7 @@ void UnifiedPDFPlugin::updateScrollingExtents()
 
     EventRegion eventRegion;
     auto eventRegionContext = eventRegion.makeContext();
-    eventRegionContext.unite(FloatRoundedRect(FloatRect({ }, size())), *renderer, renderer->checkedStyle().get());
+    eventRegionContext.unite(FloatRoundedRect(FloatRect({ }, size())), *renderer, protect(renderer->style()).get());
     scrollContainerLayer->setEventRegion(WTF::move(eventRegion));
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
@@ -39,9 +39,9 @@ void WebPopupMenu::setUpPlatformData(const IntRect&, PlatformPopupMenuData& data
 {
 #if USE(APPKIT)
     RefPtr popupClient = m_popupClient;
-    std::optional<InstalledFont> font = popupClient->menuStyle().checkedFont()->primaryFont()->toSerializableInstalledFont();
+    std::optional<InstalledFont> font = protect(popupClient->menuStyle().font())->primaryFont()->toSerializableInstalledFont();
     if (!font) {
-        double pointSize = popupClient->menuStyle().checkedFont()->primaryFont()->platformData().size();
+        double pointSize = protect(popupClient->menuStyle().font())->primaryFont()->platformData().size();
         font = Font::create(FontPlatformData(bridge_cast([NSFont menuFontOfSize:pointSize]), pointSize))->toSerializableInstalledFont();
     }
     ASSERT(font);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollbarsControllerCoordinated.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollbarsControllerCoordinated.cpp
@@ -52,7 +52,7 @@ void ScrollbarsControllerCoordinated::scrollbarLayoutDirectionChanged(WebCore::U
     WebCore::ScrollbarsControllerGeneric::scrollbarLayoutDirectionChanged(scrollbarLayoutDirection);
 
     if (RefPtr scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setScrollbarLayoutDirection(checkedScrollableArea(), scrollbarLayoutDirection);
+        scrollingCoordinator->setScrollbarLayoutDirection(protect(scrollableArea()), scrollbarLayoutDirection);
 }
 
 bool ScrollbarsControllerCoordinated::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar& scrollbar) const
@@ -77,25 +77,25 @@ void ScrollbarsControllerCoordinated::updateScrollbarStyle()
     // and length are properly updated.
     updateScrollbarsThickness();
 
-    checkedScrollableArea()->scrollbarStyleChanged(theme.usesOverlayScrollbars() ? WebCore::ScrollbarStyle::Overlay : WebCore::ScrollbarStyle::AlwaysVisible, true);
+    protect(scrollableArea())->scrollbarStyleChanged(theme.usesOverlayScrollbars() ? WebCore::ScrollbarStyle::Overlay : WebCore::ScrollbarStyle::AlwaysVisible, true);
 }
 
 void ScrollbarsControllerCoordinated::scrollbarOpacityChanged()
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setScrollbarOpacity(checkedScrollableArea());
+        scrollingCoordinator->setScrollbarOpacity(protect(scrollableArea()));
 }
 
 void ScrollbarsControllerCoordinated::hoveredPartChanged(WebCore::Scrollbar& scrollbar)
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setHoveredAndPressedScrollbarParts(checkedScrollableArea());
+        scrollingCoordinator->setHoveredAndPressedScrollbarParts(protect(scrollableArea()));
 }
 
 void ScrollbarsControllerCoordinated::pressedPartChanged(WebCore::Scrollbar& scrollbar)
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setHoveredAndPressedScrollbarParts(checkedScrollableArea());
+        scrollingCoordinator->setHoveredAndPressedScrollbarParts(protect(scrollableArea()));
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -50,25 +50,25 @@ RemoteScrollbarsController::RemoteScrollbarsController(WebCore::ScrollableArea& 
 void RemoteScrollbarsController::scrollbarLayoutDirectionChanged(WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection)
 {
     if (RefPtr scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setScrollbarLayoutDirection(checkedScrollableArea(), scrollbarLayoutDirection);
+        scrollingCoordinator->setScrollbarLayoutDirection(protect(scrollableArea()), scrollbarLayoutDirection);
 }
 
 void RemoteScrollbarsController::mouseEnteredContentArea()
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setMouseIsOverContentArea(checkedScrollableArea(), true);
+        scrollingCoordinator->setMouseIsOverContentArea(protect(scrollableArea()), true);
 }
 
 void RemoteScrollbarsController::mouseExitedContentArea()
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setMouseIsOverContentArea(checkedScrollableArea(), false);
+        scrollingCoordinator->setMouseIsOverContentArea(protect(scrollableArea()), false);
 }
 
 void RemoteScrollbarsController::mouseMovedInContentArea()
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setMouseMovedInContentArea(checkedScrollableArea());
+        scrollingCoordinator->setMouseMovedInContentArea(protect(scrollableArea()));
 }
 
 void RemoteScrollbarsController::mouseEnteredScrollbar(WebCore::Scrollbar* scrollbar) const
@@ -109,7 +109,7 @@ bool RemoteScrollbarsController::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar
 
 bool RemoteScrollbarsController::shouldRegisterScrollbars() const
 {
-    return !checkedScrollableArea()->usesAsyncScrolling();
+    return !protect(scrollableArea())->usesAsyncScrolling();
 }
 
 void RemoteScrollbarsController::setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation orientation, int minimumThumbLength)
@@ -134,7 +134,7 @@ void RemoteScrollbarsController::updateScrollbarEnabledState(WebCore::Scrollbar&
 void RemoteScrollbarsController::scrollbarWidthChanged(WebCore::ScrollbarWidth width)
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setScrollbarWidth(checkedScrollableArea(), width);
+        scrollingCoordinator->setScrollbarWidth(protect(scrollableArea()), width);
 
     updateScrollbarsThickness();
 }
@@ -150,13 +150,13 @@ void RemoteScrollbarsController::updateScrollbarStyle()
     // and length are properly updated.
     updateScrollbarsThickness();
 
-    checkedScrollableArea()->scrollbarStyleChanged(theme.usesOverlayScrollbars() ? WebCore::ScrollbarStyle::Overlay : WebCore::ScrollbarStyle::AlwaysVisible, true);
+    protect(scrollableArea())->scrollbarStyleChanged(theme.usesOverlayScrollbars() ? WebCore::ScrollbarStyle::Overlay : WebCore::ScrollbarStyle::AlwaysVisible, true);
 }
 
 void RemoteScrollbarsController::scrollbarColorChanged(std::optional<WebCore::ScrollbarColor> color)
 {
     if (auto scrollingCoordinator = m_coordinator.get())
-        scrollingCoordinator->setScrollbarColor(checkedScrollableArea(), color);
+        scrollingCoordinator->setScrollbarColor(protect(scrollableArea()), color);
 }
 
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1675,7 +1675,7 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
     result.isContentRichlyEditable = selection.isContentRichlyEditable();
     result.isInPasswordField = selection.isInPasswordField();
     result.hasComposition = editor->hasComposition();
-    result.shouldIgnoreSelectionChanges = editor->ignoreSelectionChanges() || (editor->client() && !editor->checkedClient()->shouldRevealCurrentSelectionAfterInsertion());
+    result.shouldIgnoreSelectionChanges = editor->ignoreSelectionChanges() || (editor->client() && !protect(editor->client())->shouldRevealCurrentSelectionAfterInsertion());
     result.triggeredByAccessibilitySelectionChange = m_pendingEditorStateUpdateStatus == PendingEditorStateUpdateStatus::ScheduledDuringAccessibilitySelectionChange || m_isChangingSelectionForAccessibility;
 
     Ref<Document> document = *frame->document();

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -77,7 +77,7 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
     if (!renderer)
         return { };
 
-    if (renderer->hasLayer() && renderer->checkedEnclosingLayer()->isComposited()) {
+    if (renderer->hasLayer() && protect(renderer->enclosingLayer())->isComposited()) {
         FloatQuad contentsBox = static_cast<FloatRect>(renderer->enclosingLayer()->backing()->contentsBox());
         contentsBox = renderer->localToAbsoluteQuad(contentsBox);
         return protect(document->view())->contentsToRootView(contentsBox.boundingBox());


### PR DESCRIPTION
#### bdc535f8fe2dcf3a605e3eddbc67ef2a50162b6a
<pre>
Reduce use of `checked*()` functions in Source/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=308387">https://bugs.webkit.org/show_bug.cgi?id=308387</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::fromFormData):
(WebCore::FetchBody::arrayBuffer):
(WebCore::FetchBody::blob):
(WebCore::FetchBody::bytes):
(WebCore::FetchBody::json):
(WebCore::FetchBody::text):
(WebCore::FetchBody::formData):
(WebCore::FetchBody::consume):
(WebCore::FetchBody::consumeAsStream):
(WebCore::FetchBody::consumeArrayBuffer):
(WebCore::FetchBody::consumeArrayBufferView):
(WebCore::FetchBody::consumeText):
(WebCore::FetchBody::consumeFormData):
(WebCore::FetchBody::loadingFailed):
(WebCore::FetchBody::loadingSucceeded):
(WebCore::FetchBody::bodyAsFormData const):
(WebCore::FetchBody::convertReadableStreamToArrayBuffer):
(WebCore::FetchBody::take):
(WebCore::FetchBody::clone):
* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::checkedConsumer): Deleted.
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::createFetchResponse):
(WebCore::FetchResponse::Loader::start):
(WebCore::FetchResponse::consumeBodyReceivedByChunk):
(WebCore::FetchResponse::setBodyData):
(WebCore::FetchResponse::consumeChunk):
(WebCore::FetchResponse::receivedData):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::performCurrentOpenOperationAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::startVersionChangeTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::createIndexAsyncAfterQuotaCheck):
(WebCore::IDBServer::UniqueIDBDatabase::didGenerateIndexKeyForRecord):
(WebCore::IDBServer::UniqueIDBDatabase::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabase::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::getRecord):
(WebCore::IDBServer::UniqueIDBDatabase::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabase::getCount):
(WebCore::IDBServer::UniqueIDBDatabase::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabase::openCursor):
(WebCore::IDBServer::UniqueIDBDatabase::iterateCursor):
(WebCore::IDBServer::UniqueIDBDatabase::commitTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::activateTransactionInBackingStore):
(WebCore::IDBServer::UniqueIDBDatabase::takeNextRunnableTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::abortActiveTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::close):
(WebCore::IDBServer::UniqueIDBDatabase::hasDataInMemory const):
(WebCore::IDBServer::UniqueIDBDatabase::filePath const):
(WebCore::IDBServer::UniqueIDBDatabase::checkedBackingStore const): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::abortTransactionWithoutCallback):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::connectionClosedFromClient):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::didFireVersionChangeEvent):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::didFinishHandlingVersionChange):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::createVersionChangeTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::establishTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::checkedDatabase): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::database):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::checkedDatabase const): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp:
(WebCore::IDBResultData::openDatabaseSuccess):
(WebCore::IDBResultData::openDatabaseUpgradeNeeded):
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::startRecording):
(WebCore::MediaRecorder::pauseRecording):
(WebCore::MediaRecorder::resumeRecording):
(WebCore::MediaRecorder::stopRecordingInternal):
(WebCore::MediaRecorder::checkedPrivate): Deleted.
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/webaudio/AnalyserNode.cpp:
(WebCore::AnalyserNode::process):
(WebCore::AnalyserNode::updatePullStatus):
* Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp:
(WebCore::AudioBasicInspectorNode::pullInputs):
* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp:
(WebCore::AudioBasicProcessorNode::pullInputs):
(WebCore::AudioBasicProcessorNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::setBufferForBindings):
* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::renderQuantum):
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::checkedInput): Deleted.
(WebCore::AudioNode::checkedOutput): Deleted.
* Source/WebCore/Modules/webaudio/AudioNode.h:
(WTF::protect):
* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::disable):
(WebCore::AudioNodeInput::enable):
(WebCore::AudioNodeInput::didUpdate):
* Source/WebCore/Modules/webaudio/AudioNodeInput.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::propagateChannelCount):
(WebCore::AudioNodeOutput::pull):
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
(WebCore::AudioWorkletNode::updatePullStatus):
(WebCore::AudioWorkletNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::updateTailProcessingNodes):
(WebCore::BaseAudioContext::disableOutputsForFinishedTailProcessingNodes):
(WebCore::BaseAudioContext::finishTailProcessing):
(WebCore::BaseAudioContext::deleteMarkedNodes):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::TailProcessingNode::node const):
(WebCore::BaseAudioContext::TailProcessingNode::checkedNode const): Deleted.
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
(WebCore::BiquadFilterNode::setType):
(WebCore::BiquadFilterNode::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadFilterNode.h:
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::process):
(WebCore::ConvolverNode::setBufferForBindings):
(WebCore::ConvolverNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/DelayNode.cpp:
(WebCore::DelayNode::create):
(WebCore::DelayNode::checkedDelayTime): Deleted.
* Source/WebCore/Modules/webaudio/DelayNode.h:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp:
(WebCore::DynamicsCompressorNode::process):
* Source/WebCore/Modules/webaudio/GainNode.cpp:
(WebCore::GainNode::checkNumberOfChannelsForInput):
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::setFormat):
(WebCore::MediaElementAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp:
(WebCore::MediaStreamAudioSourceNode::setFormat):
(WebCore::MediaStreamAudioSourceNode::process):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::parentTable const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
(WebCore::AccessibilityNodeObject::checkedNode const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityObjectInlines.h:
(WebCore::AccessibilityObject::checkedAxObjectCache const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::titleUIElement const):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
(WebCore::AccessibilityRenderObject::checkedRenderer const): Deleted.
* Source/WebCore/accessibility/AccessibilityScrollbar.cpp:
(WebCore::AccessibilityScrollbar::setValue):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::elementAccessibilityHitTest const):
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::propertyValueForVariableName):
* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::hasLastData):
(WebCore::DeviceMotionController::getLastEvent):
(WebCore::DeviceMotionController::checkedClient): Deleted.
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::hasLastData):
(WebCore::DeviceOrientationController::getLastEvent):
(WebCore::DeviceOrientationController::checkedClient): Deleted.
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::m_registry):
(WebCore::MessagePortChannel::~MessagePortChannel):
(WebCore::MessagePortChannel::checkedRegistry const): Deleted.
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::checkedClient const): Deleted.
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/TextCheckingHelper.cpp:
(WebCore::TextCheckingHelper::findMisspelledWords const):
(WebCore::TextCheckingHelper::findFirstMisspelledWordOrUngrammaticalPhrase const):
(WebCore::TextCheckingHelper::findUngrammaticalPhrases const):
(WebCore::TextCheckingHelper::checkedClient const): Deleted.
* Source/WebCore/editing/TextCheckingHelper.h:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::editingAttributedStringInternal):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::setDisabledState):
(WebCore::HTMLLinkElement::process):
(WebCore::HTMLLinkElement::insertedIntoAncestor):
(WebCore::HTMLLinkElement::addPendingSheet):
(WebCore::HTMLLinkElement::checkedStyleScope): Deleted.
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMarqueeElement.cpp:
(WebCore::HTMLMarqueeElement::renderMarquee const):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::cellAbove const):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateBufferDataTarget):
(WebCore::WebGL2RenderingContext::validateAndCacheBufferBinding):
(WebCore::WebGL2RenderingContext::vertexAttribIPointer):
(WebCore::WebGL2RenderingContext::drawBuffers):
(WebCore::WebGL2RenderingContext::resumeTransformFeedback):
(WebCore::WebGL2RenderingContext::setIndexedBufferBinding):
(WebCore::WebGL2RenderingContext::getIndexedParameter):
(WebCore::WebGL2RenderingContext::uncacheDeletedBuffer):
* Source/WebCore/html/canvas/WebGLDrawBuffers.cpp:
(WebCore::WebGLDrawBuffers::drawBuffersWEBGL):
* Source/WebCore/html/canvas/WebGLObject.h:
(WTF::protect):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::validateAndCacheBufferBinding):
(WebCore::WebGLRenderingContextBase::uncacheDeletedBuffer):
(WebCore::WebGLRenderingContextBase::deleteRenderbuffer):
(WebCore::WebGLRenderingContextBase::deleteTexture):
(WebCore::WebGLRenderingContextBase::disableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::validateVertexArrayObject):
(WebCore::WebGLRenderingContextBase::enableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::getVertexAttrib):
(WebCore::WebGLRenderingContextBase::vertexAttribPointer):
(WebCore::WebGLRenderingContextBase::vertexAttribDivisor):
* Source/WebCore/inspector/InspectorWebAgentBase.h:
(WebCore::InspectorAgentBase::environment):
(WebCore::InspectorAgentBase::checkedEnvironment): Deleted.
* Source/WebCore/inspector/InstrumentingAgents.cpp:
(WebCore::InstrumentingAgents::developerExtrasEnabled const):
* Source/WebCore/inspector/InstrumentingAgents.h:
(WebCore::InstrumentingAgents::checkedEnvironment const): Deleted.
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::startTracking):
(WebCore::InspectorAnimationAgent::stopTracking):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
(WebCore::InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation):
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
(WebCore::InspectorCPUProfilerAgent::startTracking):
(WebCore::InspectorCPUProfilerAgent::stopTracking):
(WebCore::InspectorCPUProfilerAgent::collectSample):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::mediaMetricsTimerFired):
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
(WebCore::InspectorMemoryAgent::startTracking):
(WebCore::InspectorMemoryAgent::stopTracking):
(WebCore::InspectorMemoryAgent::didHandleMemoryPressure):
(WebCore::InspectorMemoryAgent::collectSample):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildObjectForTiming):
(WebCore::InspectorNetworkAgent::timestamp):
(WebCore::InspectorNetworkAgent::didFinishLoading):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::enable):
(WebCore::InspectorPageAgent::timestamp):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::internalStart):
(WebCore::InspectorTimelineAgent::internalStop):
(WebCore::InspectorTimelineAgent::timestamp):
(WebCore::InspectorTimelineAgent::timestampFromMonotonicTime):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::internalStart):
(WebCore::PageTimelineAgent::didCompleteRenderingFrame):
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::computeViewportIntersectionRect):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setUnderPageBackgroundColorOverride):
(WebCore::Page::addRelevantRepaintedObject):
(WebCore::Page::addRelevantUnpaintedObject):
(WebCore::Page::updateFixedContainerEdges):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::tiledBackingUsageChanged):
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::TextIndicator::createWithRange):
(WebCore::estimatedTextColorsForRange):
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::handleKeyUpEvent):
(WebCore::KeyboardScrollingAnimator::stopScrollingImmediately):
(WebCore::KeyboardScrollingAnimator::checkedScrollableArea const): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.h:
* Source/WebCore/platform/PopupMenuStyle.h:
(WebCore::PopupMenuStyle::font const):
(WebCore::PopupMenuStyle::checkedFont const): Deleted.
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::handleWheelEvent):
(WebCore::ScrollAnimator::setCurrentPosition):
(WebCore::ScrollAnimator::scrollOffset const):
(WebCore::ScrollAnimator::allowsHorizontalScrolling const):
(WebCore::ScrollAnimator::allowsVerticalScrolling const):
(WebCore::ScrollAnimator::stretchAmount const):
(WebCore::ScrollAnimator::edgePinnedState const):
(WebCore::ScrollAnimator::isPinnedOnSide const):
(WebCore::ScrollAnimator::pageScaleFactor const):
(WebCore::ScrollAnimator::startAnimationCallback):
(WebCore::ScrollAnimator::scrollAnimationEnabled const):
(WebCore::ScrollAnimator::cancelAnimations):
(WebCore::ScrollAnimator::scrollingNodeIDForTesting const):
* Source/WebCore/platform/ScrollAnimator.h:
(WebCore::ScrollAnimator::scrollableArea const):
(WebCore::ScrollAnimator::checkedScrollableArea const): Deleted.
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::offsetDidChange):
(WebCore::Scrollbar::setFrameRect):
(WebCore::Scrollbar::autoscrollPressedPart):
(WebCore::Scrollbar::moveThumb):
(WebCore::Scrollbar::setHoveredPart):
(WebCore::Scrollbar::setPressedPart):
(WebCore::Scrollbar::mouseMoved):
(WebCore::Scrollbar::mouseEntered):
(WebCore::Scrollbar::mouseExited):
(WebCore::Scrollbar::mouseDown):
(WebCore::Scrollbar::setEnabled):
(WebCore::Scrollbar::shouldParticipateInHitTesting):
(WebCore::Scrollbar::isWindowActive const):
(WebCore::Scrollbar::invalidateRect):
(WebCore::Scrollbar::convertToContainingView const):
(WebCore::Scrollbar::convertFromContainingView const):
(WebCore::Scrollbar::deviceScaleFactor const):
(WebCore::Scrollbar::shouldRegisterScrollbar const):
(WebCore::Scrollbar::minimumThumbLength const):
(WebCore::Scrollbar::updateScrollbarThickness):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/ScrollbarInlines.h:
(WebCore::Scrollbar::checkedScrollableArea const): Deleted.
* Source/WebCore/platform/ScrollbarsController.cpp:
(WebCore::ScrollbarsController::shouldSuspendScrollbarAnimations const):
* Source/WebCore/platform/ScrollbarsController.h:
* Source/WebCore/platform/ScrollbarsControllerInlines.h:
(WebCore::ScrollbarsController::checkedScrollableArea const): Deleted.
* Source/WebCore/platform/ThreadTimers.cpp:
(WebCore::ThreadTimers::updateSharedTimer):
(WebCore::ThreadTimers::checkedSharedTimer): Deleted.
* Source/WebCore/platform/ThreadTimers.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::beginInterruption):
(WebCore::PlatformMediaSession::endInterruption):
(WebCore::PlatformMediaSession::pauseSession):
(WebCore::PlatformMediaSession::stopSession):
(WebCore::PlatformMediaSession::didReceiveRemoteControlCommand):
(WebCore::PlatformMediaSession::canPlayConcurrently const):
(WebCore::PlatformMediaSession::selectBestMediaSession):
(WebCore::PlatformMediaSession::logger const):
(WebCore::PlatformMediaSession::logIdentifier const):
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
(WebCore::PlatformMediaSessionInterface::client const):
(WebCore::PlatformMediaSessionInterface::checkedClient const): Deleted.
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::tiledBacking const):
(WebCore::GraphicsLayer::checkedTiledBacking const): Deleted.
* Source/WebCore/platform/mac/ScrollAnimatorMac.mm:
(WebCore::ScrollAnimatorMac::handleWheelEventPhase):
(WebCore::ScrollAnimatorMac::handleWheelEvent):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::didCreateScrollerImp):
(WebCore::ScrollbarThemeMac::isLayoutDirectionRTL):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(-[WebScrollerImpDelegate scrollbarsController]):
(-[WebScrollerImpDelegate layer]):
(-[WebScrollerImpDelegate mouseLocationInScrollerForScrollerImp:]):
(-[WebScrollerImpDelegate effectiveAppearanceForScrollerImp:]):
(WebCore::ScrollbarsControllerMac::didBeginScrollGesture):
(WebCore::ScrollbarsControllerMac::didEndScrollGesture):
(WebCore::ScrollbarsControllerMac::didAddVerticalScrollbar):
(WebCore::ScrollbarsControllerMac::didAddHorizontalScrollbar):
(WebCore::ScrollbarsControllerMac::notifyContentAreaScrolled):
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):
(WebCore::ScrollbarsControllerMac::sendContentAreaScrolledTimerFired):
(WebCore::ScrollbarsControllerMac::sendContentAreaScrolledSoon):
(WebCore::ScrollbarsControllerMac::horizontalScrollbarStateForTesting const):
(WebCore::ScrollbarsControllerMac::verticalScrollbarStateForTesting const):
(WebCore::ScrollbarsControllerMac::wheelEventTestMonitor const):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC pipActionPlay:]):
(-[WebVideoPresentationInterfaceMacObjC pipActionPause:]):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
(WebCore::ScreenCaptureSessionSource::observer const):
(WebCore::ScreenCaptureSessionSource::checkedObserver const): Deleted.
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::hasCookies const):
(WebCore::NetworkStorageSession::checkedCookieStorageObserver const): Deleted.
* Source/WebCore/platform/network/mac/CookieStorageMac.mm:
(WebCore::startObservingCookieChanges):
(WebCore::stopObservingCookieChanges):
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::gridAreaForIndefiniteGridAxisItem):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paint):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::setFullRepaintOnParentInlineBoxLayerIfNeeded):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintBeforeStyleChange):
(WebCore::RenderElement::didAttachChild):
(WebCore::findNextLayer):
(WebCore::layerNextSiblingRespectingTopLayer):
(WebCore::addLayers):
(WebCore::RenderElement::removeLayers):
(WebCore::RenderElement::styleWillChange):
(WebCore::RenderElement::willBeDestroyed):
(WebCore::RenderElement::registerForVisibleInViewportCallback):
(WebCore::RenderElement::unregisterForVisibleInViewportCallback):
(WebCore::RenderElement::imageFrameAvailable):
(WebCore::RenderElement::didRemoveCachedImageClient):
(WebCore::RenderElement::repaintOldAndNewPositionsForSVGRenderer const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::style const):
(WebCore::RenderElement::checkedStyle const): Deleted.
(WebCore::RenderObject::checkedParent const): Deleted.
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::checkedImageResource const): Deleted.
* Source/WebCore/rendering/RenderImage.h:
(WebCore::RenderImage::imageResource const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::checkedLayer const): Deleted.
* Source/WebCore/rendering/RenderLayerModelObject.h:
(WebCore::RenderLayerModelObject::layer const):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::collectSelectionGeometries):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setLayerNeedsFullRepaint):
(WebCore::RenderObject::setLayerNeedsFullRepaintForOutOfFlowMovementLayout):
(WebCore::RenderObject::collectSelectionGeometries):
(WebCore::RenderObject::repaintUsingContainer const):
(WebCore::RenderObject::outputRegionsInformation const):
(WebCore::RenderObject::willBeDestroyed):
(WebCore::RenderObject::insertedIntoTree):
(WebCore::RenderObject::willBeRemovedFromTree):
(WebCore::borderAndTextRects):
(WebCore::RenderObject::checkedView const): Deleted.
(WebCore::RenderObject::checkedEnclosingLayer const): Deleted.
(WebCore::RenderObject::checkedContainingBlock const): Deleted.
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::firstLineStyle const):
* Source/WebCore/rendering/RenderObjectStyle.h:
(WebCore::RenderObject::checkedStyle const): Deleted.
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::RenderScrollbar::getScrollbarPseudoStyle const):
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::RenderSelection::clear):
(WebCore::RenderSelection::apply):
* Source/WebCore/rendering/RenderSelectionGeometry.h:
(WebCore::RenderSelectionGeometryBase::repaintContainer const):
(WebCore::RenderSelectionGeometryBase::checkedRepaintContainer const): Deleted.
* Source/WebCore/rendering/RenderTable.h:
(WebCore::RenderTable::bgColor const):
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::checkedTable const): Deleted.
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::styleDidChange):
(WebCore::RenderTableCol::insertedIntoTree):
(WebCore::RenderTableCol::nextColumn const):
(WebCore::RenderTableCol::borderAdjoiningCellStartBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellEndBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellBefore const):
(WebCore::RenderTableCol::borderAdjoiningCellAfter const):
(WebCore::RenderTableCol::offsetLeft const):
(WebCore::RenderTableCol::offsetTop const):
(WebCore::RenderTableCol::offsetWidth const):
(WebCore::RenderTableCol::offsetHeight const):
(WebCore::RenderTableCol::checkedTable const): Deleted.
* Source/WebCore/rendering/RenderTableCol.h:
* Source/WebCore/rendering/RenderTableRowInlines.h:
(WebCore::RenderTableRow::borderAdjoiningTableStart const):
(WebCore::RenderTableRow::borderAdjoiningTableEnd const):
* Source/WebCore/rendering/RenderTableSectionInlines.h:
(WebCore::RenderTableSection::borderAdjoiningTableEnd const):
(WebCore::RenderTableSection::borderAdjoiningTableStart const):
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::checkedStyle const): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::adjustSwitchStyle const):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::failedToLoadPosterImage const):
(WebCore::RenderVideo::hasPosterFrameSize const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::checkedCompositor): Deleted.
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintFileUploadIconDecorations):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::currentObject):
(WebCore::BreakingContext::checkedCurrentObject): Deleted.
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::nextLineBreak):
* Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h:
(WebCore::RenderMathMLBlock::ruleThicknessFallback const):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.h:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
(WebCore::RenderStyle::checkedFontCascade const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::computeClipPath const):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::drawMarkers):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyMaskClipping):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::drawContentIntoContext):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::createTileImage const):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::checkedViewportContainer const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::style const):
(WebCore::Style::BuilderState::renderStyle const):
(WebCore::Style::BuilderState::checkedStyle const): Deleted.
(WebCore::Style::BuilderState::checkedRenderStyle const): Deleted.
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::checkedFontCascade const): Deleted.
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::setFilterEffectAttribute):
(WebCore::SVGFEDiffuseLightingElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::setFilterEffectAttribute):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::setFilterEffectAttribute):
(WebCore::SVGFESpecularLightingElement::createFilterEffect const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::updateCurrentTranslate):
(WebCore::SVGSVGElement::svgAttributeChanged):
(WebCore::SVGSVGElement::scrollToFragment):
* Source/WebCore/svg/properties/SVGPropertyTraits.cpp:
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::checkedWorkerLoaderProxy const): Deleted.
* Source/WebCore/workers/WorkerOrWorkletThread.h:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::prepareDatabase):
(WebCore::SWRegistrationDatabase::checkedDatabase const): Deleted.
* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::validateRegistrationDomain):
(WebCore::SWServer::startScriptFetch):
(WebCore::SWServer::tryInstallContextData):
(WebCore::SWServer::createContextConnection):
(WebCore::SWServer::checkedDelegate const): Deleted.
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::updateState):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::isSelectableTextNode const):
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::clientShouldResumeAutoplaying):
(WebKit::RemoteMediaSessionManager::clientMayResumePlayback):
(WebKit::RemoteMediaSessionManager::clientShouldSuspendPlayback):
(WebKit::RemoteMediaSessionManager::clientSetShouldPlayToPlaybackTarget):
(WebKit::RemoteMediaSessionManager::clientDidReceiveRemoteControlCommand):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::tiledBackingUsageChanged):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::tiledBackingUsageChanged):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollbarsControllerCoordinated.cpp:
(WebKit::ScrollbarsControllerCoordinated::scrollbarLayoutDirectionChanged):
(WebKit::ScrollbarsControllerCoordinated::updateScrollbarStyle):
(WebKit::ScrollbarsControllerCoordinated::scrollbarOpacityChanged):
(WebKit::ScrollbarsControllerCoordinated::hoveredPartChanged):
(WebKit::ScrollbarsControllerCoordinated::pressedPartChanged):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::scrollbarLayoutDirectionChanged):
(WebKit::RemoteScrollbarsController::mouseEnteredContentArea):
(WebKit::RemoteScrollbarsController::mouseExitedContentArea):
(WebKit::RemoteScrollbarsController::mouseMovedInContentArea):
(WebKit::RemoteScrollbarsController::shouldRegisterScrollbars const):
(WebKit::RemoteScrollbarsController::scrollbarWidthChanged):
(WebKit::RemoteScrollbarsController::updateScrollbarStyle):
(WebKit::RemoteScrollbarsController::scrollbarColorChanged):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::inlineVideoFrame):

Canonical link: <a href="https://commits.webkit.org/308010@main">https://commits.webkit.org/308010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dca505490318badc5005a89b10e4a39b46431dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146231 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99692 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f8b0e46-4820-44d7-91fb-e8fdc70f538c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112526 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80496 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bdf5452-2d3a-4723-b12c-012960cb12e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93396 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd98179a-ea0e-43ab-91ef-853d68ed1e98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14149 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11905 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157219 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/390 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120550 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130294 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74463 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7770 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82097 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18245 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->