### PR TITLE
Sync `the-autofocus-attribute` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: autofocus
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS autofocus works on area element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute">
+<link rel='author' href='mailto:sefeng@mozilla.com'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<map name="mymap">
+  <area id="myarea" shape="circle" coords="100,100,80" href="#" autofocus>
+</map>
+<img style="width:200px; height: 200px"
+     usemap="#mymap"
+     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mP4%2F58BAAT%2FAf9jgNErAAAAAElFTkSuQmCC">
+<script>
+promise_test(async t => {
+  await waitForLoad(window);
+  await waitUntilStableAutofocusState(window);
+  const area = document.querySelector("area");
+  assert_equals(document.activeElement, area);
+}, 'autofocus works on area element');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog-expected.txt
@@ -1,0 +1,4 @@
+
+PASS <dialog> can contain autofocus, without stopping page autofocus content from working
+PASS <dialog>-contained autofocus element gets focused when the dialog is shown
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute">
+<link rel='author' href='mailto:masonf@chromium.org'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
+  w.document.body.innerHTML = '<dialog><div tabindex=0 autofocus></dialog><input autofocus>';
+  await waitUntilStableAutofocusState(w);
+  assert_equals(w.document.activeElement.tagName, 'INPUT');
+}, '<dialog> can contain autofocus, without stopping page autofocus content from working');
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
+  w.document.body.innerHTML = '<dialog><div tabindex=0 autofocus></dialog><input autofocus>';
+  await waitUntilStableAutofocusState(w);
+  w.document.querySelector('dialog').show();
+  assert_equals(w.document.activeElement.tagName, 'DIV');
+}, '<dialog>-contained autofocus element gets focused when the dialog is shown');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-top.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-top.html
@@ -10,9 +10,12 @@
 
 promise_test(async () => {
   await waitForLoad(window);
+  const iframe = document.querySelector('iframe');
   await waitUntilStableAutofocusState();
-  assert_equals(document.activeElement, document.querySelector('iframe'),
+  assert_equals(document.activeElement, iframe,
       'Autofocus elements in iframes should be focused.');
+  const doc = iframe.contentDocument;
+  assert_true(!doc.querySelector(':target'));
 
   let input = document.createElement('input');
   input.autofocus = true;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/child-autofocus.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/child-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/erase-first.css
+/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/frame-with-a.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/frame-with-anchor.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/frame-with-autofocus-element.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/grand-child-autofocus.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/spin-by-blocking-style-sheet.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/spin-by-blocking-style-sheet.html
@@ -2,16 +2,18 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/utils.js"></script>
-<link rel="stylesheet" href="resources/erase-first.css?pipe=trickle(d1)">
 
 <input id="first" autofocus>
 <input id="second" autofocus>
+
+<link rel="stylesheet" href="resources/erase-first.css?pipe=trickle(d1)">
 
 <script>
 'use strict';
 
 promise_test(async () => {
-  await waitForEvent(document.body, 'focus', {capture:true});
+  await waitForLoad(window);
+  await waitForAnimationFrame();
   assert_equals(document.activeElement.id, 'second');
 }, 'Script-blocking style sheet should pause flushing autofocus candidates.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/w3c-import.log
@@ -14,6 +14,9 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area.html
+/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-in-not-fully-active-document.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-on-stable-document.html
 /LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-empty.html


### PR DESCRIPTION
#### 11f1cc7006f99ff631fa8baa302cacc863701533
<pre>
Sync `the-autofocus-attribute` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=308390">https://bugs.webkit.org/show_bug.cgi?id=308390</a>
<a href="https://rdar.apple.com/170876974">rdar://170876974</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4f841cd96f08c9cadb0d6a8a7628075985f87de4">https://github.com/web-platform-tests/wpt/commit/4f841cd96f08c9cadb0d6a8a7628075985f87de4</a>

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-area.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-top.html:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/spin-by-blocking-style-sheet.html:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/307981@main">https://commits.webkit.org/307981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d214a1d83b23dbe651be06759c653cf4efee9aa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99609 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69be9d95-9aa3-4224-a9a6-ec013e09b670) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112441 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c548467-321b-4411-a47a-ec25dd3debd0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93312 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3071bebc-bba2-405b-97d0-b71157ddb0c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14060 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2255 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157127 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120464 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120765 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30940 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74336 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7598 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18254 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17988 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->