### PR TITLE
[JSC] Shrink sizeof(JSBigInt)

### DIFF
--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1027,7 +1027,7 @@ public:
         JumpList doneCases;
         doneCases.append(branchTest32(Zero, destGPR));
         load64(Address(cellGPR, JSBigInt::offsetOfData()), destGPR);
-        doneCases.append(branchTest8(Zero, Address(cellGPR, JSBigInt::offsetOfSign())));
+        doneCases.append(branchTest8(Zero, Address(cellGPR, JSCell::typeInfoFlagsOffset()), TrustedImm32(TypeInfoPerCellBit)));
         neg64(destGPR);
         doneCases.link(this);
     }

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -3621,7 +3621,7 @@ std::optional<unsigned> JSBigInt::concurrentHash()
 unsigned JSBigInt::hashSlow()
 {
     ASSERT(!m_hash);
-    m_hash = computeHash(dataStorage(), length(), m_sign);
+    m_hash = computeHash(dataStorage(), length(), sign());
     return m_hash;
 }
 

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -90,11 +90,6 @@ public:
         return OBJECT_OFFSETOF(JSBigInt, m_length);
     }
 
-    static constexpr size_t offsetOfSign()
-    {
-        return OBJECT_OFFSETOF(JSBigInt, m_sign);
-    }
-
     static constexpr size_t offsetOfData()
     {
         return WTF::roundUpToMultipleOf<alignof(Digit)>(sizeof(JSBigInt));
@@ -104,8 +99,8 @@ public:
 
     JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
 
-    void setSign(bool sign) { m_sign = sign; }
-    bool sign() const { return m_sign; }
+    void setSign(bool sign) { setPerCellBit(sign); }
+    bool sign() const { return perCellBit(); }
 
     unsigned length() const { return m_length; }
 
@@ -625,7 +620,6 @@ private:
 
     const unsigned m_length;
     unsigned m_hash { 0 };
-    uint8_t m_sign { false };
 };
 
 inline JSBigInt* asHeapBigInt(JSValue value)


### PR DESCRIPTION
#### d2f75e3929bbcf18893ccc6a2aa4b186499b85b3
<pre>
[JSC] Shrink sizeof(JSBigInt)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308409">https://bugs.webkit.org/show_bug.cgi?id=308409</a>
<a href="https://rdar.apple.com/170899581">rdar://170899581</a>

Reviewed by Keith Miller.

Use perCellBit to store sign bit. This makes minimum JSBigInt size
16bytes.

* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::toBigInt64):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::hashSlow):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/308026@main">https://commits.webkit.org/308026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ed4a8849bbf92345d8afb66813fff4c8cf9989d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99658 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3419cc0c-0134-4339-be80-00f7d10beea8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112488 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80479 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9691e892-9051-499f-9196-f4770c36e443) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83a687df-9989-4c46-a759-76ac89e7652d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14107 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11866 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2307 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138163 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157180 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6984 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120512 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74416 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7704 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177491 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18308 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82059 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45548 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18040 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->