### PR TITLE
[iOS] Implement `showPicker()` for <select> elements

### DIFF
--- a/LayoutTests/fast/forms/ios/select-show-picker-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-show-picker-expected.txt
@@ -1,0 +1,18 @@
+Test that HTMLSelectElement.showPicker() works on iOS by displaying the native picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+=== Test 1: showPicker() without user activation should throw ===
+PASS select.showPicker() threw exception NotAllowedError: Select showPicker() requires a user gesture..
+
+=== Test 2: showPicker() with user activation should display the picker ===
+PASS select.matches(':open') is false
+Native picker appeared after showPicker()
+PASS select.matches(':open') is true
+PASS select.options[0].checkVisibility() is false
+PASS select.matches(':open') is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ Show select picker

--- a/LayoutTests/fast/forms/ios/select-show-picker.html
+++ b/LayoutTests/fast/forms/ios/select-show-picker.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<select id="select">
+    <option>Apple</option>
+    <option>Banana</option>
+    <option>Cherry</option>
+</select>
+<button onclick="select.showPicker()" id="button">Show select picker</button>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Test that HTMLSelectElement.showPicker() works on iOS by displaying the native picker.");
+
+    // Test 1: showPicker() without user activation should throw
+    debug("=== Test 1: showPicker() without user activation should throw ===");
+
+    shouldThrow("select.showPicker()", '"NotAllowedError: Select showPicker() requires a user gesture."');
+
+    // Test 2: showPicker() with user activation should display the picker
+    debug("");
+    debug("=== Test 2: showPicker() with user activation should display the picker ===");
+
+    // Verify select is not open yet
+    shouldBeFalse("select.matches(':open')");
+
+    await UIHelper.activateElement(button);
+
+    // Wait for the context menu (native picker) to appear
+    await UIHelper.waitForContextMenuToShow();
+    debug("Native picker appeared after showPicker()");
+
+    // Verify select matches :open pseudo-class
+    shouldBeTrue("select.matches(':open')");
+
+    // In-page options should not be visible (since native picker is used).
+    shouldBeFalse("select.options[0].checkVisibility()");
+
+    // Dismiss the picker
+    await UIHelper.dismissMenu();
+    await UIHelper.waitForContextMenuToHide();
+
+    // Verify select no longer matches :open
+    shouldBeFalse("select.matches(':open')");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7173,17 +7173,17 @@ SecureContextChecksEnabled:
 
 SelectShowPickerEnabled:
   type: bool
-  status: testable
+  status: stable
   category: dom
   humanReadableName: "<select> showPicker() method"
   humanReadableDescription: "Enable showPicker() method on <select>"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 SelectTrailingWhitespaceEnabled:

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -2001,6 +2001,16 @@ void HTMLSelectElement::showPickerInternal()
     if (!usesBaseAppearancePicker()) {
 #if !PLATFORM(IOS_FAMILY)
         showPopup();
+#else
+        RefPtr frame = document().frame();
+        if (!frame)
+            return;
+
+        RefPtr page = document().page();
+        if (!page)
+            return;
+
+        page->chrome().client().requestShowPickerForElement(*this);
 #endif
         return;
     }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -598,6 +598,11 @@ public:
     virtual RefPtr<PopupMenu> createPopupMenu(PopupMenuClient&) const = 0;
     virtual RefPtr<SearchPopupMenu> createSearchPopupMenu(PopupMenuClient&) const = 0;
 
+#if PLATFORM(IOS_FAMILY)
+    // Request to show the picker for a select element programmatically.
+    virtual void requestShowPickerForElement(HTMLSelectElement&) { }
+#endif
+
     virtual void notifyScrollerThumbIsVisibleInRect(const IntRect&) { }
     virtual void recommendedScrollbarStyleDidChange(ScrollbarStyle) { }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1098,6 +1098,17 @@ RefPtr<SearchPopupMenu> WebChromeClient::createSearchPopupMenu(PopupMenuClient& 
     return WebSearchPopupMenu::create(page.get(), &client);
 }
 
+#if PLATFORM(IOS_FAMILY)
+void WebChromeClient::requestShowPickerForElement(HTMLSelectElement& element)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    page->showPickerForSelectElement(element);
+}
+#endif
+
 GraphicsLayerFactory* WebChromeClient::graphicsLayerFactory() const
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -235,6 +235,10 @@ private:
     RefPtr<WebCore::PopupMenu> createPopupMenu(WebCore::PopupMenuClient&) const final;
     RefPtr<WebCore::SearchPopupMenu> createSearchPopupMenu(WebCore::PopupMenuClient&) const final;
 
+#if PLATFORM(IOS_FAMILY)
+    void requestShowPickerForElement(WebCore::HTMLSelectElement&) final;
+#endif
+
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() const final;
     void attachRootGraphicsLayer(WebCore::LocalFrame&, WebCore::GraphicsLayer*) final;
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1178,6 +1178,9 @@ public:
     void setFocusedElementValue(const WebCore::ElementContext&, const String&);
     void setFocusedElementSelectedIndex(const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection);
     void setSelectElementIsOpen(const WebCore::ElementContext&, bool isOpen);
+#if PLATFORM(IOS_FAMILY)
+    void showPickerForSelectElement(WebCore::HTMLSelectElement&);
+#endif
     void setIsShowingInputViewForFocusedElement(bool);
     bool isShowingInputViewForFocusedElement() const { return m_isShowingInputViewForFocusedElement; }
     void updateSelectionAppearance();

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1217,6 +1217,20 @@ void WebPage::setSelectElementIsOpen(const WebCore::ElementContext& context, boo
         select->setPopupIsVisible(isOpen);
 }
 
+void WebPage::showPickerForSelectElement(HTMLSelectElement& element)
+{
+    RefPtr localFrame = element.document().frame();
+    if (!localFrame)
+        return;
+
+    if (element.document().focusedElement() == &element) {
+        // Element is already focused, re-send focus information to UI process to trigger picker.
+        if (auto focusedElementInformation = this->focusedElementInformation())
+            send(Messages::WebPageProxy::ElementDidFocus(WTF::move(*focusedElementInformation), m_userIsInteracting, m_recentlyBlurredElement, m_lastActivityStateChanges, UserData()));
+    } else
+        protect(corePage())->focusController().setFocusedElement(&element, localFrame);
+}
+
 void WebPage::setIsShowingInputViewForFocusedElement(bool showingInputView)
 {
     m_isShowingInputViewForFocusedElement = showingInputView;


### PR DESCRIPTION
#### 76f90eb806ea98cb4b06d07130c0118d3e1c81a3
<pre>
[iOS] Implement `showPicker()` for &lt;select&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=308405">https://bugs.webkit.org/show_bug.cgi?id=308405</a>
<a href="https://rdar.apple.com/170894634">rdar://170894634</a>

Reviewed by NOBODY (OOPS!).

Emulate focus on the select to trigger the picker on iOS.

* LayoutTests/fast/forms/ios/select-show-picker-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-show-picker.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::requestShowPickerForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::requestShowPickerForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::showPickerForSelectElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76f90eb806ea98cb4b06d07130c0118d3e1c81a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc958907-0ecf-46e0-8372-08606124cead) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112494 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80480 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61db1c58-49b6-42f5-a1a2-449833030e00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93365 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/002cc597-ef6b-4f52-999b-924b1ad752cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11871 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2313 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138169 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157186 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6990 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/357 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120517 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120818 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74434 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7718 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82065 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45550 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18046 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->