### PR TITLE
[Swift in WebKit] Apply swift-format to WebKit/GPUProcess and fix formatting

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -264,7 +264,7 @@ extension WKBridgeUpdateMesh {
             return []
         }
 
-#if compiler(>=6.2)
+        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -273,7 +273,7 @@ extension WKBridgeUpdateMesh {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<instanceTransformsCount).map { unsafe matrices[$0] }
         }
-#else
+        #else
         return data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -282,7 +282,7 @@ extension WKBridgeUpdateMesh {
             let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<instanceTransformsCount).map { matrices[$0] }
         }
-#endif
+        #endif
     }
 }
 
@@ -808,15 +808,15 @@ extension WKBridgeLiteral {
 #if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit) && !os(visionOS)
 
 internal func toData<T>(_ input: [T]) -> Data {
-#if compiler(>=6.2)
+    #if compiler(>=6.2)
     unsafe input.withUnsafeBytes { bufferPointer in
         Data(bufferPointer)
     }
-#else
+    #else
     input.withUnsafeBytes { bufferPointer in
         Data(bufferPointer)
     }
-#endif
+    #endif
 }
 
 private func toDataArray<T>(_ input: [[T]]) -> [Data] {
@@ -891,7 +891,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
-#if compiler(>=6.2)
+        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -900,7 +900,7 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<jointTransformsCount).map { unsafe matrices[$0] }
         }
-#else
+        #else
         return data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -909,7 +909,7 @@ extension WKBridgeSkinningData {
             let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<jointTransformsCount).map { matrices[$0] }
         }
-#endif
+        #endif
     }
 
     var inverseBindPoses: [simd_float4x4] {
@@ -930,7 +930,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
-#if compiler(>=6.2)
+        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -939,7 +939,7 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<inverseBindPosesCount).map { unsafe matrices[$0] }
         }
-#else
+        #else
         return data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -948,7 +948,7 @@ extension WKBridgeSkinningData {
             let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<inverseBindPosesCount).map { matrices[$0] }
         }
-#endif
+        #endif
     }
 
     var influenceJointIndices: [UInt32] {
@@ -969,7 +969,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
-#if compiler(>=6.2)
+        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -978,7 +978,7 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: UInt32.self)
             return (0..<influenceJointIndicesCount).map { unsafe matrices[$0] }
         }
-#else
+        #else
         return data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -987,7 +987,7 @@ extension WKBridgeSkinningData {
             let matrices = baseAddress.assumingMemoryBound(to: UInt32.self)
             return (0..<influenceJointIndicesCount).map { matrices[$0] }
         }
-#endif
+        #endif
     }
 
     var influenceWeights: [Float] {
@@ -1008,7 +1008,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
-#if compiler(>=6.2)
+        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -1017,7 +1017,7 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: Float.self)
             return (0..<influenceWeightsCount).map { unsafe matrices[$0] }
         }
-#else
+        #else
         return data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -1026,7 +1026,7 @@ extension WKBridgeSkinningData {
             let matrices = baseAddress.assumingMemoryBound(to: Float.self)
             return (0..<influenceWeightsCount).map { matrices[$0] }
         }
-#endif
+        #endif
     }
 
     @nonobjc

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -810,7 +810,7 @@ private func makeMTLTextureFromImageAsset(
     let bytesPerRow = imageAsset.width * imageAsset.bytesPerPixel
     let bytesPerImage = bytesPerRow * imageAsset.height
 
-#if compiler(>=6.2)
+    #if compiler(>=6.2)
     unsafe imageAssetData.bytes.withUnsafeBytes { textureBytes in
         guard let textureBytesBaseAddress = textureBytes.baseAddress else {
             return
@@ -829,7 +829,7 @@ private func makeMTLTextureFromImageAsset(
             )
         }
     }
-#else
+    #else
     imageAssetData.bytes.withUnsafeBytes { textureBytes in
         guard let textureBytesBaseAddress = textureBytes.baseAddress else {
             return
@@ -848,7 +848,7 @@ private func makeMTLTextureFromImageAsset(
             )
         }
     }
-#endif
+    #endif
 
     return mtlTexture
 }


### PR DESCRIPTION
#### 0567fc53e06987baaba00693ea668670974ea0cf
<pre>
[Swift in WebKit] Apply swift-format to WebKit/GPUProcess and fix formatting
<a href="https://bugs.webkit.org/show_bug.cgi?id=308399">https://bugs.webkit.org/show_bug.cgi?id=308399</a>
<a href="https://rdar.apple.com/170890253">rdar://170890253</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(WKBridgeUpdateMesh.instanceTransforms):
(WKBridgeSkinningData.jointTransforms):
(WKBridgeSkinningData.inverseBindPoses):
(WKBridgeSkinningData.influenceJointIndices):
(WKBridgeSkinningData.influenceWeights):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/307995@main">https://commits.webkit.org/307995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/670e92c950bdf8b91ff47a5aaca1178095d139f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99639 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c6e909d-a725-4a74-a878-b86f81bd3136) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112470 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6e9bc43-8ee7-4f20-91bf-d6d72d9e609b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14824 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93341 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4c7c710-dc5f-4f2b-8e42-5fae376de1c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14090 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123656 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157160 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/331 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120493 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30945 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74385 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7665 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82039 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18078 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->