### PR TITLE
Reduce protectedFoo() usage in css/ and style/

### DIFF
--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Logging.h
@@ -33,7 +33,7 @@ namespace CSS {
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Calc auto const& value)
 {
-    return ts << value.protectedCalculation().get();
+    return ts << protect(value.calcValue()).get();
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Numeric auto const& value)

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -47,12 +47,12 @@ void unevaluatedCalcDeref(CSSCalc::Value* calc)
 }
 
 UnevaluatedCalcBase::UnevaluatedCalcBase(CSSCalc::Value& value)
-    : calc { value }
+    : m_calc { value }
 {
 }
 
 UnevaluatedCalcBase::UnevaluatedCalcBase(Ref<CSSCalc::Value>&& value)
-    : calc { WTF::move(value) }
+    : m_calc { WTF::move(value) }
 {
 }
 
@@ -65,12 +65,12 @@ UnevaluatedCalcBase::~UnevaluatedCalcBase() = default;
 
 CSSCalc::Value& UnevaluatedCalcBase::leakRef()
 {
-    return calc.leakRef();
+    return m_calc.leakRef();
 }
 
 bool UnevaluatedCalcBase::equal(const UnevaluatedCalcBase& other) const
 {
-    return protect(calcValue())->equals(other.calc.get());
+    return protect(calcValue())->equals(other.m_calc.get());
 }
 
 bool UnevaluatedCalcBase::requiresConversionData() const

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -60,7 +60,8 @@ void unevaluatedCalcDeref(CSSCalc::Value*);
 // will be evaluated to, allowing the processing of calc in generic code.
 
 // Non-generic base type to allow code sharing and out-of-line definitions.
-struct UnevaluatedCalcBase {
+class UnevaluatedCalcBase {
+public:
     UnevaluatedCalcBase(CSSCalc::Value&);
     UnevaluatedCalcBase(Ref<CSSCalc::Value>&&);
 
@@ -70,7 +71,7 @@ struct UnevaluatedCalcBase {
     UnevaluatedCalcBase& operator=(UnevaluatedCalcBase&&);
     ~UnevaluatedCalcBase();
 
-    CSSCalc::Value& calcValue() const { return calc; }
+    CSSCalc::Value& calcValue() const { return m_calc; }
     [[nodiscard]] CSSCalc::Value& NODELETE leakRef();
 
     bool requiresConversionData() const;
@@ -90,7 +91,7 @@ struct UnevaluatedCalcBase {
     bool equal(const UnevaluatedCalcBase&) const;
 
 private:
-    Ref<CSSCalc::Value> calc;
+    Ref<CSSCalc::Value> m_calc;
 };
 
 template<NumericRaw RawType> struct UnevaluatedCalc : UnevaluatedCalcBase {

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -72,7 +72,10 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     LengthWrapperBase(Fixed fixed) : m_value(indexForFixed, fixed.unresolvedValue()) { }
     LengthWrapperBase(Fixed fixed, bool hasQuirk) : m_value(indexForFixed, fixed.unresolvedValue(), hasQuirk) { }
     LengthWrapperBase(Percentage percent) : m_value(indexForPercentage, percent.value) { }
-    LengthWrapperBase(Calc&& calc) : m_value(indexForCalc, calc.protectedCalculation()) { }
+    LengthWrapperBase(Calc&& calc)
+        : m_value(indexForCalc, protect(calc.calculation()))
+    {
+    }
     LengthWrapperBase(Specified&& specified) : m_value(toData(specified)) { }
     LengthWrapperBase(const Specified& specified) : m_value(toData(specified)) { }
 
@@ -169,7 +172,7 @@ private:
                 return LengthWrapperData { indexForPercentage, percentage.value };
             },
             [](const Calc& calc) {
-                return LengthWrapperData { indexForCalc, calc.protectedCalculation() };
+                return LengthWrapperData { indexForCalc, protect(calc.calculation()) };
             }
         );
     }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h
@@ -50,7 +50,7 @@ template<auto R, typename V, CSS::PrimitiveKeyword... Ks> struct ToCSS<Primitive
                 return CSS::LengthPercentageRaw<R, V> { percentage.unit, percentage.value };
             },
             [&](const typename LengthPercentage<R, V>::Calc& calculation) -> Result {
-                return CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R, V>> { makeCalc(calculation.protectedCalculation(), style) };
+                return CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R, V>> { makeCalc(protect(calculation.calculation()), style) };
             },
             [&]<CSSValueID Id>(const Constant<Id>& identifier) -> Result {
                 return toCSS(identifier, style);

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -40,7 +40,7 @@ inline Calculation::Child copyCalculation(Ref<Calculation::Value> value)
 
 inline Calculation::Child copyCalculation(Calc auto const& value)
 {
-    return value.protectedCalculation()->copyRoot();
+    return protect(value.calculation())->copyRoot();
 }
 
 template<auto R, typename V> Calculation::Child copyCalculation(const Number<R, V>& value)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -265,14 +265,14 @@ template<auto R, typename V> struct ToCSS<Length<R, V>> {
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::AnglePercentage<R, V>>> {
     auto operator()(const UnevaluatedCalculation<CSS::AnglePercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::AnglePercentage<R, V>::Calc
     {
-        return typename CSS::AnglePercentage<R, V>::Calc { CSSCalc::Value::create(value.protectedCalculation(), style) };
+        return typename CSS::AnglePercentage<R, V>::Calc { CSSCalc::Value::create(protect(value.calculation()), style) };
     }
 };
 
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::LengthPercentage<R, V>>> {
     auto operator()(const UnevaluatedCalculation<CSS::LengthPercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::LengthPercentage<R, V>::Calc
     {
-        return typename CSS::LengthPercentage<R, V>::Calc { CSSCalc::Value::create(value.protectedCalculation(), style) };
+        return typename CSS::LengthPercentage<R, V>::Calc { CSSCalc::Value::create(protect(value.calculation()), style) };
     }
 };
 
@@ -288,7 +288,7 @@ template<auto R, typename V> struct ToCSS<AnglePercentage<R, V>> {
                 return typename CSS::AnglePercentage<R, V>::Raw { percentage.unit, percentage.value };
             },
             [&](const typename AnglePercentage<R, V>::Calc& calculation) -> CSS::AnglePercentage<R> {
-                return typename CSS::AnglePercentage<R, V>::Calc { CSSCalc::Value::create(calculation.protectedCalculation(), style) };
+                return typename CSS::AnglePercentage<R, V>::Calc { CSSCalc::Value::create(protect(calculation.calculation()), style) };
             }
         );
     }
@@ -309,7 +309,7 @@ template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
                 return typename CSS::LengthPercentage<R, V>::Raw { percentage.unit, percentage.value };
             },
             [&](const typename LengthPercentage<R, V>::Calc& calculation) -> CSS::LengthPercentage<R> {
-                return typename CSS::LengthPercentage<R, V>::Calc { CSSCalc::Value::create(calculation.protectedCalculation(), style) };
+                return typename CSS::LengthPercentage<R, V>::Calc { CSSCalc::Value::create(protect(calculation.calculation()), style) };
             }
         );
     }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -110,14 +110,14 @@ template<Calc Calculation, typename Result> struct Evaluation<Calculation, Resul
     template<typename... Rest> auto operator()(const Calculation& calculation, Result referenceLength, ZoomNeeded token, Rest&&... rest) -> Result
         requires (Calculation::range.zoomOptions == CSS::RangeZoomOptions::Default)
     {
-        return evaluate<Result>(calculation.protectedCalculation(), referenceLength, token, std::forward<Rest>(rest)...);
+        return evaluate<Result>(protect(calculation.calculation()), referenceLength, token, std::forward<Rest>(rest)...);
     }
 
 
     template<typename... Rest> auto operator()(const Calculation& calculation, Result referenceLength, ZoomFactor usedZoom, Rest&&... rest) -> Result
         requires (Calculation::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
-        return evaluate<Result>(calculation.protectedCalculation(), referenceLength, usedZoom, std::forward<Rest>(rest)...);
+        return evaluate<Result>(protect(calculation.calculation()), referenceLength, usedZoom, std::forward<Rest>(rest)...);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -35,7 +35,7 @@ namespace Style {
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Calc auto const& value)
 {
-    return ts << value.protectedCalculation().get();
+    return ts << protect(value.calculation()).get();
 }
 
 template<auto R, typename V> WTF::TextStream& operator<<(WTF::TextStream& ts, const Length<R, V>& value)

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.cpp
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.cpp
@@ -31,17 +31,17 @@ namespace WebCore {
 namespace Style {
 
 UnevaluatedCalculationBase::UnevaluatedCalculationBase(Calculation::Value& value)
-    : calc { value }
+    : m_calc { value }
 {
 }
 
 UnevaluatedCalculationBase::UnevaluatedCalculationBase(Ref<Calculation::Value>&& value)
-    : calc { WTF::move(value) }
+    : m_calc { WTF::move(value) }
 {
 }
 
 UnevaluatedCalculationBase::UnevaluatedCalculationBase(Calculation::Child&& root, CSS::Category category, CSS::Range range)
-    : calc {
+    : m_calc {
         Calculation::Value::create(
             category,
             CSS::Range { range.min, range.max },
@@ -58,14 +58,9 @@ UnevaluatedCalculationBase& UnevaluatedCalculationBase::operator=(UnevaluatedCal
 
 UnevaluatedCalculationBase::~UnevaluatedCalculationBase() = default;
 
-Ref<Calculation::Value> UnevaluatedCalculationBase::protectedCalculation() const
-{
-    return calc;
-}
-
 bool UnevaluatedCalculationBase::equal(const UnevaluatedCalculationBase& other) const
 {
-    return arePointingToEqualData(calc, other.calc);
+    return arePointingToEqualData(m_calc, other.m_calc);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
@@ -37,7 +37,8 @@ struct Child;
 }
 
 // Non-generic base type to allow code sharing and out-of-line definitions.
-struct UnevaluatedCalculationBase {
+class UnevaluatedCalculationBase {
+public:
     explicit UnevaluatedCalculationBase(Calculation::Value&);
     explicit UnevaluatedCalculationBase(Ref<Calculation::Value>&&);
     explicit UnevaluatedCalculationBase(Calculation::Child&&, CSS::Category, CSS::Range);
@@ -49,12 +50,12 @@ struct UnevaluatedCalculationBase {
 
     WEBCORE_EXPORT ~UnevaluatedCalculationBase();
 
-    Ref<Calculation::Value> protectedCalculation() const;
+    Calculation::Value& calculation() const { return m_calc; }
 
     bool equal(const UnevaluatedCalculationBase&) const;
 
 private:
-    Ref<Calculation::Value> calc;
+    Ref<Calculation::Value> m_calc;
 };
 
 // Wrapper for `Ref<Calculation::Value>` that includes range and category as part of the type.


### PR DESCRIPTION
#### c420855489baf7219f106ea39590c504edbe2ec2
<pre>
Reduce protectedFoo() usage in css/ and style/
<a href="https://bugs.webkit.org/show_bug.cgi?id=308400">https://bugs.webkit.org/show_bug.cgi?id=308400</a>
<a href="https://rdar.apple.com/170890400">rdar://170890400</a>

Reviewed by Chris Dumez.

Replace protectedFoo() wrapper methods with protect()
free function calls in Source/WebCore/css/ and Source/WebCore/style/

No new tests, as no change in functionality.

* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::exposedComputedCSSPropertyIDs const):
(WebCore::CSSComputedStyleDeclaration::length const):
(WebCore::CSSComputedStyleDeclaration::item const):
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::pump):
(WebCore::CSSFontFace::font):
(WebCore::CSSFontFace::protectedDocument): Deleted.
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::shouldIgnoreFontLoadCompletions const):
(WebCore::CSSFontFaceSource::fontLoaded):
(WebCore::CSSFontFaceSource::load):
(WebCore::CSSFontFaceSource::protectedCSSFontFace const): Deleted.
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::CSSPositionTryRule::reattach):
(WebCore::CSSPositionTryRule::style):
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::protectedContents): Deleted.
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSValueList.h:
(WebCore::CSSValueContainingVector::protectedItem const): Deleted.
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
(WebCore::DeprecatedCSSOMPrimitiveValue::cssText const):
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h:
(WebCore::DeprecatedCSSOMPrimitiveValue::protectedValue const): Deleted.
* Source/WebCore/css/PropertySetCSSDescriptors.cpp:
(WebCore::PropertySetCSSDescriptors::cssText const):
(WebCore::PropertySetCSSDescriptors::setCssText):
(WebCore::PropertySetCSSDescriptors::getPropertyCSSValue):
(WebCore::PropertySetCSSDescriptors::getPropertyValue):
(WebCore::PropertySetCSSDescriptors::getPropertyPriority):
(WebCore::PropertySetCSSDescriptors::getPropertyShorthand):
(WebCore::PropertySetCSSDescriptors::isPropertyImplicit):
(WebCore::PropertySetCSSDescriptors::setProperty):
(WebCore::PropertySetCSSDescriptors::removeProperty):
(WebCore::PropertySetCSSDescriptors::getPropertyValueInternal const):
(WebCore::PropertySetCSSDescriptors::setPropertyInternal):
(WebCore::PropertySetCSSDescriptors::cssParserContext const):
(WebCore::PropertySetCSSDescriptors::protectedPropertySet const): Deleted.
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumePageRule):
(WebCore::CSSParser::consumeScopeRule):
(WebCore::CSSParser::consumeStyleRule):
(WebCore::CSSParser::protectedStyleSheet const): Deleted.
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
(WebCore::CSSPropertyParserHelpers::isGridTrackFixedSized):
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::conversionData const):
(WebCore::SizesAttributeParser::protectedDocument const): Deleted.
* Source/WebCore/css/parser/SizesAttributeParser.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveData.h:
(WebCore::CSS::PrimitiveData::PrimitiveData):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h:
(WebCore::CSS::CSSValueCreation&lt;CSSType&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Logging.h:
(WebCore::CSS::operator&lt;&lt;):
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
(WebCore::CSS::UnevaluatedCalcBase::UnevaluatedCalcBase):
(WebCore::CSS::UnevaluatedCalcBase::leakRef):
(WebCore::CSS::UnevaluatedCalcBase::equal const):
(WebCore::CSS::UnevaluatedCalcBase::requiresConversionData const):
(WebCore::CSS::UnevaluatedCalcBase::serializationForCSS const):
(WebCore::CSS::UnevaluatedCalcBase::collectComputedStyleDependencies const):
(WebCore::CSS::UnevaluatedCalcBase::simplifyBase const):
(WebCore::CSS::UnevaluatedCalcBase::evaluate const):
(WebCore::CSS::UnevaluatedCalcBase::protectedCalc const): Deleted.
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
(WebCore::CSS::UnevaluatedCalcBase::calc const):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::parseStyleSheet):
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::addSubresourceAttributeURLs const):
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
(WebCore::Style::LengthWrapperBase::LengthWrapperBase):
(WebCore::Style::LengthWrapperBase::toData):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h:
(WebCore::Style::copyCalculation):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h:
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.cpp:
(WebCore::Style::UnevaluatedCalculationBase::UnevaluatedCalculationBase):
(WebCore::Style::UnevaluatedCalculationBase::equal const):
(WebCore::Style::UnevaluatedCalculationBase::protectedCalculation const): Deleted.
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h:
(WebCore::Style::UnevaluatedCalculationBase::calculation const):
* Source/WebCore/style/values/svg/StyleSVGPaint.cpp:
(WebCore::Style::CSSValueConversion&lt;SVGPaint&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/308164@main">https://commits.webkit.org/308164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b9cf31f96cd8887771a1235d23da18fb694dd03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e69d9ae6-5171-4d75-8679-765e408b9cc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113002 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a6acf0e-8d96-4a59-8730-015f5fbb7994) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e5394b3-659e-41d4-a741-96c300d88f78) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2768 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157653 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121006 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31045 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131391 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18755 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18485 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->