### PR TITLE
REGRESSION (306807@main): Unrecognized selector -scrollViewDidScroll: under -[WKScrollViewDelegateForwarder forwardInvocation:]

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -971,7 +971,7 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 #if PLATFORM(IOS_FAMILY)
     [_remoteObjectRegistry _invalidate];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [_scrollView setInternalDelegate:nil];
+    [_scrollView _invalidateInternalDelegate];
 #endif
 
 #if PLATFORM(MAC) && HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -43,6 +43,7 @@
 - (void)_setBouncesInternal:(BOOL)horizontal vertical:(BOOL)vertical;
 - (BOOL)_setContentScrollInsetInternal:(UIEdgeInsets)insets;
 - (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
+- (void)_invalidateInternalDelegate;
 
 - (void)_resetContentInset;
 @property (nonatomic, readonly) BOOL _contentInsetWasExternallyOverridden;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -212,6 +212,12 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
     return _internalDelegate.getAutoreleased();
 }
 
+- (void)_invalidateInternalDelegate
+{
+    _internalDelegate = nil;
+    [self _updateDelegate];
+}
+
 - (void)setInternalDelegate:(WKWebView <UIScrollViewDelegate> *)internalDelegate
 {
     if (internalDelegate == _internalDelegate.get())

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -896,6 +896,23 @@ TEST(WKScrollViewTests, ContentInsetAdjustmentBehaviorChangeAfterViewportFitChan
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.body.clientWidth"], "280");
 }
 
+TEST(WKScrollViewTests, DoNotCrashIfScrollViewOutlivesWebView)
+{
+    RetainPtr delegate = adoptNS([NSObject<UIScrollViewDelegate> new]);
+    RetainPtr<UIScrollView> scrollView;
+
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+        scrollView = [webView scrollView];
+        [scrollView setDelegate:delegate];
+    }
+
+    Util::spinRunLoop(); // Make sure the web view has been deallocated.
+
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+    [window addSubview:scrollView.get()];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 6ede33e742f29f884116edc86a0cc2a2bcacd366
<pre>
REGRESSION (306807@main): Unrecognized selector -scrollViewDidScroll: under -[WKScrollViewDelegateForwarder forwardInvocation:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=308402">https://bugs.webkit.org/show_bug.cgi?id=308402</a>
<a href="https://rdar.apple.com/170105626">rdar://170105626</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

After the safer CPP changes in 306807@main turned `_internalDelegate` into a `WeakObjCPtr`, it&apos;s
possible to end up in a scenario where `WKScrollViewDelegateForwarder` receives an unrecognized
selector that was intended for `WKWebView`. This happens when:

1.  The scroll view get an external delegate from the WebKit client (which internally creates a
    `WKScrollViewDelegateForwarder` that forwards scroll view delegate calls to either the web view
    or the WebKit client&apos;s delegate). When calling into `-[UIScrollView setDelegate:]`, UIKit also
    caches the results of `-respondsToSelector:` on the delegate forwarder for all scroll view
    delegate methods.

2.  The web view is later deallocated (`-[WKWebView dealloc]`). Before calling into
    `-setInternalDelegate:`, however, `_internalDelegate` in `WKScrollView` is already set to `nil`
    due to `WeakObjCPtr` semantics, which causes `-[WKScrollView setInternalDelegate:]` to bail
    early and **not** update the real delegate (which remains `WKScrollViewDelegateForwarder`).

3.  Later on, if the scroll view is used in any way that causes one of the scroll view delegate
    methods that `WKWebView` responds to (per the cached results in [1]), UIKit ends up trying to
    invoke that selector on `WKScrollViewDelegateForwarder`, which has since been detached from its
    web view. The end result is an unrecognized selector and an ObjC exception.

This is essentially a TOCTOU between [1] (where UIKit checks that the delegate forwarder responds to
selectors like `scrollViewDidScroll:`, etc.) and [3] (where UIKit goes to invoke the selector), in
the case where the internal delegate (web view) is destroyed in the interim.

To fix this, we add a second method to forcibly invalidate the `_internalDelegate` and call into
`-[UIScrollView setDelegate:]` to update the cached `respondsToSelector:` flags.

Test: WKScrollViewTests.DoNotCrashIfScrollViewOutlivesWebView

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView dealloc]):
* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _invalidateInternalDelegate]):

See above for more details.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, DoNotCrashIfScrollViewOutlivesWebView)):

Canonical link: <a href="https://commits.webkit.org/307999@main">https://commits.webkit.org/307999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c2a59a39b5c214106a45e11e6022e686586b83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99643 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5510e0c-046b-4b27-8dff-fe62b60920fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112473 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80466 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12193150-0a8b-4de7-aede-f3b10c92bbfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93344 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96a3342f-0f32-4582-88cf-9e37c5f04ace) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14093 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11850 "Found 1 new API test failure: TestWebKitAPI.AppHighlights.AppHighlightRestoreFailure (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2291 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157164 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120497 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30948 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74389 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82043 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18025 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->