### PR TITLE
[JSC] Better HeapBigIntUse speculation in DFG / FTL

### DIFF
--- a/JSTests/stress/heap-bigint-dfg-ftl-arith-bitwise-compare.js
+++ b/JSTests/stress/heap-bigint-dfg-ftl-arith-bitwise-compare.js
@@ -1,0 +1,97 @@
+function testAdd(a, b) { return a + b; }
+function testSub(a, b) { return a - b; }
+function testMul(a, b) { return a * b; }
+function testDiv(a, b) { return a / b; }
+function testMod(a, b) { return a % b; }
+function testBitAnd(a, b) { return a & b; }
+function testBitOr(a, b) { return a | b; }
+function testBitXor(a, b) { return a ^ b; }
+function testBitLShift(a, b) { return a << b; }
+function testBitRShift(a, b) { return a >> b; }
+function testBitNot(a) { return ~a; }
+function testLess(a, b) { return a < b; }
+function testLessEq(a, b) { return a <= b; }
+function testGreater(a, b) { return a > b; }
+function testGreaterEq(a, b) { return a >= b; }
+function testEq(a, b) { return a == b; }
+function testStrictEq(a, b) { return a === b; }
+
+for (let i = 0; i < 100000; i++) {
+    // Arithmetic
+    if (testAdd(1n, 2n) !== 3n)
+        throw new Error("add failed");
+    if (testSub(5n, 3n) !== 2n)
+        throw new Error("sub failed");
+    if (testMul(3n, 4n) !== 12n)
+        throw new Error("mul failed");
+    if (testDiv(10n, 3n) !== 3n)
+        throw new Error("div failed");
+    if (testMod(10n, 3n) !== 1n)
+        throw new Error("mod failed");
+
+    // Bitwise
+    if (testBitAnd(0xFFn, 0x0Fn) !== 0x0Fn)
+        throw new Error("bitand failed");
+    if (testBitOr(0xF0n, 0x0Fn) !== 0xFFn)
+        throw new Error("bitor failed");
+    if (testBitXor(0xFFn, 0x0Fn) !== 0xF0n)
+        throw new Error("bitxor failed");
+    if (testBitLShift(1n, 8n) !== 256n)
+        throw new Error("lshift failed");
+    if (testBitRShift(256n, 4n) !== 16n)
+        throw new Error("rshift failed");
+    if (testBitNot(0n) !== -1n)
+        throw new Error("bitnot failed");
+
+    // Comparisons
+    if (testLess(1n, 2n) !== true)
+        throw new Error("less failed");
+    if (testLess(2n, 1n) !== false)
+        throw new Error("less false case failed");
+    if (testLessEq(2n, 2n) !== true)
+        throw new Error("lesseq failed");
+    if (testLessEq(3n, 2n) !== false)
+        throw new Error("lesseq false case failed");
+    if (testGreater(3n, 2n) !== true)
+        throw new Error("greater failed");
+    if (testGreater(1n, 2n) !== false)
+        throw new Error("greater false case failed");
+    if (testGreaterEq(2n, 2n) !== true)
+        throw new Error("greatereq failed");
+    if (testGreaterEq(1n, 2n) !== false)
+        throw new Error("greatereq false case failed");
+    if (testEq(2n, 2n) !== true)
+        throw new Error("eq failed");
+    if (testEq(1n, 2n) !== false)
+        throw new Error("eq false case failed");
+    if (testStrictEq(2n, 2n) !== true)
+        throw new Error("stricteq failed");
+    if (testStrictEq(1n, 2n) !== false)
+        throw new Error("stricteq false case failed");
+}
+
+// Test with larger BigInts to exercise HeapBigInt path (not BigInt32)
+let big1 = 123456789012345678901234567890n;
+let big2 = 987654321098765432109876543210n;
+for (let i = 0; i < 100000; i++) {
+    if (testAdd(big1, big2) !== 1111111110111111111011111111100n)
+        throw new Error("big add failed");
+    if (testSub(big2, big1) !== 864197532086419753208641975320n)
+        throw new Error("big sub failed");
+    if (testLess(big1, big2) !== true)
+        throw new Error("big less failed");
+    if (testGreater(big2, big1) !== true)
+        throw new Error("big greater failed");
+    if (testEq(big1, big1) !== true)
+        throw new Error("big eq failed");
+    if (testStrictEq(big1, big1) !== true)
+        throw new Error("big stricteq failed");
+    if (testStrictEq(big1, big2) !== false)
+        throw new Error("big stricteq false case failed");
+    if (testBitAnd(big1, big2) !== (big1 & big2))
+        throw new Error("big bitand failed");
+    if (testBitOr(big1, big2) !== (big1 | big2))
+        throw new Error("big bitor failed");
+    if (testBitXor(big1, big2) !== (big1 ^ big2))
+        throw new Error("big bitxor failed");
+}

--- a/JSTests/stress/heap-bigint-dfg-ftl-inc-dec.js
+++ b/JSTests/stress/heap-bigint-dfg-ftl-inc-dec.js
@@ -1,0 +1,39 @@
+// Test HeapBigInt increment/decrement (Inc/Dec nodes)
+function testInc(a) { return ++a; }
+function testDec(a) { return --a; }
+function testPostInc(a) {
+    let old = a;
+    a++;
+    if (a !== old + 1n)
+        throw new Error("postinc failed: " + a + " !== " + (old + 1n));
+    return a;
+}
+function testPostDec(a) {
+    let old = a;
+    a--;
+    if (a !== old - 1n)
+        throw new Error("postdec failed");
+    return a;
+}
+
+let big = 123456789012345678901234567890n;
+for (let i = 0; i < 100000; i++) {
+    if (testInc(big) !== 123456789012345678901234567891n)
+        throw new Error("inc failed");
+    if (testDec(big) !== 123456789012345678901234567889n)
+        throw new Error("dec failed");
+    testPostInc(big);
+    testPostDec(big);
+}
+
+// Also test with small BigInts to exercise HeapBigInt path
+for (let i = 0; i < 100000; i++) {
+    if (testInc(0n) !== 1n)
+        throw new Error("inc 0n failed");
+    if (testDec(0n) !== -1n)
+        throw new Error("dec 0n failed");
+    if (testInc(-1n) !== 0n)
+        throw new Error("inc -1n failed");
+    if (testDec(1n) !== 0n)
+        throw new Error("dec 1n failed");
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -990,7 +990,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 break;
             }
 
-            setNonCellTypeForNode(node, 
+            setNonCellTypeForNode(node,
                 typeOfDoubleSum(
                     forNode(node->child1()).m_type, forNode(node->child2()).m_type));
             break;
@@ -1078,7 +1078,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 setConstant(node, jsDoubleNumber(left.asNumber() - right.asNumber()));
                 break;
             }
-            setNonCellTypeForNode(node, 
+            setNonCellTypeForNode(node,
                 typeOfDoubleDifference(
                     forNode(node->child1()).m_type, forNode(node->child2()).m_type));
             break;
@@ -1277,7 +1277,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 break;
             }
 
-            setNonCellTypeForNode(node, 
+            setNonCellTypeForNode(node,
                 typeOfDoubleProduct(
                     forNode(node->child1()).m_type, forNode(node->child2()).m_type));
             break;

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -78,24 +78,13 @@ bool doesGC(Graph& graph, Node* node)
     case PhantomLocal:
     case SetArgumentDefinitely:
     case SetArgumentMaybe:
-    case ArithBitNot:
-    case ArithBitAnd:
-    case ArithBitOr:
-    case ArithBitXor:
-    case ArithBitLShift:
-    case ArithBitRShift:
     case ArithBitURShift:
     case ValueToInt32:
     case UInt32ToNumber:
     case DoubleAsInt32:
-    case ArithAdd:
     case ArithClz32:
-    case ArithSub:
     case ArithNegate:
-    case ArithMul:
     case ArithIMul:
-    case ArithDiv:
-    case ArithMod:
     case ArithAbs:
     case ArithMin:
     case ArithMax:
@@ -280,6 +269,17 @@ bool doesGC(Graph& graph, Node* node)
     case NumberIsNaN:
     case NumberIsFinite:
     case NumberIsSafeInteger:
+    case ArithBitNot:
+    case ArithBitAnd:
+    case ArithBitOr:
+    case ArithBitXor:
+    case ArithBitLShift:
+    case ArithBitRShift:
+    case ArithAdd:
+    case ArithSub:
+    case ArithMul:
+    case ArithDiv:
+    case ArithMod:
         return false;
 
 #if ASSERT_ENABLED
@@ -534,14 +534,13 @@ bool doesGC(Graph& graph, Node* node)
     case CompareLessEq:
     case CompareGreater:
     case CompareGreaterEq:
-        // FIXME: Add AnyBigIntUse and HeapBigIntUse specific optimizations in DFG / FTL code generation and ensure it does not perform GC.
-        // https://bugs.webkit.org/show_bug.cgi?id=210923
         if (node->isBinaryUseKind(Int32Use)
 #if USE(JSVALUE64)
             || node->isBinaryUseKind(Int52RepUse)
 #endif
             || node->isBinaryUseKind(DoubleRepUse)
             || node->isBinaryUseKind(BigInt32Use)
+            || node->isBinaryUseKind(HeapBigIntUse)
             || node->isBinaryUseKind(StringIdentUse)
             )
             return false;
@@ -564,6 +563,7 @@ bool doesGC(Graph& graph, Node* node)
             || node->isBinaryUseKind(DoubleRepUse)
             || node->isBinaryUseKind(SymbolUse)
             || node->isSymmetricBinaryUseKind(SymbolUse, UntypedUse)
+            || node->isBinaryUseKind(HeapBigIntUse)
             || node->isBinaryUseKind(StringIdentUse)
             || node->isSymmetricBinaryUseKind(ObjectUse, UntypedUse)
             || node->isBinaryUseKind(ObjectUse)

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -505,6 +505,35 @@ public:
     }
 #endif
 
+    bool binaryArithShouldSpeculateHeapBigInt(Node* node)
+    {
+        if (Node::shouldSpeculateHeapBigInt(node->child1().node(), node->child2().node()))
+            return true;
+
+        if (hasExitSite(node, BadType))
+            return false;
+
+        auto isHeapBigIntOrOther = [](Node* n) {
+            SpeculatedType prediction = n->prediction();
+            return prediction && !(prediction & ~(SpecHeapBigInt | SpecOther));
+        };
+
+        return (node->child1()->shouldSpeculateHeapBigInt() && isHeapBigIntOrOther(node->child2().node()))
+            || (node->child2()->shouldSpeculateHeapBigInt() && isHeapBigIntOrOther(node->child1().node()));
+    }
+
+    bool unaryArithShouldSpeculateHeapBigInt(Node* node)
+    {
+        if (node->child1()->shouldSpeculateHeapBigInt())
+            return true;
+
+        if (hasExitSite(node, BadType))
+            return false;
+
+        SpeculatedType prediction = node->child1()->prediction();
+        return prediction && !(prediction & ~(SpecHeapBigInt | SpecOther));
+    }
+
     bool variadicArithShouldSpeculateInt32(Node* node, PredictionPass pass)
     {
         bool result = true;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4014,6 +4014,33 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplGreaterEq, uintptr_t
     return codePointCompare(a, b) >= 0;
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntLess, uintptr_t, (JSCell* a, JSCell* b))
+{
+    return JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b)) == JSBigInt::ComparisonResult::LessThan;
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntLessEq, uintptr_t, (JSCell* a, JSCell* b))
+{
+    auto result = JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b));
+    return result == JSBigInt::ComparisonResult::LessThan || result == JSBigInt::ComparisonResult::Equal;
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntGreater, uintptr_t, (JSCell* a, JSCell* b))
+{
+    return JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b)) == JSBigInt::ComparisonResult::GreaterThan;
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntGreaterEq, uintptr_t, (JSCell* a, JSCell* b))
+{
+    auto result = JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b));
+    return result == JSBigInt::ComparisonResult::GreaterThan || result == JSBigInt::ComparisonResult::Equal;
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntEq, uintptr_t, (JSCell* a, JSCell* b))
+{
+    return JSBigInt::equals(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationCompareStringLess, uintptr_t, (JSGlobalObject* globalObject, JSString* a, JSString* b))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -376,6 +376,11 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplLess, uintptr_t, (S
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplLessEq, uintptr_t, (StringImpl*, StringImpl*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplGreater, uintptr_t, (StringImpl*, StringImpl*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplGreaterEq, uintptr_t, (StringImpl*, StringImpl*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntLess, uintptr_t, (JSCell*, JSCell*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntLessEq, uintptr_t, (JSCell*, JSCell*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntGreater, uintptr_t, (JSCell*, JSCell*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntGreaterEq, uintptr_t, (JSCell*, JSCell*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntEq, uintptr_t, (JSCell*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationCompareStringLess, uintptr_t, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationCompareStringLessEq, uintptr_t, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationCompareStringGreater, uintptr_t, (JSGlobalObject*, JSString*, JSString*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -220,6 +220,8 @@ private:
             if (left && right) {
                 if (isFullNumberOrBooleanSpeculationExpectingDefined(left) && isFullNumberOrBooleanSpeculationExpectingDefined(right))
                     changed |= mergePrediction(SpecInt32Only);
+                else if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else {
                     if (node->mayHaveBigIntResult())
                         changed |= mergePrediction(SpecBigInt);
@@ -240,6 +242,8 @@ private:
                 else if (m_graph.unaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+                else if (m_graph.unaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else if (isBigIntSpeculation(prediction))
                     changed |= mergePrediction(SpecBigInt);
                 else {
@@ -273,6 +277,8 @@ private:
                 else if (m_graph.binaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+                else if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else if (isBigIntSpeculation(left) && isBigIntSpeculation(right))
                     changed |= mergePrediction(SpecBigInt);
                 else {
@@ -346,6 +352,8 @@ private:
                 else if (m_graph.binaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+                else if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else if (isBigIntSpeculation(left) && isBigIntSpeculation(right))
                     changed |= mergePrediction(SpecBigInt);
                 else {
@@ -377,6 +385,8 @@ private:
                 else if (m_graph.unaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+                else if (m_graph.unaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else if (isBigIntSpeculation(prediction))
                     changed |= mergePrediction(SpecBigInt);
                 else {
@@ -408,6 +418,8 @@ private:
                 else if (node->op() == ToNumeric && m_graph.unaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+                else if (node->op() == ToNumeric && m_graph.unaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else if (node->op() == ToNumeric && isBigIntSpeculation(prediction))
                     changed |= mergePrediction(SpecBigInt);
                 else {
@@ -426,7 +438,9 @@ private:
             SpeculatedType right = node->child2()->prediction();
 
             if (left && right) {
-                if (node->child1()->shouldSpeculateBigInt() && node->child2()->shouldSpeculateBigInt())          
+                if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
+                else if (node->child1()->shouldSpeculateBigInt() && node->child2()->shouldSpeculateBigInt())
                     changed |= mergePrediction(SpecBigInt);
                 else if (isFullNumberOrBooleanSpeculationExpectingDefined(left)
                     && isFullNumberOrBooleanSpeculationExpectingDefined(right))
@@ -499,6 +513,8 @@ private:
                 else if (op == ValueMul && m_graph.binaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+                else if (op == ValueMul && m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else if (op == ValueMul && isBigIntSpeculation(left) && isBigIntSpeculation(right))
                     changed |= mergePrediction(SpecBigInt);
                 else {
@@ -532,7 +548,9 @@ private:
                         changed |= mergePrediction(SpecInt52Any);
                     else
                         changed |= mergePrediction(SpecBytecodeDouble);
-                } else if ((op == ValueDiv || op == ValueMod) && isBigIntSpeculation(left) && isBigIntSpeculation(right))
+                } else if ((op == ValueDiv || op == ValueMod) && m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
+                else if ((op == ValueDiv || op == ValueMod) && isBigIntSpeculation(left) && isBigIntSpeculation(right))
                     changed |= mergePrediction(SpecBigInt);
                 else {
                     changed |= mergePrediction(SpecInt32Only | SpecBytecodeDouble);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1396,6 +1396,7 @@ public:
 
     void compileSymbolEquality(Node*);
     void compileHeapBigIntEquality(Node*);
+    void compileHeapBigIntCompare(Node*, RelationalCondition);
     void compilePeepHoleSymbolEquality(Node*, Node* branchNode);
 #if USE(JSVALUE64)
     void compileNeitherDoubleNorHeapBigIntToNotDoubleStrictEquality(Node*, Edge neitherDoubleNorHeapBigInt, Edge notDouble);


### PR DESCRIPTION
#### 38c024bb251e05a3c3f6f08ed5a02de68c24b1b1
<pre>
[JSC] Better HeapBigIntUse speculation in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=308406">https://bugs.webkit.org/show_bug.cgi?id=308406</a>
<a href="https://rdar.apple.com/170895703">rdar://170895703</a>

Reviewed by Yijia Huang.

This patch adds HeapBigIntUse specialization for comparisons.
Also, we add unaryArithShouldSpeculateHeapBigInt / binaryArithShouldSpeculateHeapBigInt.
They are tolerant against Other (null / undefined) pollutions and
putting HeapBigIntUse in a better manner.

Tests: JSTests/stress/heap-bigint-dfg-ftl-arith-bitwise-compare.js
       JSTests/stress/heap-bigint-dfg-ftl-inc-dec.js

* JSTests/stress/heap-bigint-dfg-ftl-arith-bitwise-compare.js: Added.
(testAdd):
(testSub):
(testMul):
(testDiv):
(testMod):
(testBitAnd):
(testBitOr):
(testBitXor):
(testBitLShift):
(testBitRShift):
(testBitNot):
(testLess):
(testLessEq):
(testGreater):
(testGreaterEq):
(testEq):
(testStrictEq):
* JSTests/stress/heap-bigint-dfg-ftl-inc-dec.js: Added.
(testInc):
(testDec):
(testPostInc):
(testPostDec):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::fixupToThis):
(JSC::DFG::FixupPhase::fixupToNumberOrToNumericOrCallNumberConstructor):
(JSC::DFG::FixupPhase::fixupCompareStrictEqAndSameValue):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/308054@main">https://commits.webkit.org/308054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/967fe58237f6bed75ed74f081570fd77786a5817

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19038 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18939 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/155028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14993 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/2474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138332 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123829 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157349 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7154 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/520 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18855 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/120966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74659 "Failed to checkout and rebase branch from PR 59181") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22566 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177660 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18476 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18205 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->