### PR TITLE
Suppress safer C++ warnings on wrapper function in WebKit

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -58,7 +58,8 @@ template<typename DestinationClass, typename SourceClass> inline CLANG_POINTER_C
 
 template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass& object)
 {
-    return checkedObjCCast<typename WrapperTraits<ObjectClass>::WrapperClass>(object.wrapper());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return checkedObjCCast<typename WrapperTraits<ObjectClass>::WrapperClass>(object.wrapper());
 }
 
 template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass* object)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm
@@ -34,12 +34,14 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)targetFrame
 {
-    return wrapper(protect(*_formInfo)->targetFrame());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_formInfo)->targetFrame());
 }
 
 - (WKFrameInfo *)sourceFrame
 {
-    return wrapper(protect(*_formInfo)->sourceFrame());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_formInfo)->sourceFrame());
 }
 
 - (NSURL *)submissionURL

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
@@ -54,7 +54,8 @@
 
 - (WKContentWorld *)world
 {
-    return wrapper(API::ContentWorld::worldForIdentifier(_ref->info().worldIdentifier));
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(API::ContentWorld::worldForIdentifier(_ref->info().worldIdentifier));
 }
 
 - (void)windowProxyFrameInfo:(void (^)(WKFrameInfo *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -105,7 +105,8 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKFrameInfo *)sourceFrame
 {
-    return wrapper(protect(*_navigationAction)->sourceFrame());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_navigationAction)->sourceFrame());
 }
 
 - (WKFrameInfo *)targetFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -88,7 +88,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)_navigationInitiatingFrame
 {
-    return wrapper(RefPtr { _navigationResponse.get() }->navigationInitiatingFrame());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(RefPtr { _navigationResponse.get() }->navigationInitiatingFrame());
 }
 
 - (WKNavigation *)_navigation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -406,7 +406,8 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (WKWebsiteDataStore *)_websiteDataStore
 {
-    return wrapper(_websitePolicies->websiteDataStore());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(_websitePolicies->websiteDataStore());
 }
 
 - (void)_setWebsiteDataStore:(WKWebsiteDataStore *)websiteDataStore
@@ -416,7 +417,8 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (WKUserContentController *)_userContentController
 {
-    return wrapper(_websitePolicies->userContentController());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(_websitePolicies->userContentController());
 }
 
 - (void)_setUserContentController:(WKUserContentController *)userContentController

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -409,7 +409,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 + (WKWebsiteDataStore *)defaultDataStore
 {
-    return wrapper(WebKit::WebsiteDataStore::defaultDataStore());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(WebKit::WebsiteDataStore::defaultDataStore());
 }
 
 + (WKWebsiteDataStore *)nonPersistentDataStore
@@ -496,7 +497,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKHTTPCookieStore *)httpCookieStore
 {
-    return wrapper(protect(*_websiteDataStore)->cookieStore());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_websiteDataStore)->cookieStore());
 }
 
 static WallTime toSystemClockTime(NSDate *date)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -107,7 +107,8 @@ IGNORE_WARNINGS_END
 
 - (NSData *)resumeData
 {
-    return WebKit::wrapper(_download->_download->legacyResumeData());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return WebKit::wrapper(_download->_download->legacyResumeData());
 }
 
 - (WKFrameInfo *)originatingFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -69,7 +69,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 - (WKProcessPool *)processPool
 {
-    return wrapper(protect(*_configuration)->processPool());
+    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_configuration)->processPool());
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -296,7 +296,8 @@ static WKURLRequestRef willSendRequestForFrame(WKBundlePageRef, WKBundleFrameRef
         if (substituteRequest != originalRequest.get())
             return substituteRequest ? WKURLRequestCreateWithNSURLRequest(substituteRequest.get()) : nullptr;
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequest:redirectResponse:)]) {
-        RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
+        // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
+        SUPPRESS_UNCOUNTED_ARG RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
         RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() willSendRequest:originalRequest.get()
             redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().protectedNSURLResponse().get()];
 


### PR DESCRIPTION
#### 935b5b63171f3ce18d5577c8cdfd3d9380394344
<pre>
Suppress safer C++ warnings on wrapper function in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=308403">https://bugs.webkit.org/show_bug.cgi?id=308403</a>

Reviewed by Wenson Hsieh.

wrapper functions in WebKit are annotated as CLANG_POINTER_CONVERSION so static analyzer shouldn&apos;t
emit any safer C++ warnings but they currently do. Suppress these warnings while we figure out
the root cause in clang side.

No new tests since there should be no behavioral changes.

* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::wrapper):
* Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm:
(-[WKFormInfo targetFrame]):
(-[WKFormInfo sourceFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm:
(-[WKJSHandle world]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction sourceFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _navigationInitiatingFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _websiteDataStore]):
(-[WKWebpagePreferences _userContentController]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore defaultDataStore]):
(-[WKWebsiteDataStore httpCookieStore]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload resumeData]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration processPool]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(willSendRequestForFrame):

Canonical link: <a href="https://commits.webkit.org/307994@main">https://commits.webkit.org/307994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9f161a49e8c44a7c126d7028f2b5396d1df809a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154844 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/814d59b0-f199-477c-9031-44a2e9812e9c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112472 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74b9db3e-7bb2-4ee0-bce8-c89291885d2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14826 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93343 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12716da2-dc09-4262-bb5d-707ff01ee179) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14092 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123658 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157163 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18670 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120796 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74388 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7667 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82042 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18081 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->