### PR TITLE
Make isFormListedElement, isValidatedFormListedElement, and isEnumeratable NODELETE

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -660,8 +660,8 @@ public:
     virtual bool isMediaElement() const { return false; }
 #endif
 
-    virtual bool isFormListedElement() const { return false; }
-    virtual bool isValidatedFormListedElement() const { return false; }
+    virtual bool NODELETE isFormListedElement() const { return false; }
+    virtual bool NODELETE isValidatedFormListedElement() const { return false; }
     virtual bool NODELETE isMaybeFormAssociatedCustomElement() const { return false; }
     virtual bool isSpinButtonElement() const { return false; }
     virtual bool isTextFormControlElement() const { return false; }

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -42,8 +42,8 @@ public:
     FormAssociatedCustomElement(HTMLMaybeFormAssociatedCustomElement&);
     virtual ~FormAssociatedCustomElement();
 
-    bool isFormListedElement() const final { return true; }
-    bool isValidatedFormListedElement() const final { return true; }
+    bool NODELETE isFormListedElement() const final { return true; }
+    bool NODELETE isValidatedFormListedElement() const final { return true; }
 
     FormAssociatedElement* NODELETE asFormAssociatedElement() final { return this; }
     FormListedElement* NODELETE asFormListedElement() final { return this; }
@@ -53,7 +53,7 @@ public:
     const HTMLElement& asHTMLElement() const final { return *m_element.get(); }
 
     void reset() final;
-    bool isEnumeratable() const final;
+    bool NODELETE isEnumeratable() const final;
 
     void setFormValue(CustomElementFormValue&& submissionValue, std::optional<CustomElementFormValue>&& state);
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -35,7 +35,7 @@ public:
     Ref<HTMLElement> asProtectedHTMLElement() { return asHTMLElement(); }
     virtual const HTMLElement& asHTMLElement() const = 0;
     Ref<const HTMLElement> asProtectedHTMLElement() const { return asHTMLElement(); }
-    virtual bool isFormListedElement() const = 0;
+    virtual bool NODELETE isFormListedElement() const = 0;
 
     virtual void formWillBeDestroyed() { m_form = nullptr; }
 

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -48,8 +48,8 @@ public:
 
     ValidityState& validity();
 
-    virtual bool isValidatedFormListedElement() const = 0;
-    virtual bool isEnumeratable() const = 0;
+    virtual bool NODELETE isValidatedFormListedElement() const = 0;
+    virtual bool NODELETE isEnumeratable() const = 0;
 
     // Returns the 'name' attribute value. If this element has no name
     // attribute, it returns an empty string instead of null string.

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -71,7 +71,7 @@ private:
 
     bool appendFormData(DOMFormData&) final;
 
-    bool isEnumeratable() const final { return true; }
+    bool NODELETE isEnumeratable() const final { return true; }
     bool isLabelable() const final { return true; }
     bool isInteractiveContent() const final { return true; }
 

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -47,7 +47,7 @@ private:
 
     bool isDisabledFormControl() const final;
     bool isActuallyDisabled() const final;
-    bool isEnumeratable() const final { return true; }
+    bool NODELETE isEnumeratable() const final { return true; }
     bool supportsFocus() const final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     const AtomString& formControlType() const final;

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -41,8 +41,8 @@ public:
 
     virtual ~HTMLFormControlElement();
 
-    bool isValidatedFormListedElement() const final { return true; }
-    bool isFormListedElement() const final { return true; }
+    bool NODELETE isValidatedFormListedElement() const final { return true; }
+    bool NODELETE isFormListedElement() const final { return true; }
 
     bool matchesValidPseudoClass() const override { return ValidatedFormListedElement::matchesValidPseudoClass(); }
     bool matchesInvalidPseudoClass() const override { return ValidatedFormListedElement::matchesInvalidPseudoClass(); }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -214,7 +214,7 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
 
-    bool isFormListedElement() const final { return false; }
+    bool NODELETE isFormListedElement() const final { return false; }
     FormAssociatedElement* NODELETE asFormAssociatedElement() final { return this; }
     HTMLImageElement& asHTMLElement() final { return *this; }
     const HTMLImageElement& asHTMLElement() const final { return *this; }

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -383,7 +383,7 @@ private:
     int defaultTabIndex() const final;
     bool isKeyboardFocusable(const FocusEventData&) const final;
     bool isMouseFocusable() const final;
-    bool isEnumeratable() const final;
+    bool NODELETE isEnumeratable() const final;
     bool isLabelable() const final;
     void updateFocusAppearance(SelectionRestorationMode, SelectionRevealMode) final;
     bool shouldUseInputMethod() final;

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -38,8 +38,8 @@ public:
     static Ref<HTMLMaybeFormAssociatedCustomElement> create(const QualifiedName& tagName, Document&);
 
     bool NODELETE isMaybeFormAssociatedCustomElement() const final { return true; }
-    bool isFormListedElement() const final;
-    bool isValidatedFormListedElement() const final;
+    bool NODELETE isFormListedElement() const final;
+    bool NODELETE isValidatedFormListedElement() const final;
     bool NODELETE isFormAssociatedCustomElement() const;
 
     FormAssociatedElement* NODELETE asFormAssociatedElement() final;

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -93,10 +93,10 @@ private:
     HTMLObjectElement& asHTMLElement() final { return *this; }
     const HTMLObjectElement& asHTMLElement() const final { return *this; }
 
-    bool isFormListedElement() const final { return true; }
-    bool isValidatedFormListedElement() const final { return false; }
+    bool NODELETE isFormListedElement() const final { return true; }
+    bool NODELETE isValidatedFormListedElement() const final { return false; }
 
-    bool isEnumeratable() const final { return true; }
+    bool NODELETE isEnumeratable() const final { return true; }
 
     bool canContainRangeEndPoint() const final;
 

--- a/Source/WebCore/html/HTMLOutputElement.h
+++ b/Source/WebCore/html/HTMLOutputElement.h
@@ -59,7 +59,7 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
     const AtomString& formControlType() const final;
-    bool isEnumeratable() const final { return true; }
+    bool NODELETE isEnumeratable() const final { return true; }
     bool isLabelable() const final { return true; }
     bool supportsFocus() const final;
     void reset() final;

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -213,7 +213,7 @@ private:
     
     bool canStartSelection() const final { return false; }
 
-    bool isEnumeratable() const final { return true; }
+    bool NODELETE isEnumeratable() const final { return true; }
     bool isLabelable() const final { return true; }
 
     bool isInteractiveContent() const final { return true; }

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -86,7 +86,7 @@ private:
     
     void subtreeHasChanged() final;
 
-    bool isEnumeratable() const final { return true; }
+    bool NODELETE isEnumeratable() const final { return true; }
     bool isLabelable() const final { return true; }
 
     bool isInteractiveContent() const final { return true; }

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -75,7 +75,7 @@ public:
     // This must be called any time the result of willValidate() has changed.
     bool isValidFormControlElement() const { return m_isValid; }
 
-    bool isEnumeratable() const override { return false; }
+    bool NODELETE isEnumeratable() const override { return false; }
 
     bool wasInteractedWithSinceLastFormSubmitEvent() const { return m_wasInteractedWithSinceLastFormSubmitEvent; }
     void setInteractedWithSinceLastFormSubmitEvent(bool);


### PR DESCRIPTION
#### b25f1751af5ad0acdf1749bf993650c053478a55
<pre>
Make isFormListedElement, isValidatedFormListedElement, and isEnumeratable NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=308404">https://bugs.webkit.org/show_bug.cgi?id=308404</a>

Reviewed by Wenson Hsieh.

Annotate these functions as NODELETE as their implementations are all trivial.

No new tests since there should be no behavioral changes.

* Source/WebCore/dom/Element.h:
(WebCore::Element::isFormListedElement const):
(WebCore::Element::isValidatedFormListedElement const):
* Source/WebCore/html/FormAssociatedCustomElement.h:
* Source/WebCore/html/FormAssociatedElement.h:
* Source/WebCore/html/FormListedElement.h:
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLFieldSetElement.h:
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLOutputElement.h:
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/ValidatedFormListedElement.h:

Canonical link: <a href="https://commits.webkit.org/308001@main">https://commits.webkit.org/308001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db93b9837cbd941a9b5ca3c37d83be29c67ded41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a784ba15-f107-4480-b6c4-9f8248af0084) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112474 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80468 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be976a48-561c-4f19-b7e0-934ccc450a5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93345 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7d9ca45-2c50-4b60-b0f4-4ddfc485faee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11851 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157165 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/336 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120496 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120797 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74392 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7682 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82044 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18026 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->