### PR TITLE
Autofocus should not be processed when a subframe has focus or when topDocument has a focused element

### DIFF
--- a/LayoutTests/fast/forms/form-submission-crash-3.html
+++ b/LayoutTests/fast/forms/form-submission-crash-3.html
@@ -4,29 +4,18 @@
 <script>
 description("Test for proper handling of form removal.");
 
-jsTestIsAsync = true;
-
-function eventhandler() {
-    div1.innerHTML = "foo";
-    gc();
-    setTimeout(finishJSTest, 10);
-}
- 
-function eventhandler2() {
-}
-
 function start() {
     button.setAttribute("form", "form1");
     button.setCustomValidity("foo");
-    button.onfocus = eventhandler2;
-    input.onfocus = eventhandler;
     button.click();
+    div1.innerHTML = "foo";
+    gc();
     testPassed('if not crashed.');
 }
 </script>
 </head>
 <body>
-<input id="input" autofocus="autofocus" type="button">
+<input id="input" type="button">
 <div id="div1">
     <form id="form1"></form>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-not-processed-when-top-document-has-focused-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-not-processed-when-top-document-has-focused-element-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS If topDocument's focused area is topDocument but has a focused element, autofocus is not processed.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-not-processed-when-top-document-has-focused-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-not-processed-when-top-document-has-focused-element.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<input id="focused">
+
+<script>
+'use strict';
+
+promise_test(async () => {
+  await waitForLoad(window);
+
+  // Focus an element in the top document directly.
+  document.querySelector('#focused').focus();
+  assert_equals(document.activeElement, document.querySelector('#focused'),
+    'Prereq: input should be focused');
+
+  let input = document.createElement('input');
+  input.autofocus = true;
+  document.body.appendChild(input);
+
+  await waitUntilStableAutofocusState();
+  assert_equals(document.activeElement, document.querySelector('#focused'),
+    'activeElement should not be changed');
+  assert_not_equals(document.activeElement, input);
+}, 'If topDocument\'s focused area is topDocument but has a focused element, autofocus is not processed.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/focusable-area-in-top-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/focusable-area-in-top-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL If topDocument's focused area is not topDocument, autofocus is not processed. assert_equals: activeElement should not be changed expected Element node <iframe srcdoc="<input><script>document.querySelector('in... but got Element node <input autofocus=""></input>
+PASS If topDocument's focused area is not topDocument, autofocus is not processed.
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2008-2014 Google Inc. All rights reserved.
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
@@ -6384,7 +6384,7 @@ void Document::flushAutofocusCandidates()
     if (m_autofocusCandidates.isEmpty())
         return;
 
-    if (cssTarget()) {
+    if (focusedElement() || page->focusController().focusedFrame() != frame() || cssTarget()) {
         m_autofocusCandidates.clear();
         page->setAutofocusProcessed();
         return;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2008-2014 Google Inc. All rights reserved.
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
@@ -6325,7 +6325,7 @@ void Document::flushAutofocusCandidates()
     if (m_autofocusCandidates.isEmpty())
         return;
 
-    if (cssTarget()) {
+    if (focusedElement() || page->focusController().focusedFrame() != frame() || cssTarget()) {
         m_autofocusCandidates.clear();
         page->setAutofocusProcessed();
         return;


### PR DESCRIPTION
#### 0fc4cef61ee8a2636012958d72d41d987dc6b3d5
<pre>
Autofocus should not be processed when a subframe has focus or when topDocument has a focused element
<a href="https://bugs.webkit.org/show_bug.cgi?id=308393">https://bugs.webkit.org/show_bug.cgi?id=308393</a>
<a href="https://rdar.apple.com/170881575">rdar://170881575</a>

Reviewed by Ryosuke Niwa and Tim Nguyen.

The spec [1] requires that if topDocument&apos;s focused area is not
topDocument itself, autofocus candidates should be emptied and
autofocus marked as processed. The check belongs in flushAutofocusCandidates()
which is where the spec defines it.

Mark autofocus as processed and bail out if the top document has
a focused element, or if the focused frame is not the main frame.

[1] <a href="https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates">https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates</a>

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::flushAutofocusCandidates):
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/focusable-area-in-top-document-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-not-processed-when-top-document-has-focused-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/autofocus-not-processed-when-top-document-has-focused-element.html: Added.

* LayoutTests/fast/forms/form-submission-crash-3.html:
Updated crash test to not depend on autofocus to complete. The test
validates that form removal during submission does not crash; the
prior version relied on an autofocus-triggered onfocus handler to
remove the form, which no longer fires now that autofocus is
correctly skipped when another element has focus.

Canonical link: <a href="https://commits.webkit.org/314000@main">https://commits.webkit.org/314000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfe8ad5706d0282299be3c166bdd8ceca88bde33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121503 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/522805f8-ed5b-45e2-9d09-ee1eeca55b14) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127605 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89791 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b08430ce-f833-4512-bbc9-4e03b5691a25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29904 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147631 "Found 1 new API test failure: TestWebKitAPI.WebKit.FirstResponderSuppression (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108152 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce171713-1464-4ffc-ba8f-a527a81601d5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28951 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27574 "Found 1 new API test failure: TestWebKitAPI.WebKit.FirstResponderSuppression (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21044 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138853 "Found 21 new API test failures: TestWebKitAPI.KeyboardInputTests.RangedSelectionRectAfterRestoringFirstResponderWithRetainActiveFocusedState, TestWebKitAPI.KeyboardInputTests.CharactersAroundCaretSelection, TestWebKitAPI.DocumentEditingContext.RequestAutocorrectedRanges, TestWebKitAPI.KeyboardInputTests.CustomInputViewAndInputAccessoryView, TestWebKitAPI.AutocorrectionTests.AutocorrectionIndicatorsDismissAfterNextWord, TestWebKitAPI.WebKit.CaptureTextFromCamera, TestWebKitAPI.KeyboardInputTests.AllowKeypressForRegularCharacters, TestWebKitAPI.WebKit.CopyInAutoFilledAndViewablePasswordField, TestWebKitAPI.AutocorrectionTests.AutocorrectionContextDoesNotIncludeNewlineInTextField, TestWebKitAPI.KeyboardInputTests.CanHandleKeyEventInCompletionHandler ... (failure)") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175806 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28627 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135917 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36714 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100519 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23999 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110046 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36398 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2054 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36548 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->