### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebKit

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -178,9 +178,9 @@ public:
 
     Logger& logger();
 
-    const String& mediaCacheDirectory() const;
+    const String& NODELETE mediaCacheDirectory() const;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
-    const String& mediaKeysStorageDirectory() const;
+    const String& NODELETE mediaKeysStorageDirectory() const;
 #endif
 
 #if ENABLE(MEDIA_STREAM)
@@ -196,7 +196,7 @@ public:
     bool allowsDisplayCapture() const { return m_allowsDisplayCapture; }
 #endif
 #if ENABLE(VIDEO)
-    RemoteVideoFrameObjectHeap& videoFrameObjectHeap() const;
+    RemoteVideoFrameObjectHeap& NODELETE videoFrameObjectHeap() const;
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     void startCapturingAudio();
@@ -273,7 +273,7 @@ public:
     void takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&&);
 #endif
 
-    bool isAlwaysOnLoggingAllowed() const;
+    bool NODELETE isAlwaysOnLoggingAllowed() const;
 
 #if USE(AUDIO_SESSION)
     RemoteAudioSessionProxy& audioSessionProxy();

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -109,15 +109,15 @@ public:
 
     void prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&&);
     void processDidResume();
-    void resume();
+    void NODELETE resume();
 
-    void connectionToWebProcessClosed(IPC::Connection&);
+    void NODELETE connectionToWebProcessClosed(IPC::Connection&);
 
     GPUConnectionToWebProcess* webProcessConnection(WebCore::ProcessIdentifier) const;
 
-    const String& mediaCacheDirectory(PAL::SessionID) const;
+    const String& NODELETE mediaCacheDirectory(PAL::SessionID) const;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
-    const String& mediaKeysStorageDirectory(PAL::SessionID) const;
+    const String& NODELETE mediaKeysStorageDirectory(PAL::SessionID) const;
 #endif
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
@@ -203,7 +203,7 @@ private:
     void removeSession(PAL::SessionID);
     void updateSandboxAccess(const Vector<SandboxExtension::Handle>&);
 
-    bool updatePreference(std::optional<bool>& oldPreference, std::optional<bool>& newPreference);
+    bool NODELETE updatePreference(std::optional<bool>& oldPreference, std::optional<bool>& newPreference);
     void userPreferredLanguagesChanged(Vector<String>&&);
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -71,11 +71,11 @@ public:
     WebCore::IOSurfacePool& ioSurfacePool() const { return m_ioSurfacePool; }
 #endif
 
-    void didCreateImageBuffer(WebCore::RenderingPurpose, WebCore::RenderingMode);
-    void didReleaseImageBuffer(WebCore::RenderingPurpose, WebCore::RenderingMode);
-    bool reachedAcceleratedImageBufferLimit(WebCore::RenderingPurpose) const;
-    bool reachedImageBufferForCanvasLimit() const;
-    WebCore::ImageBufferResourceLimits getResourceLimitsForTesting() const;
+    void NODELETE didCreateImageBuffer(WebCore::RenderingPurpose, WebCore::RenderingMode);
+    void NODELETE didReleaseImageBuffer(WebCore::RenderingPurpose, WebCore::RenderingMode);
+    bool NODELETE reachedAcceleratedImageBufferLimit(WebCore::RenderingPurpose) const;
+    bool NODELETE reachedImageBufferForCanvasLimit() const;
+    WebCore::ImageBufferResourceLimits NODELETE getResourceLimitsForTesting() const;
 
     void lowMemoryHandler();
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelObjectHeap.h
@@ -57,7 +57,7 @@ public:
 
     ~ModelObjectHeap();
 
-    void addObject(WebModelIdentifier, RemoteMesh&);
+    void NODELETE addObject(WebModelIdentifier, RemoteMesh&);
 
     void removeObject(WebModelIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -61,20 +61,20 @@ public:
 
     ~WebMesh();
 
-    bool isValid() const;
-    void render() const;
-    void update(const WebModel::UpdateMeshDescriptor&);
-    void updateTexture(const WebModel::UpdateTextureDescriptor&);
-    void updateMaterial(const WebModel::UpdateMaterialDescriptor&);
-    void setTransform(const simd_float4x4&);
+    bool NODELETE isValid() const;
+    void NODELETE render() const;
+    void NODELETE update(const WebModel::UpdateMeshDescriptor&);
+    void NODELETE updateTexture(const WebModel::UpdateTextureDescriptor&);
+    void NODELETE updateMaterial(const WebModel::UpdateMaterialDescriptor&);
+    void NODELETE setTransform(const simd_float4x4&);
     void setCameraDistance(float);
-    void setEnvironmentMap(const WebModel::ImageAsset&);
-    void play(bool);
+    void NODELETE setEnvironmentMap(const WebModel::ImageAsset&);
+    void NODELETE play(bool);
 
 private:
     WebMesh(const WebModelCreateMeshDescriptor&);
 
-    void processUpdates() const;
+    void NODELETE processUpdates() const;
 
     RetainPtr<NSMutableArray> m_textures;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -171,7 +171,7 @@ protected:
 
     void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
 
-    RemoteResourceCache& resourceCache() const;
+    RemoteResourceCache& NODELETE resourceCache() const;
     WebCore::GraphicsContext& context() { return m_context; }
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier) const;
     std::optional<WebCore::SourceImage> sourceImage(WebCore::RenderingResourceIdentifier) const;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -59,7 +59,7 @@ public:
 private:
     RemoteImageBuffer(Ref<WebCore::ImageBuffer>&&, WebCore::RenderingResourceIdentifier, RemoteGraphicsContextIdentifier, RemoteRenderingBackend&);
     void startListeningForIPC();
-    IPC::StreamConnectionWorkQueue& workQueue() const;
+    IPC::StreamConnectionWorkQueue& NODELETE workQueue() const;
 
     // IPC::StreamMessageReceiver
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -69,7 +69,7 @@ private:
     RemoteImageBufferSet(ImageBufferSetIdentifier, RemoteGraphicsContextIdentifier, RemoteRenderingBackend&);
 
     void startListeningForIPC();
-    IPC::StreamConnectionWorkQueue& workQueue() const;
+    IPC::StreamConnectionWorkQueue& NODELETE workQueue() const;
 
     // IPC::StreamMessageReceiver
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -111,7 +111,7 @@ public:
     virtual ~RemoteRenderingBackend();
     void stopListeningForIPC();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     RemoteResourceCache& remoteResourceCache() { return m_remoteResourceCache; }
     RemoteSharedResourceCache& sharedResourceCache() { return m_sharedResourceCache; }
@@ -199,7 +199,7 @@ private:
     void createTextDetector(ShapeDetectionIdentifier);
     void releaseTextDetector(ShapeDetectionIdentifier);
 
-    bool shouldUseLockdownFontParser() const;
+    bool NODELETE shouldUseLockdownFontParser() const;
 
     void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -125,7 +125,7 @@ private:
 
 
     void requestAdapter(const WebGPU::RequestAdapterOptions&, WebGPUIdentifier, CompletionHandler<void(std::optional<RemoteGPURequestAdapterResponse>&&)>&&);
-    void createModelBacking(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, WebKit::WebModelIdentifier, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+    void NODELETE createModelBacking(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, WebKit::WebModelIdentifier, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
 
     void createPresentationContext(const WebGPU::PresentationContextDescriptor&, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -100,7 +100,7 @@ private:
 #if PLATFORM(COCOA)
     void startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex, PlatformXR::RateMapDescription&&);
 #endif
-    void endFrame();
+    void NODELETE endFrame();
 
     Ref<WebCore::WebGPU::XRProjectionLayer> m_backing;
     WeakRef<WebGPU::ObjectHeap> m_objectHeap;

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -64,7 +64,7 @@ private:
 
     Logger& logger();
     ASCIILiteral logClassName() const { return "LocalAudioSessionRoutingArbitrator"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -161,7 +161,7 @@ public:
 #endif
     }
 
-    bool isPlaying() const { return m_isPlaying; }
+    bool NODELETE isPlaying() const { return m_isPlaying; }
 
     size_t audioUnitLatency() const
     {
@@ -174,7 +174,7 @@ public:
 
 private:
 #if PLATFORM(COCOA)
-    void incrementTotalFrameCount(UInt32 numberOfFrames)
+    void NODELETE incrementTotalFrameCount(UInt32 numberOfFrames)
     {
         static_assert(std::atomic<UInt32>::is_always_lock_free, "Shared memory atomic usage assumes lock free primitives are used");
         if (m_frameCount)
@@ -206,9 +206,9 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const { return "RemoteAudioDestination"_s; }
-    WTFLogChannel& logChannel() const { return WebKit2LogMedia; }
-    uint64_t logIdentifier() const { return m_logIdentifier; }
-    Logger& logger() const { return m_logger; }
+    WTFLogChannel& NODELETE logChannel() const { return WebKit2LogMedia; }
+    uint64_t NODELETE logIdentifier() const { return m_logIdentifier; }
+    Logger& NODELETE logger() const { return m_logger; }
 
     Ref<Logger> m_logger;
     const uint64_t m_logIdentifier;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -46,7 +46,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static bool categoryCanMixWithOthers(AudioSession::CategoryType category)
+static bool NODELETE categoryCanMixWithOthers(AudioSession::CategoryType category)
 {
     return category == AudioSession::CategoryType::AmbientSound;
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -185,7 +185,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     Logger& logger() { return m_logger; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
     ASCIILiteral logClassName() const { return "RemoteAudioVideoRendererProxyManager"; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -81,7 +81,7 @@ public:
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
 
-    bool allowsExitUnderMemoryPressure() const;
+    bool NODELETE allowsExitUnderMemoryPressure() const;
 
     const String& mediaKeysStorageDirectory() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
@@ -57,7 +57,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
-    bool allowsExitUnderMemoryPressure() const;
+    bool NODELETE allowsExitUnderMemoryPressure() const;
 
     void ref() const final;
     void deref() const final;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -74,7 +74,7 @@ public:
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
 
-    bool allowsExitUnderMemoryPressure() const;
+    bool NODELETE allowsExitUnderMemoryPressure() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -81,7 +81,7 @@ private:
     const Logger& logger() const final { return m_logger; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "RemoteLegacyCDMSessionProxy"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     // Messages

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -111,7 +111,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const { return "RemoteMediaPlayerManagerProxy"; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
     uint64_t logIdentifier() const { return m_logIdentifier; }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -406,7 +406,7 @@ private:
     const Logger& logger() { return mediaPlayerLogger(); }
     uint64_t logIdentifier() { return mediaPlayerLogIdentifier(); }
     ASCIILiteral logClassName() const { return "RemoteMediaPlayerProxy"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     Vector<Ref<RemoteAudioTrackProxy>> m_audioTracks;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -95,7 +95,7 @@ private:
     void unmarkEndOfStream();
     void setMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState);
     void setTimeFudgeFactor(const MediaTime&);
-    void attached();
+    void NODELETE attached();
     void shutdown();
 
     void disconnect();

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -75,7 +75,7 @@ public:
     void deref() const final { IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>::deref(); }
 
     void stopListeningForIPC(Ref<LibWebRTCCodecsProxy>&& refFromConnection);
-    bool allowsExitUnderMemoryPressure() const;
+    bool NODELETE allowsExitUnderMemoryPressure() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess);
 private:

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -399,7 +399,7 @@ void LibWebRTCCodecsProxy::releaseEncoder(VideoEncoderIdentifier identifier)
     m_hasEncodersOrDecoders = !m_encoders.isEmpty() || !m_decoders.isEmpty();
 }
 
-static bool validateEncoderInitializationData(WebCore::VideoCodecType codecType, bool useLowLatency, size_t width, size_t height)
+static bool NODELETE validateEncoderInitializationData(WebCore::VideoCodecType codecType, bool useLowLatency, size_t width, size_t height)
 {
     switch (codecType) {
     case WebCore::VideoCodecType::H264:
@@ -437,7 +437,7 @@ LibWebRTCCodecsProxy::Encoder* LibWebRTCCodecsProxy::findEncoder(VideoEncoderIde
     return &iterator->value;
 }
 
-static inline webrtc::VideoRotation toWebRTCVideoRotation(WebCore::VideoFrame::Rotation rotation)
+static inline webrtc::VideoRotation NODELETE toWebRTCVideoRotation(WebCore::VideoFrame::Rotation rotation)
 {
     switch (rotation) {
     case WebCore::VideoFrame::Rotation::None:

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -108,7 +108,7 @@ public:
         }
     }
 
-    bool isObservingMedia() const { return m_isObservingMedia; }
+    bool NODELETE isObservingMedia() const { return m_isObservingMedia; }
 
     void whenReady(UserMediaCaptureManagerProxy::CreateSourceCallback&& createCallback)
     {
@@ -122,8 +122,8 @@ public:
         });
     }
 
-    bool isUsingSource(const RealtimeMediaSource& source) const { return m_source.ptr() == &source; }
-    RealtimeMediaSource& source() { return m_source; }
+    bool NODELETE isUsingSource(const RealtimeMediaSource& source) const { return m_source.ptr() == &source; }
+    RealtimeMediaSource& NODELETE source() { return m_source; }
 
     void audioUnitWillStart() final
     {
@@ -521,7 +521,7 @@ CaptureSourceOrError UserMediaCaptureManagerProxy::createMicrophoneSource(const 
     return source;
 }
 
-static bool canCaptureFromMultipleCameras()
+static bool NODELETE canCaptureFromMultipleCameras()
 {
 #if PLATFORM(IOS_FAMILY)
     return false;

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
@@ -100,7 +100,7 @@ public:
     void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
-    bool hasSourceProxies() const;
+    bool NODELETE hasSourceProxies() const;
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -66,7 +66,7 @@ public:
 private:
     BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, WebCore::BackgroundFetchRecordLoaderClient&, const WebCore::BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&);
 
-    const URL& currentURL() const;
+    const URL& NODELETE currentURL() const;
 
     // NetworkDataTaskClient
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -1446,7 +1446,7 @@ Vector<ITPThirdPartyDataForSpecificFirstParty> ResourceLoadStatisticsStore::getT
     return thirdPartyDataForSpecificFirstPartyDomains;
 }
 
-static bool hasBeenThirdParty(unsigned timesUnderFirstParty)
+static bool NODELETE hasBeenThirdParty(unsigned timesUnderFirstParty)
 {
     return timesUnderFirstParty > 0;
 }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -114,7 +114,7 @@ public:
     Vector<ITPThirdPartyData> aggregatedThirdPartyData() const;
     void updateCookieBlocking(CompletionHandler<void()>&&);
     void processStatisticsAndDataRecords(CompletionHandler<void()>&&);
-    void cancelPendingStatisticsProcessingRequest();
+    void NODELETE cancelPendingStatisticsProcessingRequest();
     void mergeStatistics(Vector<ResourceLoadStatistics>&&);
     void runIncrementalVacuumCommand();
     void dumpResourceLoadStatistics(CompletionHandler<void(const String&)>&&);
@@ -129,7 +129,7 @@ public:
     void grandfatherExistingWebsiteData(CompletionHandler<void()>&&);
     void setGrandfathered(const RegistrableDomain&, bool value);
     bool isGrandfathered(const RegistrableDomain&) const;
-    void setGrandfatheringTime(Seconds);
+    void NODELETE setGrandfatheringTime(Seconds);
 
     bool isRegisteredAsSubresourceUnder(const SubResourceDomain&, const TopFrameDomain&) const;
     bool isRegisteredAsSubFrameUnder(const SubFrameDomain&, const TopFrameDomain&) const;
@@ -149,18 +149,18 @@ public:
     void setTopFrameUniqueRedirectTo(const TopFrameDomain&, const RedirectDomain&);
     void setTopFrameUniqueRedirectFrom(const TopFrameDomain&, const RedirectDomain&);
 
-    void setIsRunningTest(bool);
+    void NODELETE setIsRunningTest(bool);
     void logTestingEvent(String&&);
     void setTimeAdvanceForTesting(Seconds);
 
-    void setMaxStatisticsEntries(size_t maximumEntryCount);
-    void setPruneEntriesDownTo(size_t pruneTargetCount);
+    void NODELETE setMaxStatisticsEntries(size_t maximumEntryCount);
+    void NODELETE setPruneEntriesDownTo(size_t pruneTargetCount);
     void resetParametersToDefaultValues();
 
     bool shouldSkip(const RegistrableDomain&) const;
-    void setShouldClassifyResourcesBeforeDataRecordsRemoval(bool);
-    void setTimeToLiveUserInteraction(Seconds);
-    void setMinimumTimeBetweenDataRecordsRemoval(Seconds);
+    void NODELETE setShouldClassifyResourcesBeforeDataRecordsRemoval(bool);
+    void NODELETE setTimeToLiveUserInteraction(Seconds);
+    void NODELETE setMinimumTimeBetweenDataRecordsRemoval(Seconds);
     void setResourceLoadStatisticsDebugMode(bool);
     bool isDebugModeEnabled() const { return m_debugModeEnabled; };
     void setPrevalentResourceForDebugMode(const RegistrableDomain&);
@@ -317,7 +317,7 @@ private:
     void setIsScheduledForAllScriptWrittenStorageRemoval(const RegistrableDomain&, DataRemovalFrequency);
     DataRemovalFrequency dataRemovalFrequency(const RegistrableDomain&) const;
     void clearTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement(const NavigatedToDomain&, CompletionHandler<void()>&&);
-    bool shouldEnforceSameSiteStrictForSpecificDomain(const RegistrableDomain&) const;
+    bool NODELETE shouldEnforceSameSiteStrictForSpecificDomain(const RegistrableDomain&) const;
     RegistrableDomainsToDeleteOrRestrictWebsiteDataFor registrableDomainsToDeleteOrRestrictWebsiteDataFor();
 
     bool shouldRemoveDataRecords() const;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -217,7 +217,7 @@ public:
     void setPersistedDomains(const HashSet<RegistrableDomain>&);
     void didCreateNetworkProcess();
 
-    NetworkSession* networkSession();
+    NetworkSession* NODELETE networkSession();
     void invalidateAndCancel();
 
     void resourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics>&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
+++ b/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
@@ -37,7 +37,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static CFHTTPCookieStorageAcceptPolicy toCFHTTPCookieStorageAcceptPolicy(HTTPCookieAcceptPolicy policy)
+static CFHTTPCookieStorageAcceptPolicy NODELETE toCFHTTPCookieStorageAcceptPolicy(HTTPCookieAcceptPolicy policy)
 {
     switch (policy) {
     case HTTPCookieAcceptPolicy::AlwaysAccept:

--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -40,7 +40,7 @@
 
 using namespace WebKit;
 
-static RefPtr<NetworkProcess>& firstNetworkProcess()
+static RefPtr<NetworkProcess>& NODELETE firstNetworkProcess()
 {
     static NeverDestroyed<RefPtr<NetworkProcess>> networkProcess;
     return networkProcess.get();

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -46,14 +46,14 @@ public:
     void downloadReceivedBytes(uint64_t);
     void timerFired();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
 private:
     WeakRef<Download> m_download;
 
     double measuredThroughputRate() const;
-    uint32_t testSpeedMultiplier() const;
+    uint32_t NODELETE testSpeedMultiplier() const;
     
     struct Timestamp {
         MonotonicTime time;

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -100,7 +100,7 @@ private:
     void didReceiveBuffer(const WebCore::FragmentedSharedBuffer&) override { };
     void didFinishLoading(const WebCore::NetworkLoadMetrics&) override { };
     void didFailLoading(const WebCore::ResourceError&) override;
-    bool isDownloadTriggeredWithDownloadAttribute() const;
+    bool NODELETE isDownloadTriggeredWithDownloadAttribute() const;
 
     // MessageSender.
     IPC::Connection* messageSenderConnection() const override;

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/Daemon/DaemonEntryPoint.h
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/Daemon/DaemonEntryPoint.h
@@ -27,6 +27,6 @@
 
 namespace WebKit {
 
-int DaemonMain(int, const char**);
+int NODELETE DaemonMain(int, const char**);
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkActivityTracker.h
+++ b/Source/WebKit/NetworkProcess/NetworkActivityTracker.h
@@ -72,9 +72,9 @@ public:
     explicit NetworkActivityTracker(Label, Domain = Domain::WebKit);
     ~NetworkActivityTracker();
 
-    void setParent(NetworkActivityTracker&);
-    void start();
-    void complete(CompletionCode);
+    void NODELETE setParent(NetworkActivityTracker&);
+    void NODELETE start();
+    void NODELETE complete(CompletionCode);
 
 #if HAVE(NW_ACTIVITY)
     nw_activity_t getPlatformObject() const { return m_networkActivity.get(); }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -278,7 +278,7 @@ public:
     void allowAccessToFile(const String& path);
     void loadCancelledDownloadRedirectRequestInFrame(const WebCore::ResourceRequest&, const WebCore::FrameIdentifier&, const WebCore::PageIdentifier&);
 
-    bool isAlwaysOnLoggingAllowed() const;
+    bool NODELETE isAlwaysOnLoggingAllowed() const;
 
 private:
     NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier&&);

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
@@ -51,7 +51,7 @@ public:
     using BackendCallback = CompletionHandler<void(WebCore::ContentExtensions::ContentExtensionsBackend&)>;
     void contentExtensionsBackend(UserContentControllerIdentifier, BackendCallback&&);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
 private:

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -118,7 +118,7 @@ public:
     void clearClient() { m_client = nullptr; }
 
     std::optional<DownloadID> pendingDownloadID() const { return m_pendingDownloadID.asOptional(); }
-    PendingDownload* pendingDownload() const;
+    PendingDownload* NODELETE pendingDownload() const;
     void setPendingDownloadID(DownloadID downloadID)
     {
         ASSERT(!m_pendingDownloadID);

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -87,9 +87,9 @@ public:
     void setH2PingCallback(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&);
 
     void setTimingAllowFailedFlag();
-    std::optional<WebCore::FrameIdentifier> webFrameID() const;
-    std::optional<WebCore::PageIdentifier> webPageID() const;
-    Ref<NetworkProcess> networkProcess();
+    std::optional<WebCore::FrameIdentifier> NODELETE webFrameID() const;
+    std::optional<WebCore::PageIdentifier> NODELETE webPageID() const;
+    Ref<NetworkProcess> NODELETE networkProcess();
 
     size_t bytesTransferredOverNetwork() const;
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -193,7 +193,7 @@ public:
     void removeNetworkConnectionToWebProcess(NetworkConnectionToWebProcess&);
 
     AuthenticationManager& authenticationManager();
-    DownloadManager& downloadManager();
+    DownloadManager& NODELETE downloadManager();
 
     void setSession(PAL::SessionID, std::unique_ptr<NetworkSession>&&);
     NetworkSession* networkSession(PAL::SessionID) const final;
@@ -320,8 +320,8 @@ public:
 
     void notifyMediaStreamingActivity(bool);
 
-    void setPrivateClickMeasurementEnabled(bool);
-    bool privateClickMeasurementEnabled() const;
+    void NODELETE setPrivateClickMeasurementEnabled(bool);
+    bool NODELETE privateClickMeasurementEnabled() const;
     void setPrivateClickMeasurementDebugMode(PAL::SessionID, bool);
 
 #if HAVE(ENHANCED_SECURITY_LINKS)
@@ -337,7 +337,7 @@ public:
     void preconnectTo(PAL::SessionID, WebPageProxyIdentifier, WebCore::PageIdentifier, WebCore::ResourceRequest&&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>, uint64_t requiredCookiesVersion);
 
     void setSessionIsControlledByAutomation(PAL::SessionID, bool);
-    bool sessionIsControlledByAutomation(PAL::SessionID) const;
+    bool NODELETE sessionIsControlledByAutomation(PAL::SessionID) const;
 
     void connectionToWebProcessClosed(IPC::Connection&, PAL::SessionID);
 
@@ -376,7 +376,7 @@ public:
     void simulatePrivateClickMeasurementConversion(PAL::SessionID, int priority, int triggerData, const URL& sourceURL, const URL& destinationURL);
     void dumpPrivateClickMeasurement(PAL::SessionID, CompletionHandler<void(String)>&&);
     void clearPrivateClickMeasurement(PAL::SessionID, CompletionHandler<void()>&&);
-    bool allowsPrivateClickMeasurementTestFunctionality() const;
+    bool NODELETE allowsPrivateClickMeasurementTestFunctionality() const;
     void setPrivateClickMeasurementOverrideTimerForTesting(PAL::SessionID, bool value, CompletionHandler<void()>&&);
     void markAttributedPrivateClickMeasurementsAsExpiredForTesting(PAL::SessionID, CompletionHandler<void()>&&);
     void setPrivateClickMeasurementEphemeralMeasurementForTesting(PAL::SessionID, bool value, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -875,7 +875,7 @@ void NetworkResourceLoader::processClearSiteDataHeader(const WebCore::ResourceRe
     }
 }
 
-static BrowsingContextGroupSwitchDecision toBrowsingContextGroupSwitchDecision(const std::optional<CrossOriginOpenerPolicyEnforcementResult>& currentCoopEnforcementResult)
+static BrowsingContextGroupSwitchDecision NODELETE toBrowsingContextGroupSwitchDecision(const std::optional<CrossOriginOpenerPolicyEnforcementResult>& currentCoopEnforcementResult)
 {
     if (!currentCoopEnforcementResult || !currentCoopEnforcementResult->needsBrowsingContextGroupSwitch)
         return BrowsingContextGroupSwitchDecision::StayInGroup;
@@ -1457,7 +1457,7 @@ void NetworkResourceLoader::restartNetworkLoad(WebCore::ResourceRequest&& newReq
         startNetworkLoad(WTF::move(newRequest), FirstLoad::No);
 }
 
-static bool shouldTryToMatchRegistrationOnRedirection(const FetchOptions& options, bool isServiceWorkerLoaded)
+static bool NODELETE shouldTryToMatchRegistrationOnRedirection(const FetchOptions& options, bool isServiceWorkerLoaded)
 {
     if (options.mode == FetchOptions::Mode::Navigate)
         return true;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -173,12 +173,12 @@ public:
     void setWorkerRouterEvaluationStart(MonotonicTime);
     void setWorkerCacheLookupStart(MonotonicTime);
     void setWorkerMatchedRouterSource(WebCore::RouterSourceEnum);
-    void setWorkerFinalRouterSource(WebCore::RouterSourceEnum);
+    void NODELETE setWorkerFinalRouterSource(WebCore::RouterSourceEnum);
 
     std::optional<WebCore::ResourceError> doCrossOriginOpenerHandlingOfResponse(const WebCore::ResourceResponse&);
     void sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup(const WebCore::ResourceResponse&, PrivateRelayed, bool needsContinueDidReceiveResponseMessage);
 
-    bool isAppInitiated();
+    bool NODELETE isAppInitiated();
 
 #if ENABLE(CONTENT_FILTERING)
     bool continueAfterServiceWorkerReceivedData(const WebCore::SharedBuffer&);
@@ -280,7 +280,7 @@ private:
     void sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<WebCore::FormData>&& report, WebCore::ViolationReportType) final;
     String httpUserAgent() const final { return originalRequest().httpUserAgent(); }
     void initializeReportingEndpoints(const WebCore::ResourceResponse&);
-    WebCore::FrameIdentifier frameIdentifierForReport() const;
+    WebCore::FrameIdentifier NODELETE frameIdentifierForReport() const;
 
     enum class IsFromServiceWorker : bool { No, Yes };
     void willSendRedirectedRequestInternal(WebCore::ResourceRequest&&, WebCore::ResourceRequest&& redirectRequest, WebCore::ResourceResponse&&, IsFromServiceWorker, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
@@ -289,7 +289,7 @@ private:
     void startRequest(const WebCore::ResourceRequest&);
     bool abortIfServiceWorkersOnly();
 
-    bool shouldSendResourceLoadMessages() const;
+    bool NODELETE shouldSendResourceLoadMessages() const;
 
     void sendDidReceiveDataMessage(const WebCore::FragmentedSharedBuffer&);
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -141,7 +141,7 @@ public:
 
     WebResourceLoadStatisticsStore* resourceLoadStatistics() const { return m_resourceLoadStatistics.get(); }
     void setTrackingPreventionEnabled(bool);
-    bool isTrackingPreventionEnabled() const;
+    bool NODELETE isTrackingPreventionEnabled() const;
     static WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&);
     static WebCore::IsKnownCrossSiteTracker isResourceFromKnownCrossSiteTracker(const URL& firstParty, const URL& resource);
     static bool isRequestBlockable(const WebCore::ResourceRequest&);
@@ -152,8 +152,8 @@ public:
     void setResourceLoadStatisticsLogTestingEvent(bool log) { m_enableResourceLoadStatisticsLogTestingEvent = log; }
     virtual bool hasIsolatedSession(const WebCore::RegistrableDomain&) const { return false; }
     virtual void clearIsolatedSessions() { }
-    void setShouldDowngradeReferrerForTesting(bool);
-    bool shouldDowngradeReferrer() const;
+    void NODELETE setShouldDowngradeReferrerForTesting(bool);
+    bool NODELETE shouldDowngradeReferrer() const;
     void setThirdPartyCookieBlockingMode(WebCore::ThirdPartyCookieBlockingMode);
     WebCore::ThirdPartyCookieBlockingMode thirdPartyCookieBlockingMode() const { return m_thirdPartyCookieBlockingMode; }
     void setShouldEnbleSameSiteStrictEnforcement(WebCore::SameSiteStrictEnforcementEnabled);
@@ -185,7 +185,7 @@ public:
     void setPrivateClickMeasurementTokenSignatureURLForTesting(URL&&);
     void setPrivateClickMeasurementAttributionReportURLsForTesting(URL&& sourceURL, URL&& destinationURL);
     void markPrivateClickMeasurementsAsExpiredForTesting();
-    void setPrivateClickMeasurementEphemeralMeasurementForTesting(bool);
+    void NODELETE setPrivateClickMeasurementEphemeralMeasurementForTesting(bool);
     void setPCMFraudPreventionValuesForTesting(String&& unlinkableToken, String&& secretToken, String&& signature, String&& keyID);
     void firePrivateClickMeasurementTimerImmediatelyForTesting();
     void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&);
@@ -200,7 +200,7 @@ public:
 
     NetworkCache::Cache* cache() { return m_cache.get(); }
 
-    PrefetchCache& prefetchCache();
+    PrefetchCache& NODELETE prefetchCache();
     void clearPrefetchCache() { m_prefetchCache->clear(); }
 
     virtual RefPtr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy);
@@ -229,7 +229,7 @@ public:
     void registerSWServerConnection(WebSWServerConnection&);
     void unregisterSWServerConnection(WebSWServerConnection&);
 
-    bool hasServiceWorkerDatabasePath() const;
+    bool NODELETE hasServiceWorkerDatabasePath() const;
 
     void getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&&);
     void getBackgroundFetchState(const String&, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&&);
@@ -250,7 +250,7 @@ public:
     void setPrivateClickMeasurementDebugMode(bool);
     bool privateClickMeasurementDebugModeEnabled() const { return m_privateClickMeasurementDebugModeEnabled; }
 
-    void setShouldSendPrivateTokenIPCForTesting(bool);
+    void NODELETE setShouldSendPrivateTokenIPCForTesting(bool);
     bool shouldSendPrivateTokenIPCForTesting() const { return m_shouldSendPrivateTokenIPCForTesting; }
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     void setOptInCookiePartitioningEnabled(bool);
@@ -316,7 +316,7 @@ protected:
     NetworkSession(NetworkProcess&, const NetworkSessionCreationParameters&);
 
     void forwardResourceLoadStatisticsSettings();
-    WebSWOriginStore* swOriginStore() const;
+    WebSWOriginStore* NODELETE swOriginStore() const;
 
     // SWServerDelegate
     void softUpdate(WebCore::ServiceWorkerJobData&&, bool shouldRefreshCache, WebCore::ResourceRequest&&, CompletionHandler<void(WebCore::WorkerFetchResult&&)>&&) final;

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -89,7 +89,7 @@ private:
     void close(int32_t code, const String& reason);
     void sendDelayedError();
 
-    NetworkSession* session() const;
+    NetworkSession* NODELETE session() const;
 
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final { return m_identifier.toUInt64(); }

--- a/Source/WebKit/NetworkProcess/PingLoad.h
+++ b/Source/WebKit/NetworkProcess/PingLoad.h
@@ -69,7 +69,7 @@ private:
 
     void initialize(NetworkProcess&);
 
-    const URL& currentURL() const;
+    const URL& NODELETE currentURL() const;
 
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;
     void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) final;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h
@@ -65,7 +65,7 @@ public:
 private:
     EphemeralStore();
 
-    void reset();
+    void NODELETE reset();
 
     std::optional<WebCore::PrivateClickMeasurement> m_clickMeasurement;
 };

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
@@ -175,7 +175,7 @@ bool messageTypeSendsReply(MessageType messageType)
     return false;
 }
 
-static RefPtr<PrivateClickMeasurementManager>& managerPointer()
+static RefPtr<PrivateClickMeasurementManager>& NODELETE managerPointer()
 {
     static NeverDestroyed<RefPtr<PrivateClickMeasurementManager>> manager;
     return manager.get();
@@ -187,7 +187,7 @@ void initializePCMStorageInDirectory(const String& storageDirectory)
     managerPointer() = PrivateClickMeasurementManager::create(makeUniqueRef<PCM::DaemonClient>(), storageDirectory);
 }
 
-static PrivateClickMeasurementManager& daemonManagerSingleton()
+static PrivateClickMeasurementManager& NODELETE daemonManagerSingleton()
 {
     ASSERT(managerPointer());
     return *managerPointer();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
@@ -110,7 +110,7 @@ using EncodedMessage = Vector<uint8_t>;
 
 void decodeMessageAndSendToManager(const Daemon::Connection&, MessageType, std::span<const uint8_t> encodedMessage, CompletionHandler<void(Vector<uint8_t>&&)>&&);
 void doDailyActivityInManager();
-bool messageTypeSendsReply(MessageType);
+bool NODELETE messageTypeSendsReply(MessageType);
 
 void initializePCMStorageInDirectory(const String&);
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -81,7 +81,7 @@ namespace WebKit::PCM {
 
 enum class LoadTaskIdentifierType { };
 using LoadTaskIdentifier = ObjectIdentifier<LoadTaskIdentifierType>;
-static HashMap<LoadTaskIdentifier, RetainPtr<NSURLSessionDataTask>>& taskMap()
+static HashMap<LoadTaskIdentifier, RetainPtr<NSURLSessionDataTask>>& NODELETE taskMap()
 {
     static NeverDestroyed<HashMap<LoadTaskIdentifier, RetainPtr<NSURLSessionDataTask>>> map;
     return map.get();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -65,7 +65,7 @@ public:
     void start();
     void stop() { cancel(); }
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess(const IPC::Connection&) const;
 
 private:
     ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& response, DownloadID);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -108,7 +108,7 @@ private:
     void didReceiveResponse(WebCore::ResourceResponse&&, bool needsContinueDidReceiveResponseMessage);
     void didReceiveData(const IPC::SharedBufferReference&);
     void didReceiveDataFromPreloader(const WebCore::FragmentedSharedBuffer&);
-    void didReceiveFormData(const IPC::FormDataReference&);
+    void NODELETE didReceiveFormData(const IPC::FormDataReference&);
     void didFinish(const WebCore::NetworkLoadMetrics&);
     void didFail(const WebCore::ResourceError&);
     void didNotHandle();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -89,10 +89,10 @@ public:
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     NetworkSession* session();
-    PAL::SessionID sessionID() const;
+    PAL::SessionID NODELETE sessionID() const;
 
     RefPtr<ServiceWorkerFetchTask> createFetchTask(NetworkResourceLoader&, const WebCore::ResourceRequest&);
     void fetchTaskTimedOut(WebCore::ServiceWorkerIdentifier);
@@ -184,7 +184,7 @@ private:
     uint64_t messageSenderDestinationID() const final { return 0; }
     
     template<typename U> static void sendToContextProcess(WebCore::SWServerToContextConnection&, U&& message);
-    NetworkProcess& networkProcess();
+    NetworkProcess& NODELETE networkProcess();
 
     bool isWebSWServerConnection() const final { return true; }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -71,7 +71,7 @@ public:
 
     void stop();
 
-    IPC::Connection* ipcConnection() const;
+    IPC::Connection* NODELETE ipcConnection() const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -90,7 +90,7 @@ public:
     void unregisterDownload(ServiceWorkerDownloadTask&);
 
     WebCore::ProcessIdentifier webProcessIdentifier() const final { return m_webProcessIdentifier; }
-    NetworkProcess* networkProcess();
+    NetworkProcess* NODELETE networkProcess();
 
     void didFinishInstall(const std::optional<WebCore::ServiceWorkerJobDataIdentifier>&, WebCore::ServiceWorkerIdentifier, bool wasSuccessful);
     void didFinishActivation(WebCore::ServiceWorkerIdentifier);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -37,7 +37,7 @@
 
 namespace WebKit {
 
-static HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>& allWorkers()
+static HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>& NODELETE allWorkers()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>> allWorkers;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -76,7 +76,7 @@ public:
     void resume(WebCore::SharedWorkerObjectIdentifier);
     unsigned sharedWorkerObjectsCount() const { return m_sharedWorkerObjects.size(); }
     void forEachSharedWorkerObject(NOESCAPE const Function<void(WebCore::SharedWorkerObjectIdentifier, const WebCore::TransferredMessagePort&)>&) const;
-    std::optional<WebCore::ProcessIdentifier> firstSharedWorkerObjectProcess() const;
+    std::optional<WebCore::ProcessIdentifier> NODELETE firstSharedWorkerObjectProcess() const;
 
     void didCreateContextConnection(WebSharedWorkerServerToContextConnection&);
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -66,7 +66,7 @@ public:
     explicit WebSharedWorkerServer(NetworkSession&);
     ~WebSharedWorkerServer();
 
-    PAL::SessionID sessionID();
+    PAL::SessionID NODELETE sessionID();
     WebSharedWorkerServerToContextConnection* contextConnectionForRegistrableDomain(const WebCore::RegistrableDomain&) const;
 
     void requestSharedWorker(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&&, WebCore::WorkerOptions&&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -65,7 +65,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    WebSharedWorkerServer* server();
+    WebSharedWorkerServer* NODELETE server();
     const WebSharedWorkerServer* server() const;
 
     NetworkSession* session();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -66,10 +66,10 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    std::optional<WebCore::ProcessIdentifier> webProcessIdentifier() const;
+    std::optional<WebCore::ProcessIdentifier> NODELETE webProcessIdentifier() const;
     const WebCore::RegistrableDomain& registrableDomain() const { return m_site.domain(); }
     const WebCore::Site& site() const { return m_site; }
-    IPC::Connection* ipcConnection() const;
+    IPC::Connection* NODELETE ipcConnection() const;
 
     void terminateWhenPossible() { m_shouldTerminateWhenPossible = true; }
 
@@ -87,7 +87,7 @@ public:
     void addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);
     void removeSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
 private:
     WebSharedWorkerServerToContextConnection(NetworkConnectionToWebProcess&, const WebCore::Site&, WebSharedWorkerServer&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -172,7 +172,7 @@ Key Cache::makeCacheKey(const WebCore::ResourceRequest& request)
     return { request.cachePartition(), resourceType(), range, request.url().stringWithoutFragmentIdentifier(), m_storage->salt() };
 }
 
-static bool cachePolicyAllowsExpired(WebCore::ResourceRequestCachePolicy policy)
+static bool NODELETE cachePolicyAllowsExpired(WebCore::ResourceRequestCachePolicy policy)
 {
     switch (policy) {
     case WebCore::ResourceRequestCachePolicy::ReturnCacheDataElseLoad:

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -159,7 +159,7 @@ public:
     ~Cache();
     static RefPtr<Cache> open(NetworkProcess&, const String& cachePath, OptionSet<CacheOption>, PAL::SessionID);
 
-    size_t capacity() const;
+    size_t NODELETE capacity() const;
     void updateCapacity();
 
     // Completion handler may get called back synchronously on failure.

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -66,14 +66,14 @@ public:
 #endif
 
     bool needsValidation() const;
-    void setNeedsValidation(bool);
+    void NODELETE setNeedsValidation(bool);
 
     const Storage::Record& sourceStorageRecord() const { return m_sourceStorageRecord; }
 
     void asJSON(StringBuilder&, const Storage::RecordInfo&) const;
 
     bool hasReachedPrevalentResourceAgeCap() const;
-    void capMaxAge(const Seconds);
+    void NODELETE capMaxAge(const Seconds);
 
 private:
     void initializeBufferFromStorageRecord() const;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -38,7 +38,7 @@
 namespace WebKit {
 namespace NetworkCache {
 
-static long dispatchQueueIdentifier(WorkQueue::QOS qos)
+static long NODELETE dispatchQueueIdentifier(WorkQueue::QOS qos)
 {
     switch (qos) {
     case WorkQueue::QOS::UserInteractive:

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -79,7 +79,7 @@ public:
     const HashType& hash() const { return m_hash; }
     const HashType& partitionHash() const { return m_partitionHash; }
 
-    static bool stringToHash(const String&, HashType&);
+    static bool NODELETE stringToHash(const String&, HashType&);
 
     static size_t hashStringLength() { return 2 * sizeof(m_hash); }
     String hashAsString() const { return hashAsString(m_hash); }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -157,8 +157,8 @@ public:
         return WTF::move(m_entry);
     }
 
-    const std::optional<ResourceRequest>& revalidationRequest() const { return m_speculativeValidationRequest; }
-    bool wasRevalidated() const { return !!m_speculativeValidationRequest; }
+    const std::optional<ResourceRequest>& NODELETE revalidationRequest() const { return m_speculativeValidationRequest; }
+    bool NODELETE wasRevalidated() const { return !!m_speculativeValidationRequest; }
 
 private:
     std::unique_ptr<Entry> m_entry;
@@ -210,7 +210,7 @@ public:
         saveToDiskIfReady();
     }
 
-    bool didReceiveMainResourceResponse() const { return m_didReceiveMainResourceResponse; }
+    bool NODELETE didReceiveMainResourceResponse() const { return m_didReceiveMainResourceResponse; }
     void markMainResourceResponseAsReceived()
     {
         m_didReceiveMainResourceResponse = true;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -78,15 +78,15 @@ public:
         ASSERT(m_completionHandler);
     }
 
-    Storage::ReadOperationIdentifier identifier() const { return m_identifier; }
-    const Key& key() const { return m_key; }
-    unsigned priority() const { return m_priority; }
-    bool isCanceled() const { return m_isCanceled; }
-    bool canFinish() const { return !m_waitsForRecord && !m_waitsForBlob; }
+    Storage::ReadOperationIdentifier NODELETE identifier() const { return m_identifier; }
+    const Key& NODELETE key() const { return m_key; }
+    unsigned NODELETE priority() const { return m_priority; }
+    bool NODELETE isCanceled() const { return m_isCanceled; }
+    bool NODELETE canFinish() const { return !m_waitsForRecord && !m_waitsForBlob; }
 
     void updateForStart(size_t readOperationDispatchCount);
     void updateForDispatch(bool synchronizationInProgress, bool shrinkInProgress, size_t readOperationDispatchCount);
-    void setWaitsForBlob() { m_waitsForBlob = true; }
+    void NODELETE setWaitsForBlob() { m_waitsForBlob = true; }
     void finishReadRecord(Record&&, MonotonicTime recordIOStartTime, MonotonicTime recordIOEndTime);
     void finishReadBlob(BlobStorage::Blob&&, MonotonicTime blobIOStartTime, MonotonicTime blobIOEndTime);
     void cancel();
@@ -220,10 +220,10 @@ public:
         ASSERT(isMainRunLoop());
     }
 
-    Storage::WriteOperationIdentifier identifier() const { return m_identifier; }
-    const Record& record() const WTF_REQUIRES_CAPABILITY(mainThread) { return m_record; }
+    Storage::WriteOperationIdentifier NODELETE identifier() const { return m_identifier; }
+    const Record& NODELETE record() const WTF_REQUIRES_CAPABILITY(mainThread) { return m_record; }
     void invokeMappedBodyHandler(const Data&);
-    bool storeBlobInMemoryCache() const { return m_storeBlobInMemoryCache; }
+    bool NODELETE storeBlobInMemoryCache() const { return m_storeBlobInMemoryCache; }
 
 private:
     Storage::WriteOperationIdentifier m_identifier;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -126,7 +126,7 @@ public:
 
     void setCapacity(size_t);
     size_t capacity() const { return m_capacity; }
-    size_t approximateSize() const;
+    size_t NODELETE approximateSize() const;
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
     static const unsigned version = 17;
@@ -182,8 +182,8 @@ private:
     ConcurrentWorkQueue& backgroundIOQueue() { return m_backgroundIOQueue.get(); }
     WorkQueue& serialBackgroundIOQueue() { return m_serialBackgroundIOQueue.get(); }
 
-    bool mayContain(const Key&) const;
-    bool mayContainBlob(const Key&) const;
+    bool NODELETE mayContain(const Key&) const;
+    bool NODELETE mayContainBlob(const Key&) const;
 
     void addToRecordFilter(const Key&);
     void deleteFiles(const Key&);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -114,7 +114,7 @@ static void applyBasicAuthorizationHeader(WebCore::ResourceRequest& request, con
     request.setHTTPHeaderField(WebCore::HTTPHeaderName::Authorization, credential.serializationForBasicAuthorizationHeader());
 }
 
-static float toNSURLSessionTaskPriority(WebCore::ResourceLoadPriority priority)
+static float NODELETE toNSURLSessionTaskPriority(WebCore::ResourceLoadPriority priority)
 {
     switch (priority) {
     case WebCore::ResourceLoadPriority::VeryLow:

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -137,7 +137,7 @@ static NSURLSessionResponseDisposition toNSURLSessionResponseDisposition(WebCore
     }
 }
 
-static NSURLSessionAuthChallengeDisposition toNSURLSessionAuthChallengeDisposition(WebKit::AuthenticationChallengeDisposition disposition)
+static NSURLSessionAuthChallengeDisposition NODELETE toNSURLSessionAuthChallengeDisposition(WebKit::AuthenticationChallengeDisposition disposition)
 {
     switch (disposition) {
     case WebKit::AuthenticationChallengeDisposition::UseCredential:
@@ -160,7 +160,7 @@ static WebCore::NetworkLoadPriority toNetworkLoadPriority(float priority)
     return WebCore::NetworkLoadPriority::Medium;
 }
 
-static WebCore::PrivacyStance toPrivacyStance(nw_connection_privacy_stance_t stance)
+static WebCore::PrivacyStance NODELETE toPrivacyStance(nw_connection_privacy_stance_t stance)
 {
     switch (stance) {
     case nw_connection_privacy_stance_unknown:

--- a/Source/WebKit/NetworkProcess/mac/SecItemShim.mm
+++ b/Source/WebKit/NetworkProcess/mac/SecItemShim.mm
@@ -58,7 +58,7 @@ extern "C" void _CFURLConnectionSetFrameworkStubs(const struct _CFNFrameworksStu
 
 namespace WebKit {
 
-static WeakPtr<NetworkProcess>& globalNetworkProcess()
+static WeakPtr<NetworkProcess>& NODELETE globalNetworkProcess()
 {
     static NeverDestroyed<WeakPtr<NetworkProcess>> networkProcess;
     return networkProcess.get();

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -50,7 +50,7 @@ public:
     ~CacheStorageCache();
     const String& name() const { return m_name; }
     const String& uniqueName() const { return m_uniqueName; }
-    CacheStorageManager* manager();
+    CacheStorageManager* NODELETE manager();
 
     void getSize(CompletionHandler<void(uint64_t)>&&);
     void open(WebCore::DOMCacheEngine::CacheIdentifierCallback&&);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -69,8 +69,8 @@ public:
     void unlockStorage(IPC::Connection::UniqueID);
 
     void connectionClosed(IPC::Connection::UniqueID);
-    bool hasDataInMemory();
-    bool isActive();
+    bool NODELETE hasDataInMemory();
+    bool NODELETE isActive();
     String representationString();
     FileSystem::Salt salt() const { return m_salt; }
     void requestSpace(uint64_t size, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -73,7 +73,7 @@ public:
 
     Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError> createSyncAccessHandle();
     std::optional<FileSystemStorageError> closeSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier);
-    std::optional<WebCore::FileSystemSyncAccessHandleIdentifier> activeSyncAccessHandle();
+    std::optional<WebCore::FileSystemSyncAccessHandleIdentifier> NODELETE activeSyncAccessHandle();
 
     Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError> createWritable(bool keepExistingData);
     std::optional<FileSystemStorageError> closeWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason);
@@ -83,7 +83,7 @@ public:
 private:
     FileSystemStorageHandle(FileSystemStorageManager&, Type, String&& path, String&& name);
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> requestCreateHandle(IPC::Connection::UniqueID, Type, String&& name, bool createIfNecessary);
-    bool isActiveSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier);
+    bool NODELETE isActiveSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier);
     std::optional<FileSystemStorageError> executeCommandForWritableInternal(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t>, bool hasDataError);
     std::optional<size_t> computeCommandSpace(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t>, bool hasDataError);
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -43,7 +43,7 @@ public:
     static Ref<FileSystemStorageManager> create(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);
     ~FileSystemStorageManager();
 
-    bool isActive() const;
+    bool NODELETE isActive() const;
     uint64_t allocatedUnusedCapacity() const;
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> createHandle(IPC::Connection::UniqueID, FileSystemStorageHandle::Type, String&& path, String&& name, bool createIfNecessary);
     const String& getPath(WebCore::FileSystemHandleIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -41,7 +41,7 @@ public:
 
     std::optional<WebCore::IDBConnectionIdentifier> identifier() const final { return m_identifier; }
     IPC::Connection::UniqueID ipcConnection() const { return m_connection; }
-    WebCore::IDBServer::IDBConnectionToClient& connectionToClient();
+    WebCore::IDBServer::IDBConnectionToClient& NODELETE connectionToClient();
 
 private:
     // IDBConnectionToClientDelegate

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -58,7 +58,7 @@ public:
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
     IDBStorageManager(const String& path, IDBStorageRegistry&, QuotaCheckFunction&&, bool useSQLiteMemoryBackingStore);
     ~IDBStorageManager();
-    bool isActive() const;
+    bool NODELETE isActive() const;
     bool hasDataInMemory() const;
     void closeDatabasesForDeletion();
     void stopDatabaseActivitiesForSuspend();

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -50,7 +50,7 @@ public:
     static String localStorageFilePath(const String& directory);
 
     LocalStorageManager(const String& path, StorageAreaRegistry&);
-    bool isActive() const;
+    bool NODELETE isActive() const;
     bool hasDataInMemory() const;
     void clearDataInMemory();
     void clearDataOnDisk();

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -83,7 +83,7 @@ static constexpr auto persistedFileName = "persisted"_s;
 static constexpr Seconds originLastModificationTimeUpdateInterval = 30_s;
 
 // FIXME: Remove this if rdar://104754030 is fixed.
-static HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>& activePaths()
+static HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>& NODELETE activePaths()
 {
     static MainRunLoopNeverDestroyed<HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>> pathToManagerMap;
     return pathToManagerMap;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -165,7 +165,7 @@ private:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
     bool isStorageTypeEnabled(IPC::Connection&, WebCore::StorageType) const;
     bool isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
-    bool useSQLiteMemoryBackingStore() const;
+    bool NODELETE useSQLiteMemoryBackingStore() const;
 
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
@@ -259,7 +259,7 @@ private:
     void cacheStorageRepresentation(CompletionHandler<void(const String&)>&&);
 
     void cloneSessionStorageNamespace(StorageNamespaceIdentifier, StorageNamespaceIdentifier);
-    bool shouldManageServiceWorkerRegistrationsByOrigin();
+    bool NODELETE shouldManageServiceWorkerRegistrationsByOrigin();
     void migrateServiceWorkerRegistrationsToOrigins();
     Vector<WebCore::ServiceWorkerScripts> updateServiceWorkerRegistrationsByOrigin(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&);
 

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -53,8 +53,8 @@ public:
     void requestSpace(uint64_t spaceRequested, RequestCallback&&);
     void didIncreaseQuota(QuotaIncreaseRequestIdentifier, std::optional<uint64_t> newQuota);
 
-    void resetQuotaUpdatedBasedOnUsageForTesting();
-    void resetQuotaForTesting();
+    void NODELETE resetQuotaUpdatedBasedOnUsageForTesting();
+    void NODELETE resetQuotaForTesting();
     void updateParametersForTesting(Parameters&&);
 
 private:

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -69,8 +69,8 @@ public:
     std::optional<StorageType> toStorageType(WebsiteDataType) const;
     String toStorageIdentifier(StorageType) const;
     StorageBucket(const String& rootPath, const String& identifier, const String& localStoragePath, const String& idbStoragePath, const String& cacheStoragePath, UnifiedOriginStorageLevel);
-    StorageBucketMode mode() const { return m_mode; }
-    void setMode(StorageBucketMode mode) { m_mode = mode; }
+    StorageBucketMode NODELETE mode() const { return m_mode; }
+    void NODELETE setMode(StorageBucketMode mode) { m_mode = mode; }
     void connectionClosed(IPC::Connection::UniqueID);
     String typeStoragePath(StorageType) const;
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&, FileSystemStorageManager::QuotaCheckFunction&&);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -69,7 +69,7 @@ public:
     void connectionClosed(IPC::Connection::UniqueID);
     WebCore::StorageEstimate estimate();
     const String& path() const { return m_path; }
-    OriginQuotaManager& quotaManager();
+    OriginQuotaManager& NODELETE quotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);
     FileSystemStorageManager* existingFileSystemStorageManager();
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -78,7 +78,7 @@ bool NetworkMDNSRegister::hasRegisteredName(const String& name) const
 }
 
 #if ENABLE_MDNS
-static HashMap<NetworkMDNSRegister::PendingRegistrationRequestIdentifier, std::unique_ptr<NetworkMDNSRegister::PendingRegistrationRequest>>& pendingRegistrationRequestMap()
+static HashMap<NetworkMDNSRegister::PendingRegistrationRequestIdentifier, std::unique_ptr<NetworkMDNSRegister::PendingRegistrationRequest>>& NODELETE pendingRegistrationRequestMap()
 {
     static NeverDestroyed<HashMap<NetworkMDNSRegister::PendingRegistrationRequestIdentifier, std::unique_ptr<NetworkMDNSRegister::PendingRegistrationRequest>>> map;
     return map.get();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -77,7 +77,7 @@ public:
     NetworkMDNSRegister(NetworkConnectionToWebProcess&);
     ~NetworkMDNSRegister();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
@@ -111,7 +111,7 @@ private:
     void unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier);
     void registerMDNSName(WebCore::ScriptExecutionContextIdentifier, const String& ipAddress, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&&);
 
-    PAL::SessionID sessionID() const;
+    PAL::SessionID NODELETE sessionID() const;
 
     WeakRef<NetworkConnectionToWebProcess> m_connection;
     HashSet<String> m_registeredNames;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -57,14 +57,14 @@ public:
 #if ASSERT_ENABLED
     bool isStarted() const { return m_isStarted; }
 #endif
-    NetworkRTCProvider& rtcProvider();
+    NetworkRTCProvider& NODELETE rtcProvider();
 
     void onNetworksChanged(const Vector<RTCNetwork>&, const RTCNetwork::IPAddress&, const RTCNetwork::IPAddress&);
 
     const RTCNetwork::IPAddress& ipv4() const;
     const RTCNetwork::IPAddress& ipv6()  const;
 
-    void ref();
+    void NODELETE ref();
     void deref();
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -158,7 +158,7 @@ private:
 
     void signalSocketIsClosed(WebCore::LibWebRTCSocketIdentifier);
 
-    void assertIsRTCNetworkThread();
+    void NODELETE assertIsRTCNetworkThread();
 
     static constexpr size_t maxSockets { 256 };
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -66,14 +66,14 @@ public:
     class ConnectionStateTracker : public ThreadSafeRefCounted<ConnectionStateTracker> {
     public:
         static Ref<ConnectionStateTracker> create() { return adoptRef(*new ConnectionStateTracker()); }
-        void markAsStopped() { m_isStopped = true; }
-        bool isStopped() const { return m_isStopped; }
-        bool shouldLogMissingECN() const { return !m_didLogMissingECN; }
-        void didLogMissingECN() { m_didLogMissingECN = true; }
+        void NODELETE markAsStopped() { m_isStopped = true; }
+        bool NODELETE isStopped() const { return m_isStopped; }
+        bool NODELETE shouldLogMissingECN() const { return !m_didLogMissingECN; }
+        void NODELETE didLogMissingECN() { m_didLogMissingECN = true; }
 
-        bool hasPendingSend() const { return m_pendingSendCount; }
-        void incrementPendingSendCount() { ++m_pendingSendCount; }
-        void decrementPendingSendCount()
+        bool NODELETE hasPendingSend() const { return m_pendingSendCount; }
+        void NODELETE incrementPendingSendCount() { ++m_pendingSendCount; }
+        void NODELETE decrementPendingSendCount()
         {
             ASSERT(m_pendingSendCount);
             --m_pendingSendCount;

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -88,8 +88,8 @@ public:
     void destroyBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamSendBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool withFin, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&);
-    void datagramIncomingMaxAgeUpdated(std::optional<double>);
-    void datagramOutgoingMaxAgeUpdated(std::optional<double>);
+    void NODELETE datagramIncomingMaxAgeUpdated(std::optional<double>);
+    void NODELETE datagramOutgoingMaxAgeUpdated(std::optional<double>);
     void datagramIncomingHighWaterMarkUpdated(double);
     void datagramOutgoingHighWaterMarkUpdated(double);
 
@@ -105,7 +105,7 @@ public:
     void destroyStream(WebCore::WebTransportStreamIdentifier, std::optional<WebCore::WebTransportStreamErrorCode>);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
     bool isSessionClosed() const;
 private:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -116,7 +116,7 @@ private:
     {
     }
     static Lock syncMessageStateMapLock;
-    static HashMap<Ref<SerialFunctionDispatcher>, ThreadSafeWeakPtr<SyncMessageState>>& syncMessageStateMap() WTF_REQUIRES_LOCK(syncMessageStateMapLock)
+    static HashMap<Ref<SerialFunctionDispatcher>, ThreadSafeWeakPtr<SyncMessageState>>& NODELETE syncMessageStateMap() WTF_REQUIRES_LOCK(syncMessageStateMapLock)
     {
         static NeverDestroyed<HashMap<Ref<SerialFunctionDispatcher>, ThreadSafeWeakPtr<SyncMessageState>>> map;
         return map;
@@ -317,7 +317,7 @@ Ref<Connection> Connection::createClientConnection(Identifier&& identifier)
     return adoptRef(*new Connection(WTF::move(identifier), false));
 }
 
-static HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock)
+static HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& NODELETE connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock)
 {
     static NeverDestroyed<HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>> map;
     return map;

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -371,8 +371,8 @@ public:
     static RefPtr<Connection> connection(UniqueID);
     UniqueID uniqueID() const { return m_uniqueID; }
 
-    void setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(bool);
-    void setShouldExitOnSyncMessageSendFailure(bool);
+    void NODELETE setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(bool);
+    void NODELETE setShouldExitOnSyncMessageSendFailure(bool);
 
     // The set callback will be called on the connection work queue when the connection is closed,
     // before didCall is called on the client thread. Must be called before the connection is opened.
@@ -380,7 +380,7 @@ public:
     // on the work queue, for example if we want to handle them on some other thread we could avoid
     // handling the message on the client thread first.
     typedef void (*DidCloseOnConnectionWorkQueueCallback)(Connection*);
-    void setDidCloseOnConnectionWorkQueueCallback(DidCloseOnConnectionWorkQueueCallback);
+    void NODELETE setDidCloseOnConnectionWorkQueueCallback(DidCloseOnConnectionWorkQueueCallback);
 
     using OutgoingMessageQueueIsGrowingLargeCallback = Function<void()>;
     void setOutgoingMessageQueueIsGrowingLargeCallback(OutgoingMessageQueueIsGrowingLargeCallback&&);
@@ -517,7 +517,7 @@ public:
 
     void ignoreTimeoutsForTesting() { m_ignoreTimeoutsForTesting = true; }
 
-    void enableIncomingMessagesThrottling();
+    void NODELETE enableIncomingMessagesThrottling();
 
 #if ENABLE(IPC_TESTING_API)
     void addMessageObserver(const MessageObserver&);
@@ -549,11 +549,11 @@ public:
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     static bool signpostsEnabled();
-    static void forceEnableSignposts();
+    static void NODELETE forceEnableSignposts();
 #endif
 
-    static bool shouldCrashOnMessageCheckFailure();
-    static void setShouldCrashOnMessageCheckFailure(bool);
+    static bool NODELETE shouldCrashOnMessageCheckFailure();
+    static void NODELETE setShouldCrashOnMessageCheckFailure(bool);
 
 #if ENABLE(IPC_TESTING_API)
     bool hasErrorString() const { return !m_errorString.isNull(); }
@@ -569,7 +569,7 @@ private:
     Connection(Identifier&&, bool isServer, Thread::QOS = Thread::QOS::Default);
     Connection();
     void platformInitialize(Identifier&&);
-    bool platformPrepareForOpen();
+    bool NODELETE platformPrepareForOpen();
     void platformOpen();
     void platformInvalidate();
 

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.h
@@ -60,10 +60,10 @@ public:
     }
 
     [[nodiscard]] bool decodeFixedLengthData(std::span<uint8_t> data);
-    std::span<const uint8_t> decodeFixedLengthReference(size_t);
+    std::span<const uint8_t> NODELETE decodeFixedLengthReference(size_t);
 
 private:
-    [[nodiscard]] bool bufferIsLargeEnoughToContainBytes(size_t) const;
+    [[nodiscard]] bool NODELETE bufferIsLargeEnoughToContainBytes(size_t) const;
 
     std::span<const uint8_t> m_buffer;
     size_t m_bufferPosition { 0 };

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -97,16 +97,16 @@ public:
     bool matches(const ReceiverMatcher& matcher) const { return matcher.matches(messageReceiverName(), destinationID()); }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
-    ShouldDispatchWhenWaitingForSyncReply shouldDispatchMessageWhenWaitingForSyncReply() const;
+    ShouldDispatchWhenWaitingForSyncReply NODELETE shouldDispatchMessageWhenWaitingForSyncReply() const;
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || m_isAllowedWhenWaitingForSyncReplyOverride; }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
-    bool shouldUseFullySynchronousModeForTesting() const;
-    bool shouldMaintainOrderingWithAsyncMessages() const;
+    bool NODELETE shouldUseFullySynchronousModeForTesting() const;
+    bool NODELETE shouldMaintainOrderingWithAsyncMessages() const;
     void setIsAllowedWhenWaitingForSyncReplyOverride(bool value) { m_isAllowedWhenWaitingForSyncReplyOverride = value; }
     bool isAsyncReplyMessage() const { return isAsyncReply(messageName()); }
 
 #if PLATFORM(MAC)
-    void setImportanceAssertion(ImportanceAssertion&&);
+    void NODELETE setImportanceAssertion(ImportanceAssertion&&);
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -102,7 +102,7 @@ void Encoder::wrapForTesting(UniqueRef<Encoder>&& original)
         addAttachment(WTF::move(attachment));
 }
 
-static inline size_t roundUpToAlignment(size_t value, size_t alignment)
+static inline size_t NODELETE roundUpToAlignment(size_t value, size_t alignment)
 {
     return ((value + alignment - 1) / alignment) * alignment;
 }

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -65,11 +65,11 @@ public:
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
 
-    void setShouldDispatchMessageWhenWaitingForSyncReply(ShouldDispatchWhenWaitingForSyncReply);
+    void NODELETE setShouldDispatchMessageWhenWaitingForSyncReply(ShouldDispatchWhenWaitingForSyncReply);
 
-    bool isFullySynchronousModeForTesting() const;
-    void setFullySynchronousModeForTesting();
-    void setShouldMaintainOrderingWithAsyncMessages();
+    bool NODELETE isFullySynchronousModeForTesting() const;
+    void NODELETE setFullySynchronousModeForTesting();
+    void NODELETE setShouldMaintainOrderingWithAsyncMessages();
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || isFullySynchronousModeForTesting(); }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
 
@@ -103,13 +103,13 @@ public:
 private:
     std::span<uint8_t> grow(size_t alignment, size_t);
 
-    std::span<uint8_t> capacityBuffer();
+    std::span<uint8_t> NODELETE capacityBuffer();
     std::span<const uint8_t> capacityBuffer() const;
 
-    bool hasAttachments() const;
+    bool NODELETE hasAttachments() const;
 
     void encodeHeader();
-    const OptionSet<MessageFlags>& messageFlags() const;
+    const OptionSet<MessageFlags>& NODELETE messageFlags() const;
     OptionSet<MessageFlags>& messageFlags();
 
     void freeBufferIfNecessary();

--- a/Source/WebKit/Platform/IPC/MessageLog.h
+++ b/Source/WebKit/Platform/IPC/MessageLog.h
@@ -70,7 +70,7 @@ struct MessageLogMetadata {
     MessageName initialValue;
 };
 
-WK_EXPORT MessageLog<messageLogCapacity>& messageLog();
-WK_EXPORT const MessageLogMetadata& messageLogMetadata();
+WK_EXPORT MessageLog<messageLogCapacity>& NODELETE messageLog();
+WK_EXPORT const MessageLogMetadata& NODELETE messageLogMetadata();
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -73,7 +73,7 @@ public:
     ~StreamClientConnection();
 
     void setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait);
-    bool hasSemaphores() const;
+    bool NODELETE hasSemaphores() const;
     void setMaxBatchSize(unsigned);
 
     void open(Connection::Client&, SerialFunctionDispatcher& = RunLoop::currentSingleton());
@@ -104,8 +104,8 @@ public:
     void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiverBase&, uint64_t destinationID = 0);
     void removeWorkQueueMessageReceiver(ReceiverName, uint64_t destinationID = 0);
 
-    StreamClientConnectionBuffer& bufferForTesting();
-    Connection& connectionForTesting();
+    StreamClientConnectionBuffer& NODELETE bufferForTesting();
+    Connection& NODELETE connectionForTesting();
 
     // Returns the timeout moment for current time.
     Timeout defaultTimeout() const { return m_defaultTimeoutDuration; }
@@ -116,7 +116,7 @@ public:
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     static bool signpostsEnabled();
-    static void forceEnableSignposts();
+    static void NODELETE forceEnableSignposts();
 #endif
 
 private:

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -118,7 +118,7 @@ public:
 
     static constexpr size_t maximumSize() { return std::min(static_cast<size_t>(ClientOffset::serverIsSleepingTag), static_cast<size_t>(ClientOffset::serverIsSleepingTag)) - 1; }
 
-    std::span<uint8_t> headerForTesting();
+    std::span<uint8_t> NODELETE headerForTesting();
     std::span<uint8_t> dataForTesting() LIFETIME_BOUND { return mutableSpan(); }
 
     static constexpr bool sharedMemorySizeIsValid(size_t size) { return headerSize() < size && size <= headerSize() + maximumSize(); }

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -104,7 +104,7 @@ public:
         HasMoreMessages
     };
     DispatchResult dispatchStreamMessages(size_t messageLimit);
-    void markCurrentlyDispatchedMessageAsInvalid(ASCIILiteral error);
+    void NODELETE markCurrentlyDispatchedMessageAsInvalid(ASCIILiteral error);
 
     void open(Client&, StreamConnectionWorkQueue&);
     void invalidate();

--- a/Source/WebKit/Platform/IPC/cocoa/MachMessage.cpp
+++ b/Source/WebKit/Platform/IPC/cocoa/MachMessage.cpp
@@ -33,7 +33,7 @@
 namespace IPC {
 
 // Version of round_msg() using CheckedSize for extra safety.
-static inline CheckedSize safeRoundMsg(CheckedSize value)
+static inline CheckedSize NODELETE safeRoundMsg(CheckedSize value)
 {
     constexpr size_t alignment = sizeof(natural_t);
     return ((value + (alignment - 1)) / alignment) * alignment;

--- a/Source/WebKit/Platform/IPC/cocoa/MachMessage.h
+++ b/Source/WebKit/Platform/IPC/cocoa/MachMessage.h
@@ -42,14 +42,14 @@ public:
     static std::unique_ptr<MachMessage> create(MessageName, size_t);
     ~MachMessage();
 
-    static CheckedSize messageSize(size_t bodySize, size_t portDescriptorCount, size_t memoryDescriptorCount);
+    static CheckedSize NODELETE messageSize(size_t bodySize, size_t portDescriptorCount, size_t memoryDescriptorCount);
 
     size_t size() const { return m_size; }
     mach_msg_header_t* header() LIFETIME_BOUND { return m_messageHeader; }
 
     std::span<uint8_t> span() LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast<uint8_t*>(m_messageHeader), m_size); }
 
-    void leakDescriptors();
+    void NODELETE leakDescriptors();
 
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -223,7 +223,7 @@ NSSet *objectForKey<NSSet>(NSDictionary *dictionary, id key, bool nilIfEmpty, Cl
 
 // MARK: JSON Helpers
 
-static inline NSJSONReadingOptions toReadingImpl(JSONOptionSet options)
+static inline NSJSONReadingOptions NODELETE toReadingImpl(JSONOptionSet options)
 {
     NSJSONReadingOptions result = 0;
     if (options.contains(JSONOptions::FragmentsAllowed))
@@ -231,7 +231,7 @@ static inline NSJSONReadingOptions toReadingImpl(JSONOptionSet options)
     return result;
 }
 
-static inline NSJSONWritingOptions toWritingImpl(JSONOptionSet options)
+static inline NSJSONWritingOptions NODELETE toWritingImpl(JSONOptionSet options)
 {
     NSJSONWritingOptions result = 0;
     if (options.contains(JSONOptions::FragmentsAllowed))

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -97,7 +97,7 @@ public:
     // with this context is desired.
     WTF::MachSendRight createFencePort();
 
-    LayerHostingContextID cachedContextID();
+    LayerHostingContextID NODELETE cachedContextID();
 
 #if USE(EXTENSIONKIT)
     RetainPtr<BELayerHierarchy> hostable() const { return m_hostable; }

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
@@ -52,7 +52,7 @@ public:
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&, NOESCAPE CompletionHandler<void()>&& postCommitAction);
     WebCore::FloatSize videoLayerSize() const { return m_videoLayerSize; }
     void setVideoLayerSizeIfPossible();
-    void setInitialVideoLayerSize(const WebCore::FloatSize&);
+    void NODELETE setInitialVideoLayerSize(const WebCore::FloatSize&);
 
 private:
     Vector<LayerHostingContextCallback> m_layerHostingContextRequests;

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -66,7 +66,7 @@ namespace WebKit {
 // FIXME: Rather than having these free functions scattered about, Apple Pay data types should know
 // how to convert themselves to and from their platform representations.
 
-static PKPaymentAuthorizationStatus toPKPaymentAuthorizationStatus(WebCore::ApplePayPaymentAuthorizationResult::Status status)
+static PKPaymentAuthorizationStatus NODELETE toPKPaymentAuthorizationStatus(WebCore::ApplePayPaymentAuthorizationResult::Status status)
 {
     switch (status) {
     case WebCore::ApplePayPaymentAuthorizationResult::Success:
@@ -90,7 +90,7 @@ static PKPaymentAuthorizationStatus toPKPaymentAuthorizationStatus(WebCore::Appl
     }
 }
 
-static PKPaymentErrorCode toPKPaymentErrorCode(WebCore::ApplePayErrorCode code)
+static PKPaymentErrorCode NODELETE toPKPaymentErrorCode(WebCore::ApplePayErrorCode code)
 {
     switch (code) {
     case WebCore::ApplePayErrorCode::Unknown:

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -168,7 +168,7 @@ private:
     unsigned resourceTypeValue() const final;
 #ifdef __OBJC__
     // FIXME: Remove when WebPrivacyHelpersAdditions.mm no longer depends on it.
-    WPResourceType resourceType() const;
+    WPResourceType NODELETE resourceType() const;
 #endif
 };
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -358,7 +358,7 @@ RestrictedOpenerDomainsController::RestrictedOpenerDomainsController()
     }]);
 }
 
-static RestrictedOpenerType restrictedOpenerType(WPRestrictedOpenerType type)
+static RestrictedOpenerType NODELETE restrictedOpenerType(WPRestrictedOpenerType type)
 {
     switch (type) {
     case WPRestrictedOpenerTypeNoOpener: return RestrictedOpenerType::NoOpener;
@@ -526,10 +526,10 @@ public:
 
     TrackerAddressLookupInfo() = default;
 
-    const CString& owner() const { return m_owner; }
-    const CString& host() const { return m_host; }
+    const CString& NODELETE owner() const { return m_owner; }
+    const CString& NODELETE host() const { return m_host; }
 
-    CanBlock canBlock() const { return m_canBlock; }
+    CanBlock NODELETE canBlock() const { return m_canBlock; }
 
     static void populateIfNeeded()
     {
@@ -655,9 +655,9 @@ public:
 
     TrackerDomainLookupInfo() = default;
 
-    const CString& owner() const { return m_owner; }
+    const CString& NODELETE owner() const { return m_owner; }
 
-    CanBlock canBlock() const { return m_canBlock; }
+    CanBlock NODELETE canBlock() const { return m_canBlock; }
 
     static void populateIfNeeded()
     {

--- a/Source/WebKit/Platform/foundation/LoggingFoundation.mm
+++ b/Source/WebKit/Platform/foundation/LoggingFoundation.mm
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-String logLevelString()
+String NODELETE logLevelString()
 {
 #if !LOG_DISABLED
     return [[NSUserDefaults standardUserDefaults] stringForKey:@"WebKit2Logging"];

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -132,7 +132,7 @@ struct PendingReply {
     _remoteObjectRegistry = nullptr;
 }
 
-static uint64_t generateReplyIdentifier()
+static uint64_t NODELETE generateReplyIdentifier()
 {
     static uint64_t identifier;
 
@@ -283,7 +283,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
                 remoteObjectRegistry->sendUnusedReply(m_replyID);
             }
 
-            void didCallReplyBlock() { m_didCallReplyBlock = true; }
+            void NODELETE didCallReplyBlock() { m_didCallReplyBlock = true; }
 
         private:
             ReplyBlockCallChecker(_WKRemoteObjectRegistry *registry, uint64_t replyID)

--- a/Source/WebKit/Shared/APIWebArchive.h
+++ b/Source/WebKit/Shared/APIWebArchive.h
@@ -59,7 +59,7 @@ public:
 
     Ref<API::Data> data();
 
-    WebCore::LegacyWebArchive* coreLegacyWebArchive();
+    WebCore::LegacyWebArchive* NODELETE coreLegacyWebArchive();
 
 private:
     WebArchive(WebArchiveResource* mainResource, RefPtr<API::Array>&& subresources, RefPtr<API::Array>&& subframeArchives);

--- a/Source/WebKit/Shared/APIWebArchiveResource.h
+++ b/Source/WebKit/Shared/APIWebArchiveResource.h
@@ -51,11 +51,11 @@ public:
     static Ref<WebArchiveResource> create(RefPtr<WebCore::ArchiveResource>&&);
 
     Ref<API::Data> data();
-    WTF::String url();
-    WTF::String mimeType();
-    WTF::String textEncoding();
+    WTF::String NODELETE url();
+    WTF::String NODELETE mimeType();
+    WTF::String NODELETE textEncoding();
 
-    WebCore::ArchiveResource* coreArchiveResource();
+    WebCore::ArchiveResource* NODELETE coreArchiveResource();
 
 private:
     WebArchiveResource(API::Data*, const WTF::String& URL, const WTF::String& MIMEType, const WTF::String& textEncoding);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
@@ -48,7 +48,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPaymentCoordinatorProxy);
 
-static WeakPtr<WebPaymentCoordinatorProxy>& activePaymentCoordinatorProxy()
+static WeakPtr<WebPaymentCoordinatorProxy>& NODELETE activePaymentCoordinatorProxy()
 {
     static NeverDestroyed<WeakPtr<WebPaymentCoordinatorProxy>> activePaymentCoordinatorProxy;
     return activePaymentCoordinatorProxy.get();

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -123,7 +123,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void webProcessExited();
+    void NODELETE webProcessExited();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const
     {
         CheckedPtr client = m_client.get();
@@ -175,10 +175,10 @@ private:
     void platformBeginApplePaySetup(const PaymentSetupConfiguration&, const PaymentSetupFeatures&, CompletionHandler<void(bool)>&&);
     void platformEndApplePaySetup();
 
-    bool canBegin() const;
-    bool canCancel() const;
-    bool canCompletePayment() const;
-    bool canAbort() const;
+    bool NODELETE canBegin() const;
+    bool NODELETE canCancel() const;
+    bool NODELETE canCompletePayment() const;
+    bool NODELETE canAbort() const;
 
     void didReachFinalState(WebCore::PaymentSessionError&& = { });
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.h
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.h
@@ -47,7 +47,7 @@ RetainPtr<PKShippingMethod> toPKShippingMethod(const WebCore::ApplePayShippingMe
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
 RetainPtr<PKShippingMethods> toPKShippingMethods(const Vector<WebCore::ApplePayShippingMethod>&);
 #endif
-PKMerchantCapability toPKMerchantCapabilities(const WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities&);
+PKMerchantCapability NODELETE toPKMerchantCapabilities(const WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -147,7 +147,7 @@ PKMerchantCapability toPKMerchantCapabilities(const WebCore::ApplePaySessionPaym
     return result;
 }
 
-static PKShippingType toPKShippingType(WebCore::ApplePaySessionPaymentRequest::ShippingType shippingType)
+static PKShippingType NODELETE toPKShippingType(WebCore::ApplePaySessionPaymentRequest::ShippingType shippingType)
 {
     switch (shippingType) {
     case WebCore::ApplePaySessionPaymentRequest::ShippingType::Shipping:
@@ -218,7 +218,7 @@ RetainPtr<PKShippingMethods> toPKShippingMethods(const Vector<WebCore::ApplePayS
 
 #if HAVE(PASSKIT_SHIPPING_CONTACT_EDITING_MODE)
 
-static PKShippingContactEditingMode toPKShippingContactEditingMode(WebCore::ApplePayShippingContactEditingMode shippingContactEditingMode)
+static PKShippingContactEditingMode NODELETE toPKShippingContactEditingMode(WebCore::ApplePayShippingContactEditingMode shippingContactEditingMode)
 {
     switch (shippingContactEditingMode) {
     case WebCore::ApplePayShippingContactEditingMode::Available:
@@ -249,7 +249,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if HAVE(PASSKIT_APPLE_PAY_LATER_AVAILABILITY)
 
-static PKApplePayLaterAvailability toPKApplePayLaterAvailability(WebCore::ApplePayLaterAvailability applePayLaterAvailability)
+static PKApplePayLaterAvailability NODELETE toPKApplePayLaterAvailability(WebCore::ApplePayLaterAvailability applePayLaterAvailability)
 {
     switch (applePayLaterAvailability) {
     case WebCore::ApplePayLaterAvailability::Available:
@@ -286,7 +286,7 @@ static RetainPtr<NSSet> toNSSet(const Vector<String>& strings)
     return WTF::move(mutableSet);
 }
 
-static PKPaymentRequestAPIType toAPIType(WebCore::ApplePaySessionPaymentRequest::Requester requester)
+static PKPaymentRequestAPIType NODELETE toAPIType(WebCore::ApplePaySessionPaymentRequest::Requester requester)
 {
     switch (requester) {
     case WebCore::ApplePaySessionPaymentRequest::Requester::ApplePayJS:

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -67,7 +67,7 @@ public:
 
     // disable and enable termination of the process. when disableTermination is called, the
     // process won't terminate unless a corresponding enableTermination call is made.
-    void disableTermination();
+    void NODELETE disableTermination();
     void enableTermination();
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);

--- a/Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h
+++ b/Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h
@@ -36,7 +36,7 @@ public:
 
     ~CompletionHandlerCallChecker();
 
-    void didCallCompletionHandler();
+    void NODELETE didCallCompletionHandler();
     bool completionHandlerHasBeenCalled() const;
 
 private:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
@@ -93,7 +93,7 @@ namespace IPC {
 // makeUniqueRefWithoutFastMallocCheck<>, since we can't make the variant fast malloc'ed
 template<> struct ArgumentCoder<UniqueRef<WebKit::CFObjectValue>> {
     template<typename Encoder>
-    static void encode(Encoder&, const UniqueRef<WebKit::CFObjectValue>&);
+    static void NODELETE encode(Encoder&, const UniqueRef<WebKit::CFObjectValue>&);
     static std::optional<UniqueRef<WebKit::CFObjectValue>> decode(Decoder&);
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -142,7 +142,7 @@ public:
 
     RetainPtr<id> toID() const;
 
-    static bool valueIsAllowed(IPC::Decoder&, ObjectValue&);
+    static bool NODELETE valueIsAllowed(IPC::Decoder&, ObjectValue&);
 
     const UniqueRef<ObjectValue>& value() const { return m_value; }
 private:

--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -131,7 +131,7 @@ static bool determineTrackingPreventionStateInternal(bool appWasLinkedOnOrAfter,
     return result != kTCCAccessPreflightDenied;
 }
 
-static RefPtr<WorkQueue>& itpQueue()
+static RefPtr<WorkQueue>& NODELETE itpQueue()
 {
     static NeverDestroyed<RefPtr<WorkQueue>> itpQueue;
     return itpQueue;

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationRequest.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationRequest.h
@@ -67,8 +67,8 @@ struct InteractionInformationRequest {
     {
     }
 
-    bool isValidForRequest(const InteractionInformationRequest&, int radius = 0) const;
-    bool isApproximatelyValidForRequest(const InteractionInformationRequest&, int radius) const;
+    bool NODELETE isValidForRequest(const InteractionInformationRequest&, int radius = 0) const;
+    bool NODELETE isApproximatelyValidForRequest(const InteractionInformationRequest&, int radius) const;
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -52,7 +52,7 @@ namespace WebKit {
 
 #if ENABLE(VIDEO)
 
-bool defaultCaptionDisplaySettingsEnabled()
+bool NODELETE defaultCaptionDisplaySettingsEnabled()
 {
     return false;
 }
@@ -61,12 +61,12 @@ bool defaultCaptionDisplaySettingsEnabled()
 
 #if PLATFORM(MAC)
 
-bool defaultUseAppKitGestures()
+bool NODELETE defaultUseAppKitGestures()
 {
     return false;
 }
 
-bool defaultTextInputClientSelectionUpdatesEnabled()
+bool NODELETE defaultTextInputClientSelectionUpdatesEnabled()
 {
     return false;
 }
@@ -166,7 +166,7 @@ bool defaultTopContentInsetBackgroundCanChangeAfterScrolling()
 #endif
 }
 
-bool defaultContentInsetBackgroundFillEnabled()
+bool NODELETE defaultContentInsetBackgroundFillEnabled()
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     return isLiquidGlassEnabled();
@@ -182,7 +182,7 @@ bool defaultHostedBlurMaterialInMediaControlsEnabled()
 }
 #endif
 
-bool defaultIOSurfaceLosslessCompressionEnabled()
+bool NODELETE defaultIOSurfaceLosslessCompressionEnabled()
 {
 #if HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES) && HAVE(LOSSLESS_COMPRESSED_IOSURFACE_CG_SUPPORT)
 #define WK_CA_FEATURE_CG_COMPRESSED_IOSURFACES 15
@@ -194,7 +194,7 @@ bool defaultIOSurfaceLosslessCompressionEnabled()
 }
 
 #if ENABLE(UNIFIED_PDF)
-bool defaultUnifiedPDFEnabled()
+bool NODELETE defaultUnifiedPDFEnabled()
 {
 #if ENABLE(UNIFIED_PDF_BY_DEFAULT)
     return true;

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
@@ -48,7 +48,7 @@ public:
     void remove(xpc_connection_t);
 
     void setConnectedNetworkProcessHasDebugModeEnabled(const Daemon::Connection&, bool);
-    bool debugModeEnabled() const;
+    bool NODELETE debugModeEnabled() const;
     void broadcastConsoleMessage(JSC::MessageLevel, const String&);
     
 private:

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -108,7 +108,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     });
 }
 
-static void enterSandbox()
+static void NODELETE enterSandbox()
 {
 #if PLATFORM(MAC)
     // FIXME: Enter a sandbox here. We should only need read/write access to our database and network access and nothing else.

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -58,13 +58,13 @@
 
 namespace WebKit {
 
-static Vector<String>& overrideLanguagesFromBootstrap()
+static Vector<String>& NODELETE overrideLanguagesFromBootstrap()
 {
     static NeverDestroyed<Vector<String>> languages;
     return languages;
 }
 
-static void stageOverrideLanguagesForMainThread(Vector<String>&& languages)
+static void NODELETE stageOverrideLanguagesForMainThread(Vector<String>&& languages)
 {
     RELEASE_ASSERT(overrideLanguagesFromBootstrap().isEmpty());
     overrideLanguagesFromBootstrap().swap(languages);

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -74,11 +74,11 @@ inline bool isValid(std::optional<WebExtensionFrameIdentifier> identifier)
     return identifier && !isNone(identifier.value());
 }
 
-WebCore::FrameIdentifier toWebCoreFrameIdentifier(const WebExtensionFrameIdentifier&, const WebPage&);
+WebCore::FrameIdentifier NODELETE toWebCoreFrameIdentifier(const WebExtensionFrameIdentifier&, const WebPage&);
 
 bool matchesFrame(const WebExtensionFrameIdentifier&, const WebFrame&);
 
-WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(std::optional<WebCore::FrameIdentifier>);
+WebExtensionFrameIdentifier NODELETE toWebExtensionFrameIdentifier(std::optional<WebCore::FrameIdentifier>);
 WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame&);
 WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const FrameInfoData&);
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -87,7 +87,7 @@ public:
     int close();
 
     sqlite3* sqlite3Handle() const { return m_db; };
-    void assertQueue();
+    void NODELETE assertQueue();
     WorkQueue& queue() const { return m_queue; };
 
 private:

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
@@ -81,7 +81,7 @@ protected:
 
 private:
     void vacuum();
-    bool isDatabaseOpen();
+    bool NODELETE isDatabaseOpen();
     String openDatabase(const URL& databaseURL, WebExtensionSQLiteDatabase::AccessType, bool deleteDatabaseFileOnError);
     String deleteDatabaseFileAtURL(const URL& databaseURL, bool reopenDatabase);
     String deleteDatabase();

--- a/Source/WebKit/Shared/RTCPacketOptions.cpp
+++ b/Source/WebKit/Shared/RTCPacketOptions.cpp
@@ -55,7 +55,7 @@ static_assert(static_cast<webrtc::DiffServCodePoint>(RTCPacketOptions::Different
 static_assert(static_cast<webrtc::DiffServCodePoint>(RTCPacketOptions::DifferentiatedServicesCodePoint::CS6) == webrtc::DSCP_CS6);
 static_assert(static_cast<webrtc::DiffServCodePoint>(RTCPacketOptions::DifferentiatedServicesCodePoint::CS7) == webrtc::DSCP_CS7);
 
-static RTCPacketOptions::DifferentiatedServicesCodePoint toDifferentiatedServicesCodePoint(webrtc::DiffServCodePoint dscp)
+static RTCPacketOptions::DifferentiatedServicesCodePoint NODELETE toDifferentiatedServicesCodePoint(webrtc::DiffServCodePoint dscp)
 {
     switch (dscp) {
     case webrtc::DSCP_NO_CHANGE:

--- a/Source/WebKit/Shared/RTCPacketOptions.h
+++ b/Source/WebKit/Shared/RTCPacketOptions.h
@@ -78,7 +78,7 @@ struct RTCPacketOptions {
 
     explicit RTCPacketOptions(const SerializableData&);
 
-    SerializableData serializableData() const;
+    SerializableData NODELETE serializableData() const;
 
     webrtc::AsyncSocketPacketOptions options;
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -136,14 +136,14 @@ public:
     float scale() const { return m_parameters.scale; }
     WebCore::ContentsFormat contentsFormat() const { return m_parameters.contentsFormat; }
     WebCore::DestinationColorSpace colorSpace() const { return m_parameters.colorSpace; }
-    WebCore::PixelFormat pixelFormat() const;
+    WebCore::PixelFormat NODELETE pixelFormat() const;
     Type type() const { return m_parameters.type; }
     bool isOpaque() const { return m_parameters.isOpaque; }
-    unsigned bytesPerPixel() const;
+    unsigned NODELETE bytesPerPixel() const;
     bool supportsPartialRepaint() const;
     bool drawingRequiresClearedPixels() const;
 
-    PlatformCALayerRemote& layer() const;
+    PlatformCALayerRemote& NODELETE layer() const;
 
     void encode(IPC::Encoder&) const;
 
@@ -179,7 +179,7 @@ public:
     void markFrontBufferVolatileForTesting();
 
 protected:
-    RemoteLayerBackingStoreCollection* backingStoreCollection() const;
+    RemoteLayerBackingStoreCollection* NODELETE backingStoreCollection() const;
 
     void drawInContext(WebCore::GraphicsContext&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -59,7 +59,7 @@ public:
     RemoteLayerBackingStoreCollection(RemoteLayerTreeContext&);
     virtual ~RemoteLayerBackingStoreCollection();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void markFrontBufferVolatileForTesting(RemoteLayerBackingStore&);
@@ -88,7 +88,7 @@ public:
 
     virtual void gpuProcessConnectionWasDestroyed();
 
-    RemoteLayerTreeContext& layerTreeContext() const;
+    RemoteLayerTreeContext& NODELETE layerTreeContext() const;
 
 protected:
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -134,7 +134,7 @@ public:
     RemoteLayerTreeTransaction& operator=(RemoteLayerTreeTransaction&&);
 
     std::optional<WebCore::PlatformLayerIdentifier> rootLayerID() const { return m_rootLayerID.asOptional(); }
-    void setRootLayerID(WebCore::PlatformLayerIdentifier);
+    void NODELETE setRootLayerID(WebCore::PlatformLayerIdentifier);
     void layerPropertiesChanged(PlatformCALayerRemote&);
     void setCreatedLayers(Vector<LayerCreationProperties>);
     void setDestroyedLayerIDs(Vector<WebCore::PlatformLayerIdentifier>);
@@ -145,15 +145,15 @@ public:
     void dump() const;
 #endif
     
-    bool hasAnyLayerChanges() const;
+    bool NODELETE hasAnyLayerChanges() const;
 
     const Vector<LayerCreationProperties>& createdLayers() const { return m_createdLayers; }
     const Vector<WebCore::PlatformLayerIdentifier>& destroyedLayers() const { return m_destroyedLayerIDs; }
     const Vector<WebCore::PlatformLayerIdentifier>& layerIDsWithNewlyUnreachableBackingStore() const { return m_layerIDsWithNewlyUnreachableBackingStore; }
 
-    HashSet<Ref<PlatformCALayerRemote>>& changedLayers();
+    HashSet<Ref<PlatformCALayerRemote>>& NODELETE changedLayers();
 
-    const LayerPropertiesMap& changedLayerProperties() const;
+    const LayerPropertiesMap& NODELETE changedLayerProperties() const;
     LayerPropertiesMap& changedLayerProperties();
 
     void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }

--- a/Source/WebKit/Shared/SharedStringHashTable.h
+++ b/Source/WebKit/Shared/SharedStringHashTable.h
@@ -34,8 +34,8 @@ public:
     SharedStringHashTable();
     ~SharedStringHashTable();
 
-    bool add(WebCore::SharedStringHash);
-    bool remove(WebCore::SharedStringHash);
+    bool NODELETE add(WebCore::SharedStringHash);
+    bool NODELETE remove(WebCore::SharedStringHash);
     void clear();
 };
 

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
@@ -34,7 +34,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static inline unsigned doubleHash(unsigned key)
+static inline unsigned NODELETE doubleHash(unsigned key)
 {
     key = ~key + (key >> 23);
     key ^= (key << 12);

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
@@ -39,13 +39,13 @@ public:
     SharedStringHashTableReadOnly();
     ~SharedStringHashTableReadOnly();
 
-    bool contains(WebCore::SharedStringHash) const;
+    bool NODELETE contains(WebCore::SharedStringHash) const;
 
     WebCore::SharedMemory* sharedMemory() const { return m_sharedMemory.get(); }
     void setSharedMemory(RefPtr<WebCore::SharedMemory>&&);
 
 protected:
-    WebCore::SharedStringHash* findSlot(WebCore::SharedStringHash) const;
+    WebCore::SharedStringHash* NODELETE findSlot(WebCore::SharedStringHash) const;
 
     RefPtr<WebCore::SharedMemory> m_sharedMemory;
     unsigned m_tableSizeMask { 0 };

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -341,47 +341,47 @@ public:
         return index;
     }
 
-    bool useTagNameForTextFormControls() const
+    bool NODELETE useTagNameForTextFormControls() const
     {
         return m_versionBehaviors.contains(TextExtractionVersionBehavior::TagNameForTextFormControls);
     }
 
-    bool includeRects() const
+    bool NODELETE includeRects() const
     {
         return !onlyIncludeText() && m_options.flags.contains(TextExtractionOptionFlag::IncludeRects);
     }
 
-    bool includeURLs() const
+    bool NODELETE includeURLs() const
     {
         return !onlyIncludeText() && m_options.flags.contains(TextExtractionOptionFlag::IncludeURLs);
     }
 
-    bool shortenURLs() const
+    bool NODELETE shortenURLs() const
     {
         return m_options.flags.contains(TextExtractionOptionFlag::ShortenURLs);
     }
 
-    bool onlyIncludeText() const
+    bool NODELETE onlyIncludeText() const
     {
         return m_options.flags.contains(TextExtractionOptionFlag::OnlyIncludeText);
     }
 
-    bool useHTMLOutput() const
+    bool NODELETE useHTMLOutput() const
     {
         return m_options.outputFormat == TextExtractionOutputFormat::HTMLMarkup;
     }
 
-    bool useMarkdownOutput() const
+    bool NODELETE useMarkdownOutput() const
     {
         return m_options.outputFormat == TextExtractionOutputFormat::Markdown;
     }
 
-    bool useTextTreeOutput() const
+    bool NODELETE useTextTreeOutput() const
     {
         return m_options.outputFormat == TextExtractionOutputFormat::TextTree;
     }
 
-    bool useJSONOutput() const
+    bool NODELETE useJSONOutput() const
     {
         return m_options.outputFormat == TextExtractionOutputFormat::MinifiedJSON;
     }
@@ -421,7 +421,7 @@ public:
         m_urlStringStack.append(WTF::move(urlString));
     }
 
-    std::optional<String> currentURLString() const
+    std::optional<String> NODELETE currentURLString() const
     {
         if (m_urlStringStack.isEmpty())
             return std::nullopt;
@@ -429,7 +429,7 @@ public:
         return { m_urlStringStack.last() };
     }
 
-    void popURLString()
+    void NODELETE popURLString()
     {
         if (m_urlStringStack.isEmpty()) {
             ASSERT_NOT_REACHED();
@@ -439,9 +439,9 @@ public:
         m_urlStringStack.removeLast();
     }
 
-    void pushSuperscript() { m_superscriptLevel++; }
-    bool superscriptLevel() const { return m_superscriptLevel; }
-    void popSuperscript()
+    void NODELETE pushSuperscript() { m_superscriptLevel++; }
+    bool NODELETE superscriptLevel() const { return m_superscriptLevel; }
+    void NODELETE popSuperscript()
     {
         if (!m_superscriptLevel) {
             ASSERT_NOT_REACHED();
@@ -450,9 +450,9 @@ public:
         m_superscriptLevel--;
     }
 
-    void pushStrikethrough() { m_strikethroughLevel++; }
-    bool isInsideStrikethrough() const { return m_strikethroughLevel > 0; }
-    void popStrikethrough()
+    void NODELETE pushStrikethrough() { m_strikethroughLevel++; }
+    bool NODELETE isInsideStrikethrough() const { return m_strikethroughLevel > 0; }
+    void NODELETE popStrikethrough()
     {
         if (!m_strikethroughLevel) {
             ASSERT_NOT_REACHED();
@@ -570,7 +570,7 @@ private:
         protect(rootJSONObject())->setInteger("version"_s, version());
     }
 
-    uint32_t version() const
+    uint32_t NODELETE version() const
     {
         return m_options.version.value_or(currentTextExtractionOutputVersion);
     }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -48,9 +48,9 @@ public:
 
     Ref<FrameState> copyFrameStateWithChildren();
 
-    std::optional<WebCore::FrameIdentifier> frameID() const;
+    std::optional<WebCore::FrameIdentifier> NODELETE frameID() const;
     WebCore::BackForwardFrameItemIdentifier identifier() const { return m_identifier; }
-    const String& url() const;
+    const String& NODELETE url() const;
 
     WebBackForwardListFrameItem* parent() const { return m_parent; }
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
@@ -58,7 +58,7 @@ public:
 
     Ref<WebBackForwardListFrameItem> rootFrame();
     Ref<WebBackForwardListFrameItem> mainFrame();
-    WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
+    WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
 
     WebBackForwardListItem* backForwardListItem() const;
 
@@ -76,7 +76,7 @@ private:
 
     String loggingStringAtIndent(size_t);
 
-    static HashMap<std::pair<WebCore::BackForwardFrameItemIdentifier, WebCore::BackForwardItemIdentifier>, WeakRef<WebBackForwardListFrameItem>>& allItems();
+    static HashMap<std::pair<WebCore::BackForwardFrameItemIdentifier, WebCore::BackForwardItemIdentifier>, WeakRef<WebBackForwardListFrameItem>>& NODELETE allItems();
 
     WeakPtr<WebBackForwardListItem> m_backForwardListItem;
     const WebCore::BackForwardFrameItemIdentifier m_identifier;

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -64,9 +64,9 @@ public:
     Ref<FrameState> navigatedFrameState() const;
     Ref<FrameState> mainFrameState() const;
 
-    const String& originalURL() const;
-    const String& url() const;
-    const String& title() const;
+    const String& NODELETE originalURL() const;
+    const String& NODELETE url() const;
+    const String& NODELETE title() const;
     bool wasCreatedByJSWithoutUserInteraction() const;
 
     const URL& resourceDirectoryURL() const { return m_resourceDirectoryURL; }
@@ -86,7 +86,7 @@ public:
 
     WebBackForwardCacheEntry* backForwardCacheEntry() const { return m_backForwardCacheEntry.get(); }
 
-    SuspendedPageProxy* suspendedPage() const;
+    SuspendedPageProxy* NODELETE suspendedPage() const;
 
     std::optional<WebCore::FrameIdentifier> navigatedFrameID() const { return m_navigatedFrameID; }
 

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.h
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.h
@@ -48,7 +48,7 @@ private:
     std::span<const uint8_t> frameURLFiltersBytecode() const final;
     std::span<const uint8_t> serializedActions() const final;
     
-    std::span<const uint8_t> spanWithOffsetAndLength(size_t, size_t) const;
+    std::span<const uint8_t> NODELETE spanWithOffsetAndLength(size_t, size_t) const;
 
     WebCompiledContentRuleListData m_data;
 };

--- a/Source/WebKit/Shared/WebCompiledContentRuleListData.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleListData.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-static size_t ruleListDataSize(size_t topURLFiltersBytecodeOffset, size_t topURLFiltersBytecodeSize)
+static size_t NODELETE ruleListDataSize(size_t topURLFiltersBytecodeOffset, size_t topURLFiltersBytecodeSize)
 {
     return topURLFiltersBytecodeOffset + topURLFiltersBytecodeSize;
 }

--- a/Source/WebKit/Shared/WebContextMenuItem.h
+++ b/Source/WebKit/Shared/WebContextMenuItem.h
@@ -53,7 +53,7 @@ public:
 
     Ref<API::Array> submenuItemsAsAPIArray() const;
 
-    API::Object* userData() const;
+    API::Object* NODELETE userData() const;
     void setUserData(API::Object*);
 
     const WebContextMenuItemData& data() { return m_webContextMenuItemData; }

--- a/Source/WebKit/Shared/WebContextMenuItemData.h
+++ b/Source/WebKit/Shared/WebContextMenuItemData.h
@@ -53,7 +53,7 @@ public:
     
     WebCore::ContextMenuItem core() const;
     
-    API::Object* userData() const;
+    API::Object* NODELETE userData() const;
     void setUserData(API::Object*);
 
 private:

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -67,7 +67,7 @@ public:
 
     MonotonicTime timestamp() const { return m_timestamp; }
 
-    bool isActivationTriggeringEvent() const;
+    bool NODELETE isActivationTriggeringEvent() const;
     WTF::UUID authorizationToken() const { return m_authorizationToken; }
 
 private:

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -238,7 +238,7 @@ OptionSet<WebEventModifier> kit(OptionSet<WebCore::PlatformEvent::Modifier> modi
     return result;
 }
 
-static double forceForEvent(const WebMouseEvent& webEvent)
+static double NODELETE forceForEvent(const WebMouseEvent& webEvent)
 {
     switch (webEvent.type()) {
     case WebEventType::MouseDown:

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -77,7 +77,7 @@ WebCore::PlatformGestureEvent platform(const WebGestureEvent&);
 WebCore::MouseEventInputSource platform(WebMouseEventInputSource);
 
 WebCore::MouseButton platform(WebMouseEventButton);
-WebMouseEventButton kit(WebCore::MouseButton);
+WebMouseEventButton NODELETE kit(WebCore::MouseButton);
 
 WebCore::PlatformEvent::Type platform(WebEventType);
 WebEventType kit(WebCore::PlatformEvent::Type);

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -50,7 +50,7 @@ struct WebFoundTextRange {
         uint64_t endOffset { 0 };
 
         bool operator==(const PDFData& other) const = default;
-        unsigned hash() const;
+        unsigned NODELETE hash() const;
         static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
     };
 

--- a/Source/WebKit/Shared/WebImage.h
+++ b/Source/WebKit/Shared/WebImage.h
@@ -56,7 +56,7 @@ public:
     virtual ~WebImage();
 
     WebCore::IntSize size() const;
-    const WebCore::ImageBufferParameters* parameters() const;
+    const WebCore::ImageBufferParameters* NODELETE parameters() const;
     std::optional<ParametersAndHandle> parametersAndHandle() const;
     bool isEmpty() const { return !m_buffer; }
 

--- a/Source/WebKit/Shared/WebKeyboardEvent.h
+++ b/Source/WebKit/Shared/WebKeyboardEvent.h
@@ -79,7 +79,7 @@ public:
     bool isKeypad() const { return m_isKeypad; }
     bool isSystemKey() const { return m_isSystemKey; }
 
-    static bool isKeyboardEventType(WebEventType);
+    static bool NODELETE isKeyboardEventType(WebEventType);
 
 #if PLATFORM(WPE)
     static String keyValueStringForWPEKeyval(unsigned);

--- a/Source/WebKit/Shared/WebMemorySampler.h
+++ b/Source/WebKit/Shared/WebMemorySampler.h
@@ -75,7 +75,7 @@ class WebMemorySampler final : public CanMakeCheckedPtr<WebMemorySampler> {
     WTF_MAKE_TZONE_ALLOCATED(WebMemorySampler);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebMemorySampler);
 public:
-    static WebMemorySampler* singleton();
+    static WebMemorySampler* NODELETE singleton();
     void start(const double interval = 0);
     void start(SandboxExtension::Handle&&, const String&, const double interval = 0);
     void stop();

--- a/Source/WebKit/Shared/WebMouseEvent.h
+++ b/Source/WebKit/Shared/WebMouseEvent.h
@@ -58,7 +58,7 @@ enum class WebMouseEventSyntheticClickType : uint8_t {
     OneFingerTap,
     TwoFingerTap
 };
-WebMouseEventSyntheticClickType syntheticClickType(const WebCore::NavigationAction&);
+WebMouseEventSyntheticClickType NODELETE syntheticClickType(const WebCore::NavigationAction&);
 
 enum class WebMouseEventInputSource : uint8_t { UserDriven, Automation };
 
@@ -102,7 +102,7 @@ public:
     void setPredictedEvents(const Vector<WebMouseEvent>& predictedEvents) { m_predictedEvents = predictedEvents; }
     Vector<WebMouseEvent> predictedEvents() const { return m_predictedEvents; }
 
-    static bool isMouseEventType(WebEventType);
+    static bool NODELETE isMouseEventType(WebEventType);
 
 private:
     WebMouseEventButton m_button { WebMouseEventButton::None };

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -109,7 +109,7 @@ bool defaultTextInputClientSelectionUpdatesEnabled();
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-bool defaultCaptureAudioInGPUProcessEnabled();
+bool NODELETE defaultCaptureAudioInGPUProcessEnabled();
 bool defaultManageCaptureStatusBarInGPUProcessEnabled();
 double defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes();
 #endif
@@ -119,10 +119,10 @@ bool defaultMediaSourceEnabled();
 #endif
 
 #if ENABLE(MEDIA_SOURCE)
-bool defaultManagedMediaSourceEnabled();
-bool defaultMediaSourcePrefersDecompressionSession();
+bool NODELETE defaultManagedMediaSourceEnabled();
+bool NODELETE defaultMediaSourcePrefersDecompressionSession();
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-bool defaultManagedMediaSourceNeedsAirPlay();
+bool NODELETE defaultManagedMediaSourceNeedsAirPlay();
 #endif
 #endif
 
@@ -137,7 +137,7 @@ bool defaultRemoveBackgroundEnabled();
 #endif
 
 #if ENABLE(GAMEPAD)
-bool defaultGamepadVibrationActuatorEnabled();
+bool NODELETE defaultGamepadVibrationActuatorEnabled();
 #endif
 
 #if ENABLE(WEB_AUTHN)
@@ -158,7 +158,7 @@ bool defaultRunningBoardThrottlingEnabled();
 bool defaultShouldDropNearSuspendedAssertionAfterDelay();
 bool defaultShouldTakeNearSuspendedAssertion();
 bool defaultShowModalDialogEnabled();
-bool defaultLinearMediaPlayerEnabled();
+bool NODELETE defaultLinearMediaPlayerEnabled();
 
 bool defaultShouldEnableScreenOrientationAPI();
 bool defaultPopoverAttributeEnabled();
@@ -167,10 +167,10 @@ bool defaultUseGPUProcessForDOMRenderingEnabled();
 #if USE(LIBWEBRTC)
 bool defaultPeerConnectionEnabledAvailable();
 #endif
-bool defaultWebRTCSocketsServiceClassEnabled();
+bool NODELETE defaultWebRTCSocketsServiceClassEnabled();
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-bool defaultBuiltInNotificationsEnabled();
+bool NODELETE defaultBuiltInNotificationsEnabled();
 #endif
 
 #if ENABLE(DEVICE_ORIENTATION)
@@ -181,7 +181,7 @@ bool defaultDeviceOrientationPermissionAPIEnabled();
 bool defaultRequiresPageVisibilityForVideoToBeNowPlaying();
 #endif
 
-bool defaultCookieStoreAPIEnabled();
+bool NODELETE defaultCookieStoreAPIEnabled();
 
 bool defaultContentInsetBackgroundFillEnabled();
 bool defaultTopContentInsetBackgroundCanChangeAfterScrolling();
@@ -198,7 +198,7 @@ bool defaultIFrameResourceMonitoringEnabled();
 bool defaultPreferSpatialAudioExperience();
 #endif
 
-bool defaultRTCEncodedStreamsQuirkEnabled();
+bool NODELETE defaultRTCEncodedStreamsQuirkEnabled();
 
 bool defaultMutationEventsEnabled();
 
@@ -218,16 +218,16 @@ bool defaultIOSurfaceLosslessCompressionEnabled();
 bool defaultUnifiedPDFEnabled();
 #endif
 
-bool defaultScrollbarColorEnabled();
+bool NODELETE defaultScrollbarColorEnabled();
 
-bool defaultAllowMultipleCommitLayerTreePending();
+bool NODELETE defaultAllowMultipleCommitLayerTreePending();
 
 #if ENABLE(VIDEO)
 bool defaultCaptionDisplaySettingsEnabled();
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-bool defaultShouldEnableScreenCapture();
+bool NODELETE defaultShouldEnableScreenCapture();
 #endif
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)

--- a/Source/WebKit/Shared/WebPreferencesStore.cpp
+++ b/Source/WebKit/Shared/WebPreferencesStore.cpp
@@ -33,7 +33,7 @@ namespace WebKit {
 
 typedef HashMap<String, bool> BoolOverridesMap;
 
-static BoolOverridesMap& boolTestRunnerOverridesMap()
+static BoolOverridesMap& NODELETE boolTestRunnerOverridesMap()
 {
     static NeverDestroyed<BoolOverridesMap> map;
     return map;

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -90,7 +90,7 @@ public:
 
     bool isMomentumEvent() const { return momentumPhase() != Phase::None && momentumPhase() != Phase::WillBegin; }
 
-    static bool isWheelEventType(WebEventType);
+    static bool NODELETE isWheelEventType(WebEventType);
 
 private:
     WebCore::IntPoint m_position;

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.h
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.h
@@ -50,7 +50,7 @@ private:
     static bool canCoalesce(const WebWheelEvent&, const WebWheelEvent&);
     static WebWheelEvent coalesce(const WebWheelEvent&, const WebWheelEvent&);
 
-    bool shouldDispatchEventNow(const WebWheelEvent&) const;
+    bool NODELETE shouldDispatchEventNow(const WebWheelEvent&) const;
 
     Deque<NativeWebWheelEvent, 2> m_wheelEventQueue;
     Deque<std::unique_ptr<CoalescedEventSequence>> m_eventsBeingProcessed;

--- a/Source/WebKit/Shared/WebsiteAutoplayPolicy.h
+++ b/Source/WebKit/Shared/WebsiteAutoplayPolicy.h
@@ -38,6 +38,6 @@ enum class WebsiteAutoplayPolicy : uint8_t {
     Deny
 };
 
-WebCore::AutoplayPolicy core(WebsiteAutoplayPolicy);
+WebCore::AutoplayPolicy NODELETE core(WebsiteAutoplayPolicy);
 
 }

--- a/Source/WebKit/Shared/WebsiteData/WebsiteData.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteData.h
@@ -69,7 +69,7 @@ struct WebsiteData {
 
     HashSet<String> hostNamesWithHSTSCache;
     HashSet<WebCore::RegistrableDomain> registrableDomainsWithResourceLoadStatistics;
-    static WebsiteDataProcessType ownerProcess(WebsiteDataType);
+    static WebsiteDataProcessType NODELETE ownerProcess(WebsiteDataType);
     static OptionSet<WebsiteDataType> filter(OptionSet<WebsiteDataType>, WebsiteDataProcessType);
 };
 

--- a/Source/WebKit/Shared/cf/CoreIPCNumber.h
+++ b/Source/WebKit/Shared/cf/CoreIPCNumber.h
@@ -67,7 +67,7 @@ public:
     CoreIPCNumber& operator=(const CoreIPCNumber& other) = default;
 
     RetainPtr<CFNumberRef> createCFNumber() const;
-    CoreIPCNumber::NumberHolder get() const;
+    CoreIPCNumber::NumberHolder NODELETE get() const;
     RetainPtr<id> toID() const;
 
 private:

--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -50,11 +50,11 @@ public:
     static WebMouseEvent createWebMouseEvent(NSEvent *, NSEvent *lastPressureEvent, NSView *windowView, WebMouseEventInputSource);
     static WebWheelEvent createWebWheelEvent(NSEvent *, NSView *windowView);
     static WebKeyboardEvent createWebKeyboardEvent(NSEvent *, bool handledByInputMethod, bool replacesSoftSpace, const Vector<WebCore::KeypressCommand>&);
-    static bool shouldBeHandledAsContextClick(const WebCore::PlatformMouseEvent&);
+    static bool NODELETE shouldBeHandledAsContextClick(const WebCore::PlatformMouseEvent&);
 
 #if defined(__OBJC__)
-    static NSEventModifierFlags toNSEventModifierFlags(OptionSet<WebKit::WebEventModifier>);
-    static NSInteger toNSButtonNumber(WebKit::WebMouseEventButton);
+    static NSEventModifierFlags NODELETE toNSEventModifierFlags(OptionSet<WebKit::WebEventModifier>);
+    static NSInteger NODELETE toNSButtonNumber(WebKit::WebMouseEventButton);
 #endif
 #endif // USE(APPKIT)
 };

--- a/Source/WebKit/UIProcess/API/APIContentRuleList.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.h
@@ -47,7 +47,7 @@ public:
     ContentRuleList(Ref<WebKit::WebCompiledContentRuleList>&&, WebKit::NetworkCache::Data&&);
     virtual ~ContentRuleList();
 
-    const WTF::String& name() const;
+    const WTF::String& NODELETE name() const;
     const WebKit::WebCompiledContentRuleList& compiledRuleList() const { return m_compiledRuleList.get(); }
     
     static bool supportsRegularExpression(const WTF::String&);

--- a/Source/WebKit/UIProcess/API/APIContentRuleListAction.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListAction.h
@@ -37,12 +37,12 @@ public:
     static Ref<ContentRuleListAction> create(WebCore::ContentRuleListResults::Result&&);
     virtual ~ContentRuleListAction();
 
-    bool blockedLoad() const;
-    bool madeHTTPS() const;
-    bool blockedCookies() const;
-    bool redirected() const;
-    bool modifiedHeaders() const;
-    const Vector<WTF::String>& notifications() const;
+    bool NODELETE blockedLoad() const;
+    bool NODELETE madeHTTPS() const;
+    bool NODELETE blockedCookies() const;
+    bool NODELETE redirected() const;
+    bool NODELETE modifiedHeaders() const;
+    const Vector<WTF::String>& NODELETE notifications() const;
 
 private:
     ContentRuleListAction(WebCore::ContentRuleListResults::Result&&);

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -101,7 +101,7 @@ static WTF::String constructedPath(const WTF::String& base, const WTF::String& i
 // represent the size and offset of the structure in memory, possibly with compiler-added padding.
 constexpr size_t currentVersionFileHeaderSize = 2 * sizeof(uint32_t) + 7 * sizeof(uint64_t);
 
-static constexpr size_t headerSize(uint32_t version)
+static constexpr size_t NODELETE headerSize(uint32_t version)
 {
     if (version < 12)
         return 2 * sizeof(uint32_t) + 5 * sizeof(uint64_t);
@@ -119,7 +119,7 @@ struct ContentRuleListMetaData {
     uint64_t unused64bits1 { 0 };
     uint64_t unused64bits2 { 0 }; // Additional space on disk reserved so we can add something without incrementing the version number.
 
-    size_t fileSize() const
+    size_t NODELETE fileSize() const
     {
         return headerSize(version)
             + sourceSize
@@ -368,7 +368,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             m_fileHandle = { };
         }
 
-        bool hadErrorWhileWritingToFile() { return m_hadFileError; }
+        bool NODELETE hadErrorWhileWritingToFile() { return m_hadFileError; }
 
     private:
         void writeToFile(bool value)

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -85,7 +85,7 @@ private:
 #endif // ENABLE(CONTENT_EXTENSIONS)
 };
 
-const std::error_category& contentRuleListStoreErrorCategory();
+const std::error_category& NODELETE contentRuleListStoreErrorCategory();
 
 inline std::error_code make_error_code(ContentRuleListStore::Error error)
 {

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -41,13 +41,13 @@ OptionSet<WebKit::ContentWorldOption> ContentWorld::defaultOptions()
     return WebKit::ContentWorldOption::Inspectable;
 }
 
-static HashMap<WTF::String, WeakRef<ContentWorld>>& sharedWorldNameMap()
+static HashMap<WTF::String, WeakRef<ContentWorld>>& NODELETE sharedWorldNameMap()
 {
     static NeverDestroyed<HashMap<WTF::String, WeakRef<ContentWorld>>> sharedMap;
     return sharedMap;
 }
 
-static HashMap<WebKit::ContentWorldIdentifier, WeakRef<ContentWorld>>& sharedWorldIdentifierMap()
+static HashMap<WebKit::ContentWorldIdentifier, WeakRef<ContentWorld>>& NODELETE sharedWorldIdentifierMap()
 {
     static NeverDestroyed<HashMap<WebKit::ContentWorldIdentifier, WeakRef<ContentWorld>>> sharedMap;
     return sharedMap;

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -40,7 +40,7 @@ namespace API {
 
 class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld>, public CanMakeWeakPtr<ContentWorld> {
 public:
-    static OptionSet<WebKit::ContentWorldOption> defaultOptions();
+    static OptionSet<WebKit::ContentWorldOption> NODELETE defaultOptions();
     static ContentWorld* worldForIdentifier(WebKit::ContentWorldIdentifier);
     static Ref<ContentWorld> sharedWorldWithName(const WTF::String&, OptionSet<WebKit::ContentWorldOption> = defaultOptions() );
     static Ref<ContentWorld> createNamelessWorld(OptionSet<WebKit::ContentWorldOption>);

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
@@ -43,29 +43,29 @@ public:
 
     Ref<ContentWorldConfiguration> copy() const;
 
-    const WTF::String& name() const;
+    const WTF::String& NODELETE name() const;
     void setName(WTF::String&&);
 
-    bool allowAccessToClosedShadowRoots() const;
-    void setAllowAccessToClosedShadowRoots(bool);
+    bool NODELETE allowAccessToClosedShadowRoots() const;
+    void NODELETE setAllowAccessToClosedShadowRoots(bool);
 
-    bool allowAutofill() const;
-    void setAllowAutofill(bool);
+    bool NODELETE allowAutofill() const;
+    void NODELETE setAllowAutofill(bool);
 
-    bool allowElementUserInfo() const;
-    void setAllowElementUserInfo(bool);
+    bool NODELETE allowElementUserInfo() const;
+    void NODELETE setAllowElementUserInfo(bool);
 
-    bool disableLegacyBuiltinOverrides() const;
-    void setDisableLegacyBuiltinOverrides(bool);
+    bool NODELETE disableLegacyBuiltinOverrides() const;
+    void NODELETE setDisableLegacyBuiltinOverrides(bool);
 
-    bool allowJSHandleCreation() const;
-    void setAllowJSHandleCreation(bool);
+    bool NODELETE allowJSHandleCreation() const;
+    void NODELETE setAllowJSHandleCreation(bool);
 
-    bool allowNodeSerialization() const;
-    void setAllowNodeSerialization(bool);
+    bool NODELETE allowNodeSerialization() const;
+    void NODELETE setAllowNodeSerialization(bool);
 
-    bool isInspectable() const;
-    void setInspectable(bool);
+    bool NODELETE isInspectable() const;
+    void NODELETE setInspectable(bool);
 
     OptionSet<WebKit::ContentWorldOption> optionSet() const;
 

--- a/Source/WebKit/UIProcess/API/APIFormInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFormInfo.h
@@ -40,11 +40,11 @@ public:
 
     virtual ~FormInfo();
 
-    API::FrameInfo* targetFrame() const;
-    API::FrameInfo* sourceFrame() const;
-    const WTF::URL& submissionURL() const;
-    const WTF::String& httpMethod() const;
-    const Vector<std::pair<WTF::String, WTF::String>>& formValues() const;
+    API::FrameInfo* NODELETE targetFrame() const;
+    API::FrameInfo* NODELETE sourceFrame() const;
+    const WTF::URL& NODELETE submissionURL() const;
+    const WTF::String& NODELETE httpMethod() const;
+    const Vector<std::pair<WTF::String, WTF::String>>& NODELETE formValues() const;
 
 private:
     FormInfo(API::FrameInfo&, API::FrameInfo& sourceFrame, const WTF::URL& submissionURL, const WTF::String& httpMethod, const Vector<std::pair<WTF::String, WTF::String>>& formValues);

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
@@ -85,7 +85,7 @@ public:
 
     void filterAppBoundCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
 
-    bool isOptInCookiePartitioningEnabled() const;
+    bool NODELETE isOptInCookiePartitioningEnabled() const;
 
 #if USE(SOUP)
     void replaceCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
@@ -48,7 +48,7 @@ public:
     void addURLSchemeHandler(Ref<WebKit::WebURLSchemeHandler>&&, const WTF::String& urlScheme);
     const Vector<URLSchemeHandlerPair>& urlSchemeHandlers() { return m_customURLSchemes; }
     
-    WebKit::WebProcessPool* processPool();
+    WebKit::WebProcessPool* NODELETE processPool();
     void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
 
 private:

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -129,8 +129,8 @@ public:
     size_t redirectChainIndex(const WTF::URL&);
 
     bool wasUserInitiated() const { return m_lastNavigationAction && !!m_lastNavigationAction->userGestureTokenIdentifier; }
-    bool isRequestFromClientOrUserInput() const;
-    void markRequestAsFromClientInput();
+    bool NODELETE isRequestFromClientOrUserInput() const;
+    void NODELETE markRequestAsFromClientInput();
     void markAsFromLoadData() { m_isFromLoadData = true; }
     bool isFromLoadData() const { return m_isFromLoadData; }
 
@@ -185,7 +185,7 @@ public:
     void setSafeBrowsingCheckOngoing(size_t, bool);
     bool safeBrowsingCheckOngoing(size_t);
     bool safeBrowsingCheckOngoing();
-    void setSafeBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
+    void NODELETE setSafeBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
     RefPtr<WebKit::BrowsingWarning> NODELETE safeBrowsingWarning();
     void setSafeBrowsingCheckTimedOut() { m_safeBrowsingCheckTimedOut = true; }
     bool safeBrowsingCheckTimedOut() { return m_safeBrowsingCheckTimedOut; }
@@ -197,7 +197,7 @@ public:
 
     void setPendingSharedProcess(WebKit::FrameProcess&);
 
-    void setHasStorageForCurrentSite(bool);
+    void NODELETE setHasStorageForCurrentSite(bool);
     bool hasStorageForCurrentSite() const { return m_hasStorageForCurrentSite; }
 
     void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -125,23 +125,23 @@ public:
         WebCore::SecurityOriginData securityOrigin;
         bool operator==(const OpenerInfo&) const;
     };
-    const std::optional<OpenerInfo>& openerInfo() const;
+    const std::optional<OpenerInfo>& NODELETE openerInfo() const;
     void setOpenerInfo(std::optional<OpenerInfo>&&);
-    void consumeOpenerInfo();
+    void NODELETE consumeOpenerInfo();
 
-    const WebCore::Site& openedSite() const;
+    const WebCore::Site& NODELETE openedSite() const;
     void setOpenedSite(const WebCore::Site&);
 
-    const WTF::String& openedMainFrameName() const;
+    const WTF::String& NODELETE openedMainFrameName() const;
     void setOpenedMainFrameName(const WTF::String&);
 
     WebCore::SandboxFlags initialSandboxFlags() const { return m_data.initialSandboxFlags; }
-    void setInitialSandboxFlags(WebCore::SandboxFlags);
+    void NODELETE setInitialSandboxFlags(WebCore::SandboxFlags);
 
     WebCore::ReferrerPolicy initialReferrerPolicy() const { return m_data.initialReferrerPolicy; }
-    void setInitialReferrerPolicy(WebCore::ReferrerPolicy);
+    void NODELETE setInitialReferrerPolicy(WebCore::ReferrerPolicy);
 
-    const std::optional<WebCore::WindowFeatures>& windowFeatures() const;
+    const std::optional<WebCore::WindowFeatures>& NODELETE windowFeatures() const;
     void setWindowFeatures(WebCore::WindowFeatures&&);
 
     WebKit::WebProcessPool& processPool() const;
@@ -151,36 +151,36 @@ public:
     void setUserContentController(RefPtr<WebKit::WebUserContentControllerProxy>&&);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    const WTF::URL& requiredWebExtensionBaseURL() const;
+    const WTF::URL& NODELETE requiredWebExtensionBaseURL() const;
     void setRequiredWebExtensionBaseURL(WTF::URL&&);
 
-    WebKit::WebExtensionController* webExtensionController() const;
+    WebKit::WebExtensionController* NODELETE webExtensionController() const;
     void setWebExtensionController(RefPtr<WebKit::WebExtensionController>&&);
 
-    WebKit::WebExtensionController* weakWebExtensionController() const;
+    WebKit::WebExtensionController* NODELETE weakWebExtensionController() const;
     void setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
-    WebKit::WebPageGroup* pageGroup();
+    WebKit::WebPageGroup* NODELETE pageGroup();
     void setPageGroup(RefPtr<WebKit::WebPageGroup>&&);
 
     WebKit::WebPreferences& preferences() const;
     void setPreferences(RefPtr<WebKit::WebPreferences>&&);
 
-    WebKit::WebPageProxy* relatedPage() const;
+    WebKit::WebPageProxy* NODELETE relatedPage() const;
     void setRelatedPage(WeakPtr<WebKit::WebPageProxy>&& relatedPage) { m_data.relatedPage = WTF::move(relatedPage); }
 
-    WebKit::WebPageProxy* pageToCloneSessionStorageFrom() const;
-    void setPageToCloneSessionStorageFrom(WeakPtr<WebKit::WebPageProxy>&&);
+    WebKit::WebPageProxy* NODELETE pageToCloneSessionStorageFrom() const;
+    void NODELETE setPageToCloneSessionStorageFrom(WeakPtr<WebKit::WebPageProxy>&&);
 
-    WebKit::WebPageProxy* alternateWebViewForNavigationGestures() const;
-    void setAlternateWebViewForNavigationGestures(WeakPtr<WebKit::WebPageProxy>&&);
+    WebKit::WebPageProxy* NODELETE alternateWebViewForNavigationGestures() const;
+    void NODELETE setAlternateWebViewForNavigationGestures(WeakPtr<WebKit::WebPageProxy>&&);
 
     WebKit::VisitedLinkStore& visitedLinkStore() const;
     void setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&&);
 
     WebKit::WebsiteDataStore& websiteDataStore() const;
-    WebKit::WebsiteDataStore* websiteDataStoreIfExists() const;
+    WebKit::WebsiteDataStore* NODELETE websiteDataStoreIfExists() const;
     void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
 
     WebsitePolicies& defaultWebsitePolicies() const;
@@ -268,7 +268,7 @@ public:
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
-    ApplicationManifest* applicationManifest() const;
+    ApplicationManifest* NODELETE applicationManifest() const;
     void setApplicationManifest(RefPtr<ApplicationManifest>&&);
 #endif
 
@@ -336,7 +336,7 @@ public:
 
 #if ENABLE(APPLE_PAY)
     bool applePayEnabled() const;
-    void setApplePayEnabled(bool);
+    void NODELETE setApplePayEnabled(bool);
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)
@@ -460,8 +460,8 @@ public:
     void setDelaysWebProcessLaunchUntilFirstLoad(bool);
     bool delaysWebProcessLaunchUntilFirstLoad() const;
 
-    void setAllowPostingLegacySynchronousMessages(bool);
-    bool allowPostingLegacySynchronousMessages() const;
+    void NODELETE setAllowPostingLegacySynchronousMessages(bool);
+    bool NODELETE allowPostingLegacySynchronousMessages() const;
 
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_data.contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_data.contentSecurityPolicyModeForExtension; }

--- a/Source/WebKit/UIProcess/API/APIScriptMessage.h
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.h
@@ -54,7 +54,7 @@ public:
     NSString *cocoaName() const { return m_cocoaName.get(); }
 #endif
     API::Object* apiBody() const { return m_apiBody.get(); }
-    WebKit::WebPageProxy* page() const;
+    WebKit::WebPageProxy* NODELETE page() const;
     API::FrameInfo& frame() const { return m_frame.get(); }
     const WTF::String& name() const { return m_name; }
     API::ContentWorld& world() const { return m_world.get(); }

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -74,7 +74,7 @@ public:
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 
-    bool isSameElement(const TargetedElementInfo&) const;
+    bool NODELETE isSameElement(const TargetedElementInfo&) const;
 
     WebCore::NodeIdentifier nodeIdentifier() const { return m_info.nodeIdentifier; }
     WebCore::ScriptExecutionContextIdentifier documentIdentifier() const { return m_info.documentIdentifier; }

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -159,7 +159,7 @@ public:
     bool allowSharedProcess() const { return m_data.allowSharedProcess; }
     void setAllowSharedProcess(bool allowSharedProcess) { m_data.allowSharedProcess = allowSharedProcess; }
 
-    const WebCore::ResourceRequest& alternateRequest() const;
+    const WebCore::ResourceRequest& NODELETE alternateRequest() const;
     void setAlternateRequest(WebCore::ResourceRequest&&);
 
     bool allowsJSHandleCreationInPageWorld() const { return m_data.allowsJSHandleCreationInPageWorld; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -37,7 +37,7 @@
 #import <wtf/cocoa/VectorCocoa.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
-static WKErrorCode toWKErrorCode(const std::error_code& error)
+static WKErrorCode NODELETE toWKErrorCode(const std::error_code& error)
 {
     ASSERT(error.category() == API::contentRuleListStoreErrorCategory());
     switch (static_cast<API::ContentRuleListStore::Error>(error.value())) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -177,7 +177,7 @@ static std::optional<WebCore::Cookie> makeVectorElement(const WebCore::Cookie*, 
     self._protectedCookieStore->unregisterObserver(*result);
 }
 
-static WebCore::HTTPCookieAcceptPolicy toHTTPCookieAcceptPolicy(WKCookiePolicy wkCookiePolicy)
+static WebCore::HTTPCookieAcceptPolicy NODELETE toHTTPCookieAcceptPolicy(WKCookiePolicy wkCookiePolicy)
 {
     switch (wkCookiePolicy) {
     case WKCookiePolicyAllow:
@@ -188,7 +188,7 @@ static WebCore::HTTPCookieAcceptPolicy toHTTPCookieAcceptPolicy(WKCookiePolicy w
     ASSERT_NOT_REACHED();
 }
 
-static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
+static WKCookiePolicy NODELETE toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 {
     switch (policy) {
     case WebCore::HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -44,7 +44,7 @@
 
 @implementation WKNavigationAction
 
-static WKNavigationType toWKNavigationType(WebCore::NavigationType navigationType)
+static WKNavigationType NODELETE toWKNavigationType(WebCore::NavigationType navigationType)
 {
     switch (navigationType) {
     case WebCore::NavigationType::LinkClicked:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -268,7 +268,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     protect(*_preferences)->setTelephoneNumberParsingEnabled(telephoneNumberDetectionIsEnabled);
 }
 
-static WebCore::StorageBlockingPolicy toStorageBlockingPolicy(_WKStorageBlockingPolicy policy)
+static WebCore::StorageBlockingPolicy NODELETE toStorageBlockingPolicy(_WKStorageBlockingPolicy policy)
 {
     switch (policy) {
     case _WKStorageBlockingPolicyAllowAll:
@@ -283,7 +283,7 @@ static WebCore::StorageBlockingPolicy toStorageBlockingPolicy(_WKStorageBlocking
     return WebCore::StorageBlockingPolicy::AllowAll;
 }
 
-static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
+static _WKStorageBlockingPolicy NODELETE toAPI(WebCore::StorageBlockingPolicy policy)
 {
     switch (policy) {
     case WebCore::StorageBlockingPolicy::AllowAll:
@@ -797,7 +797,7 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
     protect(*_preferences)->setShouldAllowUserInstalledFonts(_shouldAllowUserInstalledFonts);
 }
 
-static _WKEditableLinkBehavior toAPI(WebCore::EditableLinkBehavior behavior)
+static _WKEditableLinkBehavior NODELETE toAPI(WebCore::EditableLinkBehavior behavior)
 {
     switch (behavior) {
     case WebCore::EditableLinkBehavior::Default:
@@ -816,7 +816,7 @@ static _WKEditableLinkBehavior toAPI(WebCore::EditableLinkBehavior behavior)
     return _WKEditableLinkBehaviorNeverLive;
 }
 
-static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehavior wkBehavior)
+static WebCore::EditableLinkBehavior NODELETE toEditableLinkBehavior(_WKEditableLinkBehavior wkBehavior)
 {
     switch (wkBehavior) {
     case _WKEditableLinkBehaviorDefault:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -742,7 +742,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 @synthesize totalSystemCPUTime = _totalSystemCPUTime;
 @synthesize physicalFootprint = _physicalFootprint;
 
-static _WKProcessState processStateFromThrottleState(WebKit::ProcessThrottleState state)
+static _WKProcessState NODELETE processStateFromThrottleState(WebKit::ProcessThrottleState state)
 {
     switch (state) {
     case WebKit::ProcessThrottleState::Foreground:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -379,7 +379,7 @@ static inline NSSet<WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtens
     return extensionContext->hasPermission(url, toImplNullable(tab, extensionContext.get()).get());
 }
 
-static inline WKWebExtensionContextPermissionStatus toAPI(WebKit::WebExtensionContext::PermissionState status)
+static inline WKWebExtensionContextPermissionStatus NODELETE toAPI(WebKit::WebExtensionContext::PermissionState status)
 {
     switch (status) {
     case WebKit::WebExtensionContext::PermissionState::DeniedExplicitly:
@@ -642,7 +642,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtension
     extensionContext->clearUserGesture(toImpl(tab, extensionContext.get()));
 }
 
-static inline id<WKWebExtensionWindow> toAPI(const RefPtr<WebKit::WebExtensionWindow>& window)
+static inline id<WKWebExtensionWindow> NODELETE toAPI(const RefPtr<WebKit::WebExtensionWindow>& window)
 {
     return window ? window->delegate() : nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -395,7 +395,7 @@ static bool shouldRestrictBaseURLSchemes()
     return shouldRestrictBaseURLSchemes;
 }
 
-static WebCore::RectEdges<bool> toRectEdges(_WKRectEdge edges)
+static WebCore::RectEdges<bool> NODELETE toRectEdges(_WKRectEdge edges)
 {
     return {
         static_cast<bool>(edges & _WKRectEdgeTop),
@@ -406,7 +406,7 @@ static WebCore::RectEdges<bool> toRectEdges(_WKRectEdge edges)
 }
 
 #if PLATFORM(MAC)
-static uint32_t convertUserInterfaceDirectionPolicy(WKUserInterfaceDirectionPolicy policy)
+static uint32_t NODELETE convertUserInterfaceDirectionPolicy(WKUserInterfaceDirectionPolicy policy)
 {
     switch (policy) {
     case WKUserInterfaceDirectionPolicyContent:
@@ -417,7 +417,7 @@ static uint32_t convertUserInterfaceDirectionPolicy(WKUserInterfaceDirectionPoli
     return static_cast<uint32_t>(WebCore::UserInterfaceDirectionPolicy::Content);
 }
 
-static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection direction)
+static uint32_t NODELETE convertSystemLayoutDirection(NSUserInterfaceLayoutDirection direction)
 {
     switch (direction) {
     case NSUserInterfaceLayoutDirectionLeftToRight:
@@ -1378,7 +1378,7 @@ static bool validateArgument(id argument)
     _page->resumeAllMediaPlayback(makeBlockPtr(completionHandler));
 }
 
-static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState mediaPlaybackState)
+static WKMediaPlaybackState NODELETE toWKMediaPlaybackState(WebKit::MediaPlaybackState mediaPlaybackState)
 {
     switch (mediaPlaybackState) {
     case WebKit::MediaPlaybackState::NoMediaPlayback:
@@ -2344,7 +2344,7 @@ static RetainPtr<NSDictionary> dictionaryRepresentationForEditorState(const WebK
     };
 }
 
-static NSTextAlignment nsTextAlignment(WebKit::TextAlignment alignment)
+static NSTextAlignment NODELETE nsTextAlignment(WebKit::TextAlignment alignment)
 {
     switch (alignment) {
     case WebKit::TextAlignment::Natural:
@@ -2362,7 +2362,7 @@ static NSTextAlignment nsTextAlignment(WebKit::TextAlignment alignment)
     return NSTextAlignmentNatural;
 }
 
-static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& editorState, _WKSelectionAttributes previousAttributes)
+static _WKSelectionAttributes NODELETE selectionAttributes(const WebKit::EditorState& editorState, _WKSelectionAttributes previousAttributes)
 {
     _WKSelectionAttributes attributes = _WKSelectionAttributeNoSelection;
     if (editorState.selectionIsNone)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -834,7 +834,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
                 coordinatorClient->coordinatorStateChanged(state);
         }
 
-        std::optional<WebCore::ExceptionData> result(bool success) const
+        std::optional<WebCore::ExceptionData> NODELETE result(bool success) const
         {
             if (!success)
                 return { WebCore::ExceptionData { WebCore::ExceptionCode::InvalidStateError, String() } };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -77,7 +77,7 @@ WebKit::WebContentMode webContentMode(WKContentMode contentMode)
 
 #endif // PLATFORM(IOS_FAMILY)
 
-WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy(WebCore::HTTPSByDefaultMode httpsByDefault)
+WKWebpagePreferencesUpgradeToHTTPSPolicy NODELETE upgradeToHTTPSPolicy(WebCore::HTTPSByDefaultMode httpsByDefault)
 {
     switch (httpsByDefault) {
     case WebCore::HTTPSByDefaultMode::Disabled:
@@ -93,7 +93,7 @@ WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy(WebCore::HTTPSByDe
     return WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested;
 }
 
-WebCore::HTTPSByDefaultMode httpsByDefaultMode(WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy)
+WebCore::HTTPSByDefaultMode NODELETE httpsByDefaultMode(WKWebpagePreferencesUpgradeToHTTPSPolicy upgradeToHTTPSPolicy)
 {
     switch (upgradeToHTTPSPolicy) {
     case WKWebpagePreferencesUpgradeToHTTPSPolicyKeepAsRequested:
@@ -110,7 +110,7 @@ WebCore::HTTPSByDefaultMode httpsByDefaultMode(WKWebpagePreferencesUpgradeToHTTP
     return WebCore::HTTPSByDefaultMode::Disabled;
 }
 
-static _WKWebsiteMouseEventPolicy mouseEventPolicy(WebCore::MouseEventPolicy policy)
+static _WKWebsiteMouseEventPolicy NODELETE mouseEventPolicy(WebCore::MouseEventPolicy policy)
 {
     switch (policy) {
     case WebCore::MouseEventPolicy::Default:
@@ -124,7 +124,7 @@ static _WKWebsiteMouseEventPolicy mouseEventPolicy(WebCore::MouseEventPolicy pol
     return _WKWebsiteMouseEventPolicyDefault;
 }
 
-static WebCore::MouseEventPolicy coreMouseEventPolicy(_WKWebsiteMouseEventPolicy policy)
+static WebCore::MouseEventPolicy NODELETE coreMouseEventPolicy(_WKWebsiteMouseEventPolicy policy)
 {
     switch (policy) {
     case _WKWebsiteMouseEventPolicyDefault:
@@ -138,7 +138,7 @@ static WebCore::MouseEventPolicy coreMouseEventPolicy(_WKWebsiteMouseEventPolicy
     return WebCore::MouseEventPolicy::Default;
 }
 
-static _WKWebsiteModalContainerObservationPolicy modalContainerObservationPolicy(WebCore::ModalContainerObservationPolicy policy)
+static _WKWebsiteModalContainerObservationPolicy NODELETE modalContainerObservationPolicy(WebCore::ModalContainerObservationPolicy policy)
 {
     switch (policy) {
     case WebCore::ModalContainerObservationPolicy::Disabled:
@@ -150,7 +150,7 @@ static _WKWebsiteModalContainerObservationPolicy modalContainerObservationPolicy
     return _WKWebsiteModalContainerObservationPolicyDisabled;
 }
 
-static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPolicy(_WKWebsiteModalContainerObservationPolicy policy)
+static WebCore::ModalContainerObservationPolicy NODELETE coreModalContainerObservationPolicy(_WKWebsiteModalContainerObservationPolicy policy)
 {
     switch (policy) {
     case _WKWebsiteModalContainerObservationPolicyDisabled:
@@ -314,7 +314,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 }
 
 #if ENABLE(DEVICE_ORIENTATION)
-static WebCore::DeviceOrientationOrMotionPermissionState toDeviceOrientationOrMotionPermissionState(_WKWebsiteDeviceOrientationAndMotionAccessPolicy policy)
+static WebCore::DeviceOrientationOrMotionPermissionState NODELETE toDeviceOrientationOrMotionPermissionState(_WKWebsiteDeviceOrientationAndMotionAccessPolicy policy)
 {
     switch (policy) {
     case _WKWebsiteDeviceOrientationAndMotionAccessPolicyAsk:
@@ -336,7 +336,7 @@ static WebCore::DeviceOrientationOrMotionPermissionState toDeviceOrientationOrMo
 }
 
 #if ENABLE(DEVICE_ORIENTATION)
-static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrientationAndMotionAccessPolicy(WebCore::DeviceOrientationOrMotionPermissionState state)
+static _WKWebsiteDeviceOrientationAndMotionAccessPolicy NODELETE toWKWebsiteDeviceOrientationAndMotionAccessPolicy(WebCore::DeviceOrientationOrMotionPermissionState state)
 {
     switch (state) {
     case WebCore::DeviceOrientationOrMotionPermissionState::Prompt:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -33,7 +33,7 @@
 #import "_WKResourceLoadInfoInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
 
-static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::ResourceLoadInfo::Type type)
+static _WKResourceLoadInfoResourceType NODELETE toWKResourceLoadInfoResourceType(WebKit::ResourceLoadInfo::Type type)
 {
     using namespace WebKit;
     switch (type) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -218,7 +218,7 @@ NSString * const _WKLocalAuthenticatorCredentialLastUsedDateKey = @"_WKLocalAuth
     return _panel->rpId().createNSString().autorelease();
 }
 
-static _WKWebAuthenticationTransport wkWebAuthenticationTransport(WebCore::AuthenticatorTransport transport)
+static _WKWebAuthenticationTransport NODELETE wkWebAuthenticationTransport(WebCore::AuthenticatorTransport transport)
 {
     switch (transport) {
     case WebCore::AuthenticatorTransport::Usb:
@@ -250,7 +250,7 @@ static _WKWebAuthenticationTransport wkWebAuthenticationTransport(WebCore::Authe
     return _transports.get();
 }
 
-static _WKWebAuthenticationType wkWebAuthenticationType(WebCore::ClientDataType type)
+static _WKWebAuthenticationType NODELETE wkWebAuthenticationType(WebCore::ClientDataType type)
 {
     switch (type) {
     case WebCore::ClientDataType::Create:
@@ -263,7 +263,7 @@ static _WKWebAuthenticationType wkWebAuthenticationType(WebCore::ClientDataType 
     }
 }
 
-static fido::AuthenticatorSupportedOptions::UserVerificationAvailability coreUserVerificationAvailability(_WKWebAuthenticationUserVerificationAvailability wkAvailability)
+static fido::AuthenticatorSupportedOptions::UserVerificationAvailability NODELETE coreUserVerificationAvailability(_WKWebAuthenticationUserVerificationAvailability wkAvailability)
 {
     switch (wkAvailability) {
     case _WKWebAuthenticationUserVerificationAvailabilitySupportedAndConfigured:
@@ -877,7 +877,7 @@ static Vector<WebCore::PublicKeyCredentialParameters> publicKeyCredentialParamet
     });
 }
 
-static WebCore::AuthenticatorTransport authenticatorTransport(_WKWebAuthenticationTransport transport)
+static WebCore::AuthenticatorTransport NODELETE authenticatorTransport(_WKWebAuthenticationTransport transport)
 {
     switch (transport) {
     case _WKWebAuthenticationTransportUSB:
@@ -916,7 +916,7 @@ static Vector<WebCore::PublicKeyCredentialDescriptor> publicKeyCredentialDescrip
     });
 }
 
-static std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment(_WKAuthenticatorAttachment attachment)
+static std::optional<WebCore::AuthenticatorAttachment> NODELETE authenticatorAttachment(_WKAuthenticatorAttachment attachment)
 {
     switch (attachment) {
     case _WKAuthenticatorAttachmentAll:
@@ -931,7 +931,7 @@ static std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment(_
     }
 }
 
-static WebCore::UserVerificationRequirement userVerification(_WKUserVerificationRequirement uv)
+static WebCore::UserVerificationRequirement NODELETE userVerification(_WKUserVerificationRequirement uv)
 {
     switch (uv) {
     case _WKUserVerificationRequirementRequired:
@@ -946,7 +946,7 @@ static WebCore::UserVerificationRequirement userVerification(_WKUserVerification
     }
 }
 
-static std::optional<WebCore::ResidentKeyRequirement> toWebCore(_WKResidentKeyRequirement uv)
+static std::optional<WebCore::ResidentKeyRequirement> NODELETE toWebCore(_WKResidentKeyRequirement uv)
 {
     switch (uv) {
     case _WKResidentKeyRequirementNotPresent:
@@ -974,7 +974,7 @@ static WebCore::AuthenticatorSelectionCriteria authenticatorSelectionCriteria(_W
     return result;
 }
 
-static WebCore::AttestationConveyancePreference attestationConveyancePreference(_WKAttestationConveyancePreference attestation)
+static WebCore::AttestationConveyancePreference NODELETE attestationConveyancePreference(_WKAttestationConveyancePreference attestation)
 {
     switch (attestation) {
     case _WKAttestationConveyancePreferenceNone:
@@ -1045,7 +1045,7 @@ static WebCore::AuthenticationExtensionsClientInputs authenticationExtensionsCli
     return result;
 }
 
-static WebCore::MediationRequirement toWebCore(_WKWebAuthenticationMediationRequirement mediation)
+static WebCore::MediationRequirement NODELETE toWebCore(_WKWebAuthenticationMediationRequirement mediation)
 {
     switch (mediation) {
     case _WKWebAuthenticationMediationRequirementSilent:
@@ -1083,7 +1083,7 @@ static WebCore::MediationRequirement toWebCore(_WKWebAuthenticationMediationRequ
 }
 
 #if ENABLE(WEB_AUTHN)
-static _WKAuthenticatorAttachment authenticatorAttachmentToWKAuthenticatorAttachment(WebCore::AuthenticatorAttachment attachment)
+static _WKAuthenticatorAttachment NODELETE authenticatorAttachmentToWKAuthenticatorAttachment(WebCore::AuthenticatorAttachment attachment)
 {
     switch (attachment) {
     case WebCore::AuthenticatorAttachment::Platform:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
@@ -97,7 +97,7 @@ IGNORE_NULL_CHECK_WARNINGS_END
     return self;
 }
 
-static _WKWebPushPermissionState toWKPermissionsState(WebCore::PushPermissionState state)
+static _WKWebPushPermissionState NODELETE toWKPermissionsState(WebCore::PushPermissionState state)
 {
     switch (state) {
     case WebCore::PushPermissionState::Denied:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -418,7 +418,7 @@ static void checkURLArgument(NSURL *url)
     protect(_configuration.get())->setGeneralStorageDirectory(url.path);
 }
 
-static _WKUnifiedOriginStorageLevel toWKUnifiedOriginStorageLevel(WebKit::UnifiedOriginStorageLevel level)
+static _WKUnifiedOriginStorageLevel NODELETE toWKUnifiedOriginStorageLevel(WebKit::UnifiedOriginStorageLevel level)
 {
     switch (level) {
     case WebKit::UnifiedOriginStorageLevel::None:
@@ -430,7 +430,7 @@ static _WKUnifiedOriginStorageLevel toWKUnifiedOriginStorageLevel(WebKit::Unifie
     }
 }
 
-static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedOriginStorageLevel wkLevel)
+static WebKit::UnifiedOriginStorageLevel NODELETE toUnifiedOriginStorageLevel(_WKUnifiedOriginStorageLevel wkLevel)
 {
     switch (wkLevel) {
     case _WKUnifiedOriginStorageLevelNone:

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.h
@@ -31,8 +31,8 @@
 #import <WebCore/ScrollTypes.h>
 #import <WebKit/_WKOverlayScrollbarStyle.h>
 
-_WKOverlayScrollbarStyle toAPIScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle>);
-std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScrollbarStyle);
+_WKOverlayScrollbarStyle NODELETE toAPIScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle>);
+std::optional<WebCore::ScrollbarOverlayStyle> NODELETE toCoreScrollbarStyle(_WKOverlayScrollbarStyle);
 
 @interface WKWebView (WKInternalMac) <WebViewImplDelegate>
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -93,7 +93,7 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
     return std::nullopt;
 }
 
-static WebCore::FloatBoxExtent coreBoxExtentsFromEdgeInsets(NSEdgeInsets insets)
+static WebCore::FloatBoxExtent NODELETE coreBoxExtentsFromEdgeInsets(NSEdgeInsets insets)
 {
     return {
         static_cast<float>(insets.top),

--- a/Source/WebKit/UIProcess/AboutSchemeHandler.h
+++ b/Source/WebKit/UIProcess/AboutSchemeHandler.h
@@ -50,7 +50,7 @@ public:
 private:
     AboutSchemeHandler();
 
-    void platformInitialize();
+    void NODELETE platformInitialize();
 
     void platformStartTask(WebPageProxy&, WebURLSchemeTask&) final;
     void platformStopTask(WebPageProxy&, WebURLSchemeTask&) final { }

--- a/Source/WebKit/UIProcess/Authentication/WebCredential.h
+++ b/Source/WebKit/UIProcess/Authentication/WebCredential.h
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new WebCredential(credential));
     }
 
-    const WebCore::Credential& credential();
+    const WebCore::Credential& NODELETE credential();
 
 private:
     explicit WebCredential(const WebCore::Credential&);

--- a/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h
+++ b/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h
@@ -39,13 +39,13 @@ public:
     }
     
     const String& protocol() const;
-    const String& host() const;
-    int port() const;
-    const String& realm() const;
+    const String& NODELETE host() const;
+    int NODELETE port() const;
+    const String& NODELETE realm() const;
     bool isProxy() const;
-    WebCore::ProtectionSpace::ServerType serverType() const;
+    WebCore::ProtectionSpace::ServerType NODELETE serverType() const;
     bool receivesCredentialSecurely() const;
-    WebCore::ProtectionSpace::AuthenticationScheme authenticationScheme() const;
+    WebCore::ProtectionSpace::AuthenticationScheme NODELETE authenticationScheme() const;
 
     const WebCore::ProtectionSpace& protectionSpace() const { return m_coreProtectionSpace; }
 

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -106,7 +106,7 @@ void BidiBrowsingContextAgent::close(const BrowsingContext& browsingContext, std
 
 static constexpr Inspector::Protocol::Automation::BrowsingContextPresentation defaultBrowsingContextPresentation = Inspector::Protocol::Automation::BrowsingContextPresentation::Tab;
 
-static Inspector::Protocol::Automation::BrowsingContextPresentation browsingContextPresentationFromCreateType(Inspector::Protocol::BidiBrowsingContext::CreateType createType)
+static Inspector::Protocol::Automation::BrowsingContextPresentation NODELETE browsingContextPresentationFromCreateType(Inspector::Protocol::BidiBrowsingContext::CreateType createType)
 {
     switch (createType) {
     case Inspector::Protocol::BidiBrowsingContext::CreateType::Tab:
@@ -278,7 +278,7 @@ void BidiBrowsingContextAgent::handleUserPrompt(const BrowsingContext& browsingC
 static constexpr Seconds defaultPageLoadTimeout = 300_s;
 static constexpr ReadinessState defaultReadinessState = ReadinessState::Interactive;
 
-static PageLoadStrategy pageLoadStrategyFromReadinessState(ReadinessState state)
+static PageLoadStrategy NODELETE pageLoadStrategyFromReadinessState(ReadinessState state)
 {
     switch (state) {
     case ReadinessState::None:

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -72,7 +72,7 @@ public:
 private:
     void processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&);
     void collectExecutionReadyFrameRealms(const FrameTreeNodeData&, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes = true);
-    bool isFrameExecutionReady(const FrameInfoData&);
+    bool NODELETE isFrameExecutionReady(const FrameInfoData&);
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createRealmInfoForFrame(const FrameInfoData&);
     std::optional<String> contextHandleForFrame(const FrameInfoData&);
     String generateRealmIdForFrame(const FrameInfoData&);

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -161,7 +161,7 @@ public:
     void run(std::optional<WebCore::FrameIdentifier>, Vector<SimulatedInputKeyFrame>&& keyFrames, const HashMap<String, Ref<SimulatedInputSource>>& inputSources, AutomationCompletionHandler&&);
     void cancel();
 
-    bool isActive() const;
+    bool NODELETE isActive() const;
 
 private:
     SimulatedInputDispatcher(WebPageProxy&, SimulatedInputDispatcher::Client&);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -449,7 +449,7 @@ void WebAutomationSession::getBrowsingContext(const Inspector::Protocol::Automat
     });
 }
 
-static Inspector::Protocol::Automation::BrowsingContextPresentation toProtocol(API::AutomationSessionClient::BrowsingContextPresentation value)
+static Inspector::Protocol::Automation::BrowsingContextPresentation NODELETE toProtocol(API::AutomationSessionClient::BrowsingContextPresentation value)
 {
     switch (value) {
     case API::AutomationSessionClient::BrowsingContextPresentation::Tab:
@@ -781,7 +781,7 @@ void WebAutomationSession::hideWindowForPage(WebPageProxy& page, WTF::Completion
 }
 
 #if ENABLE(WEBDRIVER_BIDI)
-static Inspector::Protocol::BidiBrowsingContext::UserPromptType toProtocolUserPromptType(API::AutomationSessionClient::JavaScriptDialogType dialogType)
+static Inspector::Protocol::BidiBrowsingContext::UserPromptType NODELETE toProtocolUserPromptType(API::AutomationSessionClient::JavaScriptDialogType dialogType)
 {
     switch (dialogType) {
     case API::AutomationSessionClient::JavaScriptDialogType::Alert:
@@ -1449,7 +1449,7 @@ void WebAutomationSession::resolveParentFrameHandle(const Inspector::Protocol::A
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::ResolveParentFrame(page->webPageIDInMainFrameProcess(), frameID), WTF::move(completionHandler));
 }
 
-static std::optional<CoordinateSystem> protocolStringToCoordinateSystem(Inspector::Protocol::Automation::CoordinateSystem coordinateSystem)
+static std::optional<CoordinateSystem> NODELETE protocolStringToCoordinateSystem(Inspector::Protocol::Automation::CoordinateSystem coordinateSystem)
 {
     switch (coordinateSystem) {
     case Inspector::Protocol::Automation::CoordinateSystem::Page:
@@ -1726,7 +1726,7 @@ void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol:
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::SetFilesForInputFileUpload(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, WTF::move(newFileList)), WTF::move(completionHandler));
 }
 
-static inline Inspector::Protocol::Automation::CookieSameSitePolicy toProtocolSameSitePolicy(WebCore::Cookie::SameSitePolicy policy)
+static inline Inspector::Protocol::Automation::CookieSameSitePolicy NODELETE toProtocolSameSitePolicy(WebCore::Cookie::SameSitePolicy policy)
 {
     switch (policy) {
     case WebCore::Cookie::SameSitePolicy::None:
@@ -1739,7 +1739,7 @@ static inline Inspector::Protocol::Automation::CookieSameSitePolicy toProtocolSa
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static inline WebCore::Cookie::SameSitePolicy toWebCoreSameSitePolicy(Inspector::Protocol::Automation::CookieSameSitePolicy policy)
+static inline WebCore::Cookie::SameSitePolicy NODELETE toWebCoreSameSitePolicy(Inspector::Protocol::Automation::CookieSameSitePolicy policy)
 {
     switch (policy) {
     case Inspector::Protocol::Automation::CookieSameSitePolicy::None:
@@ -1930,7 +1930,7 @@ CommandResult<void> WebAutomationSession::setSessionPermissions(Ref<JSON::Array>
 }
 
 #if ENABLE(WEB_AUTHN)
-static WebCore::AuthenticatorTransport toAuthenticatorTransport(Inspector::Protocol::Automation::AuthenticatorTransport transport)
+static WebCore::AuthenticatorTransport NODELETE toAuthenticatorTransport(Inspector::Protocol::Automation::AuthenticatorTransport transport)
 {
     switch (transport) {
     case Inspector::Protocol::Automation::AuthenticatorTransport::Usb:
@@ -2350,7 +2350,7 @@ void WebAutomationSession::simulateWheelInteraction(WebPageProxy& page, const We
 #endif // ENABLE(WEBDRIVER_ACTIONS_API)
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-static WebEventModifier protocolModifierToWebEventModifier(Inspector::Protocol::Automation::KeyModifier modifier)
+static WebEventModifier NODELETE protocolModifierToWebEventModifier(Inspector::Protocol::Automation::KeyModifier modifier)
 {
     switch (modifier) {
     case Inspector::Protocol::Automation::KeyModifier::Alt:
@@ -2533,7 +2533,7 @@ void WebAutomationSession::performKeyboardInteractions(const Inspector::Protocol
 }
 
 #if ENABLE(WEBDRIVER_ACTIONS_API)
-static SimulatedInputSourceType simulatedInputSourceTypeFromProtocolSourceType(Inspector::Protocol::Automation::InputSourceType protocolType)
+static SimulatedInputSourceType NODELETE simulatedInputSourceTypeFromProtocolSourceType(Inspector::Protocol::Automation::InputSourceType protocolType)
 {
     switch (protocolType) {
     case Inspector::Protocol::Automation::InputSourceType::Null:
@@ -2557,7 +2557,7 @@ static SimulatedInputSourceType simulatedInputSourceTypeFromProtocolSourceType(I
 #if ENABLE(WEBDRIVER_ACTIONS_API)
 // §15.4.2 Keyboard actions
 // https://w3c.github.io/webdriver/#dfn-normalised-key-value
-static VirtualKey normalizedVirtualKey(VirtualKey key)
+static VirtualKey NODELETE normalizedVirtualKey(VirtualKey key)
 {
     switch (key) {
     case Inspector::Protocol::Automation::VirtualKey::ControlRight:

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -159,7 +159,7 @@ public:
     void setSessionIdentifier(const String& sessionIdentifier) { m_sessionIdentifier = sessionIdentifier; }
     String sessionIdentifier() const { return m_sessionIdentifier; }
 
-    WebProcessPool* processPool() const;
+    WebProcessPool* NODELETE processPool() const;
     void setProcessPool(WebProcessPool*);
 
     void navigationOccurredForFrame(const WebFrameProxy&);
@@ -189,7 +189,7 @@ public:
     void didEnterFullScreenForPage(const WebPageProxy&);
     void didExitFullScreenForPage(const WebPageProxy&);
 
-    bool shouldAllowGetUserMediaForPage(const WebPageProxy&) const;
+    bool NODELETE shouldAllowGetUserMediaForPage(const WebPageProxy&) const;
 
 #if ENABLE(REMOTE_INSPECTOR)
     String name() const { return m_sessionIdentifier; }
@@ -198,8 +198,8 @@ public:
     void disconnect(Inspector::FrontendChannel&);
 
     void init();
-    bool isPaired() const;
-    bool isPendingTermination() const;
+    bool NODELETE isPaired() const;
+    bool NODELETE isPendingTermination() const;
 #endif
 
     void terminate();
@@ -298,7 +298,7 @@ public:
 #endif
 
     // Event Simulation Support.
-    bool isSimulatingUserInteraction() const;
+    bool NODELETE isSimulatingUserInteraction() const;
 #if ENABLE(WEBDRIVER_ACTIONS_API)
     SimulatedInputDispatcher& inputDispatcherForPage(WebPageProxy&);
 #endif
@@ -347,9 +347,9 @@ private:
 
     // Platform-dependent implementations.
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-    void resetMouseState();
+    void NODELETE resetMouseState();
     void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime = 0.5_s, int maxDistance = 0);
-    void updateLastPosition(const WebCore::IntPoint&, int maxDistance = 0);
+    void NODELETE updateLastPosition(const WebCore::IntPoint&, int maxDistance = 0);
     void platformSimulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInViewport, OptionSet<WebEventModifier>, const String& pointerType);
     static OptionSet<WebEventModifier> platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers);
 #endif

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -175,7 +175,7 @@ static WebCore::IntPoint viewportLocationToWindowLocation(WebCore::IntPoint loca
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 
-static unsigned nsEventButtonNumberFromAutomationMouseButton(MouseButton button)
+static unsigned NODELETE nsEventButtonNumberFromAutomationMouseButton(MouseButton button)
 {
     switch (button) {
     case MouseButton::Right:
@@ -191,7 +191,7 @@ static unsigned nsEventButtonNumberFromAutomationMouseButton(MouseButton button)
     }
 }
 
-static WebMouseEventButton automationMouseButtonToPlatformMouseButton(MouseButton button)
+static WebMouseEventButton NODELETE automationMouseButtonToPlatformMouseButton(MouseButton button)
 {
     switch (button) {
     case MouseButton::Left:   return WebMouseEventButton::Left;
@@ -323,7 +323,7 @@ OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(We
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
-static bool virtualKeyHasStickyModifier(VirtualKey key)
+static bool NODELETE virtualKeyHasStickyModifier(VirtualKey key)
 {
     // Returns whether the key's modifier flags should affect other events while pressed down.
     switch (key) {
@@ -349,7 +349,7 @@ static bool virtualKeyHasStickyModifier(VirtualKey key)
 // PlatformEventFactoryMac::codeForKeyEvent.
 static constexpr unsigned short unknownKeyCode = USHRT_MAX;
 
-static int keyCodeForCharKey(CharKey charKey)
+static int NODELETE keyCodeForCharKey(CharKey charKey)
 {
     if (charKey.length() != 1)
         return unknownKeyCode;
@@ -636,7 +636,7 @@ static unsigned short keyCodeForVirtualKey(VirtualKey key)
     }
 }
 
-static NSEventModifierFlags eventModifierFlagsForVirtualKey(VirtualKey key)
+static NSEventModifierFlags NODELETE eventModifierFlagsForVirtualKey(VirtualKey key)
 {
     // Computes the modifiers changed by the virtual key when it is pressed or released.
     // The mapping from keys to modifiers is specified in the documentation for NSEvent.

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -66,13 +66,13 @@
 
 namespace WebKit {
 
-static HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>& connectionToProcessMap()
+static HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>& NODELETE connectionToProcessMap()
 {
     static MainRunLoopNeverDestroyed<HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>> map;
     return map.get();
 }
 
-static Seconds adjustedTimeoutForThermalState(Seconds timeout)
+static Seconds NODELETE adjustedTimeoutForThermalState(Seconds timeout)
 {
 #if PLATFORM(VISION)
     return WebCore::ThermalMitigationNotifier::isThermalMitigationEnabled() ? (timeout * 20) : timeout;

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -150,7 +150,7 @@ public:
     {
         return m_connection == &connection;
     }
-    static AuxiliaryProcessProxy* WTF_NULLABLE fromConnection(const IPC::Connection&);
+    static AuxiliaryProcessProxy* NODELETE WTF_NULLABLE fromConnection(const IPC::Connection&);
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
     void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -56,7 +56,7 @@ private:
     bool shouldBeActive() const;
     bool isActive() const;
     void scheduleNextResponsivenessCheck();
-    ResponsivenessTimer::Client& client() const;
+    ResponsivenessTimer::Client& NODELETE client() const;
 
     WeakRef<WebProcessProxy> m_webProcessProxy;
     Seconds m_checkingInterval;

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -70,7 +70,7 @@ void AutomationSessionClient::didDisconnectFromRemote(WebAutomationSession& sess
         [m_delegate.get() _automationSessionDidDisconnectFromRemote:RetainPtr { wrapper(session) }.get()];
 }
 
-static inline _WKAutomationSessionBrowsingContextOptions toAPI(API::AutomationSessionBrowsingContextOptions options)
+static inline _WKAutomationSessionBrowsingContextOptions NODELETE toAPI(API::AutomationSessionBrowsingContextOptions options)
 {
     uint16_t wkOptions = 0;
 
@@ -81,7 +81,7 @@ static inline _WKAutomationSessionBrowsingContextOptions toAPI(API::AutomationSe
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_IN_WEBDRIVER)
-static inline _WKAutomationSessionWebExtensionResourceOptions toAPI(API::AutomationSessionWebExtensionResourceOptions options)
+static inline _WKAutomationSessionWebExtensionResourceOptions NODELETE toAPI(API::AutomationSessionWebExtensionResourceOptions options)
 {
     uint16_t wkOptions = 0;
 
@@ -214,7 +214,7 @@ void AutomationSessionClient::setUserInputForCurrentJavaScriptPromptOnPage(WebAu
         [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() setUserInput:value.createNSString().get() forCurrentJavaScriptDialogForWebView:webView.get()];
 }
 
-static std::optional<API::AutomationSessionClient::JavaScriptDialogType> toImpl(_WKAutomationSessionJavaScriptDialogType type)
+static std::optional<API::AutomationSessionClient::JavaScriptDialogType> NODELETE toImpl(_WKAutomationSessionJavaScriptDialogType type)
 {
     switch (type) {
     case _WKAutomationSessionJavaScriptDialogTypeNone:
@@ -228,7 +228,7 @@ static std::optional<API::AutomationSessionClient::JavaScriptDialogType> toImpl(
     }
 }
 
-static API::AutomationSessionClient::BrowsingContextPresentation toImpl(_WKAutomationSessionBrowsingContextPresentation presentation)
+static API::AutomationSessionClient::BrowsingContextPresentation NODELETE toImpl(_WKAutomationSessionBrowsingContextPresentation presentation)
 {
     switch (presentation) {
     case _WKAutomationSessionBrowsingContextPresentationTab:

--- a/Source/WebKit/UIProcess/Cocoa/CSPExtensionUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/CSPExtensionUtilities.h
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-_WKContentSecurityPolicyModeForExtension toWKContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension);
-WebCore::ContentSecurityPolicyModeForExtension toContentSecurityPolicyModeForExtension(_WKContentSecurityPolicyModeForExtension);
+_WKContentSecurityPolicyModeForExtension NODELETE toWKContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension);
+WebCore::ContentSecurityPolicyModeForExtension NODELETE toContentSecurityPolicyModeForExtension(_WKContentSecurityPolicyModeForExtension);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
@@ -64,7 +64,7 @@ void DiagnosticLoggingClient::logDiagnosticMessage(WebKit::WebPageProxy*, const 
         [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message.createNSString().get() description:description.createNSString().get()];
 }
 
-static _WKDiagnosticLoggingResultType toWKDiagnosticLoggingResultType(WebCore::DiagnosticLoggingResultType result)
+static _WKDiagnosticLoggingResultType NODELETE toWKDiagnosticLoggingResultType(WebCore::DiagnosticLoggingResultType result)
 {
     switch (result) {
     case WebCore::DiagnosticLoggingResultPass:
@@ -76,7 +76,7 @@ static _WKDiagnosticLoggingResultType toWKDiagnosticLoggingResultType(WebCore::D
     }
 }
 
-static _WKDiagnosticLoggingDomain toWKDiagnosticLoggingDomain(WebCore::DiagnosticLoggingDomain domain)
+static _WKDiagnosticLoggingDomain NODELETE toWKDiagnosticLoggingDomain(WebCore::DiagnosticLoggingDomain domain)
 {
     switch (domain) {
     case WebCore::DiagnosticLoggingDomain::Media:

--- a/Source/WebKit/UIProcess/Cocoa/MediaUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/MediaUtilities.h
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-_WKMediaCaptureStateDeprecated toWKMediaCaptureStateDeprecated(WebCore::MediaProducerMediaStateFlags);
-_WKMediaMutedState toWKMediaMutedState(WebCore::MediaProducerMutedStateFlags);
+_WKMediaCaptureStateDeprecated NODELETE toWKMediaCaptureStateDeprecated(WebCore::MediaProducerMediaStateFlags);
+_WKMediaMutedState NODELETE toWKMediaMutedState(WebCore::MediaProducerMutedStateFlags);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1444,7 +1444,7 @@ void NavigationState::NavigationClient::didFinishLoadForQuickLookDocumentInMainF
 #endif
 
 #if HAVE(APP_SSO)
-static SOAuthorizationLoadPolicy soAuthorizationLoadPolicy(_WKSOAuthorizationLoadPolicy policy)
+static SOAuthorizationLoadPolicy NODELETE soAuthorizationLoadPolicy(_WKSOAuthorizationLoadPolicy policy)
 {
     switch (policy) {
     case _WKSOAuthorizationLoadPolicyAllow:
@@ -1456,7 +1456,7 @@ static SOAuthorizationLoadPolicy soAuthorizationLoadPolicy(_WKSOAuthorizationLoa
     return SOAuthorizationLoadPolicy::Allow;
 }
 
-static _WKSOAuthorizationLoadPolicy wkSOAuthorizationLoadPolicy(SOAuthorizationLoadPolicy policy)
+static _WKSOAuthorizationLoadPolicy NODELETE wkSOAuthorizationLoadPolicy(SOAuthorizationLoadPolicy policy)
 {
     switch (policy) {
     case SOAuthorizationLoadPolicy::Allow:

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
@@ -55,27 +55,27 @@ namespace WebKit {
 
 #pragma mark - Conversions from web types to platform types.
 
-CocoaWritingToolsBehavior convertToCocoaWritingToolsBehavior(WebCore::WritingTools::Behavior);
+CocoaWritingToolsBehavior NODELETE convertToCocoaWritingToolsBehavior(WebCore::WritingTools::Behavior);
 
-WTRequestedTool convertToPlatformRequestedTool(WebCore::WritingTools::RequestedTool);
+WTRequestedTool NODELETE convertToPlatformRequestedTool(WebCore::WritingTools::RequestedTool);
 
-WTTextSuggestionState convertToPlatformTextSuggestionState(WebCore::WritingTools::TextSuggestionState);
+WTTextSuggestionState NODELETE convertToPlatformTextSuggestionState(WebCore::WritingTools::TextSuggestionState);
 
 RetainPtr<WTContext> convertToPlatformContext(const WebCore::WritingTools::Context&);
 
 #pragma mark - Conversions from platform types to web types.
 
-WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(CocoaWritingToolsBehavior);
+WebCore::WritingTools::Behavior NODELETE convertToWebWritingToolsBehavior(CocoaWritingToolsBehavior);
 
-WebCore::WritingTools::RequestedTool convertToWebRequestedTool(WTRequestedTool);
+WebCore::WritingTools::RequestedTool NODELETE convertToWebRequestedTool(WTRequestedTool);
 
-WebCore::WritingTools::TextSuggestionState convertToWebTextSuggestionState(WTTextSuggestionState);
+WebCore::WritingTools::TextSuggestionState NODELETE convertToWebTextSuggestionState(WTTextSuggestionState);
 
-WebCore::WritingTools::Action convertToWebAction(WTAction);
+WebCore::WritingTools::Action NODELETE convertToWebAction(WTAction);
 
-WebCore::WritingTools::SessionType convertToWebSessionType(WTSessionType);
+WebCore::WritingTools::SessionType NODELETE convertToWebSessionType(WTSessionType);
 
-WebCore::WritingTools::SessionCompositionType convertToWebCompositionSessionType(WTCompositionSessionType);
+WebCore::WritingTools::SessionCompositionType NODELETE convertToWebCompositionSessionType(WTCompositionSessionType);
 
 std::optional<WebCore::WritingTools::Context> convertToWebContext(WTContext *);
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -145,7 +145,7 @@ private:
     void setVolume(double) final;
     void setPlayingOnSecondScreen(bool) final;
     void sendRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&) final;
-    void setVideoReceiverEndpoint(const WebCore::VideoReceiverEndpoint&) final;
+    void NODELETE setVideoReceiverEndpoint(const WebCore::VideoReceiverEndpoint&) final;
     const WebCore::VideoReceiverEndpoint& videoReceiverEndpoint() const { return m_videoReceiverEndpoint; }
     const std::optional<WebCore::VideoReceiverEndpointIdentifier>& videoReceiverEndpointIdentifier() const { return m_videoReceiverEndpointIdentifier; }
 
@@ -191,7 +191,7 @@ private:
     bool prefersAutoDimming() const final { return m_prefersAutoDimming; }
     void setPrefersAutoDimming(bool) final;
 
-    void swapVideoReceiverEndpointsWith(PlaybackSessionModelContext&);
+    void NODELETE swapVideoReceiverEndpointsWith(PlaybackSessionModelContext&);
 
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(uint64_t identifier) { m_logIdentifier = identifier; }
@@ -199,7 +199,7 @@ private:
     const Logger* loggerPtr() const;
 
     ASCIILiteral logClassName() const { return "PlaybackSessionModelContext"_s; };
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakPtr<PlaybackSessionManagerProxy> m_manager;
@@ -351,7 +351,7 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
     void setVideoReceiverEndpoint(PlaybackSessionContextIdentifier, const WebCore::VideoReceiverEndpoint&, WebCore::VideoReceiverEndpointIdentifier);
-    void swapVideoReceiverEndpoints(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
+    void NODELETE swapVideoReceiverEndpoints(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setSpatialTrackingLabel(PlaybackSessionContextIdentifier, const String&);
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -96,7 +96,7 @@ protected:
     WebPageProxy* page() const { return m_page.get(); }
     State state() const { return m_state; }
     ASCIILiteral stateString() const;
-    ASCIILiteral initiatingActionString() const;
+    ASCIILiteral NODELETE initiatingActionString() const;
     void setState(State state) { m_state = state; }
     const API::NavigationAction* navigationAction() { return m_navigationAction.get(); }
     Ref<API::NavigationAction> releaseNavigationAction();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -64,7 +64,7 @@ static constexpr auto Redirect = "Redirect"_s;
 static constexpr auto PopUp = "PopUp"_s;
 static constexpr auto SubFrame = "SubFrame"_s;
 
-static ASCIILiteral toString(const SOAuthorizationSession::InitiatingAction& action)
+static ASCIILiteral NODELETE toString(const SOAuthorizationSession::InitiatingAction& action)
 {
     switch (action) {
     case SOAuthorizationSession::InitiatingAction::Redirect:

--- a/Source/WebKit/UIProcess/Cocoa/SafeBrowsingUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/SafeBrowsingUtilities.h
@@ -48,7 +48,7 @@ struct NamespacedCollection {
 using NamespacedLists = NSDictionary<NSString *, NSArray<NSString *> *>;
 void listsForNamespace(NamespacedCollection&&, CompletionHandler<void(NamespacedLists *, NSError *)>&&);
 
-NamespacedCollection namespacedCollectionForTextExtraction();
+NamespacedCollection NODELETE namespacedCollectionForTextExtraction();
 
 } // namespace WebKit::SafeBrowsingUtilities
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -40,7 +40,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-inline static WKTextExtractionContainer containerType(TextExtraction::ContainerType type)
+inline static WKTextExtractionContainer NODELETE containerType(TextExtraction::ContainerType type)
 {
     switch (type) {
     case TextExtraction::ContainerType::ViewportConstrained:
@@ -72,7 +72,7 @@ inline static WKTextExtractionContainer containerType(TextExtraction::ContainerT
     }
 }
 
-static WKTextExtractionEventListenerTypes eventListenerTypes(OptionSet<TextExtraction::EventListenerCategory> eventListeners)
+static WKTextExtractionEventListenerTypes NODELETE eventListenerTypes(OptionSet<TextExtraction::EventListenerCategory> eventListeners)
 {
     WKTextExtractionEventListenerTypes result = WKTextExtractionEventListenerTypeNone;
     if (eventListeners.contains(TextExtraction::EventListenerCategory::Click))

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -764,7 +764,7 @@ void UIDelegate::UIClient::unlockScreenOrientation(WebPageProxy&)
 #endif
 }
 
-static inline _WKFocusDirection toWKFocusDirection(WKFocusDirection direction)
+static inline _WKFocusDirection NODELETE toWKFocusDirection(WKFocusDirection direction)
 {
     switch (direction) {
     case kWKFocusDirectionBackward:
@@ -793,7 +793,7 @@ bool UIDelegate::UIClient::takeFocus(WebPageProxy*, WKFocusDirection direction)
     return true;
 }
 
-static _WKAutoplayEventFlags toWKAutoplayEventFlags(OptionSet<WebCore::AutoplayEventFlags> flags)
+static _WKAutoplayEventFlags NODELETE toWKAutoplayEventFlags(OptionSet<WebCore::AutoplayEventFlags> flags)
 {
     _WKAutoplayEventFlags wkFlags = _WKAutoplayEventFlagsNone;
     if (flags.contains(WebCore::AutoplayEventFlags::HasAudio))
@@ -806,7 +806,7 @@ static _WKAutoplayEventFlags toWKAutoplayEventFlags(OptionSet<WebCore::AutoplayE
     return wkFlags;
 }
 
-static _WKAutoplayEvent toWKAutoplayEvent(WebCore::AutoplayEvent event)
+static _WKAutoplayEvent NODELETE toWKAutoplayEvent(WebCore::AutoplayEvent event)
 {
     switch (event) {
     case WebCore::AutoplayEvent::DidPreventMediaFromPlaying:
@@ -1803,7 +1803,7 @@ void UIDelegate::UIClient::confirmPDFOpening(WebPageProxy& page, const WTF::URL&
 
 #if ENABLE(WEB_AUTHN)
 
-static WebAuthenticationPanelResult webAuthenticationPanelResult(_WKWebAuthenticationPanelResult result)
+static WebAuthenticationPanelResult NODELETE webAuthenticationPanelResult(_WKWebAuthenticationPanelResult result)
 {
     switch (result) {
     case _WKWebAuthenticationPanelResultUnavailable:

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -136,7 +136,7 @@ private:
     const Logger* loggerPtr() const final;
 
     ASCIILiteral logClassName() const { return "VideoPresentationModelContext"_s; };
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakPtr<VideoPresentationManagerProxy> m_manager;
@@ -294,7 +294,7 @@ private:
     void videosInElementFullscreenChanged();
 
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const;
+    const Logger& NODELETE logger() const;
     uint64_t logIdentifier() const;
     ASCIILiteral logClassName() const;
     WTFLogChannel& logChannel() const;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -237,14 +237,14 @@ static void registerUserDefaults()
     [[NSUserDefaults standardUserDefaults] registerDefaults:registrationDictionary.get()];
 }
 
-static std::optional<bool>& cachedLockdownModeEnabledGlobally()
+static std::optional<bool>& NODELETE cachedLockdownModeEnabledGlobally()
 {
     static std::optional<bool> cachedLockdownModeEnabledGlobally;
     return cachedLockdownModeEnabledGlobally;
 }
 
 #if PLATFORM(MAC)
-static NSApplication* NSAppSingleton()
+static NSApplication* NODELETE NSAppSingleton()
 {
     return NSApp;
 }
@@ -1143,7 +1143,7 @@ static WeakHashSet<LockdownModeObserver>& lockdownModeObservers()
     return observers;
 }
 
-static std::optional<bool>& isLockdownModeEnabledGloballyForTesting()
+static std::optional<bool>& NODELETE isLockdownModeEnabledGloballyForTesting()
 {
     static NeverDestroyed<std::optional<bool>> enabledForTesting;
     return enabledForTesting;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -106,7 +106,7 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& WebProcessProxy::platform
     return platformPathsWithAssumedReadAccess;
 }
 
-static Vector<String>& mediaTypeCache()
+static Vector<String>& NODELETE mediaTypeCache()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<Vector<String>> typeCache;

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -70,7 +70,7 @@ public:
     WebCore::PlatformDisplayID displayID() const { return m_displayID; }
     WebCore::FramesPerSecond nominalFramesPerSecond() const { return m_displayNominalFramesPerSecond; }
 
-    void displayPropertiesChanged();
+    void NODELETE displayPropertiesChanged();
 
     void addObserver(Client&, DisplayLinkObserverID, WebCore::FramesPerSecond);
     void removeObserver(Client&, DisplayLinkObserverID);
@@ -134,7 +134,7 @@ private:
 class DisplayLinkCollection {
 public:
     DisplayLink& displayLinkForDisplay(WebCore::PlatformDisplayID);
-    DisplayLink* existingDisplayLinkForDisplay(WebCore::PlatformDisplayID) const;
+    DisplayLink* NODELETE existingDisplayLinkForDisplay(WebCore::PlatformDisplayID) const;
 
     std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
     void startDisplayLink(DisplayLink::Client&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond preferredFramesPerSecond);

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -88,7 +88,7 @@ public:
     void didReceiveDownloadProxyMessage(IPC::Connection&, IPC::Decoder&);
     void didReceiveSyncDownloadProxyMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
-    WebPageProxy* originatingPage() const;
+    WebPageProxy* NODELETE originatingPage() const;
 
     void setRedirectChain(Vector<URL>&& redirectChain) { m_redirectChain = WTF::move(redirectChain); }
     const Vector<URL>& redirectChain() const { return m_redirectChain; }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -66,7 +66,7 @@ public:
     bool isEmpty() const { return m_downloads.isEmpty(); }
     void invalidate();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
 private:

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -132,7 +132,7 @@ public:
     virtual bool shouldCoalesceVisualEditorStateUpdates() const { return false; }
     virtual bool shouldSendWheelEventsToEventDispatcher() const { return false; }
 
-    WebPageProxy* page() const;
+    WebPageProxy* NODELETE page() const;
     virtual void viewWillStartLiveResize() { };
     virtual void viewWillEndLiveResize() { };
 

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -38,7 +38,7 @@ using namespace WebCore;
 
 using EnhancedSecuritySitesMap = HashMap<WebCore::RegistrableDomain, EnhancedSecurityReason>;
 
-static EnhancedSecuritySitesMap& enabledSitesMap()
+static EnhancedSecuritySitesMap& NODELETE enabledSitesMap()
 {
     static MainRunLoopNeverDestroyed<EnhancedSecuritySitesMap> staticEnabledSites;
     return staticEnabledSites;
@@ -115,7 +115,7 @@ void EnhancedSecurityTracking::makeActive()
     m_activeState = ActivationState::Active;
 }
 
-static EnhancedSecurityReason reasonForEnhancedSecurity(EnhancedSecurity state)
+static EnhancedSecurityReason NODELETE reasonForEnhancedSecurity(EnhancedSecurity state)
 {
     switch (state) {
     case EnhancedSecurity::Disabled:

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
@@ -43,7 +43,7 @@ public:
     void trackNavigation(const API::Navigation&, bool hasOpenedPage);
 
     bool isEnhancedSecurityEnabled() const { return isEnhancedSecurityEnabledForState(enhancedSecurityState()); }
-    EnhancedSecurity enhancedSecurityState() const;
+    EnhancedSecurity NODELETE enhancedSecurityState() const;
     EnhancedSecurityReason enhancedSecurityReason() const { return m_activeReason; }
 
     void initializeFrom(const EnhancedSecurityTracking&);
@@ -51,9 +51,9 @@ public:
 private:
     enum class ActivationState : uint8_t { None, Dormant, Active };
 
-    void reset();
-    void makeDormant();
-    void makeActive();
+    void NODELETE reset();
+    void NODELETE makeDormant();
+    void NODELETE makeActive();
 
     void handleBackForwardNavigation(const API::Navigation&);
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -40,7 +40,7 @@
 
 namespace WebKit {
 
-static inline bool isTestEventListener(WebExtensionEventListenerType type)
+static inline bool NODELETE isTestEventListener(WebExtensionEventListenerType type)
 {
     return type == WebExtensionEventListenerType::TestOnMessage
         || type == WebExtensionEventListenerType::TestOnTestStarted

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -226,7 +226,7 @@ RefPtr<WebExtensionTab> WebExtensionWindow::activeTab(SkipValidation skipValidat
     return result;
 }
 
-WKWebExtensionWindowType toAPI(WebExtensionWindow::Type type)
+WKWebExtensionWindowType NODELETE toAPI(WebExtensionWindow::Type type)
 {
     switch (type) {
     case WebExtensionWindow::Type::Normal:
@@ -239,7 +239,7 @@ WKWebExtensionWindowType toAPI(WebExtensionWindow::Type type)
     return WKWebExtensionWindowTypeNormal;
 }
 
-static inline WebExtensionWindow::Type toImpl(WKWebExtensionWindowType type)
+static inline WebExtensionWindow::Type NODELETE toImpl(WKWebExtensionWindowType type)
 {
     switch (type) {
     case WKWebExtensionWindowTypeNormal:
@@ -260,7 +260,7 @@ WebExtensionWindow::Type WebExtensionWindow::type() const
     return toImpl([m_delegate windowTypeForWebExtensionContext:m_extensionContext->wrapper()]);
 }
 
-static inline WebExtensionWindow::State toImpl(WKWebExtensionWindowState state)
+static inline WebExtensionWindow::State NODELETE toImpl(WKWebExtensionWindowState state)
 {
     switch (state) {
     case WKWebExtensionWindowStateNormal:
@@ -285,7 +285,7 @@ WebExtensionWindow::State WebExtensionWindow::state() const
     return toImpl([m_delegate windowStateForWebExtensionContext:m_extensionContext->wrapper()]);
 }
 
-WKWebExtensionWindowState toAPI(WebExtensionWindow::State state)
+WKWebExtensionWindowState NODELETE toAPI(WebExtensionWindow::State state)
 {
     switch (state) {
     case WebExtensionWindow::State::Normal:

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -577,7 +577,7 @@ Expected<String, RefPtr<API::Error>> WebExtension::resourceStringForPath(const S
     return result;
 }
 
-static int toAPI(WebExtension::Error error)
+static int NODELETE toAPI(WebExtension::Error error)
 {
     switch (error) {
     case WebExtension::Error::Unknown:

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -82,7 +82,7 @@ public:
 
     WebExtensionCommandParameters parameters() const;
 
-    WebExtensionContext* extensionContext() const;
+    WebExtensionContext* NODELETE extensionContext() const;
 
     bool isActionCommand() const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1223,7 +1223,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
         addInjectedContent(injectedContents, pattern);
 }
 
-static WebCore::UserScriptInjectionTime toImpl(WebExtension::InjectionTime injectionTime)
+static WebCore::UserScriptInjectionTime NODELETE toImpl(WebExtension::InjectionTime injectionTime)
 {
     switch (injectionTime) {
     case WebExtension::InjectionTime::DocumentStart:
@@ -1589,7 +1589,7 @@ void WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentContr
     });
 }
 
-static HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>& webExtensionContexts()
+static HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>& NODELETE webExtensionContexts()
 {
     static NeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>> contexts;
     return contexts;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -380,7 +380,7 @@ public:
     bool hasInjectedContent();
     bool safeToInjectContent() const { return isLoaded() && m_safeToInjectContent; }
 
-    bool hasContentModificationRules();
+    bool NODELETE hasContentModificationRules();
 
     URL optionsPageURL() const;
     URL overrideNewTabPageURL() const;
@@ -555,7 +555,7 @@ public:
     bool hasActiveUserGesture(WebExtensionTab&) const;
     void clearUserGesture(WebExtensionTab&);
 
-    bool inTestingMode() const;
+    bool NODELETE inTestingMode() const;
 
 #if PLATFORM(COCOA)
     void sendTestMessage(const String& message, id argument);
@@ -644,7 +644,7 @@ public:
 
     HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet&&, ContentWorldTypeSet&&, Function<bool(WebProcessProxy&, WebPageProxy&, WebFrameProxy&)>&& predicate = nullptr) const;
 
-    const UserContentControllerProxySet& userContentControllers() const;
+    const UserContentControllerProxySet& NODELETE userContentControllers() const;
 
     template<typename T>
     void sendToProcesses(const WebProcessProxySet&, const T& message) const;
@@ -668,7 +668,7 @@ private:
 
     explicit WebExtensionContext();
 
-    int toAPIError(WebExtensionContext::Error);
+    int NODELETE toAPIError(WebExtensionContext::Error);
 
     String stateFilePath() const;
     NSDictionary *currentState() const;
@@ -1013,7 +1013,7 @@ private:
 
     bool isLoaded(IPC::Decoder&) const { return isLoaded(); }
     bool isLoadedAndPrivilegedMessage(IPC::Decoder& message) const { return isLoaded() && isPrivilegedMessage(message); }
-    bool isPrivilegedMessage(IPC::Decoder&) const;
+    bool NODELETE isPrivilegedMessage(IPC::Decoder&) const;
 
     mutable Markable<WebExtensionContextIdentifier> m_privilegedIdentifier;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -45,7 +45,7 @@ namespace WebKit {
 constexpr auto freshlyCreatedTimeout = 5_s;
 #endif
 
-static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>& webExtensionControllers()
+static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>& NODELETE webExtensionControllers()
 {
     static MainRunLoopNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>> controllers;
     return controllers;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
@@ -85,7 +85,7 @@ bool WebExtensionMatchPattern::patternsMatchPattern(const MatchPatternSet& match
     return false;
 }
 
-static HashMap<String, RefPtr<WebExtensionMatchPattern>>& patternCache()
+static HashMap<String, RefPtr<WebExtensionMatchPattern>>& NODELETE patternCache()
 {
     static MainRunLoopNeverDestroyed<HashMap<String, RefPtr<WebExtensionMatchPattern>>> cache;
     return cache;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -103,14 +103,14 @@ public:
     bool isValid() const { return m_valid; }
     bool isSupported() const;
 
-    String scheme() const;
+    String NODELETE scheme() const;
     String host() const;
-    String path() const;
+    String NODELETE path() const;
 
     bool hostIsPublicSuffix() const;
 
     bool matchesAllURLs() const { return m_matchesAllURLs; }
-    bool matchesAllHosts() const;
+    bool NODELETE matchesAllHosts() const;
 
     bool matchesURL(const URL&, OptionSet<Options> = { }) const;
     bool matchesPattern(const WebExtensionMatchPattern&, OptionSet<Options> = { }) const;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -84,7 +84,7 @@ public:
 
     WebExtensionMenuItemParameters minimalParameters() const;
 
-    WebExtensionContext* extensionContext() const;
+    WebExtensionContext* NODELETE extensionContext() const;
 
     bool matches(const WebExtensionMenuItemContextParameters&) const;
 

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -51,7 +51,7 @@ public:
     const WebCore::Site& sharedProcessMainFrameSite() const { ASSERT(!m_site); return m_mainFrameSite; }
     bool isArchiveProcess() const { return m_isArchiveProcess; }
 
-    BrowsingContextGroup* browsingContextGroup() const;
+    BrowsingContextGroup* NODELETE browsingContextGroup() const;
 
     void incrementFrameCount() { m_frameCount++; }
     void decrementFrameCount() { m_frameCount--; }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -92,7 +92,7 @@ namespace WebKit {
 using namespace WebCore;
 
 #if ENABLE(MEDIA_STREAM) && HAVE(AUDIT_TOKEN)
-static bool shouldCreateAppleCameraServiceSandboxExtension()
+static bool NODELETE shouldCreateAppleCameraServiceSandboxExtension()
 {
 #if !PLATFORM(MAC) && !PLATFORM(MACCATALYST)
     return false;
@@ -104,13 +104,13 @@ static bool shouldCreateAppleCameraServiceSandboxExtension()
 }
 #endif
 
-static WeakPtr<GPUProcessProxy>& singleton()
+static WeakPtr<GPUProcessProxy>& NODELETE singleton()
 {
     static NeverDestroyed<WeakPtr<GPUProcessProxy>> singleton;
     return singleton;
 }
 
-static RefPtr<GPUProcessProxy>& keptAliveGPUProcessProxy()
+static RefPtr<GPUProcessProxy>& NODELETE keptAliveGPUProcessProxy()
 {
     static MainRunLoopNeverDestroyed<RefPtr<GPUProcessProxy>> keptAliveGPUProcessProxy;
     return keptAliveGPUProcessProxy.get();

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -88,7 +88,7 @@ class GPUProcessProxy final : public AuxiliaryProcessProxy {
 public:
     static void keepProcessAliveTemporarily();
     static Ref<GPUProcessProxy> getOrCreate();
-    static GPUProcessProxy* singletonIfCreated();
+    static GPUProcessProxy* NODELETE singletonIfCreated();
     ~GPUProcessProxy();
 
     void createGPUProcessConnection(WebProcessProxy&, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
@@ -44,7 +44,7 @@ public:
 
     void invalidateRequests();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     // Create a request to be presented to the user.

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
@@ -47,7 +47,7 @@ public:
     
     void invalidate();
 
-    WebProcessProxy* process() const;
+    WebProcessProxy* NODELETE process() const;
 
 private:
     GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy&, GeolocationIdentifier, WebProcessProxy&);

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
@@ -44,7 +44,7 @@ class InspectorBrowserAgent final : public InspectorAgentBase, public Inspector:
 public:
     InspectorBrowserAgent(WebPageAgentContext&);
     ~InspectorBrowserAgent();
-    bool enabled() const;
+    bool NODELETE enabled() const;
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend();

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -83,14 +83,14 @@ public:
     void didCreateFrame(WebFrameProxy&);
     void willDestroyFrame(const WebFrameProxy&);
 
-    InspectorBrowserAgent* enabledBrowserAgent() const;
+    InspectorBrowserAgent* NODELETE enabledBrowserAgent() const;
     void setEnabledBrowserAgent(InspectorBrowserAgent*);
 
     void browserExtensionsEnabled(HashMap<String, String>&&);
     void browserExtensionsDisabled(HashSet<String>&&);
 
 private:
-    WebPageAgentContext webPageAgentContext();
+    WebPageAgentContext NODELETE webPageAgentContext();
     void createLazyAgents();
 
     void addTarget(std::unique_ptr<InspectorTargetProxy>&&);

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -67,7 +67,7 @@ public:
 
     ArbitrationStatus arbitrationStatus() const { return m_arbitrationStatus; }
     WallTime arbitrationUpdateTime() const { return m_arbitrationUpdateTime; }
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     void ref() const final;
     void deref() const final;
@@ -76,7 +76,7 @@ protected:
     Logger& logger();
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "AudioSessionRoutingArbitrator"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -93,7 +93,7 @@ private:
     const WTF::Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinatorProxy"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakRef<WebPageProxy> m_webPageProxy;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -148,7 +148,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final;

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -53,7 +53,7 @@ static ASCIILiteral logClassName()
     return "MediaKeySystemPermissionRequestManagerProxy"_s;
 }
 
-static WTFLogChannel& logChannel()
+static WTFLogChannel& NODELETE logChannel()
 {
     return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, EME);
 }

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -57,7 +57,7 @@ public:
     void grantRequest(MediaKeySystemPermissionRequestProxy&);
     void denyRequest(MediaKeySystemPermissionRequestProxy&, const String& message = { });
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
 private:

--- a/Source/WebKit/UIProcess/ModelElementController.h
+++ b/Source/WebKit/UIProcess/ModelElementController.h
@@ -54,9 +54,9 @@ class WebPageProxy;
 class ModelElementController : public RefCountedAndCanMakeWeakPtr<ModelElementController> {
     WTF_MAKE_TZONE_ALLOCATED(ModelElementController);
 public:
-    static Ref<ModelElementController> create(WebPageProxy&);
+    static Ref<ModelElementController> NODELETE create(WebPageProxy&);
 
-    WebPageProxy* page();
+    WebPageProxy* NODELETE page();
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
     void getCameraForModelElement(ModelIdentifier, CompletionHandler<void(Expected<WebCore::HTMLModelElementCamera, WebCore::ResourceError>)>&&);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -132,7 +132,7 @@ public:
     using OpenerDomain = WebCore::RegistrableDomain;
 
     static Ref<NetworkProcessProxy> ensureDefaultNetworkProcess();
-    static WeakPtr<NetworkProcessProxy>& defaultNetworkProcess();
+    static WeakPtr<NetworkProcessProxy>& NODELETE defaultNetworkProcess();
     static Ref<NetworkProcessProxy> create() { return adoptRef(*new NetworkProcessProxy); }
     ~NetworkProcessProxy();
 
@@ -256,7 +256,7 @@ public:
     void sendProcessDidResume(ResumeReason) final;
     ASCIILiteral clientName() const final { return "NetworkProcess"_s; }
     
-    static void setSuspensionAllowedForTesting(bool);
+    static void NODELETE setSuspensionAllowedForTesting(bool);
     void sendProcessWillSuspendImminentlyForTesting();
 
     void registerSchemeForLegacyCustomProtocol(const String&);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -94,7 +94,7 @@ HashMap<String, bool> WebNotificationManagerProxy::notificationPermissions()
     return m_provider->notificationPermissions();
 }
 
-static std::optional<WebPageProxyIdentifier> identifierForPagePointer(WebPageProxy* webPage)
+static std::optional<WebPageProxyIdentifier> NODELETE identifierForPagePointer(WebPageProxy* webPage)
 {
     return webPage ? std::optional { webPage->identifier() } : std::nullopt;
 }

--- a/Source/WebKit/UIProcess/OverrideLanguages.cpp
+++ b/Source/WebKit/UIProcess/OverrideLanguages.cpp
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-static Vector<String>& overrideLanguagesStorage()
+static Vector<String>& NODELETE overrideLanguagesStorage()
 {
     static NeverDestroyed<Vector<String>> storage;
     return storage.get();

--- a/Source/WebKit/UIProcess/OverrideLanguages.h
+++ b/Source/WebKit/UIProcess/OverrideLanguages.h
@@ -31,6 +31,6 @@
 namespace WebKit {
 
 void setOverrideLanguages(Vector<String>&&);
-const Vector<String>& overrideLanguages();
+const Vector<String>& NODELETE overrideLanguages();
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -127,7 +127,7 @@ public:
         String url;
     };
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void addObserver(Observer&);
@@ -153,13 +153,13 @@ public:
     String activeURL() const { return activeURL(m_committedState); }
 
     bool hasOnlySecureContent() const;
-    bool hasNegotiatedLegacyTLS() const;
-    void negotiatedLegacyTLS(const Transaction::Token&);
+    bool NODELETE hasNegotiatedLegacyTLS() const;
+    void NODELETE negotiatedLegacyTLS(const Transaction::Token&);
     bool wasPrivateRelayed() const { return m_committedState.wasPrivateRelayed; }
     String proxyName() { return m_committedState.proxyName; }
     WebCore::ResourceResponseSource source() { return m_committedState.source; }
 
-    double estimatedProgress() const;
+    double NODELETE estimatedProgress() const;
     bool networkRequestsInProgress() const { return m_committedState.networkRequestsInProgress; }
 
     const WebCore::CertificateInfo& certificateInfo() const { return m_committedState.certificateInfo; }
@@ -178,29 +178,29 @@ public:
 
     void didCommitLoad(const Transaction::Token&, const WebCore::CertificateInfo&, bool hasInsecureContent, bool usedLegacyTLS, bool privateRelayed, const String& proxyName, const WebCore::ResourceResponseSource, const WebCore::SecurityOriginData&);
 
-    void didFinishLoad(const Transaction::Token&);
-    void didFailLoad(const Transaction::Token&);
+    void NODELETE didFinishLoad(const Transaction::Token&);
+    void NODELETE didFailLoad(const Transaction::Token&);
 
     void didSameDocumentNavigation(const Transaction::Token&, const String& url);
 
     void setUnreachableURL(const Transaction::Token&, const String&);
 
-    const String& title() const;
+    const String& NODELETE title() const;
     void setTitle(const Transaction::Token&, String&&);
     void setTitleFromBrowsingWarning(const Transaction::Token&, const String&);
 
-    bool canGoBack() const;
-    void setCanGoBack(const Transaction::Token&, bool);
+    bool NODELETE canGoBack() const;
+    void NODELETE setCanGoBack(const Transaction::Token&, bool);
 
-    bool canGoForward() const;
-    void setCanGoForward(const Transaction::Token&, bool);
+    bool NODELETE canGoForward() const;
+    void NODELETE setCanGoForward(const Transaction::Token&, bool);
 
-    void didStartProgress(const Transaction::Token&);
+    void NODELETE didStartProgress(const Transaction::Token&);
     void didChangeProgress(const Transaction::Token&, double);
-    void didFinishProgress(const Transaction::Token&);
-    void setNetworkRequestsInProgress(const Transaction::Token&, bool);
-    void setHTTPFallbackInProgress(const Transaction::Token&, bool);
-    bool httpFallbackInProgress();
+    void NODELETE didFinishProgress(const Transaction::Token&);
+    void NODELETE setNetworkRequestsInProgress(const Transaction::Token&, bool);
+    void NODELETE setHTTPFallbackInProgress(const Transaction::Token&, bool);
+    bool NODELETE httpFallbackInProgress();
 
     void didSwapWebProcesses();
 
@@ -250,8 +250,8 @@ private:
         WebCore::ResourceResponseSource source;
     };
 
-    static bool isLoading(const Data&);
-    static String activeURL(const Data&);
+    static bool NODELETE isLoading(const Data&);
+    static String NODELETE activeURL(const Data&);
     static bool hasOnlySecureContent(const Data&);
     static double estimatedProgress(const Data&);
 

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -42,7 +42,7 @@ public:
     explicit PerActivityStateCPUUsageSampler(WebProcessPool&);
     ~PerActivityStateCPUUsageSampler();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void reportWebContentCPUTime(Seconds cpuTime, WebCore::ActivityStateForCPUSampling);

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -98,7 +98,7 @@ private:
             return adoptRef(*new CachedAssertion(cache, WTF::move(assertion)));
         }
 
-        bool isValid() const { return m_assertion->isValid(); }
+        bool NODELETE isValid() const { return m_assertion->isValid(); }
         Ref<ProcessAssertion> release() { return m_assertion.releaseNonNull(); }
 
     private:
@@ -132,7 +132,7 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessThrottler::ProcessAssertionCache);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessThrottler::ProcessAssertionCache::CachedAssertion);
 
-static uint64_t generatePrepareToSuspendRequestID()
+static uint64_t NODELETE generatePrepareToSuspendRequestID()
 {
     static uint64_t prepareToSuspendRequestID = 0;
     return ++prepareToSuspendRequestID;

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -117,7 +117,7 @@ public:
 
     using Activity = ProcessThrottlerActivity;
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     using ForegroundActivity = Activity;
@@ -127,8 +127,8 @@ public:
     Ref<Activity> backgroundActivity(ASCIILiteral name);
     Ref<Activity> quietBackgroundActivity(ASCIILiteral name);
 
-    static bool isValidBackgroundActivity(const Activity*);
-    static bool isValidForegroundActivity(const Activity*);
+    static bool NODELETE isValidBackgroundActivity(const Activity*);
+    static bool NODELETE isValidForegroundActivity(const Activity*);
 
     using TimedActivity = ProcessThrottlerTimedActivity;
 
@@ -148,7 +148,7 @@ private:
     friend class ProcessThrottlerActivity;
     friend WTF::TextStream& operator<<(WTF::TextStream&, const ProcessThrottler&);
 
-    ProcessThrottleState expectedThrottleState();
+    ProcessThrottleState NODELETE expectedThrottleState();
     void updateThrottleStateIfNeeded(ASCIILiteral);
     void updateThrottleStateNow();
     void setAssertionType(ProcessAssertionType);
@@ -163,7 +163,7 @@ private:
     void removeActivity(Activity&);
     void invalidateAllActivities();
     String assertionName(ProcessAssertionType) const;
-    ProcessAssertionType assertionTypeForState(ProcessThrottleState);
+    ProcessAssertionType NODELETE assertionTypeForState(ProcessThrottleState);
 
     void uiAssertionWillExpireImminently();
     void assertionWasInvalidated();

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -47,7 +47,7 @@ public:
     ~ProvisionalFrameProxy();
 
     WebFrameProxy& frame() const { return m_frame.get(); }
-    WebProcessProxy& process() const;
+    WebProcessProxy& NODELETE process() const;
 
     RefPtr<FrameProcess> takeFrameProcess();
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -105,7 +105,7 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
-    WebProcessProxy& process();
+    WebProcessProxy& NODELETE process();
     ProcessSwapRequestedByClient processSwapRequestedByClient() const { return m_processSwapRequestedByClient; }
     WebCore::NavigationIdentifier navigationID() const { return m_navigationID; }
     const URL& provisionalURL() const { return m_provisionalLoadURL; }
@@ -116,7 +116,7 @@ public:
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
     RefPtr<DrawingAreaProxy> takeDrawingArea();
 
-    void setNavigation(API::Navigation&);
+    void NODELETE setNavigation(API::Navigation&);
 
 #if PLATFORM(COCOA)
     Vector<uint8_t> takeAccessibilityToken() { return WTF::move(m_accessibilityToken); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -67,7 +67,7 @@ public:
 
     CALayer *layerForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     RetainPtr<CALayer> protectedLayerForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
-    CALayer *rootLayer() const;
+    CALayer *NODELETE rootLayer() const;
 
     RemoteLayerTreeDrawingAreaProxy& NODELETE drawingArea() const;
 
@@ -99,7 +99,7 @@ public:
 
     CALayer *layerWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 
-    bool replayDynamicContentScalingDisplayListsIntoBackingStore() const;
+    bool NODELETE replayDynamicContentScalingDisplayListsIntoBackingStore() const;
     bool threadedAnimationsEnabled() const;
 
     bool cssUnprefixedBackdropFilterEnabled() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
@@ -63,7 +63,7 @@ private:
             , value(data)
         { }
         
-        bool canCoalesce(ScrollingLogEvent::EventType, uint64_t blankPixelCount) const;
+        bool NODELETE canCoalesce(ScrollingLogEvent::EventType, uint64_t blankPixelCount) const;
     };
     
     unsigned blankPixelCount(const WebCore::FloatRect& visibleRect) const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -109,10 +109,10 @@ public:
 
     virtual WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent& wheelEvent) { return wheelEvent; }
 
-    std::optional<WebCore::ScrollingNodeID> rootScrollingNodeID() const;
+    std::optional<WebCore::ScrollingNodeID> NODELETE rootScrollingNodeID() const;
 
     const RemoteLayerTreeHost* layerTreeHost() const;
-    WebPageProxy& webPageProxy() const;
+    WebPageProxy& NODELETE webPageProxy() const;
 
     virtual void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID);
 #if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
@@ -124,8 +124,8 @@ public:
     void adjustMainFrameDelegatedScrollPosition(WebCore::RequestedScrollData&&);
 
     bool hasFixedOrSticky() const;
-    bool hasScrollableMainFrame() const;
-    bool hasScrollableOrZoomedMainFrame() const;
+    bool NODELETE hasScrollableMainFrame() const;
+    bool NODELETE hasScrollableOrZoomedMainFrame() const;
 
     WebCore::ScrollbarWidth mainFrameScrollbarWidth() const;
     std::optional<WebCore::ScrollbarColor> mainFrameScrollbarColor() const;
@@ -168,10 +168,10 @@ public:
     void resetStateAfterProcessExited();
 
     virtual void displayDidRefresh(WebCore::PlatformDisplayID);
-    void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);
+    void NODELETE reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>);
     void reportFilledVisibleFreshTile(MonotonicTime, unsigned);
-    bool scrollingPerformanceTestingEnabled() const;
+    bool NODELETE scrollingPerformanceTestingEnabled() const;
     
     void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
     void deferWheelEventTestCompletionForReason(std::optional<WebCore::ScrollingNodeID>, WebCore::WheelEventTestMonitor::DeferReason);
@@ -205,7 +205,7 @@ public:
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
     void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, int);
     void receivedLastScrollingTreeNodeUpdateReply();
-    bool isMonitoringWheelEvents();
+    bool NODELETE isMonitoringWheelEvents();
 
 protected:
     explicit RemoteScrollingCoordinatorProxy(WebPageProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -68,7 +68,7 @@ public:
     virtual void receivedEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, std::optional<WebCore::WheelScrollGestureState>) { };
     virtual WebCore::WheelEventHandlingResult handleWheelEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>) { return WebCore::WheelEventHandlingResult::unhandled(); }
 
-    RemoteScrollingCoordinatorProxy* scrollingCoordinatorProxy() const;
+    RemoteScrollingCoordinatorProxy* NODELETE scrollingCoordinatorProxy() const;
 
     void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction = WebCore::ScrollingLayerPositionAction::Sync) override;
     void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingTreeScrollingNode&) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -115,7 +115,7 @@ public:
     void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&);
     void updateAnimations();
-    RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
+    RefPtr<const RemoteAnimationStack> NODELETE animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID);
 #endif
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -95,7 +95,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    WebPageProxy* page() const;
+    WebPageProxy* NODELETE page() const;
 
     void injectPageIntoNewProcess();
     void processDidTerminate(WebProcessProxy&, ProcessTerminationReason);
@@ -108,7 +108,7 @@ public:
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return m_webPageID; }
     const WebCore::Site& site() const { return m_site; }
 
-    WebProcessActivityState& processActivityState();
+    WebProcessActivityState& NODELETE processActivityState();
 
     WebCore::MediaProducerMediaStateFlags mediaState() const { return m_mediaState; }
     void setDrawingArea(DrawingAreaProxy*);

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -46,7 +46,7 @@ public:
     void request(WebCore::SpeechRecognitionRequest&, FrameInfoData&&, SpeechRecognitionPermissionRequestCallback&&);
 
     void decideByDefaultAction(const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&&);
-    WebPageProxy* page();
+    WebPageProxy* NODELETE page();
 
 private:
     explicit SpeechRecognitionPermissionManager(WebPageProxy&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -62,7 +62,7 @@ public:
     void addSource(SpeechRecognitionRemoteRealtimeMediaSource&, const WebCore::CaptureDevice&);
     void removeSource(SpeechRecognitionRemoteRealtimeMediaSource&);
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
 private:
     // Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -67,7 +67,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     void start(WebCore::SpeechRecognitionConnectionClientIdentifier, String&& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&&, WebCore::FrameIdentifier, FrameInfoData&&);
     void stop(WebCore::SpeechRecognitionConnectionClientIdentifier);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -69,17 +69,17 @@ public:
 
     static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 
-    WebPageProxy* page() const;
+    WebPageProxy* NODELETE page() const;
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
     const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
-    WebBackForwardCache& backForwardCache() const;
+    WebBackForwardCache& NODELETE backForwardCache() const;
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 
-    bool pageIsClosedOrClosing() const;
+    bool NODELETE pageIsClosedOrClosing() const;
 
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
     void unsuspend();

--- a/Source/WebKit/UIProcess/TextCheckerCompletion.h
+++ b/Source/WebKit/UIProcess/TextCheckerCompletion.h
@@ -40,7 +40,7 @@ class TextCheckerCompletion : public RefCounted<TextCheckerCompletion> {
 public:
     static Ref<TextCheckerCompletion> create(TextCheckerRequestID, const WebCore::TextCheckingRequestData&, WebPageProxy&);
 
-    const WebCore::TextCheckingRequestData& textCheckingRequestData() const;
+    const WebCore::TextCheckingRequestData& NODELETE textCheckingRequestData() const;
     SpellDocumentTag spellDocumentTag();
     void didFinishCheckingText(const Vector<WebCore::TextCheckingResult>&) const;
     void didCancelCheckingText() const;

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -58,7 +58,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<UserContentControllerIdentifier, WeakRef<WebUserContentControllerProxy>>& webUserContentControllerProxies()
+static HashMap<UserContentControllerIdentifier, WeakRef<WebUserContentControllerProxy>>& NODELETE webUserContentControllerProxies()
 {
     static NeverDestroyed<HashMap<UserContentControllerIdentifier, WeakRef<WebUserContentControllerProxy>>> proxies;
     return proxies;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -220,7 +220,7 @@ void UserMediaPermissionRequestManagerProxy::clearCachedState()
 }
 
 #if ENABLE(MEDIA_STREAM)
-static uint64_t toWebCore(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason reason)
+static uint64_t NODELETE toWebCore(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason reason)
 {
     switch (reason) {
     case UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints:
@@ -911,8 +911,8 @@ public:
         m_handler(m_cameraPermission, m_microphonePermission);
     }
 
-    void setCameraPermission(PermissionState state) { m_cameraPermission = state; }
-    void setMicrophonePermission(PermissionState state) { m_microphonePermission = state; }
+    void NODELETE setCameraPermission(PermissionState state) { m_cameraPermission = state; }
+    void NODELETE setMicrophonePermission(PermissionState state) { m_microphonePermission = state; }
 
 private:
     explicit UserMediaPermissionInfoGatherer(CompletionHandler<void(PermissionState, PermissionState)>&& handler)

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -78,7 +78,7 @@ public:
     static Ref<UserMediaPermissionRequestManagerProxy> create(WebPageProxy&);
     ~UserMediaPermissionRequestManagerProxy();
 
-    WebPageProxy* page() const;
+    WebPageProxy* NODELETE page() const;
 
     void disconnectFromPage();
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -57,7 +57,7 @@ public:
     void deny(UserMediaAccessDenialReason = UserMediaAccessDenialReason::UserMediaDisabled);
 
     virtual void invalidate();
-    bool isPending() const;
+    bool NODELETE isPending() const;
 
     bool requiresAudioCapture() const { return m_eligibleAudioDevices.size(); }
     bool requiresVideoCapture() const { return !requiresDisplayCapture() && m_eligibleVideoDevices.size(); }
@@ -106,7 +106,7 @@ public:
 protected:
     UserMediaPermissionRequestProxy(UserMediaPermissionRequestManagerProxy&, std::optional<WebCore::UserMediaRequestIdentifier>, WebCore::FrameIdentifier mainFrameID, FrameInfoData&&, Ref<WebCore::SecurityOrigin>&& userMediaDocumentOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, Vector<WebCore::CaptureDevice>&& audioDevices, Vector<WebCore::CaptureDevice>&& videoDevices, WebCore::MediaStreamRequest&&, CompletionHandler<void(bool)>&&);
 
-    UserMediaPermissionRequestManagerProxy* manager() const;
+    UserMediaPermissionRequestManagerProxy* NODELETE manager() const;
 
 private:
     WeakPtr<UserMediaPermissionRequestManagerProxy> m_manager;

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -58,7 +58,7 @@ UserMediaProcessManager::UserMediaProcessManager()
 }
 
 #if ENABLE(SANDBOX_EXTENSIONS)
-static bool needsAppleCameraService()
+static bool NODELETE needsAppleCameraService()
 {
 #if !PLATFORM(MAC) && !PLATFORM(MACCATALYST)
     return false;

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.h
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.h
@@ -42,7 +42,7 @@ public:
     void ref() const { ASSERT(this == &singleton()); }
     void deref() const { ASSERT(this == &singleton()); }
 
-    bool willCreateMediaStream(UserMediaPermissionRequestManagerProxy&, const UserMediaPermissionRequestProxy&);
+    bool NODELETE willCreateMediaStream(UserMediaPermissionRequestManagerProxy&, const UserMediaPermissionRequestProxy&);
 
     void revokeSandboxExtensionsIfNeeded(WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -72,7 +72,7 @@ static const float minimumScrollEventRatioForSwipe = 0.5;
 static const float swipeSnapshotRemovalRenderTreeSizeTargetFraction = 0.5;
 #endif
 
-static HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>& viewGestureControllersForAllPages()
+static HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>& NODELETE viewGestureControllersForAllPages()
 {
     // The key in this map is the associated page ID.
     static NeverDestroyed<HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>> viewGestureControllers;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -230,7 +230,7 @@ private:
 
     static ViewGestureController* controllerForGesture(WebPageProxyIdentifier, GestureID);
 
-    static GestureID takeNextGestureID();
+    static GestureID NODELETE takeNextGestureID();
     void willBeginGesture(ViewGestureType);
     void didEndGesture();
     void resetState();
@@ -273,7 +273,7 @@ private:
         enum class ShouldIgnoreEventIfPaused : bool { No, Yes };
         bool eventOccurred(Events, ShouldIgnoreEventIfPaused = ShouldIgnoreEventIfPaused::Yes);
         bool cancelOutstandingEvent(Events);
-        bool hasOutstandingEvent(Event);
+        bool NODELETE hasOutstandingEvent(Event);
 
         void startWatchdog(Seconds);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -71,7 +71,7 @@ public:
     virtual bool isMock() const { return false; }
     virtual bool isVirtual() const { return false; }
 
-    void enableNativeSupport();
+    void NODELETE enableNativeSupport();
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
@@ -44,7 +44,7 @@ static void deviceAddedCallback(void* context, IOReturn, void*, IOHIDDeviceRef d
 }
 
 // FIXME(191518)
-static void deviceRemovedCallback(void* context, IOReturn, void*, IOHIDDeviceRef device)
+static void NODELETE deviceRemovedCallback(void* context, IOReturn, void*, IOHIDDeviceRef device)
 {
     // FIXME(191525)
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -226,7 +226,7 @@ static inline HashSet<String> produceHashSet(const Vector<PublicKeyCredentialDes
     return result;
 }
 
-static inline uint8_t authDataFlags(ClientDataType type, LocalConnection::UserVerification verification, bool synchronizable, std::optional<MediationRequirement> mediation)
+static inline uint8_t NODELETE authDataFlags(ClientDataType type, LocalConnection::UserVerification verification, bool synchronizable, std::optional<MediationRequirement> mediation)
 {
     auto flags = 0;
     if (type != ClientDataType::Create || mediation != MediationRequirement::Conditional)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -64,7 +64,7 @@ RetainPtr<id<_WKWebAuthenticationPanelDelegate>> WebAuthenticationPanelClient::d
     return m_delegate.get();
 }
 
-static _WKWebAuthenticationPanelUpdate wkWebAuthenticationPanelUpdate(WebAuthenticationStatus status)
+static _WKWebAuthenticationPanelUpdate NODELETE wkWebAuthenticationPanelUpdate(WebAuthenticationStatus status)
 {
     if (status == WebAuthenticationStatus::MultipleNFCTagsPresent)
         return _WKWebAuthenticationPanelUpdateMultipleNFCTagsPresent;
@@ -106,7 +106,7 @@ void WebAuthenticationPanelClient::updatePanel(WebAuthenticationStatus status) c
     [delegate panel:m_panel.get().get() updateWebAuthenticationPanel:wkWebAuthenticationPanelUpdate(status)];
 }
 
-static _WKWebAuthenticationResult wkWebAuthenticationResult(WebAuthenticationResult result)
+static _WKWebAuthenticationResult NODELETE wkWebAuthenticationResult(WebAuthenticationResult result)
 {
     switch (result) {
     case WebAuthenticationResult::Succeeded:
@@ -178,7 +178,7 @@ void WebAuthenticationPanelClient::requestNewPin(uint64_t minLength, CompletionH
     }).get()];
 }
 
-static _WKWebAuthenticationSource wkWebAuthenticationSource(WebAuthenticationSource result)
+static _WKWebAuthenticationSource NODELETE wkWebAuthenticationSource(WebAuthenticationSource result)
 {
     switch (result) {
     case WebAuthenticationSource::Local:
@@ -222,7 +222,7 @@ void WebAuthenticationPanelClient::selectAssertionResponse(Vector<Ref<WebCore::A
     }).get()];
 }
 
-static LocalAuthenticatorPolicy localAuthenticatorPolicy(_WKLocalAuthenticatorPolicy result)
+static LocalAuthenticatorPolicy NODELETE localAuthenticatorPolicy(_WKLocalAuthenticatorPolicy result)
 {
     switch (result) {
     case _WKLocalAuthenticatorPolicyAllow:

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -127,7 +127,7 @@ static inline RefPtr<ArrayBuffer> toArrayBufferNilIfEmpty(NSData *data)
     return ArrayBuffer::create(span(data));
 }
 
-static inline ExceptionCode toExceptionCode(NSInteger nsErrorCode)
+static inline ExceptionCode NODELETE toExceptionCode(NSInteger nsErrorCode)
 {
     ExceptionCode exceptionCode = (ExceptionCode)nsErrorCode;
 
@@ -572,7 +572,7 @@ inline static Vector<AuthenticatorTransport> toTransports(NSArray<ASAuthorizatio
     return transports;
 }
 
-static inline AuthenticatorAttachment fromASAuthorizationPublicKeyCredentialAttachment(ASAuthorizationPublicKeyCredentialAttachment attachment)
+static inline AuthenticatorAttachment NODELETE fromASAuthorizationPublicKeyCredentialAttachment(ASAuthorizationPublicKeyCredentialAttachment attachment)
 {
     if (attachment == ASAuthorizationPublicKeyCredentialAttachmentPlatform)
         return AuthenticatorAttachment::Platform;
@@ -883,7 +883,7 @@ static inline void setGlobalFrameIDForContext(RetainPtr<ASCCredentialRequestCont
     }
 }
 
-static inline ASPublicKeyCredentialResidentKeyPreference toASCResidentKeyPreference(std::optional<ResidentKeyRequirement> requirement, bool requireResidentKey)
+static inline ASPublicKeyCredentialResidentKeyPreference NODELETE toASCResidentKeyPreference(std::optional<ResidentKeyRequirement> requirement, bool requireResidentKey)
 {
     if (!requirement)
         return requireResidentKey ? ASPublicKeyCredentialResidentKeyPreferenceRequired : ASPublicKeyCredentialResidentKeyPreferenceNotPresent;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
@@ -63,7 +63,7 @@ private:
     void assembleRequest(Vector<uint8_t>&&);
     void parseRequest();
     void feedReports();
-    bool stagesMatch() const;
+    bool NODELETE stagesMatch() const;
     void shouldContinueFeedReports();
     void continueFeedReports();
     void validateExpectedCommand(const Vector<uint8_t>& actualCommand);

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h
@@ -39,7 +39,7 @@ public:
     static Ref<MockNfcService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
     NSData* transceive();
-    void receiveStopPolling();
+    void NODELETE receiveStopPolling();
     void receiveStartPolling();
 
 private:

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -141,7 +141,7 @@ static RetainPtr<id<NFReaderSessionDelegate>> protectedGlobalNFReaderSessionDele
     return globalNFReaderSessionDelegate;
 }
 
-static WeakPtr<MockNfcService>& weakGlobalNfcService()
+static WeakPtr<MockNfcService>& NODELETE weakGlobalNfcService()
 {
     static NeverDestroyed<WeakPtr<MockNfcService>> service;
     return service.get();

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-uint8_t flagsForConfig(const VirtualAuthenticatorConfiguration&);
+uint8_t NODELETE flagsForConfig(const VirtualAuthenticatorConfiguration&);
 RetainPtr<SecKeyRef> createPrivateKey();
 std::pair<Vector<uint8_t>, Vector<uint8_t>> credentialIdAndCosePubKeyForPrivateKey(RetainPtr<SecKeyRef> privateKey);
 String base64PrivateKey(RetainPtr<SecKeyRef> privateKey);

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.h
@@ -64,7 +64,7 @@ struct WebAuthenticationRequestData {
     std::optional<WebCore::SecurityOriginData> parentOrigin;
 };
 
-WebCore::ClientDataType getClientDataType(const Variant<WebCore::PublicKeyCredentialCreationOptions, WebCore::PublicKeyCredentialRequestOptions>&);
+WebCore::ClientDataType NODELETE getClientDataType(const Variant<WebCore::PublicKeyCredentialCreationOptions, WebCore::PublicKeyCredentialRequestOptions>&);
 WebCore::UserVerificationRequirement getUserVerificationRequirement(const Variant<WebCore::PublicKeyCredentialCreationOptions, WebCore::PublicKeyCredentialRequestOptions>&);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -75,7 +75,7 @@ static Vector<Vector<PublicKeyCredentialDescriptor>> batchesForCredentials(Vecto
     return batches;
 }
 
-WebAuthenticationStatus toStatus(const CtapDeviceResponseCode& error)
+WebAuthenticationStatus NODELETE toStatus(const CtapDeviceResponseCode& error)
 {
     switch (error) {
     case CtapDeviceResponseCode::kCtap2ErrPinAuthInvalid:
@@ -93,7 +93,7 @@ WebAuthenticationStatus toStatus(const CtapDeviceResponseCode& error)
     }
 }
 
-bool isPinError(const CtapDeviceResponseCode& error)
+bool NODELETE isPinError(const CtapDeviceResponseCode& error)
 {
     switch (error) {
     case CtapDeviceResponseCode::kCtap2ErrPinAuthInvalid:
@@ -107,7 +107,7 @@ bool isPinError(const CtapDeviceResponseCode& error)
     }
 }
 
-bool isTerminalPinError(const CtapDeviceResponseCode& error)
+bool NODELETE isTerminalPinError(const CtapDeviceResponseCode& error)
 {
     switch (error) {
     case CtapDeviceResponseCode::kCtap2ErrPinAuthBlocked:

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -80,7 +80,7 @@ private:
     String aaguidForDebugging() const;
 
     fido::PINUVAuthProtocol selectPinProtocol() const;
-    bool isUVSetup() const;
+    bool NODELETE isUVSetup() const;
 
     void continueSetupPinAfterCommand(Vector<uint8_t>&&, const String& pin, Ref<WebCore::CryptoKeyEC> peerKey);
     void continueSetupPinAfterGetKeyAgreement(Vector<uint8_t>&&, const String& pin);

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -48,7 +48,7 @@ public:
     explicit WebBackForwardCache(WebProcessPool&);
     ~WebBackForwardCache();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void setCapacity(WebProcessPool&, unsigned);

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -48,7 +48,7 @@ public:
     static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
     ~WebBackForwardCacheEntry();
 
-    WebBackForwardCache* backForwardCache() const;
+    WebBackForwardCache* NODELETE backForwardCache() const;
 
     SuspendedPageProxy* suspendedPage() const { return m_suspendedPage.get(); }
     Ref<SuspendedPageProxy> takeSuspendedPage();

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -571,7 +571,7 @@ RefPtr<WebBackForwardListItem> WebBackForwardList::goForwardItemSkippingItemsWit
     return itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(*this, NavigationDirection::Forward);
 }
 
-static inline void setBackForwardItemIdentifier(FrameState& frameState, BackForwardItemIdentifier itemID)
+static inline void NODELETE setBackForwardItemIdentifier(FrameState& frameState, BackForwardItemIdentifier itemID)
 {
     frameState.itemID = itemID;
     for (auto& child : frameState.children)

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -69,15 +69,15 @@ public:
     void removeAllItems();
     void clear();
 
-    WebBackForwardListItem* currentItem() const;
-    WebBackForwardListItem* backItem() const;
-    WebBackForwardListItem* forwardItem() const;
-    WebBackForwardListItem* itemAtIndex(int) const;
+    WebBackForwardListItem* NODELETE currentItem() const;
+    WebBackForwardListItem* NODELETE backItem() const;
+    WebBackForwardListItem* NODELETE forwardItem() const;
+    WebBackForwardListItem* NODELETE itemAtIndex(int) const;
 
     RefPtr<WebBackForwardListItem> goBackItemSkippingItemsWithoutUserGesture() const;
     RefPtr<WebBackForwardListItem> goForwardItemSkippingItemsWithoutUserGesture() const;
-    unsigned backListCount() const;
-    unsigned forwardListCount() const;
+    unsigned NODELETE backListCount() const;
+    unsigned NODELETE forwardListCount() const;
 
     Ref<API::Array> backList() const;
     Ref<API::Array> forwardList() const;
@@ -106,7 +106,7 @@ private:
     void addChildItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
     void didRemoveItem(WebBackForwardListItem&);
     const BackForwardListItemVector& entries() const { return m_entries; }
-    WebBackForwardListCounts counts() const;
+    WebBackForwardListCounts NODELETE counts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
 
     void updateAllFrameIDs(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -96,7 +96,7 @@ using namespace WebCore;
 
 class WebPageProxy;
 
-static HashMap<FrameIdentifier, WeakRef<WebFrameProxy>>& allFrames()
+static HashMap<FrameIdentifier, WeakRef<WebFrameProxy>>& NODELETE allFrames()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<HashMap<FrameIdentifier, WeakRef<WebFrameProxy>>> map;

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -146,13 +146,13 @@ public:
     virtual ~WebFrameProxy();
 
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
-    WebPageProxy* page() const;
+    WebPageProxy* NODELETE page() const;
 
     bool pageIsClosed() const { return !m_page; } // Needs to be thread-safe.
 
     void webProcessWillShutDown();
 
-    bool isMainFrame() const;
+    bool NODELETE isMainFrame() const;
 
     FrameLoadState& frameLoadState() { return m_frameLoadState; }
 
@@ -215,7 +215,7 @@ public:
     void disconnect();
     bool isConnected() const;
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
-    ProcessID processID() const;
+    ProcessID NODELETE processID() const;
     void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, std::optional<WebCore::SecurityOriginData>, CompletionHandler<void(WebCore::PageIdentifier)>&&);
 
     void commitProvisionalFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, String&& proxyName, WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, WebCore::DocumentSecurityPolicy&&, const UserData&);
@@ -228,7 +228,7 @@ public:
     Ref<WebFrameProxy> rootFrame();
     RefPtr<WebFrameProxy> childFrame(uint64_t index) const;
 
-    WebProcessProxy& process() const;
+    WebProcessProxy& NODELETE process() const;
     void setProcess(FrameProcess&);
     const FrameProcess& frameProcess() const { return m_frameProcess.get(); }
     FrameProcess& frameProcess() { return m_frameProcess.get(); }
@@ -251,7 +251,7 @@ public:
     void removeRemotePagesForSuspension();
     void bindAccessibilityFrameWithData(std::span<const uint8_t>);
 
-    bool isFocused() const;
+    bool NODELETE isFocused() const;
 
     struct TraversalResult {
         RefPtr<WebFrameProxy> frame;
@@ -312,12 +312,12 @@ private:
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
-    std::optional<WebCore::PageIdentifier> pageIdentifier() const;
+    std::optional<WebCore::PageIdentifier> NODELETE pageIdentifier() const;
     Ref<WebCore::SecurityOrigin> securityOrigin() const;
 
     RefPtr<WebFrameProxy> deepLastChild();
-    WebFrameProxy* firstChild() const;
-    WebFrameProxy* lastChild() const;
+    WebFrameProxy* NODELETE firstChild() const;
+    WebFrameProxy* NODELETE lastChild() const;
     WebFrameProxy* nextSibling() const;
     WebFrameProxy* previousSibling() const;
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -91,7 +91,7 @@ public:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const;
 
     bool isFullScreen();
-    bool blocksReturnToFullscreenFromPictureInPicture() const;
+    bool NODELETE blocksReturnToFullscreenFromPictureInPicture() const;
 #if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     bool isVideoElement() const { return m_isVideoElement; }
 #endif
@@ -102,7 +102,7 @@ public:
 #endif // QUICKLOOK_FULLSCREEN
     void close();
     void detachFromClient();
-    void attachToNewClient(WebFullScreenManagerProxyClient&);
+    void NODELETE attachToNewClient(WebFullScreenManagerProxyClient&);
 
     void enterFullScreenForOwnerElementsInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
     void exitFullScreenInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
@@ -143,7 +143,7 @@ private:
     const Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "WebFullScreenManagerProxy"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakPtr<WebPageProxy> m_page;

--- a/Source/WebKit/UIProcess/WebNavigationState.h
+++ b/Source/WebKit/UIProcess/WebNavigationState.h
@@ -55,7 +55,7 @@ public:
     explicit WebNavigationState(WebPageProxy&);
     ~WebNavigationState();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     Ref<API::Navigation> createBackForwardNavigation(WebCore::ProcessIdentifier, Ref<WebBackForwardListFrameItem>&& targetFrameItem, RefPtr<WebBackForwardListItem>&& currentItem, WebCore::FrameLoadType);

--- a/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.h
@@ -58,7 +58,7 @@ public:
 
     void invalidate();
 
-    WebProcessProxy* process() const;
+    WebProcessProxy* NODELETE process() const;
 
 private:
     WebOpenPanelResultListenerProxy(WebPageProxy*, WebProcessProxy&);

--- a/Source/WebKit/UIProcess/WebPageGroup.cpp
+++ b/Source/WebKit/UIProcess/WebPageGroup.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 
 using WebPageGroupMap = HashMap<PageGroupIdentifier, WeakRef<WebPageGroup>>;
 
-static WebPageGroupMap& webPageGroupMap()
+static WebPageGroupMap& NODELETE webPageGroupMap()
 {
     static NeverDestroyed<WebPageGroupMap> map;
     return map;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -843,14 +843,14 @@ WebPageProxy::Internals::~Internals() = default;
 
 #if PLATFORM(MAC)
 // FIXME: Remove this once the cause of rdar://148942809 is found and fixed.
-static std::optional<API::PageConfiguration::OpenerInfo>& openerInfoOfPageBeingOpened()
+static std::optional<API::PageConfiguration::OpenerInfo>& NODELETE openerInfoOfPageBeingOpened()
 {
     static NeverDestroyed<std::optional<API::PageConfiguration::OpenerInfo>> info;
     return info.get();
 }
 #endif
 
-static HashMap<WebPageProxyIdentifier, WeakPtr<WebPageProxy>>& webPageProxyMap()
+static HashMap<WebPageProxyIdentifier, WeakPtr<WebPageProxy>>& NODELETE webPageProxyMap()
 {
     static MainRunLoopNeverDestroyed<HashMap<WebPageProxyIdentifier, WeakPtr<WebPageProxy>>> map;
     return map.get();
@@ -5037,7 +5037,7 @@ void WebPageProxy::clearServiceWorkerEntitlementOverride(CompletionHandler<void(
 #endif
 }
 
-static std::optional<std::pair<Ref<API::WebsitePolicies>, Ref<WebProcessProxy>>> websitePoliciesAndProcess(API::WebsitePolicies* policies, const Ref<WebProcessProxy>& process)
+static std::optional<std::pair<Ref<API::WebsitePolicies>, Ref<WebProcessProxy>>> NODELETE websitePoliciesAndProcess(API::WebsitePolicies* policies, const Ref<WebProcessProxy>& process)
 {
     if (!policies)
         return std::nullopt;
@@ -6628,7 +6628,7 @@ void WebPageProxy::countStringMatches(const String& string, OptionSet<FindOption
     class CountStringMatchesCallbackAggregator : public RefCounted<CountStringMatchesCallbackAggregator> {
     public:
         static Ref<CountStringMatchesCallbackAggregator> create(CompletionHandler<void(uint32_t)>&& completionHandler) { return adoptRef(*new CountStringMatchesCallbackAggregator(WTF::move(completionHandler))); }
-        void didCountStringMatches(uint32_t matchCount) { m_matchCount += matchCount; }
+        void NODELETE didCountStringMatches(uint32_t matchCount) { m_matchCount += matchCount; }
         ~CountStringMatchesCallbackAggregator()
         {
             m_completionHandler(m_matchCount);
@@ -7924,7 +7924,7 @@ void WebPageProxy::broadcastAllDocumentSyncData(IPC::Connection& connection, Ref
 
 // Given a property in FrameTreeSyncData, returns whether the property can only be changed by the
 // process that owns the frame or not.
-static bool frameTreePropertyIsRestrictedToFrameOwningProcess(WebCore::FrameTreeSyncDataType property)
+static bool NODELETE frameTreePropertyIsRestrictedToFrameOwningProcess(WebCore::FrameTreeSyncDataType property)
 {
     switch (property) {
     case WebCore::FrameTreeSyncDataType::FrameRect:
@@ -8424,7 +8424,7 @@ void WebPageProxy::decidePolicyForNavigationActionAsync(IPC::Connection& connect
 
 #if PLATFORM(COCOA)
 // https://html.spec.whatwg.org/#hand-off-to-external-software
-static bool frameSandboxAllowsOpeningExternalCustomProtocols(SandboxFlags sandboxFlags, bool hasUserGesture)
+static bool NODELETE frameSandboxAllowsOpeningExternalCustomProtocols(SandboxFlags sandboxFlags, bool hasUserGesture)
 {
     if (!sandboxFlags.contains(SandboxFlag::Popups) || !sandboxFlags.contains(SandboxFlag::TopNavigation) || !sandboxFlags.contains(SandboxFlag::TopNavigationToCustomProtocols))
         return true;
@@ -9992,7 +9992,7 @@ void WebPageProxy::setMediaVolume(float volume)
 }
 
 #if ENABLE(MEDIA_STREAM)
-static WebCore::MediaProducerMutedStateFlags applyWebAppDesiredMutedKinds(WebCore::MediaProducerMutedStateFlags state, OptionSet<WebCore::MediaProducerMediaCaptureKind> desiredMutedKinds)
+static WebCore::MediaProducerMutedStateFlags NODELETE applyWebAppDesiredMutedKinds(WebCore::MediaProducerMutedStateFlags state, OptionSet<WebCore::MediaProducerMediaCaptureKind> desiredMutedKinds)
 {
     if (desiredMutedKinds.contains(WebCore::MediaProducerMediaCaptureKind::EveryKind))
         state.add(MediaProducer::MediaStreamCaptureIsMuted);
@@ -10012,7 +10012,7 @@ static WebCore::MediaProducerMutedStateFlags applyWebAppDesiredMutedKinds(WebCor
     return state;
 }
 
-static void updateMutedCaptureKindsDesiredByWebApp(OptionSet<WebCore::MediaProducerMediaCaptureKind>& mutedCaptureKindsDesiredByWebApp, WebCore::MediaProducerMutedStateFlags newState)
+static void NODELETE updateMutedCaptureKindsDesiredByWebApp(OptionSet<WebCore::MediaProducerMediaCaptureKind>& mutedCaptureKindsDesiredByWebApp, WebCore::MediaProducerMutedStateFlags newState)
 {
     if (newState.contains(WebCore::MediaProducerMutedState::AudioCaptureIsMuted))
         mutedCaptureKindsDesiredByWebApp.add(WebCore::MediaProducerMediaCaptureKind::Microphone);
@@ -12029,7 +12029,7 @@ void WebPageProxy::provisionalProcessDidTerminate()
     m_provisionalPage = nullptr;
 }
 
-static bool shouldReloadAfterProcessTermination(ProcessTerminationReason reason)
+static bool NODELETE shouldReloadAfterProcessTermination(ProcessTerminationReason reason)
 {
     switch (reason) {
     case ProcessTerminationReason::ExceededMemoryLimit:
@@ -17699,7 +17699,7 @@ void WebPageProxy::dropTextExtractionAssertion()
 }
 
 // See SwiftDemoLogo.swift for the rationale here
-bool shouldShowSwiftDemoLogo()
+bool NODELETE shouldShowSwiftDemoLogo()
 {
 #if ENABLE(SWIFT_DEMO_URI_SCHEME)
     return true;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -757,14 +757,14 @@ public:
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return webPageIDInMainFrameProcess(); }
     WebCore::PageIdentifier webPageIDInProcess(const WebProcessProxy&) const;
 
-    PAL::SessionID sessionID() const;
+    PAL::SessionID NODELETE sessionID() const;
 
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }
     WebFrameProxy* focusedOrMainFrame() const { return m_focusedFrame ? m_focusedFrame.get() : m_mainFrame.get(); }
 
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
-    DrawingAreaProxy* provisionalDrawingArea() const;
+    DrawingAreaProxy* NODELETE provisionalDrawingArea() const;
 
     WebNavigationState& navigationState() { return m_navigationState; }
 
@@ -816,9 +816,9 @@ public:
     void resume(CompletionHandler<void(bool)>&&);
     bool isSuspended() const { return m_isSuspended; }
 
-    WebInspectorUIProxy* inspector() const;
+    WebInspectorUIProxy* NODELETE inspector() const;
 
-    GeolocationPermissionRequestManagerProxy& geolocationPermissionRequestManager();
+    GeolocationPermissionRequestManagerProxy& NODELETE geolocationPermissionRequestManager();
 
     void resourceLoadDidSendRequest(ResourceLoadInfo&&, WebCore::ResourceRequest&&);
     void resourceLoadDidPerformHTTPRedirection(ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&);
@@ -865,10 +865,10 @@ public:
     WebExtensionController* webExtensionController();
 #endif
 
-    bool hasSleepDisabler() const;
+    bool NODELETE hasSleepDisabler() const;
 
 #if ENABLE(FULLSCREEN_API)
-    WebFullScreenManagerProxy* fullScreenManager();
+    WebFullScreenManagerProxy* NODELETE fullScreenManager();
     void setFullScreenClientForTesting(std::unique_ptr<WebKit::WebFullScreenManagerProxyClient>&&);
 
     API::FullscreenClient& fullscreenClient() const { return *m_fullscreenClient; }
@@ -877,7 +877,7 @@ public:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     PlaybackSessionManagerProxy* playbackSessionManager() { return m_playbackSessionManager.get(); }
-    VideoPresentationManagerProxy* videoPresentationManager();
+    VideoPresentationManagerProxy* NODELETE videoPresentationManager();
     void setMockVideoPresentationModeEnabled(bool);
 #endif
 
@@ -1029,7 +1029,7 @@ public:
 
     bool shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem&);
 
-    bool willHandleHorizontalScrollEvents() const;
+    bool NODELETE willHandleHorizontalScrollEvents() const;
 
     void updateWebsitePolicies(const API::WebsitePolicies&);
 
@@ -1037,7 +1037,7 @@ public:
 
     String currentURL() const;
 
-    const WebCore::FloatBoxExtent& obscuredContentInsets() const;
+    const WebCore::FloatBoxExtent& NODELETE obscuredContentInsets() const;
     void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
 #if PLATFORM(MAC)
@@ -1060,7 +1060,7 @@ public:
 #endif // PLATFORM(MAC)
 
     // Corresponds to the web content's `<meta name="theme-color">` or application manifest's `"theme_color"`.
-    WebCore::Color themeColor() const;
+    WebCore::Color NODELETE themeColor() const;
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
     std::optional<WebCore::SpatialBackdropSource> spatialBackdropSource() const;
@@ -1068,7 +1068,7 @@ public:
 
     void setShouldSuppressHDR(bool);
 
-    WebCore::Color underlayColor() const;
+    WebCore::Color NODELETE underlayColor() const;
     void setUnderlayColor(const WebCore::Color&);
 
     void triggerBrowsingContextGroupSwitchForNavigation(WebCore::NavigationIdentifier, WebCore::BrowsingContextGroupSwitchDecision, const WebCore::Site& responseSite, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&&);
@@ -1076,13 +1076,13 @@ public:
     // At this time, pageExtendedBackgroundColor can be set via pageExtendedBackgroundColorDidChange() which is a message
     // from the UIProcess, or by didCommitLayerTree(). When PLATFORM(MAC) adopts UI side compositing, we should get rid of
     // the message entirely.
-    WebCore::Color pageExtendedBackgroundColor() const;
+    WebCore::Color NODELETE pageExtendedBackgroundColor() const;
 
-    WebCore::Color sampledPageTopColor() const;
+    WebCore::Color NODELETE sampledPageTopColor() const;
 
     WebCore::Color underPageBackgroundColor() const;
     WebCore::Color underPageBackgroundColorIgnoringPlatformColor() const;
-    WebCore::Color underPageBackgroundColorOverride() const;
+    WebCore::Color NODELETE underPageBackgroundColorOverride() const;
     void setUnderPageBackgroundColorOverride(WebCore::Color&&);
 
     void viewWillStartLiveResize();
@@ -1093,7 +1093,7 @@ public:
     void clearSelection(std::optional<WebCore::FrameIdentifier> = std::nullopt);
     void restoreSelectionInFocusedEditableElement();
 
-    PageClient* pageClient() const;
+    PageClient* NODELETE pageClient() const;
 
     void setViewNeedsDisplay(const WebCore::Region&);
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated, WebCore::InterruptScrollAnimation);
@@ -1112,7 +1112,7 @@ public:
     void setHasModelElement(bool);
 #endif
 
-    void setPrivateClickMeasurement(std::nullopt_t);
+    void NODELETE setPrivateClickMeasurement(std::nullopt_t);
     void setPrivateClickMeasurement(WebCore::PrivateClickMeasurement&&);
     void setPrivateClickMeasurement(WebCore::PrivateClickMeasurement&&, String sourceDescription, String purchaser);
     void setPrivateClickMeasurementImmediately(WebCore::PrivateClickMeasurement&&);
@@ -1124,31 +1124,31 @@ public:
         String sourceDescription;
         String purchaser;
     };
-    std::optional<EventAttribution> privateClickMeasurementEventAttribution() const;
+    std::optional<EventAttribution> NODELETE privateClickMeasurementEventAttribution() const;
 
     enum class ActivityStateChangeDispatchMode : bool { Deferrable, Immediate };
     enum class ActivityStateChangeReplyMode : bool { Asynchronous, Synchronous };
     void activityStateDidChange(OptionSet<WebCore::ActivityState> mayHaveChanged, ActivityStateChangeDispatchMode = ActivityStateChangeDispatchMode::Deferrable, ActivityStateChangeReplyMode = ActivityStateChangeReplyMode::Asynchronous);
-    bool isInWindow() const;
+    bool NODELETE isInWindow() const;
     void waitForDidUpdateActivityState(ActivityStateChangeID);
     void didUpdateActivityState() { m_waitingForDidUpdateActivityState = false; }
 
     WebCore::IntSize viewSize() const;
-    bool isViewVisible() const;
-    bool isViewFocused() const;
-    bool isViewWindowActive() const;
+    bool NODELETE isViewVisible() const;
+    bool NODELETE isViewFocused() const;
+    bool NODELETE isViewWindowActive() const;
 
-    WindowKind windowKind() const;
+    WindowKind NODELETE windowKind() const;
 
     void selectAll();
     void executeEditCommand(const String& commandName, const String& argument = String());
     void executeEditCommand(const String& commandName, const String& argument, CompletionHandler<void()>&&);
     void validateCommand(const String& commandName, CompletionHandler<void(bool, int32_t)>&&);
 
-    const EditorState& editorState() const;
+    const EditorState& NODELETE editorState() const;
     bool canDelete() const { return hasSelectedRange() && isContentEditable(); }
-    bool hasSelectedRange() const;
-    bool isContentEditable() const;
+    bool NODELETE hasSelectedRange() const;
+    bool NODELETE isContentEditable() const;
 
     void increaseListLevel();
     void decreaseListLevel();
@@ -1156,18 +1156,18 @@ public:
 
     void setBaseWritingDirection(WebCore::WritingDirection);
 
-    bool maintainsInactiveSelection() const;
-    void setMaintainsInactiveSelection(bool);
+    bool NODELETE maintainsInactiveSelection() const;
+    void NODELETE setMaintainsInactiveSelection(bool);
     void setEditable(bool);
     bool isEditable() const { return m_isEditable; }
 
     void activateMediaStreamCaptureInPage();
-    bool isMediaStreamCaptureMuted() const;
+    bool NODELETE isMediaStreamCaptureMuted() const;
     void setMediaStreamCaptureMuted(bool);
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     void isConnectedToHardwareConsoleDidChange();
 #endif
-    bool isAllowedToChangeMuteState() const;
+    bool NODELETE isAllowedToChangeMuteState() const;
 
     void requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&&);
 
@@ -1427,7 +1427,7 @@ public:
     WPEView* wpeView() const;
 #endif
 
-    const std::optional<WebCore::Color>& backgroundColor() const;
+    const std::optional<WebCore::Color>& NODELETE backgroundColor() const;
     void setBackgroundColor(const std::optional<WebCore::Color>&);
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
@@ -1447,7 +1447,7 @@ public:
     void startDeferringIntersectionObservations();
     void flushDeferredIntersectionObservations();
 
-    bool isProcessingMouseEvents() const;
+    bool NODELETE isProcessingMouseEvents() const;
     void processNextQueuedMouseEvent();
     void sendMouseEvent(WebCore::FrameIdentifier, const NativeWebMouseEvent&, std::optional<Vector<SandboxExtensionHandle>>&&);
     void handleMouseEvent(const NativeWebMouseEvent&);
@@ -1457,12 +1457,12 @@ public:
     void didFinishProcessingAllPendingMouseEvents();
     void flushPendingMouseEventCallbacks();
 
-    bool isProcessingWheelEvents() const;
+    bool NODELETE isProcessingWheelEvents() const;
     void handleNativeWheelEvent(const NativeWebWheelEvent&);
     void continueWheelEventHandling(const WebWheelEvent&, const WebCore::WheelEventHandlingResult&, std::optional<bool> willStartSwipe);
     void wheelEventHandlingCompleted(bool wasHandled);
 
-    bool isProcessingKeyboardEvents() const;
+    bool NODELETE isProcessingKeyboardEvents() const;
     void sendKeyEvent(const NativeWebKeyboardEvent&);
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);
 #if PLATFORM(WIN)
@@ -1531,23 +1531,23 @@ public:
     double textZoomFactor() const { return m_textZoomFactor; }
     void setTextZoomFactor(double);
 
-    double pageZoomFactor() const;
+    double NODELETE pageZoomFactor() const;
     void setPageZoomFactor(double);
 
     void setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor);
 
-    double minPageZoomFactor() const;
-    double maxPageZoomFactor() const;
+    double NODELETE minPageZoomFactor() const;
+    double NODELETE maxPageZoomFactor() const;
 
     void scalePage(double scale, const WebCore::IntPoint& origin, CompletionHandler<void()>&&);
     void scalePageInViewCoordinates(double scale, const WebCore::IntPoint& centerInViewCoordinates);
     void scalePageRelativeToScrollPosition(double scale, const WebCore::IntPoint& origin);
-    double pageScaleFactor() const;
+    double NODELETE pageScaleFactor() const;
     double viewScaleFactor() const { return m_viewScaleFactor; }
     void scaleView(double scale);
     void setShouldScaleViewToFitDocument(bool);
     
-    float deviceScaleFactor() const;
+    float NODELETE deviceScaleFactor() const;
 #if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
     float intrinsicDeviceScaleFactor() const { return m_intrinsicDeviceScaleFactor; }
 #endif
@@ -1576,17 +1576,17 @@ public:
     void setUseFixedLayout(bool);
     void setFixedLayoutSize(const WebCore::IntSize&);
     bool useFixedLayout() const { return m_useFixedLayout; };
-    const WebCore::IntSize& fixedLayoutSize() const;
+    const WebCore::IntSize& NODELETE fixedLayoutSize() const;
 
     void setDefaultUnobscuredSize(const WebCore::FloatSize&);
-    WebCore::FloatSize defaultUnobscuredSize() const;
+    WebCore::FloatSize NODELETE defaultUnobscuredSize() const;
     void setMinimumUnobscuredSize(const WebCore::FloatSize&);
-    WebCore::FloatSize minimumUnobscuredSize() const;
+    WebCore::FloatSize NODELETE minimumUnobscuredSize() const;
     void setMaximumUnobscuredSize(const WebCore::FloatSize&);
-    WebCore::FloatSize maximumUnobscuredSize() const;
+    WebCore::FloatSize NODELETE maximumUnobscuredSize() const;
 
     void setViewExposedRect(std::optional<WebCore::FloatRect>);
-    std::optional<WebCore::FloatRect> viewExposedRect() const;
+    std::optional<WebCore::FloatRect> NODELETE viewExposedRect() const;
 
     void setAlwaysShowsHorizontalScroller(bool);
     void setAlwaysShowsVerticalScroller(bool);
@@ -1601,31 +1601,31 @@ public:
     void setSuppressScrollbarAnimations(bool);
     bool areScrollbarAnimationsSuppressed() const { return m_suppressScrollbarAnimations; }
 
-    WebCore::RectEdges<bool> pinnedState() const;
+    WebCore::RectEdges<bool> NODELETE pinnedState() const;
 
     WebCore::RectEdges<bool> rubberBandableEdgesRespectingHistorySwipe() const;
-    WebCore::RectEdges<bool> rubberBandableEdges() const;
-    void setRubberBandableEdges(WebCore::RectEdges<bool>);
-    void setRubberBandsAtLeft(bool);
-    void setRubberBandsAtRight(bool);
-    void setRubberBandsAtTop(bool);
-    void setRubberBandsAtBottom(bool);
+    WebCore::RectEdges<bool> NODELETE rubberBandableEdges() const;
+    void NODELETE setRubberBandableEdges(WebCore::RectEdges<bool>);
+    void NODELETE setRubberBandsAtLeft(bool);
+    void NODELETE setRubberBandsAtRight(bool);
+    void NODELETE setRubberBandsAtTop(bool);
+    void NODELETE setRubberBandsAtBottom(bool);
 
-    bool alwaysBounceVertical() const;
-    void setAlwaysBounceVertical(bool);
-    bool alwaysBounceHorizontal() const;
-    void setAlwaysBounceHorizontal(bool);
+    bool NODELETE alwaysBounceVertical() const;
+    void NODELETE setAlwaysBounceVertical(bool);
+    bool NODELETE alwaysBounceHorizontal() const;
+    void NODELETE setAlwaysBounceHorizontal(bool);
 
     void setShouldUseImplicitRubberBandControl(bool shouldUseImplicitRubberBandControl) { m_shouldUseImplicitRubberBandControl = shouldUseImplicitRubberBandControl; }
     bool shouldUseImplicitRubberBandControl() const { return m_shouldUseImplicitRubberBandControl; }
         
     void setEnableVerticalRubberBanding(bool);
-    bool verticalRubberBandingIsEnabled() const;
+    bool NODELETE verticalRubberBandingIsEnabled() const;
     void setEnableHorizontalRubberBanding(bool);
-    bool horizontalRubberBandingIsEnabled() const;
+    bool NODELETE horizontalRubberBandingIsEnabled() const;
         
     void setBackgroundExtendsBeyondPage(bool);
-    bool backgroundExtendsBeyondPage() const;
+    bool NODELETE backgroundExtendsBeyondPage() const;
 
     void setPaginationMode(WebCore::PaginationMode);
     WebCore::PaginationMode paginationMode() const { return m_paginationMode; }
@@ -1842,10 +1842,10 @@ public:
     WebProcessProxy* WTF_NONNULL legacyMainFrameProcessPtrForSwift() const SWIFT_NAME(legacyMainFrameProcess()) { return &legacyMainFrameProcess(); }
     WebProcessProxy& legacyMainFrameProcess() const SWIFT_NAME(__legacyMainFrameProcessUnsafe()) { return m_legacyMainFrameProcess; }
 
-    ProcessID legacyMainFrameProcessID() const;
+    ProcessID NODELETE legacyMainFrameProcessID() const;
 
     ProcessID gpuProcessID() const;
-    ProcessID modelProcessID() const;
+    ProcessID NODELETE modelProcessID() const;
 
     // rdar://168057355
     WebBackForwardCache* WTF_NONNULL backForwardCachePtrForSwift() const SWIFT_NAME(backForwardCache()) { return &backForwardCache(); }
@@ -1860,16 +1860,16 @@ public:
 
     WebPageGroup& pageGroup() { return m_pageGroup; }
 
-    bool hasRunningProcess() const;
+    bool NODELETE hasRunningProcess() const;
     void launchInitialProcessIfNecessary();
 
 #if ENABLE(DRAG_SUPPORT)
     std::optional<WebCore::DragOperation> currentDragOperation() const { return m_currentDragOperation; }
-    WebCore::DragHandlingMethod currentDragHandlingMethod() const;
+    WebCore::DragHandlingMethod NODELETE currentDragHandlingMethod() const;
     bool currentDragIsOverFileInput() const { return m_currentDragIsOverFileInput; }
     unsigned currentDragNumberOfFilesToBeAccepted() const { return m_currentDragNumberOfFilesToBeAccepted; }
-    WebCore::IntRect currentDragCaretRect() const;
-    WebCore::IntRect currentDragCaretEditableElementRect() const;
+    WebCore::IntRect NODELETE currentDragCaretRect() const;
+    WebCore::IntRect NODELETE currentDragCaretEditableElementRect() const;
     void resetCurrentDragInformation();
 #endif
 
@@ -1923,7 +1923,7 @@ public:
 #endif
 
     void setCanRunModal(bool);
-    bool canRunModal();
+    bool NODELETE canRunModal();
 
     void beginPrinting(WebFrameProxy*, const PrintInfo&);
     void endPrinting(CompletionHandler<void()>&& = [] { });
@@ -1942,7 +1942,7 @@ public:
     void drawPagesForPrinting(WebFrameProxy&, const PrintInfo&, CompletionHandler<void(std::optional<WebCore::SharedMemoryHandle>&&, WebCore::ResourceError&&)>&&);
 #endif
 
-    const PageLoadState& pageLoadState() const;
+    const PageLoadState& NODELETE pageLoadState() const;
     PageLoadState& pageLoadState();
 
 #if PLATFORM(COCOA)
@@ -1962,7 +1962,7 @@ public:
     void pdfOpenWithPreview(PDFPluginIdentifier, WebCore::FrameIdentifier);
 #endif
 
-    WebCore::IntRect visibleScrollerThumbRect() const;
+    WebCore::IntRect NODELETE visibleScrollerThumbRect() const;
 
     uint64_t renderTreeSize() const { return m_renderTreeSize; }
 
@@ -1970,7 +1970,7 @@ public:
 
     enum class FromApplication : bool { No, Yes };
     void setMuted(WebCore::MediaProducerMutedStateFlags, FromApplication = FromApplication::No, CompletionHandler<void()>&& = [] { });
-    bool isAudioMuted() const;
+    bool NODELETE isAudioMuted() const;
     void setMayStartMediaWhenInWindow(bool);
     bool mayStartMediaWhenInWindow() const { return m_mayStartMediaWhenInWindow; }
     void setMediaCaptureEnabled(bool);
@@ -2026,10 +2026,10 @@ public:
 
     bool isLayerTreeFrozenDueToSwipeAnimation() const { return m_isLayerTreeFrozenDueToSwipeAnimation; }
 
-    WebCore::IntSize minimumSizeForAutoLayout() const;
+    WebCore::IntSize NODELETE minimumSizeForAutoLayout() const;
     void setMinimumSizeForAutoLayout(const WebCore::IntSize&);
 
-    WebCore::IntSize sizeToContentAutoSizeMaximumSize() const;
+    WebCore::IntSize NODELETE sizeToContentAutoSizeMaximumSize() const;
     void setSizeToContentAutoSizeMaximumSize(const WebCore::IntSize&);
 
     bool autoSizingShouldExpandToViewHeight() const { return m_autoSizingShouldExpandToViewHeight; }
@@ -2051,7 +2051,7 @@ public:
     void didCancelCheckingText(TextCheckerRequestID);
         
     void setScrollPinningBehavior(WebCore::ScrollPinningBehavior);
-    WebCore::ScrollPinningBehavior scrollPinningBehavior() const;
+    WebCore::ScrollPinningBehavior NODELETE scrollPinningBehavior() const;
 
     void setOverlayScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle>);
     std::optional<WebCore::ScrollbarOverlayStyle> overlayScrollbarStyle() const { return m_scrollbarOverlayStyle; }
@@ -2093,20 +2093,20 @@ public:
     void willBeginViewGesture();
     void didEndViewGesture();
 
-    bool isPlayingAudio() const;
-    bool hasMediaStreaming() const;
+    bool NODELETE isPlayingAudio() const;
+    bool NODELETE hasMediaStreaming() const;
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
     void updateReportedMediaCaptureState();
 
     enum class CanDelayNotification : bool { No, Yes };
     void updatePlayingMediaDidChange(CanDelayNotification = CanDelayNotification::No);
     void updatePlayingMediaDidChangeTimerFired();
-    bool isCapturingAudio() const;
-    bool isCapturingVideo() const;
-    bool hasActiveAudioStream() const;
-    bool hasActiveVideoStream() const;
-    WebCore::MediaProducerMediaStateFlags reportedMediaState() const;
-    WebCore::MediaProducerMutedStateFlags mutedStateFlags() const;
+    bool NODELETE isCapturingAudio() const;
+    bool NODELETE isCapturingVideo() const;
+    bool NODELETE hasActiveAudioStream() const;
+    bool NODELETE hasActiveVideoStream() const;
+    WebCore::MediaProducerMediaStateFlags NODELETE reportedMediaState() const;
+    WebCore::MediaProducerMutedStateFlags NODELETE mutedStateFlags() const;
 
     void handleAutoplayEvent(WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>);
 
@@ -2287,7 +2287,7 @@ public:
     void registerAttachmentIdentifier(IPC::Connection&, const String&);
     void didInvalidateDataForAttachment(API::Attachment&);
     enum class ShouldUpdateAttachmentAttributes : bool { No, Yes };
-    ShouldUpdateAttachmentAttributes willUpdateAttachmentAttributes(const API::Attachment&);
+    ShouldUpdateAttachmentAttributes NODELETE willUpdateAttachmentAttributes(const API::Attachment&);
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -2296,9 +2296,9 @@ public:
 
     void getTextFragmentMatch(CompletionHandler<void(const String&)>&&);
 
-    const WebPreferencesStore& preferencesStore() const;
+    const WebPreferencesStore& NODELETE preferencesStore() const;
 
-    bool isPageOpenedByDOMShowingInitialEmptyDocument() const;
+    bool NODELETE isPageOpenedByDOMShowingInitialEmptyDocument() const;
 
     WebCore::IntRect syncRootViewToScreen(const WebCore::IntRect& viewRect);
 
@@ -2360,7 +2360,7 @@ public:
 #endif
 
     Logger& logger();
-    uint64_t logIdentifier() const;
+    uint64_t NODELETE logIdentifier() const;
 
     // IPC::MessageReceiver
     // Implemented in generated WebPageProxyMessageReceiver.cpp
@@ -2374,9 +2374,9 @@ public:
 #if ENABLE(MEDIA_STREAM)
     void setMockCaptureDevicesEnabledOverride(std::optional<bool>);
     void willStartCapture(UserMediaPermissionRequestProxy&, CompletionHandler<void()>&&);
-    void startMonitoringCaptureDeviceRotation(const String&);
-    void stopMonitoringCaptureDeviceRotation(const String&);
-    void rotationAngleForCaptureDeviceChanged(const String&, WebCore::VideoFrameRotation);
+    void NODELETE startMonitoringCaptureDeviceRotation(const String&);
+    void NODELETE stopMonitoringCaptureDeviceRotation(const String&);
+    void NODELETE rotationAngleForCaptureDeviceChanged(const String&, WebCore::VideoFrameRotation);
     void microphoneMuteStatusChanged(bool isMuting);
 #endif
 
@@ -2417,8 +2417,8 @@ public:
     bool isHandlingPreventableTouchMove() const { return m_touchMovePreventionState == EventPreventionState::Waiting; }
     bool isHandlingPreventableTouchEnd() const { return m_handlingPreventableTouchEndCount; }
 
-    bool hasQueuedKeyEvent() const;
-    const NativeWebKeyboardEvent& firstQueuedKeyEvent() const;
+    bool NODELETE hasQueuedKeyEvent() const;
+    const NativeWebKeyboardEvent& NODELETE firstQueuedKeyEvent() const;
 
     void grantAccessToAssetServices();
     void revokeAccessToAssetServices();
@@ -2476,7 +2476,7 @@ public:
     bool canEnterFullscreen();
     void enterFullscreen();
 
-    void failedToEnterFullscreen(PlaybackSessionContextIdentifier);
+    void NODELETE failedToEnterFullscreen(PlaybackSessionContextIdentifier);
     void willEnterFullscreen(PlaybackSessionContextIdentifier);
     void didEnterFullscreen(PlaybackSessionContextIdentifier);
     void didExitFullscreen(PlaybackSessionContextIdentifier);
@@ -2548,7 +2548,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-    UserMediaPermissionRequestManagerProxy* userMediaPermissionRequestManagerIfExists();
+    UserMediaPermissionRequestManagerProxy* NODELETE userMediaPermissionRequestManagerIfExists();
     WebCore::CaptureSourceOrError createRealtimeMediaSourceForSpeechRecognition();
     void clearUserMediaPermissionRequestHistory(WebCore::PermissionName);
     bool shouldListenToVoiceActivity() const { return m_shouldListenToVoiceActivity; }
@@ -2631,7 +2631,7 @@ public:
     void broadcastAllFrameTreeSyncData(IPC::Connection&, WebCore::FrameIdentifier,  Ref<WebCore::FrameTreeSyncData>&&);
 
     void addOpenedPage(WebPageProxy&);
-    bool hasOpenedPage() const;
+    bool NODELETE hasOpenedPage() const;
     bool hasPageOpenedByMainFrame() const;
 
     void requestImageBitmap(const WebCore::ElementContext&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&, const String& sourceMIMEType)>&&);
@@ -2708,9 +2708,9 @@ public:
     void restartXRSessionActivityOnProcessResumeIfNeeded();
 #endif
 
-    WebColorPickerClient& colorPickerClient();
+    WebColorPickerClient& NODELETE colorPickerClient();
 
-    WebPopupMenuProxyClient& popupMenuClient();
+    WebPopupMenuProxyClient& NODELETE popupMenuClient();
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtectionsPolicies() const { return m_advancedPrivacyProtectionsPolicies; }
@@ -2720,7 +2720,7 @@ public:
     void preferredBufferFormatsDidChange();
 #endif
 
-    WebPageProxyMessageReceiverRegistration& messageReceiverRegistration();
+    WebPageProxyMessageReceiverRegistration& NODELETE messageReceiverRegistration();
 
 #if HAVE(ESIM_AUTOFILL_SYSTEM_SUPPORT)
     bool shouldAllowAutoFillForCellularIdentifiers() const;
@@ -2818,7 +2818,7 @@ public:
     void sendScrollUpdateForNode(std::optional<WebCore::FrameIdentifier>, WebCore::ScrollUpdate, bool isLastUpdate);
 #endif
 
-    bool hasAllowedToRunInTheBackgroundActivity() const;
+    bool NODELETE hasAllowedToRunInTheBackgroundActivity() const;
 
     template<typename M> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&, OptionSet<IPC::SendOption> = { });
     template<typename M, typename C> void sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(std::optional<WebCore::FrameIdentifier>, M&&, C&&, OptionSet<IPC::SendOption> = { });
@@ -2853,7 +2853,7 @@ public:
     BrowsingContextGroup& browsingContextGroup() const SWIFT_NAME(__browsingContextGroupUnsafe()) { return m_browsingContextGroup; }
     std::optional<WebCore::FrameIdentifier> openerFrameIdentifier() const { return m_openerFrameIdentifier; }
 
-    WebPageProxyTesting* pageForTesting() const;
+    WebPageProxyTesting* NODELETE pageForTesting() const;
 
     void hasActiveNowPlayingSessionChanged(bool);
 
@@ -2892,7 +2892,7 @@ public:
     void restoreSessionStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 #if HAVE(AUDIT_TOKEN)
-    const std::optional<audit_token_t>& presentingApplicationAuditToken() const;
+    const std::optional<audit_token_t>& NODELETE presentingApplicationAuditToken() const;
     void setPresentingApplicationAuditToken(const audit_token_t&);
 #endif
 
@@ -2950,7 +2950,7 @@ public:
 #endif
 
     friend class TextExtractionAssertionScope;
-    UniqueRef<TextExtractionAssertionScope> createTextExtractionAssertionScope();
+    UniqueRef<TextExtractionAssertionScope> NODELETE createTextExtractionAssertionScope();
 
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
@@ -3025,7 +3025,7 @@ private:
     void didExplicitOpenForFrame(IPC::Connection&, WebCore::FrameIdentifier, URL&&, String&& mimeType);
 
     void didReceiveTitleForFrame(IPC::Connection&, WebCore::FrameIdentifier, String&&, const UserData&);
-    void didFirstLayoutForFrame(WebCore::FrameIdentifier, const UserData&);
+    void NODELETE didFirstLayoutForFrame(WebCore::FrameIdentifier, const UserData&);
     void didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection&, WebCore::FrameIdentifier, const UserData&, WallTime);
     void mainFramePluginHandlesPageScaleGestureDidChange(bool, double minScale, double maxScale);
     void didStartProgress();
@@ -3085,7 +3085,7 @@ private:
     void setStatusText(const String&);
     void mouseDidMoveOverElement(WebHitTestResultData&&, OptionSet<WebEventModifier>);
 
-    void getIsViewVisible(bool&);
+    void NODELETE getIsViewVisible(bool&);
     void setIsResizable(bool isResizable);
     void screenToRootView(const WebCore::IntPoint& screenPoint, CompletionHandler<void(const WebCore::IntPoint&)>&&);
     void rootViewPointToScreen(const WebCore::IntPoint& viewPoint, CompletionHandler<void(const WebCore::IntPoint&)>&&);
@@ -3136,11 +3136,11 @@ private:
     void requestMediaKeySystemPermissionForFrame(IPC::Connection&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, WebCore::ClientOrigin&&, const String&);
 
     void runModal();
-    void notifyScrollerThumbIsVisibleInRect(const WebCore::IntRect&);
+    void NODELETE notifyScrollerThumbIsVisibleInRect(const WebCore::IntRect&);
     void recommendedScrollbarStyleDidChange(int32_t newStyle);
-    void didChangeScrollbarsForMainFrame(bool hasHorizontalScrollbar, bool hasVerticalScrollbar);
+    void NODELETE didChangeScrollbarsForMainFrame(bool hasHorizontalScrollbar, bool hasVerticalScrollbar);
     void didChangeScrollOffsetPinningForMainFrame(WebCore::RectEdges<bool>);
-    void didChangePageCount(unsigned);
+    void NODELETE didChangePageCount(unsigned);
     void themeColorChanged(const WebCore::Color&);
     void pageExtendedBackgroundColorDidChange(const WebCore::Color&);
     void sampledPageTopColorChanged(const WebCore::Color&);
@@ -3173,7 +3173,7 @@ private:
     void requestNotificationPermission(const String& originString, CompletionHandler<void(bool allowed)>&&);
 
 #if ENABLE(WEB_ARCHIVE)
-    bool shouldAlwaysPromptForPermission(WebCore::PermissionName) const;
+    bool NODELETE shouldAlwaysPromptForPermission(WebCore::PermissionName) const;
 #endif
 
     void didChangeContentSize(const WebCore::IntSize&);
@@ -3191,11 +3191,11 @@ private:
     void closeOverlayedViews();
 
     void compositionWasCanceled();
-    void setHasFocusedElementWithUserInteraction(bool);
+    void NODELETE setHasFocusedElementWithUserInteraction(bool);
 
 #if HAVE(TOUCH_BAR)
-    void setIsTouchBarUpdateSuppressedForHiddenContentEditable(bool);
-    void setIsNeverRichlyEditableForTouchBar(bool);
+    void NODELETE setIsTouchBarUpdateSuppressedForHiddenContentEditable(bool);
+    void NODELETE setIsNeverRichlyEditableForTouchBar(bool);
 #endif
 
     void requestDOMPasteAccess(IPC::Connection&, WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);
@@ -3397,7 +3397,7 @@ private:
 
     void tryReloadAfterProcessTermination();
     void resetRecentCrashCountSoon();
-    void resetRecentCrashCount();
+    void NODELETE resetRecentCrashCount();
 
     API::DiagnosticLoggingClient* effectiveDiagnosticLoggingClient(WebCore::ShouldSample);
 
@@ -3409,7 +3409,7 @@ private:
 #endif
 
     void useFixedLayoutDidChange(bool useFixedLayout) { m_useFixedLayout = useFixedLayout; }
-    void fixedLayoutSizeDidChange(WebCore::IntSize);
+    void NODELETE fixedLayoutSizeDidChange(WebCore::IntSize);
 
     void imageOrMediaDocumentSizeChanged(const WebCore::IntSize&);
 #if ENABLE(VIDEO) && USE(GSTREAMER)
@@ -3422,7 +3422,7 @@ private:
 
     bool checkURLReceivedFromCurrentOrPreviousWebProcess(WebProcessProxy&, const String&);
     bool checkURLReceivedFromCurrentOrPreviousWebProcess(WebProcessProxy&, const URL&);
-    void willAcquireUniversalFileReadSandboxExtension(WebProcessProxy&);
+    void NODELETE willAcquireUniversalFileReadSandboxExtension(WebProcessProxy&);
 
     void handleAutoFillButtonClick(IPC::Connection&, const UserData&);
 
@@ -3606,11 +3606,11 @@ private:
     bool hasValidCapturingActivity() const;
     bool hasValidMutedCaptureAssertion() const;
 
-    bool hasValidMainFrameVisibleActivity() const;
-    bool hasValidMainFrameAudibleActivity() const;
-    bool hasValidMainFrameCapturingActivity() const;
-    bool hasValidMainFrameMutedCaptureAssertion() const;
-    bool hasValidMainFrameNetworkActivity() const;
+    bool NODELETE hasValidMainFrameVisibleActivity() const;
+    bool NODELETE hasValidMainFrameAudibleActivity() const;
+    bool NODELETE hasValidMainFrameCapturingActivity() const;
+    bool NODELETE hasValidMainFrameMutedCaptureAssertion() const;
+    bool NODELETE hasValidMainFrameNetworkActivity() const;
 
 #if PLATFORM(IOS_FAMILY)
     void takeOpeningAppLinkActivity();

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -56,7 +56,7 @@ public:
     void ref() const final;
     void deref() const final;
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
 private:
     RefPtr<WebPageProxy> mostReasonableWebPageProxy(const WebCore::SecurityOriginData&, WebCore::PermissionQuerySource) const;

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -93,10 +93,10 @@ public:
     void setStringValueForKey(const String&, const String& value, bool ephemeral);
     void forceUpdate() { update(); }
 
-    void startBatchingUpdates();
+    void NODELETE startBatchingUpdates();
     void endBatchingUpdates();
 
-    static void forceSiteIsolationAlwaysOnForTesting();
+    static void NODELETE forceSiteIsolationAlwaysOnForTesting();
 
 private:
     void platformInitializeStore();

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -57,11 +57,11 @@ public:
     void dropNetworkActivity();
     void dropTextExtractionAssertion();
 
-    bool hasValidVisibleActivity() const;
-    bool hasValidAudibleActivity() const;
-    bool hasValidCapturingActivity() const;
-    bool hasValidMutedCaptureAssertion() const;
-    bool hasValidNetworkActivity() const;
+    bool NODELETE hasValidVisibleActivity() const;
+    bool NODELETE hasValidAudibleActivity() const;
+    bool NODELETE hasValidCapturingActivity() const;
+    bool NODELETE hasValidMutedCaptureAssertion() const;
+    bool NODELETE hasValidNetworkActivity() const;
 
 #if PLATFORM(IOS_FAMILY)
     void takeOpeningAppLinkActivity();
@@ -73,7 +73,7 @@ public:
     void updateWebProcessSuspensionDelay();
     void takeAccessibilityActivityWhenInWindow();
     void takeAccessibilityActivity();
-    bool hasAccessibilityActivityForTesting() const;
+    bool NODELETE hasAccessibilityActivityForTesting() const;
     void viewDidEnterWindow();
     void viewDidLeaveWindow();
 #endif

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -65,7 +65,7 @@ void WebProcessCache::setCachedProcessLifetimeForTesting(Seconds lifetime)
     m_cachedProcessLifetime = lifetime;
 }
 
-static uint64_t generateAddRequestIdentifier()
+static uint64_t NODELETE generateAddRequestIdentifier()
 {
     static uint64_t identifier = 0;
     return ++identifier;

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -65,8 +65,8 @@ public:
 
     enum class ShouldShutDownProcess : bool { No, Yes };
     void removeProcess(WebProcessProxy&, ShouldShutDownProcess);
-    static void setCachedProcessSuspensionDelayForTesting(Seconds);
-    void setCachedProcessLifetimeForTesting(Seconds);
+    static void NODELETE setCachedProcessSuspensionDelayForTesting(Seconds);
+    void NODELETE setCachedProcessLifetimeForTesting(Seconds);
 
     void ref() const final;
     void deref() const final;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -194,7 +194,7 @@ Ref<WebProcessPool> WebProcessPool::create(API::ProcessPoolConfiguration& config
     return adoptRef(*new WebProcessPool(configuration));
 }
 
-static Vector<WeakRef<WebProcessPool>>& processPools()
+static Vector<WeakRef<WebProcessPool>>& NODELETE processPools()
 {
     static NeverDestroyed<Vector<WeakRef<WebProcessPool>>> processPools;
     return processPools;
@@ -207,7 +207,7 @@ Vector<Ref<WebProcessPool>> WebProcessPool::allProcessPools()
     });
 }
 
-static HashSet<String, ASCIICaseInsensitiveHash>& globalURLSchemesWithCustomProtocolHandlers()
+static HashSet<String, ASCIICaseInsensitiveHash>& NODELETE globalURLSchemesWithCustomProtocolHandlers()
 {
     static NeverDestroyed<HashSet<String, ASCIICaseInsensitiveHash>> set;
     return set;
@@ -470,7 +470,7 @@ void WebProcessPool::setApplicationIsActive(bool isActive)
     m_webProcessCache->setApplicationIsActive(isActive);
 }
 
-static bool shouldReportNetworkOrGPUProcessCrash(ProcessTerminationReason reason)
+static bool NODELETE shouldReportNetworkOrGPUProcessCrash(ProcessTerminationReason reason)
 {
     switch (reason) {
     case ProcessTerminationReason::ExceededMemoryLimit:
@@ -1568,7 +1568,7 @@ void WebProcessPool::countWebPagesInAllProcessesForTesting(CompletionHandler<voi
     class ResultAggregator : public RefCounted<ResultAggregator> {
     public:
         static Ref<ResultAggregator> create(CompletionHandler<void(size_t)>&& completionHandler) { return adoptRef(*new ResultAggregator(WTF::move(completionHandler))); }
-        void addWebPageCount(unsigned count) { m_count += count; }
+        void NODELETE addWebPageCount(unsigned count) { m_count += count; }
         ~ResultAggregator()
         {
             m_completionHandler(m_count);
@@ -2674,7 +2674,7 @@ void WebProcessPool::isJITDisabledInAllRemoteWorkerProcesses(CompletionHandler<v
                 m_callback(m_isJITDisabled);
         }
 
-        void setJITEnabled(bool isJITEnabled) { m_isJITDisabled &= !isJITEnabled; }
+        void NODELETE setJITEnabled(bool isJITEnabled) { m_isJITDisabled &= !isJITEnabled; }
 
     private:
         explicit JITDisabledCallbackAggregator(CompletionHandler<void(bool)>&& callback)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -273,8 +273,8 @@ public:
     DisplayLinkCollection& displayLinks() { return m_displayLinks; }
 #endif
 
-    void addSupportedPlugin(String&& matchingDomain, String&& name, HashSet<String>&& mimeTypes, HashSet<String> extensions);
-    void clearSupportedPlugins();
+    void NODELETE addSupportedPlugin(String&& matchingDomain, String&& name, HashSet<String>&& mimeTypes, HashSet<String> extensions);
+    void NODELETE clearSupportedPlugins();
 
     HashSet<ProcessID> prewarmedProcessIdentifiers();
     void activePagesOriginsInWebProcessForTesting(ProcessID, CompletionHandler<void(Vector<String>&&)>&&);
@@ -344,7 +344,7 @@ public:
 
     void prewarmProcess();
 
-    bool shouldTerminate(WebProcessProxy&);
+    bool NODELETE shouldTerminate(WebProcessProxy&);
 
     void disableProcessTermination();
     void enableProcessTermination();
@@ -360,7 +360,7 @@ public:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const;
 
     bool javaScriptConfigurationFileEnabled() { return m_javaScriptConfigurationFileEnabled; }
-    void setJavaScriptConfigurationFileEnabled(bool flag);
+    void NODELETE setJavaScriptConfigurationFileEnabled(bool flag);
 #if PLATFORM(IOS_FAMILY)
     void setJavaScriptConfigurationFileEnabledFromDefaults();
 #endif
@@ -428,7 +428,7 @@ public:
 
     void windowServerConnectionStateChanged();
 
-    static void setInvalidMessageCallback(void (*)(WKStringRef));
+    static void NODELETE setInvalidMessageCallback(void (*)(WKStringRef));
     static void didReceiveInvalidMessage(IPC::MessageName);
 
     bool isURLKnownHSTSHost(const String& urlString) const;
@@ -536,7 +536,7 @@ public:
     WebProcessWithAudibleMediaToken webProcessWithAudibleMediaToken() const;
     WebProcessWithMediaStreamingToken webProcessWithMediaStreamingToken() const;
 
-    static bool globalDelaysWebProcessLaunchDefaultValue();
+    static bool NODELETE globalDelaysWebProcessLaunchDefaultValue();
     bool delaysWebProcessLaunchDefaultValue() const { return m_delaysWebProcessLaunchDefaultValue; }
     void setDelaysWebProcessLaunchDefaultValue(bool delaysWebProcessLaunchDefaultValue) { m_delaysWebProcessLaunchDefaultValue = delaysWebProcessLaunchDefaultValue; }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1827,7 +1827,7 @@ RefPtr<API::Object> WebProcessProxy::transformHandlesToObjects(API::Object* obje
             }
         }
 
-        WebProcessProxy& process() const { return m_webProcessProxy; }
+        WebProcessProxy& NODELETE process() const { return m_webProcessProxy; }
 
         WeakRef<WebProcessProxy> m_webProcessProxy;
     };

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -251,10 +251,10 @@ public:
     WebsiteDataStore* websiteDataStore() const { ASSERT(m_websiteDataStore); return m_websiteDataStore.get(); }
     void setWebsiteDataStore(WebsiteDataStore&);
     
-    PAL::SessionID sessionID() const;
+    PAL::SessionID NODELETE sessionID() const;
 
     static bool hasReachedProcessCountLimit();
-    static void setProcessCountLimit(unsigned);
+    static void NODELETE setProcessCountLimit(unsigned);
 
     static RefPtr<WebProcessProxy> processForIdentifier(WebCore::ProcessIdentifier);
     static Ref<WebProcessProxy> fromConnection(const IPC::Connection&);
@@ -310,7 +310,7 @@ public:
 
     void consumeIfNotVerifiablyFromUIProcess(WebCore::PageIdentifier, API::UserInitiatedAction&, std::optional<WTF::UUID>);
 
-    bool isResponsive() const;
+    bool NODELETE isResponsive() const;
 
     VisibleWebPageToken visiblePageToken() const;
 
@@ -550,15 +550,15 @@ public:
     void hardwareConsoleStateChanged();
 #endif
 
-    const WeakHashSet<WebProcessProxy>* serviceWorkerClientProcesses() const;
-    const WeakHashSet<WebProcessProxy>* sharedWorkerClientProcesses() const;
+    const WeakHashSet<WebProcessProxy>* NODELETE serviceWorkerClientProcesses() const;
+    const WeakHashSet<WebProcessProxy>* NODELETE sharedWorkerClientProcesses() const;
 
     static void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
     void processPermissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
 
     Logger& logger();
 
-    void resetState();
+    void NODELETE resetState();
 
     ProcessThrottleState throttleStateForStatistics() const { return m_throttleStateForStatistics; }
     Seconds totalForegroundTime() const;
@@ -597,10 +597,10 @@ public:
     void createWasmDebuggerTarget();
     bool createWasmDebuggerDebuggable() const { return m_createWasmDebuggerDebuggable; }
     void destroyWasmDebuggerTarget();
-    void connectWasmDebuggerTarget(bool isAutomaticConnection, bool immediatelyPause);
-    void disconnectWasmDebuggerTarget();
+    void NODELETE connectWasmDebuggerTarget(bool isAutomaticConnection, bool immediatelyPause);
+    void NODELETE disconnectWasmDebuggerTarget();
     void dispatchWasmDebuggerMessage(const String& message);
-    void setWasmDebuggerTargetIndicating(bool);
+    void NODELETE setWasmDebuggerTargetIndicating(bool);
 
     void sendWasmDebuggerResponse(const String& response);
 #endif
@@ -648,9 +648,9 @@ private:
     void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
 
     using WebProcessProxyMap = HashMap<WebCore::ProcessIdentifier, CheckedRef<WebProcessProxy>>;
-    static WebProcessProxyMap& allProcessMap();
+    static WebProcessProxyMap& NODELETE allProcessMap();
     static Vector<Ref<WebProcessProxy>> allProcesses();
-    static WebPageProxyMap& globalPageMap();
+    static WebPageProxyMap& NODELETE globalPageMap();
     static Vector<Ref<WebPageProxy>> globalPages();
 
     void initializePreferencesForGPUAndNetworkProcesses(const WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -66,7 +66,7 @@ public:
     void currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&&);
     void lock(WebCore::ScreenOrientationLockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void unlock();
-    void setShouldSendChangeNotification(bool);
+    void NODELETE setShouldSendChangeNotification(bool);
 
 private:
     WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -784,7 +784,7 @@ void WebsiteDataStore::reinitializeAppBoundDomains()
 
 
 #if ENABLE(MANAGED_DOMAINS)
-static HashSet<WebCore::RegistrableDomain>& managedDomains()
+static HashSet<WebCore::RegistrableDomain>& NODELETE managedDomains()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<HashSet<WebCore::RegistrableDomain>> managedDomains;

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
@@ -43,7 +43,7 @@ class WebDeviceOrientationAndMotionAccessController : public CanMakeWeakPtr<WebD
 public:
     WebDeviceOrientationAndMotionAccessController(WebsiteDataStore&);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void shouldAllowAccess(WebPageProxy&, WebFrameProxy&, FrameInfoData&&, bool mayPrompt, CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>&&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -113,13 +113,13 @@ void WebsiteDataStore::allowWebsiteDataRecordsForAllOrigins()
     allowsWebsiteDataRecordsForAllOrigins = true;
 }
 
-static HashMap<String, PAL::SessionID>& activeGeneralStorageDirectories()
+static HashMap<String, PAL::SessionID>& NODELETE activeGeneralStorageDirectories()
 {
     static MainRunLoopNeverDestroyed<HashMap<String, PAL::SessionID>> directoryToSessionMap;
     return directoryToSessionMap;
 }
 
-static HashMap<PAL::SessionID, WeakRef<WebsiteDataStore>>& allDataStores()
+static HashMap<PAL::SessionID, WeakRef<WebsiteDataStore>>& NODELETE allDataStores()
 {
     RELEASE_ASSERT(isUIThread());
     static NeverDestroyed<HashMap<PAL::SessionID, WeakRef<WebsiteDataStore>>> map;
@@ -215,19 +215,19 @@ WebsiteDataStore::~WebsiteDataStore()
 }
 
 // FIXME: Remove this when rdar://95786441 is resolved.
-static RefPtr<WebsiteDataStore>& protectedGlobalDefaultDataStore()
+static RefPtr<WebsiteDataStore>& NODELETE protectedGlobalDefaultDataStore()
 {
     static NeverDestroyed<RefPtr<WebsiteDataStore>> globalDefaultDataStore;
     return globalDefaultDataStore.get();
 }
 
-static WeakPtr<WebsiteDataStore>& globalDefaultDataStore()
+static WeakPtr<WebsiteDataStore>& NODELETE globalDefaultDataStore()
 {
     static NeverDestroyed<WeakPtr<WebsiteDataStore>> globalDefaultDataStore;
     return globalDefaultDataStore.get();
 }
 
-static IsPersistent defaultDataStoreIsPersistent()
+static IsPersistent NODELETE defaultDataStoreIsPersistent()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     // GTK and WPE ports require explicit configuration of a WebsiteDataStore. All default storage
@@ -587,7 +587,7 @@ static WebsiteDataStore::ProcessAccessType computeNetworkProcessAccessTypeForDat
     return WebsiteDataStore::ProcessAccessType::None;
 }
 
-static WebsiteDataStore::ProcessAccessType computeWebProcessAccessTypeForDataFetch(OptionSet<WebsiteDataType> dataTypes, bool /* isNonPersistentStore */)
+static WebsiteDataStore::ProcessAccessType NODELETE computeWebProcessAccessTypeForDataFetch(OptionSet<WebsiteDataType> dataTypes, bool /* isNonPersistentStore */)
 {
     if (dataTypes.contains(WebsiteDataType::MemoryCache))
         return WebsiteDataStore::ProcessAccessType::OnlyIfLaunched;
@@ -635,7 +635,7 @@ void WebsiteDataStore::fetchDataAndApply(OptionSet<WebsiteDataType> dataTypes, O
             });
         }
 
-        const OptionSet<WebsiteDataFetchOption>& fetchOptions() const { return m_fetchOptions; }
+        const OptionSet<WebsiteDataFetchOption>& NODELETE fetchOptions() const { return m_fetchOptions; }
 
         void addWebsiteData(WebsiteData&& websiteData)
         {
@@ -873,7 +873,7 @@ auto WebsiteDataStore::computeWebProcessAccessTypeForDataRemoval(OptionSet<Websi
     return ProcessAccessType::None;
 }
 
-static WebsiteDataStore::ProcessAccessType computeWebProcessAccessTypeForDataRemovalWithRecords(OptionSet<WebsiteDataType> dataTypes)
+static WebsiteDataStore::ProcessAccessType NODELETE computeWebProcessAccessTypeForDataRemovalWithRecords(OptionSet<WebsiteDataType> dataTypes)
 {
     // FIXME: We currently don't remove resource load statistics in web process for origin data removal as TestRunner might dead lock.
     if (dataTypes.contains(WebsiteDataType::MemoryCache))

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -129,7 +129,7 @@ using RemoveDataTaskCounter = RefCounter<RemoveDataTaskCounterType>;
 class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore> {
 public:
     static WebsiteDataStore& defaultDataStore();
-    static bool defaultDataStoreExists();
+    static bool NODELETE defaultDataStoreExists();
     static void deleteDefaultDataStoreForTesting();
     static RefPtr<WebsiteDataStore> existingDataStoreForIdentifier(const WTF::UUID&);
     
@@ -149,13 +149,13 @@ public:
     NetworkProcessProxy* networkProcessIfExists() { return m_networkProcess.get(); }
     void setNetworkProcess(NetworkProcessProxy&);
     
-    static WebsiteDataStore* existingDataStoreForSessionID(PAL::SessionID);
+    static WebsiteDataStore* NODELETE existingDataStoreForSessionID(PAL::SessionID);
 
     bool isPersistent() const { return !m_sessionID.isEphemeral(); }
     PAL::SessionID sessionID() const { return m_sessionID; }
 
     enum class ProcessAccessType : uint8_t { None, OnlyIfLaunched, Launch };
-    static ProcessAccessType computeWebProcessAccessTypeForDataRemoval(OptionSet<WebsiteDataType> dataTypes, bool /* isNonPersistentStore */);
+    static ProcessAccessType NODELETE computeWebProcessAccessTypeForDataRemoval(OptionSet<WebsiteDataType> dataTypes, bool /* isNonPersistentStore */);
     
     void registerProcess(WebProcessProxy&);
     void unregisterProcess(WebProcessProxy&);
@@ -169,12 +169,12 @@ public:
     void sendNetworkProcessWillSuspendImminentlyForTesting();
     void sendNetworkProcessDidResume();
     void networkProcessDidTerminate(NetworkProcessProxy&);
-    static void makeNextNetworkProcessLaunchFailForTesting();
-    static bool shouldMakeNextNetworkProcessLaunchFailForTesting();
+    static void NODELETE makeNextNetworkProcessLaunchFailForTesting();
+    static bool NODELETE shouldMakeNextNetworkProcessLaunchFailForTesting();
 
     bool trackingPreventionEnabled() const;
     void setTrackingPreventionEnabled(bool);
-    bool resourceLoadStatisticsDebugMode() const;
+    bool NODELETE resourceLoadStatisticsDebugMode() const;
     void setResourceLoadStatisticsDebugMode(bool);
     void setResourceLoadStatisticsDebugMode(bool, CompletionHandler<void()>&&);
     void isResourceLoadStatisticsEphemeral(CompletionHandler<void(bool)>&&) const;
@@ -195,7 +195,7 @@ public:
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     bool computeIsOptInCookiePartitioningEnabled() const;
 #endif
-    void propagateSettingUpdates();
+    void NODELETE propagateSettingUpdates();
 
 #if PLATFORM(IOS_FAMILY)
     String resolvedCookieStorageDirectory();
@@ -339,7 +339,7 @@ public:
     void setHTTPCookieAcceptPolicy(WebCore::HTTPCookieAcceptPolicy);
 #endif
 
-    static void allowWebsiteDataRecordsForAllOrigins();
+    static void NODELETE allowWebsiteDataRecordsForAllOrigins();
 
 #if HAVE(SEC_KEY_PROXY)
     void addSecKeyProxyStore(Ref<SecKeyProxyStore>&&);

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -181,7 +181,7 @@ bool DisplayCaptureSessionManager::canRequestDisplayCapturePermission()
 }
 
 #if HAVE(SCREEN_CAPTURE_KIT)
-static WebCore::DisplayCapturePromptType toScreenCaptureKitPromptType(UserMediaPermissionRequestProxy::UserMediaDisplayCapturePromptType promptType)
+static WebCore::DisplayCapturePromptType NODELETE toScreenCaptureKitPromptType(UserMediaPermissionRequestProxy::UserMediaDisplayCapturePromptType promptType)
 {
     if (promptType == UserMediaPermissionRequestProxy::UserMediaDisplayCapturePromptType::Screen)
         return WebCore::DisplayCapturePromptType::Screen;

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -199,7 +199,7 @@ public:
         return *this << static_cast<uint32_t>(value);
     }
 
-    MallocSpan<uint8_t, HistoryEntryDataEncoderMalloc> finishEncoding(size_t& size)
+    MallocSpan<uint8_t, HistoryEntryDataEncoderMalloc> NODELETE finishEncoding(size_t& size)
     {
         size = m_bufferSize;
         return WTF::move(m_buffer);
@@ -254,10 +254,10 @@ private:
         m_buffer.realloc(newCapacity.value());
     }
 
-    size_t capacity() const { return m_buffer.span().size(); }
+    size_t NODELETE capacity() const { return m_buffer.span().size(); }
 
-    std::span<uint8_t> mutableBuffer() { return m_buffer.mutableSpan(); }
-    std::span<const uint8_t> buffer() const { return m_buffer.span(); }
+    std::span<uint8_t> NODELETE mutableBuffer() { return m_buffer.mutableSpan(); }
+    std::span<const uint8_t> NODELETE buffer() const { return m_buffer.span(); }
 
     size_t m_bufferSize { 0 };
     MallocSpan<uint8_t, HistoryEntryDataEncoderMalloc> m_buffer;
@@ -730,14 +730,14 @@ public:
         return *this;
     }
 
-    bool isValid() const { return m_isValid; }
-    void markInvalid()
+    bool NODELETE isValid() const { return m_isValid; }
+    void NODELETE markInvalid()
     {
         m_buffer = { };
         m_isValid = false;
     }
 
-    bool finishDecoding() { return m_isValid && m_buffer.empty(); }
+    bool NODELETE finishDecoding() { return m_isValid && m_buffer.empty(); }
 
 private:
     template<typename Type>
@@ -758,7 +758,7 @@ private:
         memcpySpan(data, consumeSpan(m_buffer, data.size()));
     }
 
-    bool alignBufferPosition(unsigned alignment, size_t size)
+    bool NODELETE alignBufferPosition(unsigned alignment, size_t size)
     {
         const uint8_t* alignedPosition = alignedBuffer(alignment);
         if (!alignedBufferIsLargeEnoughToContain(alignedPosition, size)) {
@@ -771,7 +771,7 @@ private:
         return true;
     }
 
-    const uint8_t* alignedBuffer(unsigned alignment) const
+    const uint8_t* NODELETE alignedBuffer(unsigned alignment) const
     {
         ASSERT(alignment && !(alignment & (alignment - 1)));
 
@@ -780,7 +780,7 @@ private:
     }
 
     template<typename T>
-    bool bufferIsLargeEnoughToContain(size_t numElements) const
+    bool NODELETE bufferIsLargeEnoughToContain(size_t numElements) const
     {
         static_assert(std::is_arithmetic<T>::value, "Type T must have a fixed, known encoded size!");
 
@@ -790,12 +790,12 @@ private:
         return bufferIsLargeEnoughToContain(alignof(T), numElements * sizeof(T));
     }
 
-    bool bufferIsLargeEnoughToContain(unsigned alignment, size_t size) const
+    bool NODELETE bufferIsLargeEnoughToContain(unsigned alignment, size_t size) const
     {
         return alignedBufferIsLargeEnoughToContain(alignedBuffer(alignment), size);
     }
 
-    inline bool alignedBufferIsLargeEnoughToContain(const uint8_t* alignedPosition, size_t size) const
+    inline bool NODELETE alignedBufferIsLargeEnoughToContain(const uint8_t* alignedPosition, size_t size) const
     {
         auto* bufferEnd = std::to_address(m_buffer.end());
         return bufferEnd >= alignedPosition && static_cast<size_t>(bufferEnd - alignedPosition) >= size;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -65,7 +65,7 @@ public:
     virtual ~PageClientImpl();
 
     // FIXME: Eventually WebViewImpl should become the PageClient.
-    void setImpl(WebViewImpl&);
+    void NODELETE setImpl(WebViewImpl&);
 
     void viewWillMoveToAnotherWindow();
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -744,7 +744,7 @@ String PageClientImpl::dismissCorrectionPanelSoon(WebCore::ReasonForDismissingAl
 #endif
 }
 
-static inline NSCorrectionResponse toCorrectionResponse(AutocorrectionResponse response)
+static inline NSCorrectionResponse NODELETE toCorrectionResponse(AutocorrectionResponse response)
 {
     switch (response) {
     case WebCore::AutocorrectionResponse::Reverted:

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
@@ -51,7 +51,7 @@ public:
     void hidePopupMenu() override;
     void cancelTracking() override;
 
-    NSPopUpButtonCell *popup() const;
+    NSPopUpButtonCell *NODELETE popup() const;
     bool isVisible() const { return m_isVisible; }
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -260,7 +260,7 @@ public:
     void processDidExit();
     void pageClosed();
     void didRelaunchProcess();
-    void scrollingCoordinatorWasCreated();
+    void NODELETE scrollingCoordinatorWasCreated();
 
     void setDrawsBackground(bool);
     bool drawsBackground() const;
@@ -270,7 +270,7 @@ public:
 
     void setShouldSuppressFirstResponderChanges(bool);
     bool acceptsFirstMouse(NSEvent *);
-    bool acceptsFirstResponder();
+    bool NODELETE acceptsFirstResponder();
     bool becomeFirstResponder();
     bool resignFirstResponder();
     bool isFocused() const;
@@ -296,7 +296,7 @@ public:
     CGSize fixedLayoutSize() const;
 
     Ref<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&);
-    bool isUsingUISideCompositing() const;
+    bool NODELETE isUsingUISideCompositing() const;
     void setDrawingAreaSize(CGSize);
     void updateLayer();
     static bool wantsUpdateLayer() { return true; }
@@ -306,7 +306,7 @@ public:
     RetainPtr<NSPrintOperation> printOperationWithPrintInfo(NSPrintInfo *, WebFrameProxy&);
 
     void setAutomaticallyAdjustsContentInsets(bool);
-    bool automaticallyAdjustsContentInsets() const;
+    bool NODELETE automaticallyAdjustsContentInsets() const;
     void updateContentInsetsIfAutomatic();
     void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
     WebCore::FloatBoxExtent obscuredContentInsets() const;
@@ -322,12 +322,12 @@ public:
     void setSizeToContentAutoSizeMaximumSize(CGSize);
     CGSize sizeToContentAutoSizeMaximumSize() const;
     void setShouldExpandToViewHeightForAutoLayout(bool);
-    bool shouldExpandToViewHeightForAutoLayout() const;
+    bool NODELETE shouldExpandToViewHeightForAutoLayout() const;
     void setIntrinsicContentSize(CGSize);
-    CGSize intrinsicContentSize() const;
+    CGSize NODELETE intrinsicContentSize() const;
 
     void setViewScale(CGFloat);
-    CGFloat viewScale() const;
+    CGFloat NODELETE viewScale() const;
 
     void showWarningView(const BrowsingWarning&, CompletionHandler<void(Variant<ContinueUnsafeLoad, URL>&&)>&&);
     void clearWarningView();
@@ -350,8 +350,8 @@ public:
     void windowDidChangeScreen();
     void windowDidChangeOcclusionState();
     void windowWillClose();
-    void windowWillEnterOrExitFullScreen();
-    void windowDidEnterOrExitFullScreen();
+    void NODELETE windowWillEnterOrExitFullScreen();
+    void NODELETE windowDidEnterOrExitFullScreen();
     void screenDidChangeColorSpace();
     bool shouldDelayWindowOrderingForEvent(NSEvent *);
     bool windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint);
@@ -373,7 +373,7 @@ public:
     void pageDidScroll(const WebCore::IntPoint&);
 
     NSRect scrollViewFrame();
-    bool hasScrolledContentsUnderTitlebar();
+    bool NODELETE hasScrolledContentsUnderTitlebar();
     void updateTitlebarAdjacencyState();
 
     RetainPtr<NSView> hitTest(CGPoint);
@@ -394,7 +394,7 @@ public:
     void setAlwaysBounceHorizontal(bool);
 
     void setOverlayScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle);
-    std::optional<WebCore::ScrollbarOverlayStyle> overlayScrollbarStyle() const;
+    std::optional<WebCore::ScrollbarOverlayStyle> NODELETE overlayScrollbarStyle() const;
 
     void beginDeferringViewInWindowChanges();
     // FIXME: Merge these two?
@@ -422,14 +422,14 @@ public:
     NSEvent *lastPressureEvent() { return m_lastPressureEvent.get(); }
 
 #if ENABLE(FULLSCREEN_API)
-    bool hasFullScreenWindowController() const;
+    bool NODELETE hasFullScreenWindowController() const;
     WKFullScreenWindowController *fullScreenWindowController();
     void closeFullScreenWindowController();
 #endif
     NSView *fullScreenPlaceholderView();
     NSWindow *fullScreenWindow();
 
-    bool isEditable() const;
+    bool NODELETE isEditable() const;
     bool executeSavedCommandBySelector(SEL);
     void executeEditCommandForSelector(SEL, const String& argument = String());
     void registerEditCommand(Ref<WebEditCommandProxy>&&, UndoOrRedo);
@@ -524,7 +524,7 @@ public:
     bool ignoresMouseMoveEvents() const { return m_ignoresMouseMoveEvents; }
     void setIgnoresAllEvents(bool);
     bool ignoresAllEvents() const { return m_ignoresAllEvents; }
-    void setIgnoresMouseDraggedEvents(bool);
+    void NODELETE setIgnoresMouseDraggedEvents(bool);
     bool ignoresMouseDraggedEvents() const { return m_ignoresMouseDraggedEvents; }
 
     void setAccessibilityWebProcessToken(NSData *, pid_t);
@@ -541,7 +541,7 @@ public:
     NSUInteger accessibilityRemoteChildTokenHash();
     NSUInteger accessibilityUIProcessLocalTokenHash();
     NSArray<NSNumber *> *registeredRemoteAccessibilityPids();
-    NSData *remoteAccessibilityChildToken();
+    NSData *NODELETE remoteAccessibilityChildToken();
     bool hasRemoteAccessibilityChild();
 
     void updatePrimaryTrackingAreaOptions(NSTrackingAreaOptions);
@@ -623,9 +623,9 @@ public:
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     WKAppKitGestureController *appKitGestureController() const { return m_appKitGestureController.get(); }
 #endif
-    void setAllowsBackForwardNavigationGestures(bool);
+    void NODELETE setAllowsBackForwardNavigationGestures(bool);
     bool allowsBackForwardNavigationGestures() const { return m_allowsBackForwardNavigationGestures; }
-    void setAllowsMagnification(bool);
+    void NODELETE setAllowsMagnification(bool);
     bool allowsMagnification() const { return m_allowsMagnification; }
 
     void setMagnification(double, CGPoint centerPoint);
@@ -633,7 +633,7 @@ public:
     double magnification() const;
     void setCustomSwipeViews(NSArray *);
     WebCore::FloatRect windowRelativeBoundsForCustomSwipeViews() const;
-    WebCore::FloatBoxExtent customSwipeViewsObscuredContentInsets() const;
+    WebCore::FloatBoxExtent NODELETE customSwipeViewsObscuredContentInsets() const;
     void setCustomSwipeViewsObscuredContentInsets(WebCore::FloatBoxExtent&&);
     bool tryToSwipeWithEvent(NSEvent *, bool ignoringPinnedState);
     void setDidMoveSwipeSnapshotCallback(BlockPtr<void (CGRect)>&&);
@@ -665,12 +665,12 @@ public:
     NSTextInputContext *inputContextIncludingNonEditable();
     void unmarkText();
     void setMarkedText(id string, NSRange selectedRange, NSRange replacementRange);
-    NSRange selectedRange();
+    NSRange NODELETE selectedRange();
     bool hasMarkedText();
-    NSRange markedRange();
-    NSAttributedString *attributedSubstringForProposedRange(NSRange, NSRangePointer actualRange);
-    NSUInteger characterIndexForPoint(NSPoint);
-    NSRect firstRectForCharacterRange(NSRange, NSRangePointer actualRange);
+    NSRange NODELETE markedRange();
+    NSAttributedString *NODELETE attributedSubstringForProposedRange(NSRange, NSRangePointer actualRange);
+    NSUInteger NODELETE characterIndexForPoint(NSPoint);
+    NSRect NODELETE firstRectForCharacterRange(NSRange, NSRangePointer actualRange);
     bool performKeyEquivalent(NSEvent *);
     void keyUp(NSEvent *);
     void keyDown(NSEvent *);
@@ -699,7 +699,7 @@ public:
 
     void createFlagsChangedEventMonitor();
     void removeFlagsChangedEventMonitor();
-    bool hasFlagsChangedEventMonitor();
+    bool NODELETE hasFlagsChangedEventMonitor();
 
     void mouseMoved(NSEvent *);
     void mouseDown(NSEvent *, WebMouseEventInputSource);
@@ -735,7 +735,7 @@ public:
 
     bool windowIsFrontWindowUnderMouse(NSEvent *);
 
-    bool requiresUserActionForEditingControlsManager() const;
+    bool NODELETE requiresUserActionForEditingControlsManager() const;
 
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection();
     void setUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection);
@@ -781,7 +781,7 @@ public:
 
     void effectiveAppearanceDidChange();
     bool effectiveAppearanceIsDark();
-    bool effectiveUserInterfaceLevelIsElevated();
+    bool NODELETE effectiveUserInterfaceLevelIsElevated();
 
     void takeFocus(WebCore::FocusDirection);
     void clearPromisedDragImage();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1285,7 +1285,7 @@ static NSTrackingAreaOptions trackingAreaOptions()
     return options;
 }
 
-static NSTrackingAreaOptions flagsChangedEventMonitorTrackingAreaOptions()
+static NSTrackingAreaOptions NODELETE flagsChangedEventMonitorTrackingAreaOptions()
 {
     return NSTrackingInVisibleRect | NSTrackingActiveInActiveApp | NSTrackingMouseEnteredAndExited;
 }
@@ -3597,7 +3597,7 @@ void WebViewImpl::handleRequestedCandidates(NSInteger sequenceNumber, NSArray<NS
 #endif
 }
 
-static constexpr WebCore::TextCheckingType coreTextCheckingType(NSTextCheckingType type)
+static constexpr WebCore::TextCheckingType NODELETE coreTextCheckingType(NSTextCheckingType type)
 {
     switch (type) {
     case NSTextCheckingTypeCorrection:
@@ -4355,7 +4355,7 @@ NSDragOperation WebViewImpl::draggingEntered(id<NSDraggingInfo> draggingInfo)
     return NSDragOperationCopy;
 }
 
-static NSDragOperation kit(std::optional<WebCore::DragOperation> dragOperation)
+static NSDragOperation NODELETE kit(std::optional<WebCore::DragOperation> dragOperation)
 {
     if (!dragOperation)
         return NSDragOperationNone;
@@ -4850,7 +4850,7 @@ NSArray *WebViewImpl::namesOfPromisedFilesDroppedAtDestination(NSURL *dropDestin
     return @[[path lastPathComponent]];
 }
 
-static NSPasteboardName pasteboardNameForAccessCategory(WebCore::DOMPasteAccessCategory pasteAccessCategory)
+static NSPasteboardName NODELETE pasteboardNameForAccessCategory(WebCore::DOMPasteAccessCategory pasteAccessCategory)
 {
     switch (pasteAccessCategory) {
     case WebCore::DOMPasteAccessCategory::General:
@@ -6279,7 +6279,7 @@ void WebViewImpl::mouseMoved(NSEvent *event)
     mouseMovedInternal(event);
 }
 
-static _WKRectEdge toWKRectEdge(WebCore::RectEdges<bool> edges)
+static _WKRectEdge NODELETE toWKRectEdge(WebCore::RectEdges<bool> edges)
 {
     _WKRectEdge result = _WKRectEdgeNone;
 
@@ -6298,7 +6298,7 @@ static _WKRectEdge toWKRectEdge(WebCore::RectEdges<bool> edges)
     return result;
 }
 
-static WebCore::RectEdges<bool> toRectEdges(_WKRectEdge edges)
+static WebCore::RectEdges<bool> NODELETE toRectEdges(_WKRectEdge edges)
 {
     return {
         static_cast<bool>(edges & _WKRectEdgeTop),
@@ -6397,7 +6397,7 @@ bool WebViewImpl::windowIsFrontWindowUnderMouse(NSEvent *event)
     return window.get().windowNumber != eventWindowNumber;
 }
 
-static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection direction)
+static WebCore::UserInterfaceLayoutDirection NODELETE toUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection direction)
 {
     switch (direction) {
     case NSUserInterfaceLayoutDirectionLeftToRight:
@@ -6634,7 +6634,7 @@ NSTouchBar *WebViewImpl::textTouchBar() const
     return isRichlyEditableForTouchBar() ? m_richTextTouchBar.get() : m_plainTextTouchBar.get();
 }
 
-static NSTextAlignment nsTextAlignmentFromTextAlignment(TextAlignment textAlignment)
+static NSTextAlignment NODELETE nsTextAlignmentFromTextAlignment(TextAlignment textAlignment)
 {
     switch (textAlignment) {
     case TextAlignment::Natural:

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -96,7 +96,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    WebCore::PaymentCoordinator& paymentCoordinator() const;
+    WebCore::PaymentCoordinator& NODELETE paymentCoordinator() const;
 
     // Message handlers.
     void validateMerchant(const String& validationURLString);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -147,7 +147,7 @@ WebAutomationSessionProxy::~WebAutomationSessionProxy()
 #endif
 }
 
-static bool isValidNodeHandle(const String& nodeHandle)
+static bool NODELETE isValidNodeHandle(const String& nodeHandle)
 {
     // Node identifier has the following format:
     // node-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -66,7 +66,7 @@ Ref<IPC::Connection> WebCacheStorageConnection::connection()
 }
 
 struct WebCacheStorageConnection::PromiseConverter {
-    static auto convertError(IPC::Error)
+    static auto NODELETE convertError(IPC::Error)
     {
         return makeUnexpected(WebCore::DOMCacheEngine::Error::Internal);
     }

--- a/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
+++ b/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
@@ -36,7 +36,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<PageGroupIdentifier, WeakRef<WebDatabaseProvider>>& databaseProviders()
+static HashMap<PageGroupIdentifier, WeakRef<WebDatabaseProvider>>& NODELETE databaseProviders()
 {
     static NeverDestroyed<HashMap<PageGroupIdentifier, WeakRef<WebDatabaseProvider>>> databaseProviders;
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -99,7 +99,7 @@ static inline NSString *toWebAPI(PAL::SessionID sessionID)
     return [NSString stringWithFormat:@"%@%llu", prefix, maskedValue];
 }
 
-static inline NSString *toWebAPI(WebCore::Cookie::SameSitePolicy policy)
+static inline NSString *NODELETE toWebAPI(WebCore::Cookie::SameSitePolicy policy)
 {
     switch (policy) {
     case WebCore::Cookie::SameSitePolicy::None:

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -47,7 +47,7 @@ namespace WebKit {
 
 using PortChannelPortMap = HashMap<WebExtensionPortChannelIdentifier, HashSet<WeakRef<WebExtensionAPIPort>>>;
 
-static PortChannelPortMap& webExtensionPorts()
+static PortChannelPortMap& NODELETE webExtensionPorts()
 {
     static MainRunLoopNeverDestroyed<PortChannelPortMap> ports;
     return ports;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -74,7 +74,7 @@ static NSString * const tabIdKey = @"tabId";
 
 namespace WebKit {
 
-static inline NSString *toWebAPI(WebExtensionWindow::State state)
+static inline NSString *NODELETE toWebAPI(WebExtensionWindow::State state)
 {
     switch (state) {
     case WebExtensionWindow::State::Normal:
@@ -91,7 +91,7 @@ static inline NSString *toWebAPI(WebExtensionWindow::State state)
     }
 }
 
-static inline NSString *toWebAPI(WebExtensionWindow::Type type)
+static inline NSString *NODELETE toWebAPI(WebExtensionWindow::Type type)
 {
     switch (type) {
     case WebExtensionWindow::Type::Normal:
@@ -558,7 +558,7 @@ WebExtensionAPIWindowsEvent& WebExtensionAPIWindows::onFocusChanged()
     return *m_onFocusChanged;
 }
 
-inline OptionSet<WebExtensionWindowTypeFilter> toWindowTypeFilter(WebExtensionWindow::Type type)
+inline OptionSet<WebExtensionWindowTypeFilter> NODELETE toWindowTypeFilter(WebExtensionWindow::Type type)
 {
     switch (type) {
     case WebExtensionWindow::Type::Normal:

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -397,7 +397,7 @@ JSValueRef fromObject(JSContextRef context, HashMap<String, JSValueRef>&& object
     return result;
 }
 
-static HashMap<JSGlobalContextRef, JSWeakObjectMapRef>& wrapperCache()
+static HashMap<JSGlobalContextRef, JSWeakObjectMapRef>& NODELETE wrapperCache()
 {
     static NeverDestroyed<HashMap<JSGlobalContextRef, JSWeakObjectMapRef>> wrappers;
     return wrappers;

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -63,7 +63,7 @@ public:
     ~WebExtensionCallbackHandler();
 
     JSGlobalContextRef globalContext() const { return m_globalContext.get(); }
-    JSValueRef callbackFunction() const;
+    JSValueRef NODELETE callbackFunction() const;
 
     void reportError(const String&);
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -48,7 +48,7 @@
 
 namespace WebKit {
 
-static HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContextProxy>>& webExtensionContextProxies()
+static HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContextProxy>>& NODELETE webExtensionContextProxies()
 {
     static MainRunLoopNeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContextProxy>>> contexts;
     return contexts;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, _WKWebExtensionWebRequestResourceType) {
 };
 
 #ifdef __cplusplus
-WK_EXTERN _WKWebExtensionWebRequestResourceType toWebExtensionWebRequestResourceType(const WebKit::ResourceLoadInfo&);
+WK_EXTERN _WKWebExtensionWebRequestResourceType NODELETE toWebExtensionWebRequestResourceType(const WebKit::ResourceLoadInfo&);
 #endif
 
 // https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -77,7 +77,7 @@ public:
     WebExtensionContextIdentifier unprivilegedIdentifier() const { return m_unprivilegedIdentifier; }
     Markable<WebExtensionContextIdentifier> privilegedIdentifier() const { return m_privilegedIdentifier; }
 
-    WebExtensionControllerProxy* extensionControllerProxy() const;
+    WebExtensionControllerProxy* NODELETE extensionControllerProxy() const;
 
     bool operator==(const WebExtensionContextProxy& other) const { return (this == &other); }
 
@@ -94,7 +94,7 @@ public:
 
     bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
 
-    bool inTestingMode() const;
+    bool NODELETE inTestingMode() const;
 
     bool hasDOMWrapperWorld(WebExtensionContentWorldType contentWorldType) const { return contentWorldType != WebExtensionContentWorldType::ContentScript || hasContentScriptWorld(); }
     Ref<WebCore::DOMWrapperWorld> toDOMWrapperWorld(WebExtensionContentWorldType) const;
@@ -107,9 +107,9 @@ public:
 
     void addFrameWithExtensionContent(WebFrame&);
 
-    std::optional<WebExtensionTabIdentifier> tabIdentifier(WebPage&) const;
+    std::optional<WebExtensionTabIdentifier> NODELETE tabIdentifier(WebPage&) const;
 
-    RefPtr<WebPage> backgroundPage() const;
+    RefPtr<WebPage> NODELETE backgroundPage() const;
     void setBackgroundPage(WebPage&);
 
     bool isUnsupportedAPI(const String& propertyPath, const ASCIILiteral& propertyName) const;
@@ -120,7 +120,7 @@ public:
     void addInspectorPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
 
     void addInspectorBackgroundPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
-    bool isInspectorBackgroundPage(WebPage&) const;
+    bool NODELETE isInspectorBackgroundPage(WebPage&) const;
 
     Inspector::ExtensionAppearance inspectorAppearance() const { return m_inspectorAppearance; }
     void setInspectorAppearance(Inspector::ExtensionAppearance appearance) { m_inspectorAppearance = appearance; }
@@ -200,7 +200,7 @@ private:
     void dispatchRuntimeStartupEvent();
 
     // Storage
-    void setStorageAccessLevel(bool);
+    void NODELETE setStorageAccessLevel(bool);
     void dispatchStorageChangedEvent(const Vector<String>& onChangedJSON, WebExtensionDataType, WebExtensionContentWorldType);
 
     // Tabs

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -41,7 +41,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>& webExtensionControllerProxies()
+static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>& NODELETE webExtensionControllerProxies()
 {
     static MainRunLoopNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>> controllers;
     return controllers;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -87,7 +87,7 @@ public:
     void enterFullScreenForOwnerElements(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
     void exitFullScreenInMainFrame(CompletionHandler<void()>&&);
 
-    WebCore::Element* element();
+    WebCore::Element* NODELETE element();
 
     void videoControlsManagerDidChange();
 
@@ -133,7 +133,7 @@ private:
     const Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "WebFullScreenManager"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
 #if ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.h
@@ -34,7 +34,7 @@ class ImageBufferRemotePDFDocumentBackend final : public WebCore::NullImageBuffe
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferRemotePDFDocumentBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferRemotePDFDocumentBackend);
 public:
-    static unsigned calculateBytesPerRow(const WebCore::IntSize& backendSize);
+    static unsigned NODELETE calculateBytesPerRow(const WebCore::IntSize& backendSize);
     static size_t calculateMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferRemotePDFDocumentBackend> create(const Parameters&);

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -94,7 +94,7 @@ private:
     void render() final;
     void setLabelInternal(const String&) final;
     void setEntityTransform(const WebModel::Float4x4&) final;
-    void setEntityTransformInternal(const WebModel::Float4x4&);
+    void NODELETE setEntityTransformInternal(const WebModel::Float4x4&);
 #if PLATFORM(COCOA)
     std::optional<WebModel::Float4x4> entityTransform() const final;
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -374,7 +374,7 @@ public:
 #endif
     // End of list used by generate-gpup-webgl script.
 
-    static bool handleMessageToRemovedDestination(IPC::Connection&, IPC::Decoder&);
+    static bool NODELETE handleMessageToRemovedDestination(IPC::Connection&, IPC::Decoder&);
 
 protected:
     explicit RemoteGraphicsContextGLProxy(const WebCore::GraphicsContextGLAttributes&, RemoteRenderingBackendProxy&);
@@ -404,11 +404,11 @@ private:
     void wasLost();
     void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, CString&&);
 
-    void initialize(const RemoteGraphicsContextGLInitializationState&);
+    void NODELETE initialize(const RemoteGraphicsContextGLInitializationState&);
     void waitUntilInitialized();
     void disconnectGpuProcessIfNeeded();
     void abandonGpuProcess();
-    uint32_t createObjectName();
+    uint32_t NODELETE createObjectName();
 
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection; // Only main thread use.
     RefPtr<IPC::StreamClientConnection> m_streamConnection;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -67,7 +67,7 @@ public:
     }
 
     ~RemoteImageBufferProxy();
-    bool isValid() const;
+    bool NODELETE isValid() const;
 
     void disconnect();
 
@@ -107,7 +107,7 @@ private:
 
     void prepareForBackingStoreChange();
 
-    void assertDispatcherIsCurrent() const;
+    void NODELETE assertDispatcherIsCurrent() const;
     template<typename T> void send(T&& message) const;
     template<typename T> auto sendSync(T&& message) const;
     RefPtr<IPC::StreamClientConnection> connection() const;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -69,7 +69,7 @@ public:
         return std::exchange(m_handles, std::nullopt);
     }
 
-    RenderingUpdateID renderingUpdateID() const { return m_renderingUpdateID; }
+    RenderingUpdateID NODELETE renderingUpdateID() const { return m_renderingUpdateID; }
 
 private:
     RemoteImageBufferSetProxyFlushFence(RenderingUpdateID renderingUpdateID, Seconds timeoutDuration)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -96,8 +96,8 @@ public:
     OptionSet<BufferInSetType> requestedVolatility() { return m_requestedVolatility; }
     OptionSet<BufferInSetType> confirmedVolatility() { return m_confirmedVolatility; }
     void clearVolatility();
-    void addRequestedVolatility(OptionSet<BufferInSetType> request);
-    void setConfirmedVolatility(OptionSet<BufferInSetType> types);
+    void NODELETE addRequestedVolatility(OptionSet<BufferInSetType> request);
+    void NODELETE setConfirmedVolatility(OptionSet<BufferInSetType> types);
 
     void setNeedsDisplay();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -168,7 +168,7 @@ public:
         bool requiresClearedPixels { true };
     };
 
-    void startPreparingImageBufferSetsForDisplay();
+    void NODELETE startPreparingImageBufferSetsForDisplay();
     void endPreparingImageBufferSetsForDisplay();
 
     void prepareImageBufferSetForDisplay(LayerPrepareBuffersData&&);
@@ -180,7 +180,7 @@ public:
     RenderingUpdateID renderingUpdateID() const { return m_renderingUpdateID; }
     unsigned delayedRenderingUpdateCount() const { return m_renderingUpdateID - m_didRenderingUpdateID; }
 
-    RemoteRenderingBackendIdentifier renderingBackendIdentifier() const;
+    RemoteRenderingBackendIdentifier NODELETE renderingBackendIdentifier() const;
 
     RemoteRenderingBackendIdentifier ensureBackendCreated();
 
@@ -197,7 +197,7 @@ public:
 
     static constexpr Seconds defaultTimeout = 15_s;
 
-    unsigned nativeImageCountForTesting() const;
+    unsigned NODELETE nativeImageCountForTesting() const;
 private:
     explicit RemoteRenderingBackendProxy(SerialFunctionDispatcher&);
 
@@ -219,7 +219,7 @@ private:
     void ensureGPUProcessConnection();
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool NODELETE dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
     // Returns std::nullopt if no update is needed or allocation failed.
     // Returns handle if that should be sent to the receiver process.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -98,7 +98,7 @@ private:
     void willDestroyDisplayList(const WebCore::DisplayList::DisplayList&) override;
 
     void finalizeRenderingUpdateForFonts();
-    void prepareForNextRenderingUpdate();
+    void NODELETE prepareForNextRenderingUpdate();
     void releaseFonts();
     void releaseFontCustomPlatformDatas();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -61,7 +61,7 @@ void RemoteBufferProxy::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, Web
     UNUSED_PARAM(sendResult);
 }
 
-static bool offsetOrSizeExceedsBounds(size_t dataSize, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> requestedSize)
+static bool NODELETE offsetOrSizeExceedsBounds(size_t dataSize, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> requestedSize)
 {
     return offset >= dataSize || (requestedSize.has_value() && requestedSize.value() + offset > dataSize);
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -52,7 +52,7 @@ RemoteTextureProxy::~RemoteTextureProxy()
     UNUSED_VARIABLE(sendResult);
 }
 
-static bool equalDescriptors(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& a, const std::optional<WebCore::WebGPU::TextureViewDescriptor>& b)
+static bool NODELETE equalDescriptors(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& a, const std::optional<WebCore::WebGPU::TextureViewDescriptor>& b)
 {
     if (!a && !b)
         return true;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -133,7 +133,7 @@ public:
     void playbackStateChanged(bool, MediaTimeUpdateData&&);
     void engineFailedToLoad(int64_t);
     void updateCachedState(RemoteMediaPlayerState&&);
-    void updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics&&);
+    void NODELETE updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics&&);
     void characteristicChanged(RemoteMediaPlayerState&&);
     void sizeChanged(WebCore::FloatSize);
     void firstVideoFrameAvailable();
@@ -225,13 +225,13 @@ private:
         explicit TimeProgressEstimator(const MediaPlayerPrivateRemote& parent);
         MediaTime currentTime() const;
         MediaTime cachedTime() const;
-        bool timeIsProgressing() const;
+        bool NODELETE timeIsProgressing() const;
         void pause();
         void setTime(const MediaTimeUpdateData&);
         void setRate(double);
         Lock& lock() const { return m_lock; };
         MediaTime currentTimeWithLockHeld() const;
-        MediaTime cachedTimeWithLockHeld() const;
+        MediaTime NODELETE cachedTimeWithLockHeld() const;
         void forceUseOfCachedTimeUntilNextSetTime();
 
     private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -77,7 +77,7 @@ private:
     // GPUProcessConnection::Client.
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
-    uint32_t totalFrameCount() const;
+    uint32_t NODELETE totalFrameCount() const;
 
 #if PLATFORM(IOS_FAMILY)
     void setSceneIdentifier(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -76,7 +76,7 @@ public:
 
     RemoteLegacyCDM* findCDM(WebCore::CDMPrivateInterface*) const;
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
 private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -52,7 +52,7 @@ public:
     HashSet<String>& supportedTypes();
     WebCore::MediaPlayerEnums::SupportsType supportsTypeAndCodecs(const WebCore::MediaEngineSupportParameters&);
     void addSupportedTypes(const Vector<String>&);
-    bool isEmpty() const;
+    bool NODELETE isEmpty() const;
 
 private:
     Ref<RemoteMediaPlayerManager> manager() const;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -119,7 +119,7 @@ RemoteMediaPlayerManager::RemoteMediaPlayerManager() = default;
 RemoteMediaPlayerManager::~RemoteMediaPlayerManager() = default;
 
 using RemotePlayerTypeCache = HashMap<MediaPlayerEnums::MediaEngineIdentifier, std::unique_ptr<RemoteMediaPlayerMIMETypeCache>, WTF::IntHash<MediaPlayerEnums::MediaEngineIdentifier>, WTF::StrongEnumHashTraits<MediaPlayerEnums::MediaEngineIdentifier>>;
-static RemotePlayerTypeCache& mimeCaches()
+static RemotePlayerTypeCache& NODELETE mimeCaches()
 {
     static NeverDestroyed<RemotePlayerTypeCache> caches;
     return caches;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -80,7 +80,7 @@ private:
     friend class MediaPlayerRemoteFactory;
     void getSupportedTypes(WebCore::MediaPlayerEnums::MediaEngineIdentifier, HashSet<String>&);
     WebCore::MediaPlayer::SupportsType supportsTypeAndCodecs(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const WebCore::MediaEngineSupportParameters&);
-    bool supportsKeySystem(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String& keySystem, const String& mimeType);
+    bool NODELETE supportsKeySystem(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String& keySystem, const String& mimeType);
 
     HashMap<WebCore::MediaPlayerIdentifier, ThreadSafeWeakPtr<MediaPlayerPrivateRemote>> m_players;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -41,7 +41,7 @@ public:
 
     void notifyDecodingResult(RefPtr<WebCore::VideoFrame>&&, int64_t timestamp);
 
-    void close() { m_isClosed = true; }
+    void NODELETE close() { m_isClosed = true; }
     void addDuration(int64_t timestamp, uint64_t duration) { m_timestampToDuration.insert_or_assign(timestamp, duration); }
 
 private:
@@ -77,7 +77,7 @@ public:
     void notifyEncodedChunk(Vector<uint8_t>&&, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration, std::optional<unsigned> temporalIndex);
     void notifyEncoderDescription(WebCore::VideoEncoderActiveConfiguration&&);
 
-    void close() { m_isClosed = true; }
+    void NODELETE close() { m_isClosed = true; }
 
 private:
     RemoteVideoEncoderCallbacks(WebCore::VideoEncoder::DescriptionCallback&&, WebCore::VideoEncoder::OutputCallback&&);
@@ -119,7 +119,7 @@ RemoteVideoCodecFactory::RemoteVideoCodecFactory(WebProcess& process)
 
 RemoteVideoCodecFactory::~RemoteVideoCodecFactory() = default;
 
-static bool shouldUseLocalDecoder(std::optional<WebCore::VideoCodecType> type, const WebCore::VideoDecoder::Config& config)
+static bool NODELETE shouldUseLocalDecoder(std::optional<WebCore::VideoCodecType> type, const WebCore::VideoDecoder::Config& config)
 {
     if (!type)
         return true;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -62,8 +62,8 @@ public:
 
     ~RemoteVideoFrameProxy() final;
 
-    RemoteVideoFrameIdentifier identifier() const;
-    RemoteVideoFrameReadReference newReadReference() const;
+    RemoteVideoFrameIdentifier NODELETE identifier() const;
+    RemoteVideoFrameReadReference NODELETE newReadReference() const;
 
     WebCore::IntSize size() const { return m_size; }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -181,7 +181,7 @@ static int32_t initializeVideoEncoder(webrtc::WebKitVideoEncoder encoder, const 
     return protect(WebProcess::singleton().libWebRTCCodecs())->initializeEncoder(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), codec.width, codec.height, codec.startBitrate, codec.maxBitrate, codec.minBitrate, codec.maxFramerate);
 }
 
-static inline VideoFrame::Rotation toVideoRotation(webrtc::VideoRotation rotation)
+static inline VideoFrame::Rotation NODELETE toVideoRotation(webrtc::VideoRotation rotation)
 {
     switch (rotation) {
     case webrtc::kVideoRotation_0:
@@ -555,7 +555,7 @@ void LibWebRTCCodecs::completedDecodingCV(VideoDecoderIdentifier decoderIdentifi
     webrtc::videoDecoderTaskComplete(decoder->decodedImageCallback, timeStamp, pixelBuffer.get());
 }
 
-static inline webrtc::VideoCodecType toWebRTCCodecType(WebCore::VideoCodecType type)
+static inline webrtc::VideoCodecType NODELETE toWebRTCCodecType(WebCore::VideoCodecType type)
 {
     switch (type) {
     case WebCore::VideoCodecType::H264:

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -199,7 +199,7 @@ private:
     LibWebRTCCodecs();
     void ensureGPUProcessConnectionAndDispatchToThread(Function<void()>&&);
     void ensureGPUProcessConnectionOnMainThreadWithLock() WTF_REQUIRES_LOCK(m_connectionLock);
-    void gpuProcessConnectionMayNoLongerBeNeeded();
+    void NODELETE gpuProcessConnectionMayNoLongerBeNeeded();
 
     void failedDecoding(VideoDecoderIdentifier);
     void flushDecoderCompleted(VideoDecoderIdentifier);
@@ -214,7 +214,7 @@ private:
     // GPUProcessConnection::Client
     void gpuProcessConnectionDidClose(GPUProcessConnection&);
 
-    IPC::Connection* encoderConnection(Encoder&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
+    IPC::Connection* NODELETE encoderConnection(Encoder&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
     void setEncoderConnection(Encoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
     IPC::Connection* decoderConnection(Decoder&) WTF_REQUIRES_LOCK(m_connectionLock);
     void setDecoderConnection(Decoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_connectionLock);

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -52,7 +52,7 @@ public:
 
     void didReceiveGeolocationPermissionDecision(GeolocationIdentifier, const String& authorizationToken);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
 private:

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -76,8 +76,8 @@ private:
         WeakHashSet<WebPage> pageSet;
         WeakHashSet<WebPage> highAccuracyPageSet;
     };
-    bool isUpdating(const PageSets&) const;
-    bool isHighAccuracyEnabled(const PageSets&) const;
+    bool NODELETE isUpdating(const PageSets&) const;
+    bool NODELETE isHighAccuracyEnabled(const PageSets&) const;
 
     const CheckedRef<WebProcess> m_process;
     HashMap<WebCore::RegistrableDomain, PageSets> m_pageSets;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -126,7 +126,7 @@
     return protect(*_nodeHandle)->isHTMLInputElementAutoFillButtonEnabled();
 }
 
-static WebCore::AutoFillButtonType toAutoFillButtonType(_WKAutoFillButtonType autoFillButtonType)
+static WebCore::AutoFillButtonType NODELETE toAutoFillButtonType(_WKAutoFillButtonType autoFillButtonType)
 {
     switch (autoFillButtonType) {
     case _WKAutoFillButtonTypeNone:
@@ -146,7 +146,7 @@ static WebCore::AutoFillButtonType toAutoFillButtonType(_WKAutoFillButtonType au
     return WebCore::AutoFillButtonType::None;
 }
 
-static _WKAutoFillButtonType toWKAutoFillButtonType(WebCore::AutoFillButtonType autoFillButtonType)
+static _WKAutoFillButtonType NODELETE toWKAutoFillButtonType(WebCore::AutoFillButtonType autoFillButtonType)
 {
     switch (autoFillButtonType) {
     case WebCore::AutoFillButtonType::None:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
@@ -83,8 +83,8 @@ private:
 
 // -- Caches --
 
-DOMCache<WebCore::Node*, __unsafe_unretained WKDOMNode *>& WKDOMNodeCache();
-DOMCache<WebCore::Range*, __unsafe_unretained WKDOMRange *>& WKDOMRangeCache();
+DOMCache<WebCore::Node*, __unsafe_unretained WKDOMNode *>& NODELETE WKDOMNodeCache();
+DOMCache<WebCore::Range*, __unsafe_unretained WKDOMRange *>& NODELETE WKDOMRangeCache();
 
 // -- Node and classes derived from Node. --
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
@@ -38,7 +38,7 @@ using namespace WebCore;
 
 using DOMStyleDeclarationHandleCache = HashMap<SingleThreadWeakRef<CSSStyleDeclaration>, WeakRef<InjectedBundleCSSStyleDeclarationHandle>>;
 
-static DOMStyleDeclarationHandleCache& domStyleDeclarationHandleCache()
+static DOMStyleDeclarationHandleCache& NODELETE domStyleDeclarationHandleCache()
 {
     static NeverDestroyed<DOMStyleDeclarationHandleCache> cache;
     return cache;

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -54,7 +54,7 @@ public:
 
     virtual ~InjectedBundleNodeHandle();
 
-    WebCore::Node* coreNode();
+    WebCore::Node* NODELETE coreNode();
 
     // Convenience DOM Operations
     RefPtr<InjectedBundleNodeHandle> document();
@@ -83,7 +83,7 @@ public:
     bool htmlInputElementLastChangeWasUserEdit();
     bool htmlTextAreaElementLastChangeWasUserEdit();
     bool isTextField() const;
-    bool isSelectElement() const;
+    bool NODELETE isSelectElement() const;
     bool isSelectableTextNode() const;
     
     RefPtr<InjectedBundleNodeHandle> htmlTableCellElementCellAbove();

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -63,7 +63,7 @@ using namespace WebCore;
 
 using DOMRangeHandleCache = HashMap<SingleThreadWeakRef<WebCore::Range>, WeakRef<InjectedBundleRangeHandle>>;
 
-static DOMRangeHandleCache& domRangeHandleCache()
+static DOMRangeHandleCache& NODELETE domRangeHandleCache()
 {
     static NeverDestroyed<DOMRangeHandleCache> cache;
     return cache;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
@@ -122,7 +122,7 @@ public:
 
     static bool isProcessingUserGesture();
 
-    void setTabKeyCyclesThroughElements(WebPage*, bool enabled);
+    void NODELETE setTabKeyCyclesThroughElements(WebPage*, bool enabled);
     void setSerialLoadingEnabled(bool);
     void setAccessibilityIsolatedTreeEnabled(bool);
     void dispatchPendingLoadRequests();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -41,7 +41,7 @@ namespace WebKit {
 using namespace WebCore;
 
 using ExtensionMap = HashMap<WeakRef<WebCore::DOMWindowExtension>, WeakRef<InjectedBundleDOMWindowExtension>>;
-static ExtensionMap& allExtensions()
+static ExtensionMap& NODELETE allExtensions()
 {
     static NeverDestroyed<ExtensionMap> map;
     return map;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
@@ -44,7 +44,7 @@ class WebFrame;
 class InjectedBundleDOMWindowExtension : public API::ObjectImpl<API::Object::Type::BundleDOMWindowExtension>, public CanMakeWeakPtr<InjectedBundleDOMWindowExtension> {
 public:
     static Ref<InjectedBundleDOMWindowExtension> create(WebFrame*, InjectedBundleScriptWorld*);
-    static InjectedBundleDOMWindowExtension* get(WebCore::DOMWindowExtension*);
+    static InjectedBundleDOMWindowExtension* NODELETE get(WebCore::DOMWindowExtension*);
 
     virtual ~InjectedBundleDOMWindowExtension();
     

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp
@@ -96,7 +96,7 @@ void InjectedBundlePageFormClient::textDidChangeInTextArea(WebPage* page, HTMLTe
     m_client.textDidChangeInTextArea(toAPI(page), toAPI(nodeHandle.get()), toAPI(frame), m_client.base.clientInfo);
 }
 
-static WKInputFieldActionType toWKInputFieldActionType(API::InjectedBundle::FormClient::InputFieldAction action)
+static WKInputFieldActionType NODELETE toWKInputFieldActionType(API::InjectedBundle::FormClient::InputFieldAction action)
 {
     switch (action) {
     case API::InjectedBundle::FormClient::InputFieldAction::MoveUp:

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -40,7 +40,7 @@ using namespace WebCore;
 
 using WorldMap = HashMap<SingleThreadWeakRef<const DOMWrapperWorld>, WeakRef<InjectedBundleScriptWorld>>;
 
-static WorldMap& allWorlds()
+static WorldMap& NODELETE allWorlds()
 {
     static NeverDestroyed<WorldMap> map;
     return map;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -54,18 +54,18 @@ public:
 
     virtual ~InjectedBundleScriptWorld();
 
-    const WebCore::DOMWrapperWorld& coreWorld() const;
+    const WebCore::DOMWrapperWorld& NODELETE coreWorld() const;
     WebCore::DOMWrapperWorld& coreWorld();
 
     void clearWrappers();
-    void setAllowAutofill();
-    void setAllowElementUserInfo();
-    void makeAllShadowRootsOpen();
-    void exposeClosedShadowRootsForExtensions();
-    void disableOverrideBuiltinsBehavior();
-    void setAllowJSHandleCreation();
-    void setAllowNodeSerialization();
-    void setAllowPostingLegacySynchronousMessages();
+    void NODELETE setAllowAutofill();
+    void NODELETE setAllowElementUserInfo();
+    void NODELETE makeAllShadowRootsOpen();
+    void NODELETE exposeClosedShadowRootsForExtensions();
+    void NODELETE disableOverrideBuiltinsBehavior();
+    void NODELETE setAllowJSHandleCreation();
+    void NODELETE setAllowNodeSerialization();
+    void NODELETE setAllowPostingLegacySynchronousMessages();
 
     ContentWorldIdentifier identifier() const { return m_identifier; }
     const String& name() const { return m_name; }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -47,7 +47,7 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
-    WebPage* page() const;
+    WebPage* NODELETE page() const;
 
     void updateDockingAvailability();
 

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -80,7 +80,7 @@ private:
     void trackIdentifierChanged(const String&) final;
 
     ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinator"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 
     WeakRef<WebPage> m_page;
     String m_identifier;

--- a/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.h
+++ b/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.h
@@ -43,7 +43,7 @@ public:
     MediaDeviceSandboxExtensions(Vector<String> ids, Vector<SandboxExtension::Handle>&& handles, SandboxExtension::Handle&& machBootstrapHandle);
 
     std::pair<String, Ref<SandboxExtension>> operator[](size_t i);
-    size_t size() const;
+    size_t NODELETE size() const;
 
     Vector<String> takeIDs() { return std::exchange(m_ids, { }); }
     Vector<SandboxExtension::Handle> takeHandles() { return std::exchange(m_handles, { }); }

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.h
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.h
@@ -43,7 +43,7 @@ public:
     virtual ~ARKitInlinePreviewModelPlayerMac();
 
     static void setModelElementCacheDirectory(const String&);
-    static const String& modelElementCacheDirectory();
+    static const String& NODELETE modelElementCacheDirectory();
 
 private:
     ARKitInlinePreviewModelPlayerMac(WebPage&, WebCore::ModelPlayerClient&);

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -75,7 +75,7 @@ std::optional<ModelIdentifier> ARKitInlinePreviewModelPlayerMac::modelIdentifier
     return { };
 }
 
-static String& sharedModelElementCacheDirectory()
+static String& NODELETE sharedModelElementCacheDirectory()
 {
     static NeverDestroyed<String> sharedModelElementCacheDirectory;
     return sharedModelElementCacheDirectory;

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -88,7 +88,7 @@ public:
 #endif
 
     WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy() const { return m_cookieAcceptPolicy; }
-    bool cookiesEnabled() const;
+    bool NODELETE cookiesEnabled() const;
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     void cookiesAdded(const String& host, Vector<WebCore::Cookie>&&);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -105,17 +105,17 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebLoaderStrategy);
 
-[[maybe_unused]] static uint64_t pageIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
+[[maybe_unused]] static uint64_t NODELETE pageIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
 {
     return parameters ? parameters->pageID.toUInt64() : 0;
 }
 
-[[maybe_unused]] static uint64_t frameIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
+[[maybe_unused]] static uint64_t NODELETE frameIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
 {
     return parameters ? parameters->frameID.toUInt64() : 0;
 }
 
-[[maybe_unused]] static uint64_t resourceIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
+[[maybe_unused]] static uint64_t NODELETE resourceIDForLog(const std::optional<WebResourceLoader::TrackingParameters>& parameters)
 {
     return parameters ? parameters->resourceID.toUInt64() : 0;
 }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -58,7 +58,7 @@ public:
     explicit WebLoaderStrategy(WebProcess&);
     ~WebLoaderStrategy() final;
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
     
     void loadResource(WebCore::LocalFrame&, WebCore::CachedResource&, WebCore::ResourceRequest&&, const WebCore::ResourceLoaderOptions&, CompletionHandler<void(RefPtr<WebCore::SubresourceLoader>&&)>&&) final;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -109,7 +109,7 @@ private:
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler&&, String&& unblockRequestDeniedScript, const WebCore::ResourceError&, const URL& blockedPageURL, WebCore::SubstituteData&&);
 #endif
 
-    size_t calculateBytesTransferredOverNetworkDelta(size_t bytesTransferredOverNetwork);
+    size_t NODELETE calculateBytesTransferredOverNetworkDelta(size_t bytesTransferredOverNetwork);
     void updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics&);
 
     RefPtr<WebCore::ResourceLoader> m_coreLoader;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -107,7 +107,7 @@ void LibWebRTCNetwork::dispatch(Function<void()>&& callback)
     WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread(WTF::move(callback));
 }
 
-static webrtc::EcnMarking convertToWebRTCEcnMarking(WebRTCNetwork::EcnMarking ecn)
+static webrtc::EcnMarking NODELETE convertToWebRTCEcnMarking(WebRTCNetwork::EcnMarking ecn)
 {
     switch (ecn) {
     case WebRTCNetwork::EcnMarking::kNotEct:

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -45,8 +45,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
-    void setEnumeratingAllNetworkInterfacesEnabled(bool);
-    void setEnumeratingVisibleNetworkInterfacesEnabled(bool);
+    void NODELETE setEnumeratingAllNetworkInterfacesEnabled(bool);
+    void NODELETE setEnumeratingVisibleNetworkInterfacesEnabled(bool);
 
     static void signalUsedInterface(WebCore::ScriptExecutionContextIdentifier, String&&);
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -108,7 +108,7 @@ public:
     RTCSocketFactory(WebPageProxyIdentifier, String&& userAgent, ScriptExecutionContextIdentifier, bool isFirstParty, RegistrableDomain&&);
 
     void disableRelay() final { m_flags.isRelayDisabled = true; }
-    void enableServiceClass() { m_flags.enableServiceClass = true; }
+    void NODELETE enableServiceClass() { m_flags.enableServiceClass = true; }
 
 private:
     // SuspendableSocketFactory

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -65,7 +65,7 @@ public:
     void setState(State state) { m_state = state; }
 
     void suspend();
-    void resume();
+    void NODELETE resume();
 
 private:
     bool willSend(size_t);

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -71,7 +71,7 @@ public:
     void disableNonLocalhostConnections() { m_disableNonLocalhostConnections = true; }
 
     void setConnection(RefPtr<IPC::Connection>&&);
-    IPC::Connection* connection();
+    IPC::Connection* NODELETE connection();
 
 private:
     // We cannot own sockets, clients of the factory are responsible to free them.

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
@@ -49,7 +49,7 @@ class WebMDNSRegister : public CanMakeWeakPtr<WebMDNSRegister> {
 public:
     explicit WebMDNSRegister(WebRTCNetworkBase&);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier);

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
@@ -55,7 +55,7 @@ class WebRTCMonitor {
 public:
     explicit WebRTCMonitor(LibWebRTCNetwork&);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void addObserver(WebRTCMonitorObserver& observer) { m_observers.add(observer); }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -66,7 +66,7 @@ public:
     {
     }
 
-    NetscapePlugInStreamLoader* streamLoader() { return m_streamLoader; }
+    NetscapePlugInStreamLoader* NODELETE streamLoader() { return m_streamLoader; }
     void setStreamLoader(NetscapePlugInStreamLoader& loader) { m_streamLoader = loader; }
     void clearStreamLoader();
     void addData(std::span<const uint8_t> data) { m_accumulatedData.append(data); }
@@ -76,10 +76,10 @@ public:
     bool completeIfPossible(PDFIncrementalLoader&);
     void completeUnconditionally(PDFIncrementalLoader&);
 
-    uint64_t position() const { return m_position; }
-    size_t count() const { return m_count; }
+    uint64_t NODELETE position() const { return m_position; }
+    size_t NODELETE count() const { return m_count; }
 
-    const Vector<uint8_t>& accumulatedData() const { return m_accumulatedData; };
+    const Vector<uint8_t>& NODELETE accumulatedData() const { return m_accumulatedData; };
 
 private:
     uint64_t m_position { 0 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -360,7 +360,7 @@ private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }
     void ensureDataBufferLength(uint64_t) WTF_REQUIRES_LOCK(m_streamedDataLock);
 
-    bool haveStreamedDataForRange(uint64_t offset, size_t count) const WTF_REQUIRES_LOCK(m_streamedDataLock);
+    bool NODELETE haveStreamedDataForRange(uint64_t offset, size_t count) const WTF_REQUIRES_LOCK(m_streamedDataLock);
     // This just checks whether the CFData is large enough; it doesn't know if we filled this range with data.
 
     void insertRangeRequestData(uint64_t offset, const Vector<uint8_t>&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -202,7 +202,7 @@ public:
     void removePreviewForPage(PDFDocumentLayout::PageIndex);
     void invalidatePreviewsForPageCoverage(const PDFPageCoverage&);
 
-    void setShowDebugBorders(bool);
+    void NODELETE setShowDebugBorders(bool);
 
 private:
     AsyncPDFRenderer(PDFPresentationController&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.h
@@ -48,9 +48,9 @@ class PDFDataDetectorItem : public RefCounted<PDFDataDetectorItem> {
 public:
     static Ref<PDFDataDetectorItem> create(DDScannerResult *, PDFPage *);
 
-    DDScannerResult *scannerResult() const;
-    bool hasActions() const;
-    bool isPastDate() const;
+    DDScannerResult *NODELETE scannerResult() const;
+    bool NODELETE hasActions() const;
+    bool NODELETE isPastDate() const;
     RetainPtr<PDFSelection> selection() const;
 
 private:

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -92,7 +92,7 @@ private:
 
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
 
-    bool handleKeyboardCommand(const WebKeyboardEvent&);
+    bool NODELETE handleKeyboardCommand(const WebKeyboardEvent&);
     bool handleKeyboardEventForPageNavigation(const WebKeyboardEvent&);
 
     bool wantsWheelEvents() const override { return true; }
@@ -107,7 +107,7 @@ private:
 
     bool eventCanStartPageTransition(const PlatformWheelEvent&) const;
 
-    bool canTransitionOnSide(WebCore::BoxSide) const;
+    bool NODELETE canTransitionOnSide(WebCore::BoxSide) const;
 
     // Transition state
     enum class TransitionDirection : uint8_t {
@@ -127,7 +127,7 @@ private:
         return direction == TransitionDirection::NextHorizontal || direction == TransitionDirection::NextVertical;
     }
 
-    bool canTransitionInDirection(TransitionDirection) const;
+    bool NODELETE canTransitionInDirection(TransitionDirection) const;
 
     void startOrStopAnimationTimerIfNecessary();
     void animationTimerFired();
@@ -168,8 +168,8 @@ private:
 
     void buildRows();
 
-    bool canGoToNextRow() const;
-    bool canGoToPreviousRow() const;
+    bool NODELETE canGoToNextRow() const;
+    bool NODELETE canGoToPreviousRow() const;
 
     enum class Animated : bool { No, Yes };
     void goToNextRow(Animated);
@@ -179,7 +179,7 @@ private:
     void setVisibleRow(unsigned);
     void updateLayersAfterChangeInVisibleRow(std::optional<unsigned> additionalVisibleRowIndex = { });
 
-    std::optional<unsigned> additionalVisibleRowIndexForDirection(TransitionDirection) const;
+    std::optional<unsigned> NODELETE additionalVisibleRowIndexForDirection(TransitionDirection) const;
 
     // First index is layer, second index is start/end.
     static constexpr size_t topLayerIndex = 0;
@@ -188,7 +188,7 @@ private:
     static constexpr size_t endIndex = 1;
     std::array<std::array<float, 2>, 2> layerOpacitiesForStretchOffset(TransitionDirection, WebCore::FloatSize layerOffset, WebCore::FloatSize rowSize) const;
     WebCore::FloatSize layerOffsetForStretch(TransitionDirection, WebCore::FloatSize stretchDistance, WebCore::FloatSize rowSize) const;
-    static float relevantAxisForDirection(TransitionDirection, WebCore::FloatSize);
+    static float NODELETE relevantAxisForDirection(TransitionDirection, WebCore::FloatSize);
     static void setRelevantAxisForDirection(TransitionDirection, WebCore::FloatSize&, float value);
 
     struct RowData {
@@ -208,7 +208,7 @@ private:
         RefPtr<WebCore::GraphicsLayer> backgroundLayerForPageIndex(PDFDocumentLayout::PageIndex) const;
     };
 
-    const RowData* rowDataForLayer(const WebCore::GraphicsLayer&) const;
+    const RowData* NODELETE rowDataForLayer(const WebCore::GraphicsLayer&) const;
     WebCore::FloatPoint positionForRowContainerLayer(const PDFLayoutRow&) const;
     WebCore::FloatSize rowContainerSize(const PDFLayoutRow&) const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -61,16 +61,16 @@ public:
     size_t rowCount() const;
     PDFLayoutRow rowForPageIndex(PageIndex) const;
     Vector<PDFLayoutRow> rows() const;
-    unsigned rowIndexForPageIndex(PageIndex) const;
+    unsigned NODELETE rowIndexForPageIndex(PageIndex) const;
 
     static constexpr WebCore::FloatSize documentMargin { 16, 18 };
     static constexpr WebCore::FloatSize pageMargin { 14, 16 };
 
-    bool isLeftPageIndex(PageIndex) const;
-    bool isRightPageIndex(PageIndex) const;
+    bool NODELETE isLeftPageIndex(PageIndex) const;
+    bool NODELETE isRightPageIndex(PageIndex) const;
     bool isLastPageIndex(PageIndex) const;
     PageIndex lastPageIndex() const;
-    bool isFirstPageOfRow(PageIndex) const;
+    bool NODELETE isFirstPageOfRow(PageIndex) const;
 
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     std::optional<PageIndex> indexForPage(RetainPtr<PDFPage>) const;
@@ -88,7 +88,7 @@ public:
     WebCore::FloatRect layoutBoundsForRow(PDFLayoutRow) const;
 
     // Returns 0, 90, 180, 270.
-    WebCore::IntDegrees rotationForPageAtIndex(PageIndex) const;
+    WebCore::IntDegrees NODELETE rotationForPageAtIndex(PageIndex) const;
 
     WebCore::FloatPoint documentToPDFPage(WebCore::FloatPoint documentPoint, PageIndex) const;
     WebCore::FloatRect documentToPDFPage(WebCore::FloatRect documentRect, PageIndex) const;
@@ -105,7 +105,7 @@ public:
     };
 
     OptionSet<LayoutUpdateChange> updateLayout(WebCore::IntSize pluginSize, ShouldUpdateAutoSizeScale);
-    WebCore::FloatSize contentsSize() const;
+    WebCore::FloatSize NODELETE contentsSize() const;
     WebCore::FloatSize scaledContentsSize() const;
 
     void setDisplayMode(PDFDisplayMode displayMode) { m_displayMode = displayMode; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -134,10 +134,10 @@ protected:
     };
     virtual Vector<LayerCoverage> layerCoveragesForRepaintPageCoverage(RepaintRequirements, const PDFPageCoverage&) = 0;
 
-    static Ref<WebCore::GraphicsLayer> pageBackgroundLayerForPageContainerLayer(WebCore::GraphicsLayer&);
+    static Ref<WebCore::GraphicsLayer> NODELETE pageBackgroundLayerForPageContainerLayer(WebCore::GraphicsLayer&);
 
     Ref<AsyncPDFRenderer> asyncRenderer();
-    RefPtr<AsyncPDFRenderer> asyncRendererIfExists() const;
+    RefPtr<AsyncPDFRenderer> NODELETE asyncRendererIfExists() const;
     void clearAsyncRenderer();
 
     bool shouldUseInProcessBackingStore() const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -95,7 +95,7 @@ private:
     std::optional<WebCore::PlatformLayerIdentifier> contentsLayerIdentifier() const final;
 
     void updatePageBackgroundLayers();
-    std::optional<PDFDocumentLayout::PageIndex> pageIndexForPageBackgroundLayer(const WebCore::GraphicsLayer&) const;
+    std::optional<PDFDocumentLayout::PageIndex> NODELETE pageIndexForPageBackgroundLayer(const WebCore::GraphicsLayer&) const;
     WebCore::GraphicsLayer* backgroundLayerForPage(PDFDocumentLayout::PageIndex) const;
 
     void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -100,7 +100,7 @@ public:
 
     PDFAnnotation *trackedAnnotation() const { return m_trackedAnnotation.get(); }
     RetainPtr<PDFAnnotation> protectedTrackedAnnotation() const { return m_trackedAnnotation; }
-    bool isBeingHovered() const;
+    bool NODELETE isBeingHovered() const;
 
 private:
     void resetAnnotationTrackingState();
@@ -187,7 +187,7 @@ public:
 
     void handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo&, const WebCore::IntPoint&);
 
-    bool canShowDataDetectorHighlightOverlays() const;
+    bool NODELETE canShowDataDetectorHighlightOverlays() const;
 #endif
 
     void scheduleRenderingUpdate(OptionSet<WebCore::RenderingUpdateStep> = WebCore::RenderingUpdateStep::LayerFlush);
@@ -319,7 +319,7 @@ private:
 
     WebCore::IntRect availableContentsRect() const;
 
-    WebCore::DelegatedScrollingMode scrollingMode() const;
+    WebCore::DelegatedScrollingMode NODELETE scrollingMode() const;
     bool isFullMainFramePlugin() const;
 
     void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
@@ -377,18 +377,18 @@ private:
     std::optional<PDFContextMenu> createContextMenu(const WebMouseEvent&) const;
     PDFContextMenuItem contextMenuItem(ContextMenuItemTag, bool hasAction = true) const;
     String titleForContextMenuItemTag(ContextMenuItemTag) const;
-    bool isDisplayModeContextMenuItemTag(ContextMenuItemTag) const;
-    PDFContextMenuItem separatorContextMenuItem() const;
+    bool NODELETE isDisplayModeContextMenuItemTag(ContextMenuItemTag) const;
+    PDFContextMenuItem NODELETE separatorContextMenuItem() const;
     Vector<PDFContextMenuItem> selectionContextMenuItems(const WebCore::IntPoint& contextMenuEventRootViewPoint, bool shouldPresentLookupAndSearchOptions) const;
     Vector<PDFContextMenuItem> displayModeContextMenuItems() const;
     Vector<PDFContextMenuItem> scaleContextMenuItems() const;
     Vector<PDFContextMenuItem> navigationContextMenuItemsForPageAtIndex(PDFDocumentLayout::PageIndex) const;
-    WebCore::ContextMenuAction contextMenuActionFromTag(ContextMenuItemTag) const;
+    WebCore::ContextMenuAction NODELETE contextMenuActionFromTag(ContextMenuItemTag) const;
     static ContextMenuItemTag toContextMenuItemTag(int tagValue);
     void performContextMenuAction(ContextMenuItemTag, const WebCore::IntPoint& contextMenuEventRootViewPoint);
 
-    ContextMenuItemTag contextMenuItemTagFromDisplayMode(const PDFDisplayMode&) const;
-    PDFDisplayMode displayModeFromContextMenuItemTag(const ContextMenuItemTag&) const;
+    ContextMenuItemTag NODELETE contextMenuItemTagFromDisplayMode(const PDFDisplayMode&) const;
+    PDFDisplayMode NODELETE displayModeFromContextMenuItemTag(const ContextMenuItemTag&) const;
 #endif
 
     // Autoscroll
@@ -396,7 +396,7 @@ private:
     void beginAutoscroll();
     void autoscrollTimerFired();
     void continueAutoscroll();
-    void stopAutoscroll();
+    void NODELETE stopAutoscroll();
     void scrollWithDelta(const WebCore::IntSize&);
 
     // Selections
@@ -414,7 +414,7 @@ private:
     enum class IsDraggingSelection : bool { No, Yes };
     enum class IsMarqueeSelection : bool { No, Yes };
 
-    SelectionGranularity selectionGranularityForMouseEvent(const WebMouseEvent&) const;
+    SelectionGranularity NODELETE selectionGranularityForMouseEvent(const WebMouseEvent&) const;
     void beginTrackingSelection(PDFDocumentLayout::PageIndex, const WebCore::FloatPoint& pagePoint, const WebMouseEvent&);
     void extendCurrentSelectionIfNeeded();
     void updateCurrentSelectionForContextMenuEventIfNeeded();
@@ -534,7 +534,7 @@ private:
     bool requestStartKeyboardScrollAnimation(const WebCore::KeyboardScroll& scrollData) override;
     bool requestStopKeyboardScrollAnimation(bool immediate) override;
 
-    WebCore::OverscrollBehavior overscrollBehavior() const;
+    WebCore::OverscrollBehavior NODELETE overscrollBehavior() const;
     WebCore::OverscrollBehavior horizontalOverscrollBehavior() const override { return overscrollBehavior(); }
     WebCore::OverscrollBehavior verticalOverscrollBehavior() const override { return overscrollBehavior(); }
 
@@ -613,8 +613,8 @@ private:
     void createPasswordEntryForm();
     void teardownPasswordEntryForm() override;
 
-    bool isInDiscreteDisplayMode() const;
-    bool isShowingTwoPages() const;
+    bool NODELETE isInDiscreteDisplayMode() const;
+    bool NODELETE isShowingTwoPages() const;
 
     WebCore::PlatformWheelEvent wheelEventCopyWithVelocity(const WebCore::PlatformWheelEvent&) const;
 
@@ -656,7 +656,7 @@ private:
     void clearSelection() final;
 #endif
 
-    bool shouldUseInProcessBackingStore() const;
+    bool NODELETE shouldUseInProcessBackingStore() const;
 
     bool delegatesScrollingToMainFrame() const final;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1970,7 +1970,7 @@ auto UnifiedPDFPlugin::pdfElementTypesForPagePoint(const IntPoint& pointInPDFPag
 
 #pragma mark Events
 
-static bool isContextMenuEvent(const WebMouseEvent& event)
+static bool NODELETE isContextMenuEvent(const WebMouseEvent& event)
 {
 #if PLATFORM(MAC)
     return event.menuTypeForEvent();
@@ -3304,7 +3304,7 @@ void UnifiedPDFPlugin::scrollWithDelta(const IntSize& scrollDelta)
 
 #pragma mark -
 
-static NSStringCompareOptions compareOptionsForFindOptions(WebCore::FindOptions options)
+static NSStringCompareOptions NODELETE compareOptionsForFindOptions(WebCore::FindOptions options)
 {
     bool searchForward = !options.contains(FindOption::Backwards);
     bool isCaseSensitive = !options.contains(FindOption::CaseInsensitive);

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -72,9 +72,9 @@ class PluginView final : public WebCore::PluginViewBase {
 public:
     static RefPtr<PluginView> create(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader);
 
-    WebCore::LocalFrame* frame() const;
+    WebCore::LocalFrame* NODELETE frame() const;
 
-    bool isBeingDestroyed() const;
+    bool NODELETE isBeingDestroyed() const;
 
     void manualLoadDidReceiveResponse(const WebCore::ResourceResponse&);
     void manualLoadDidReceiveData(const WebCore::SharedBuffer&);
@@ -157,7 +157,7 @@ public:
 
     void didSameDocumentNavigationForFrame(WebFrame&);
 
-    PDFPluginIdentifier pdfPluginIdentifier() const;
+    PDFPluginIdentifier NODELETE pdfPluginIdentifier() const;
 
     void setPDFDisplayMode(PDFDisplayMode);
 
@@ -199,7 +199,7 @@ private:
 
     void updateDocumentForPluginSizingBehavior();
 
-    WebCore::RenderEmbeddedObject* renderer() const;
+    WebCore::RenderEmbeddedObject* NODELETE renderer() const;
 
     // WebCore::PluginViewBase
     WebCore::PluginLayerHostingStrategy layerHostingStrategy() const final;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -65,7 +65,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    IPC::Connection& connection() const;
+    IPC::Connection& NODELETE connection() const;
 
     WeakRef<WebProcess> m_process;
 

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.h
@@ -32,7 +32,7 @@ namespace WebKit {
 
 class WebSharedWorkerProvider final : public WebCore::SharedWorkerProvider {
 public:
-    static WebSharedWorkerProvider& singleton();
+    static WebSharedWorkerProvider& NODELETE singleton();
 
 private:
     friend NeverDestroyed<WebSharedWorkerProvider>;

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -62,7 +62,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<UserContentControllerIdentifier, WeakPtr<WebUserContentController>>& userContentControllers()
+static HashMap<UserContentControllerIdentifier, WeakPtr<WebUserContentController>>& NODELETE userContentControllers()
 {
     static NeverDestroyed<HashMap<UserContentControllerIdentifier, WeakPtr<WebUserContentController>>> userContentControllers;
 
@@ -283,7 +283,7 @@ public:
 
     virtual ~WebUserMessageHandlerDescriptorProxy() = default;
 
-    ScriptMessageHandlerIdentifier identifier() { return m_identifier; }
+    ScriptMessageHandlerIdentifier NODELETE identifier() { return m_identifier; }
 
 private:
     WebUserMessageHandlerDescriptorProxy(WebUserContentController& controller, const AtomString& name, InjectedBundleScriptWorld& world, ScriptMessageHandlerIdentifier identifier)

--- a/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.cpp
@@ -46,7 +46,7 @@ struct RemoteWebLockRegistry::LocksSnapshot {
     HashMap<WebCore::WebLockIdentifier, LockRequest> pendingRequests;
     HashMap<WebCore::WebLockIdentifier, LockInfo> heldLocks;
 
-    bool isEmpty() const { return pendingRequests.isEmpty() && heldLocks.isEmpty(); }
+    bool NODELETE isEmpty() const { return pendingRequests.isEmpty() && heldLocks.isEmpty(); }
 };
 
 RemoteWebLockRegistry::RemoteWebLockRegistry(WebProcess& process)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -539,7 +539,7 @@ static bool getActionTypeForKeyEvent(KeyboardEvent* event, WKInputFieldActionTyp
     return true;
 }
 
-static API::InjectedBundle::FormClient::InputFieldAction toInputFieldAction(WKInputFieldActionType action)
+static API::InjectedBundle::FormClient::InputFieldAction NODELETE toInputFieldAction(WKInputFieldActionType action)
 {
     switch (action) {
     case WKInputFieldActionTypeMoveUp:

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -62,7 +62,7 @@ public:
         WebCore::FrameIdentifier frameID;
         WebCore::PageIdentifier pageID;
     };
-    void setHasFrameSpecificStorageAccess(FrameSpecificStorageAccessIdentifier&&);
+    void NODELETE setHasFrameSpecificStorageAccess(FrameSpecificStorageAccessIdentifier&&);
     void didLoadFromRegistrableDomain(WebCore::RegistrableDomain&&) final;
     Vector<WebCore::RegistrableDomain> loadedSubresourceDomains() const final;
 
@@ -273,7 +273,7 @@ private:
 
     void getLoadDecisionForIcons(const Vector<std::pair<WebCore::LinkIcon&, uint64_t>>&) final;
 
-    inline bool hasPlugInView() const;
+    inline bool NODELETE hasPlugInView() const;
 
     void documentLoaderDetached(WebCore::NavigationIdentifier, WebCore::LoadWillContinueInAnotherProcess) final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -35,7 +35,7 @@ namespace WebKit {
 class WebMessagePortChannelProvider final : public WebCore::MessagePortChannelProvider {
     WTF_MAKE_TZONE_ALLOCATED(WebMessagePortChannelProvider);
 public:
-    static WebMessagePortChannelProvider& singleton();
+    static WebMessagePortChannelProvider& NODELETE singleton();
 
     void messagePortSentToRemote(const WebCore::MessagePortIdentifier&);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPasteboardOverrides.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPasteboardOverrides.h
@@ -39,7 +39,7 @@ namespace WebKit {
 class WebPasteboardOverrides {
     friend NeverDestroyed<WebPasteboardOverrides>;
 public:
-    static WebPasteboardOverrides& sharedPasteboardOverrides();
+    static WebPasteboardOverrides& NODELETE sharedPasteboardOverrides();
 
     void addOverride(const String& pasteboardName, const String& type, const Vector<uint8_t>&);
     void removeOverride(const String& pasteboardName, const String& type);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -41,7 +41,7 @@ public:
     static Ref<WebPopupMenu> create(WebPage*, WebCore::PopupMenuClient*);
     ~WebPopupMenu();
 
-    WebPage* page();
+    WebPage* NODELETE page();
 
     void disconnectFromPage() { m_page = nullptr; }
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.h
@@ -54,7 +54,7 @@ public:
     void logSubresourceLoadingForTesting(const WebCore::RegistrableDomain& firstPartyDomain, const WebCore::RegistrableDomain& thirdPartyDomain, bool shouldScheduleNotification);
 
 #if !RELEASE_LOG_DISABLED
-    static void setShouldLogUserInteraction(bool);
+    static void NODELETE setShouldLogUserInteraction(bool);
 #endif
 
     String statisticsForURL(const URL&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h
@@ -42,7 +42,7 @@ public:
     // FIXME: remove platform-specific code.
     static void ensureWebsiteDataStoreSession(const WebsiteDataStoreParameters&);
 
-    WebLocalFrameLoaderClient* webFrameLoaderClient() const;
+    WebLocalFrameLoaderClient* NODELETE webFrameLoaderClient() const;
 
 private:
     WebFrameNetworkingContext(WebFrame* frame)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -175,7 +175,7 @@ void TextAnimationController::removeInitialTextAnimationForActiveWritingToolsSes
         protect(m_webPage.get())->removeTextAnimationForAnimationID(*initialAnimationID);
 }
 
-static WebCore::CharacterRange remainingCharacterRange(WebCore::CharacterRange totalRange, WebCore::CharacterRange previousRange)
+static WebCore::CharacterRange NODELETE remainingCharacterRange(WebCore::CharacterRange totalRange, WebCore::CharacterRange previousRange)
 {
     if (totalRange.length < previousRange.length)
         return totalRange;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -87,7 +87,7 @@ public:
     DrawingAreaIdentifier identifier() const { return m_identifier; }
 
 #if ENABLE(TILED_CA_DRAWING_AREA)
-    static bool supportsGPUProcessRendering(DrawingAreaType);
+    static bool NODELETE supportsGPUProcessRendering(DrawingAreaType);
 #else
     static bool supportsGPUProcessRendering();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -78,7 +78,7 @@ public:
     uint32_t replaceMatches(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly);
     
     void hideFindIndicator();
-    void resetMatchIndex();
+    void NODELETE resetMatchIndex();
     void showFindIndicatorInSelection();
 
     bool isShowingOverlay() const { return m_isShowingFindIndicator && m_findPageOverlay; }
@@ -105,8 +105,8 @@ private:
     void didFailToFindString();
     void didHideFindIndicator();
     
-    unsigned findIndicatorRadius() const;
-    bool shouldHideFindIndicatorOnScroll() const;
+    unsigned NODELETE findIndicatorRadius() const;
+    bool NODELETE shouldHideFindIndicatorOnScroll() const;
     void didScrollAffectingFindIndicatorPosition();
 
     RefPtr<WebCore::LocalFrame> frameWithSelection(WebCore::Page*);

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -102,7 +102,7 @@ private:
         WebCore::PlatformDisplayID displayID;
         WebCore::FramesPerSecond nominalFrameRate;
     };
-    std::optional<DisplayProperties> displayProperties(WebCore::PageIdentifier) const;
+    std::optional<DisplayProperties> NODELETE displayProperties(WebCore::PageIdentifier) const;
 
     void dispatchSyntheticMomentumEvent(WebWheelEvent::Phase, WebCore::FloatSize delta);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -181,7 +181,7 @@ public:
         }
     }
 
-    void setDestinationLayerID(WebCore::PlatformLayerIdentifier layerID)
+    void NODELETE setDestinationLayerID(WebCore::PlatformLayerIdentifier layerID)
     {
         m_layerID = layerID;
     }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -306,7 +306,7 @@ private:
     WebCore::IncludeDynamicContentScalingDisplayList shouldIncludeDisplayListInBackingStore() const;
 #endif
 
-    bool requiresCustomAppearanceUpdateOnBoundsChange() const;
+    bool NODELETE requiresCustomAppearanceUpdateOnBoundsChange() const;
 
     WebCore::LayerPool* layerPool() override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -526,7 +526,7 @@ RefPtr<PlatformCAAnimation> PlatformCALayerRemote::animationForKey(const String&
     return m_animations.get(key);
 }
 
-static inline bool isEquivalentLayer(const PlatformCALayer* layer, const std::optional<PlatformLayerIdentifier>& layerID)
+static inline bool NODELETE isEquivalentLayer(const PlatformCALayer* layer, const std::optional<PlatformLayerIdentifier>& layerID)
 {
     auto newLayerID = layer ? std::optional { layer->layerID() } : std::nullopt;
     return layerID == newLayerID;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -79,7 +79,7 @@ public:
     
     std::optional<WebCore::DestinationColorSpace> displayColorSpace() const;
 
-    std::optional<DrawingAreaIdentifier> drawingAreaIdentifier() const;
+    std::optional<DrawingAreaIdentifier> NODELETE drawingAreaIdentifier() const;
 
     WebCore::UseLosslessCompression useIOSurfaceLosslessCompression() const;
 
@@ -109,7 +109,7 @@ public:
     bool canShowWhileLocked() const;
 #endif
 
-    WebPage& webPage() const;
+    WebPage& NODELETE webPage() const;
 
 private:
     explicit RemoteLayerTreeContext(WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
@@ -36,7 +36,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<VisitedLinkTableIdentifier, WeakPtr<VisitedLinkTableController>>& visitedLinkTableControllers()
+static HashMap<VisitedLinkTableIdentifier, WeakPtr<VisitedLinkTableController>>& NODELETE visitedLinkTableControllers()
 {
     static NeverDestroyed<HashMap<VisitedLinkTableIdentifier, WeakPtr<VisitedLinkTableController>>> visitedLinkTableControllers;
     RELEASE_ASSERT(isMainRunLoop());

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -58,7 +58,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    bool isSupported();
+    bool NODELETE isSupported();
 
     String cookiesForDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebPageProxyIdentifier, WebCore::IncludeSecureCookies);
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, const String& cookieString, WebCore::ShouldRelaxThirdPartyCookieBlocking);
@@ -79,7 +79,7 @@ private:
     WebCore::NetworkStorageSession& inMemoryStorageSession();
 
     void pruneCacheIfNecessary();
-    bool cacheMayBeOutOfSync() const;
+    bool NODELETE cacheMayBeOutOfSync() const;
 
     // CookieChangeListener
     void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -138,7 +138,7 @@ namespace WebKit {
 using namespace JSC;
 using namespace WebCore;
 
-static uint64_t generateListenerID()
+static uint64_t NODELETE generateListenerID()
 {
     static uint64_t uniqueListenerID = 1;
     return uniqueListenerID++;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -131,9 +131,9 @@ public:
 
     static WebFrame* webFrame(std::optional<WebCore::FrameIdentifier>);
     static RefPtr<WebFrame> fromCoreFrame(const WebCore::Frame&);
-    WebCore::LocalFrame* coreLocalFrame() const;
-    WebCore::RemoteFrame* coreRemoteFrame() const;
-    WebCore::Frame* coreFrame() const;
+    WebCore::LocalFrame* NODELETE coreLocalFrame() const;
+    WebCore::RemoteFrame* NODELETE coreRemoteFrame() const;
+    WebCore::Frame* NODELETE coreFrame() const;
 
     void createProvisionalFrame(ProvisionalFrameCreationParameters&&);
     void commitProvisionalFrame();
@@ -265,7 +265,7 @@ public:
     WebCore::HandleUserInputEventResult handleMouseEvent(const WebMouseEvent&);
     bool handleKeyEvent(const WebKeyboardEvent&);
 
-    bool isFocused() const;
+    bool NODELETE isFocused() const;
 
     String frameTextForTesting(bool);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -681,7 +681,7 @@ public:
 
     void layoutIfNeeded();
     void updateRendering();
-    bool hasRootFrames();
+    bool NODELETE hasRootFrames();
     String rootFrameOriginString();
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const;
     void finalizeRenderingUpdate(OptionSet<WebCore::FinalizeRenderingUpdateFlags>);
@@ -692,7 +692,7 @@ public:
     void didCompleteRenderingFrame();
 
     void releaseMemory(WTF::Critical);
-    void willDestroyDecodedDataForAllImages();
+    void NODELETE willDestroyDecodedDataForAllImages();
 
     unsigned remoteImagesCountForTesting() const;
 
@@ -788,7 +788,7 @@ public:
 
     inline void setHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds);
 
-    WebColorChooser* activeColorChooser() const;
+    WebColorChooser* NODELETE activeColorChooser() const;
     void setActiveColorChooser(WebColorChooser*);
     void didChooseColor(const WebCore::Color&);
     void didEndColorPicker();
@@ -802,7 +802,7 @@ public:
     void didEndDateTimePicker();
 
     WebOpenPanelResultListener* activeOpenPanelResultListener() const { return m_activeOpenPanelResultListener.get(); }
-    void setActiveOpenPanelResultListener(Ref<WebOpenPanelResultListener>&&);
+    void NODELETE setActiveOpenPanelResultListener(Ref<WebOpenPanelResultListener>&&);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
@@ -833,7 +833,7 @@ public:
 
     WebFrame& mainWebFrame() const { return m_mainFrame; }
 
-    WebCore::Frame* mainFrame() const;
+    WebCore::Frame* NODELETE mainFrame() const;
     WebCore::FrameView* mainFrameView() const;
     WebCore::LocalFrameView* localMainFrameView() const;
     RefPtr<WebCore::LocalFrame> localMainFrame() const;
@@ -884,7 +884,7 @@ public:
     void accessibilityManageRemoteElementStatus(bool, int);
 #endif
     void enableAccessibilityForAllProcesses();
-    void enableAccessibility();
+    void NODELETE enableAccessibility();
 
 #if PLATFORM(MAC)
     void getAccessibilityWebProcessDebugInfo(CompletionHandler<void(WebCore::AXDebugInfo)>&&);
@@ -901,7 +901,7 @@ public:
 
     double pageScaleFactor() const;
     double totalScaleFactor() const;
-    double viewScaleFactor() const;
+    double NODELETE viewScaleFactor() const;
 
     void didScalePage(double scale, const WebCore::IntPoint& origin);
     void didScalePageInViewCoordinates(double scale, const WebCore::IntPoint& origin);
@@ -944,7 +944,7 @@ public:
 
     void stopLoading();
     void stopLoadingDueToProcessSwap();
-    bool defersLoading() const;
+    bool NODELETE defersLoading() const;
 
     void enterAcceleratedCompositingMode(WebCore::Frame&, WebCore::GraphicsLayer*);
     void exitAcceleratedCompositingMode(WebCore::Frame&);
@@ -996,14 +996,14 @@ public:
 
     void setUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInterfaceLevel);
 
-    bool windowIsFocused() const;
-    bool windowAndWebPageAreFocused() const;
+    bool NODELETE windowIsFocused() const;
+    bool NODELETE windowAndWebPageAreFocused() const;
 
 #if !PLATFORM(IOS_FAMILY)
     void setHeaderPageBanner(PageBanner*);
-    PageBanner* headerPageBanner();
+    PageBanner* NODELETE headerPageBanner();
     void setFooterPageBanner(PageBanner*);
-    PageBanner* footerPageBanner();
+    PageBanner* NODELETE footerPageBanner();
 
     void hidePageBanners();
     void showPageBanners();
@@ -1027,7 +1027,7 @@ public:
 
     RefPtr<WebImage> scaledSnapshotWithOptions(const WebCore::IntRect&, double additionalScaleFactor, SnapshotOptions);
 
-    static const WebEvent* currentEvent();
+    static const WebEvent* NODELETE currentEvent();
 
     FindController& findController() { return m_findController.get(); }
     WebFoundTextRangeController& foundTextRangeController() { return m_foundTextRangeController.get(); }
@@ -1374,13 +1374,13 @@ public:
 
     bool isStoppingLoadingDueToProcessSwap() const { return m_isStoppingLoadingDueToProcessSwap; }
 
-    bool isIOSurfaceLosslessCompressionEnabled() const;
+    bool NODELETE isIOSurfaceLosslessCompressionEnabled() const;
 
-    bool isSmartInsertDeleteEnabled();
-    void setSmartInsertDeleteEnabled(bool);
+    bool NODELETE isSmartInsertDeleteEnabled();
+    void NODELETE setSmartInsertDeleteEnabled(bool);
 
-    bool isSelectTrailingWhitespaceEnabled() const;
-    void setSelectTrailingWhitespaceEnabled(bool);
+    bool NODELETE isSelectTrailingWhitespaceEnabled() const;
+    void NODELETE setSelectTrailingWhitespaceEnabled(bool);
 
     void replaceSelectionWithText(WebCore::LocalFrame*, const String&);
     void clearSelection();
@@ -1483,7 +1483,7 @@ public:
     void runModal();
 
     void setDeviceScaleFactor(float);
-    float deviceScaleFactor() const;
+    float NODELETE deviceScaleFactor() const;
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
     void setIntrinsicDeviceScaleFactor(float f) { m_intrinsicDeviceScaleFactor = f; }
@@ -1620,7 +1620,7 @@ public:
     void stopExtendingIncrementalRenderingSuppression(unsigned token);
     bool shouldExtendIncrementalRenderingSuppression() { return !m_activeRenderingSuppressionTokens.isEmpty(); }
 
-    WebCore::ScrollPinningBehavior scrollPinningBehavior();
+    WebCore::ScrollPinningBehavior NODELETE scrollPinningBehavior();
     void setScrollPinningBehavior(WebCore::ScrollPinningBehavior);
 
     std::optional<WebCore::ScrollbarOverlayStyle> scrollbarOverlayStyle() { return m_scrollbarOverlayStyle; }
@@ -1669,8 +1669,8 @@ public:
 
     void didRestoreScrollPosition();
 
-    bool isControlledByAutomation() const;
-    void setControlledByAutomation(bool);
+    bool NODELETE isControlledByAutomation() const;
+    void NODELETE setControlledByAutomation(bool);
 
     void connectInspector(Inspector::FrontendChannel::ConnectionType);
     void disconnectInspector();
@@ -1764,7 +1764,7 @@ public:
     void didLoadFromRegistrableDomain(WebCore::RegistrableDomain&&);
     void clearLoadedSubresourceDomains();
     void getLoadedSubresourceDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>)>&&);
-    const HashSet<WebCore::RegistrableDomain>& loadedSubresourceDomains() const;
+    const HashSet<WebCore::RegistrableDomain>& NODELETE loadedSubresourceDomains() const;
 
 #if ENABLE(DEVICE_ORIENTATION)
     void shouldAllowDeviceOrientationAndMotionAccess(WebCore::FrameIdentifier, FrameInfoData&&, bool mayPrompt, CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>&&);
@@ -1847,7 +1847,7 @@ public:
 
     WebPageProxyIdentifier webPageProxyIdentifier() const { return m_webPageProxyIdentifier; }
 
-    void scheduleIntrinsicContentSizeUpdate(const WebCore::IntSize&);
+    void NODELETE scheduleIntrinsicContentSizeUpdate(const WebCore::IntSize&);
     void flushPendingIntrinsicContentSizeUpdate();
     void updateIntrinsicContentSizeIfNeeded(const WebCore::IntSize&);
 
@@ -1957,8 +1957,8 @@ public:
     void getTextFragmentRanges(CompletionHandler<void(const Vector<EditingRange>&&)>&&);
 
 #if ENABLE(APP_HIGHLIGHTS)
-    WebCore::CreateNewGroupForHighlight highlightIsNewGroup() const;
-    WebCore::HighlightRequestOriginatedInApp highlightRequestOriginatedInApp() const;
+    WebCore::CreateNewGroupForHighlight NODELETE highlightIsNewGroup() const;
+    WebCore::HighlightRequestOriginatedInApp NODELETE highlightRequestOriginatedInApp() const;
     WebCore::HighlightVisibility appHighlightsVisiblility() const { return m_appHighlightsVisible; }
 
     void createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight, WebCore::HighlightRequestOriginatedInApp, CompletionHandler<void(WebCore::AppHighlight&&)>&&);
@@ -2044,7 +2044,7 @@ public:
 
     void generateTestReport(String&& message, String&& group);
 
-    bool isUsingUISideCompositing() const;
+    bool NODELETE isUsingUISideCompositing() const;
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     void updateImageAnimationEnabled();
@@ -2067,7 +2067,7 @@ public:
     WebCore::FloatSize screenSizeForFingerprintingProtections(const WebCore::LocalFrame&, WebCore::FloatSize defaultSize) const;
 
     const Logger& logger() const;
-    uint64_t logIdentifier() const;
+    uint64_t NODELETE logIdentifier() const;
 
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && (USE(GBM) || OS(ANDROID))
     const Vector<RendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
@@ -2156,7 +2156,7 @@ public:
     WebCore::MediaSessionManagerInterface* mediaSessionManagerIfExists() const;
 
 #if ENABLE(MODEL_ELEMENT)
-    bool shouldDisableModelLoadDelaysForTesting() const;
+    bool NODELETE shouldDisableModelLoadDelaysForTesting() const;
 #endif
 
     std::unique_ptr<FrameInfoData> takeMainFrameNavigationInitiator();
@@ -2296,14 +2296,14 @@ private:
     void platformDidReceiveLoadParameters(const LoadParameters&);
     void createProvisionalFrame(ProvisionalFrameCreationParameters&&);
     void loadDidCommitInAnotherProcess(WebCore::FrameIdentifier, std::optional<WebCore::LayerHostingContextIdentifier>);
-    [[noreturn]] void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
+    [[noreturn]] void NODELETE loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
     void loadData(LoadParameters&&);
     void loadAlternateHTML(LoadParameters&&);
     void loadSimulatedRequestAndResponse(LoadParameters&&, WebCore::ResourceResponse&&);
     void getPDFFirstPageSize(WebCore::FrameIdentifier, CompletionHandler<void(WebCore::FloatSize)>&&);
     void reload(WebCore::NavigationIdentifier, OptionSet<WebCore::ReloadOption> reloadOptions, SandboxExtensionHandle&&);
     void goToBackForwardItem(GoToBackForwardItemParameters&&);
-    [[noreturn]] void goToBackForwardItemWaitingForProcessLaunch(GoToBackForwardItemParameters&&, WebKit::WebPageProxyIdentifier);
+    [[noreturn]] void NODELETE goToBackForwardItemWaitingForProcessLaunch(GoToBackForwardItemParameters&&, WebKit::WebPageProxyIdentifier);
     void tryRestoreScrollPosition();
     void setInitialFocus(bool forward, bool isKeyboardEventValid, const std::optional<WebKeyboardEvent>&, CompletionHandler<void()>&&);
     void updateIsInWindow(bool isInitialState = false);
@@ -2417,7 +2417,7 @@ private:
 #endif
 
     void setUserAgent(String&&);
-    void setHasCustomUserAgent(bool);
+    void NODELETE setHasCustomUserAgent(bool);
     void setCustomTextEncodingName(const String&);
     void suspendActiveDOMObjectsAndAnimations();
     void resumeActiveDOMObjectsAndAnimations();
@@ -2536,8 +2536,8 @@ private:
     bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
     void platformDidSelectAll();
 
-    void setHasResourceLoadClient(bool);
-    void setCanUseCredentialStorage(bool);
+    void NODELETE setHasResourceLoadClient(bool);
+    void NODELETE setCanUseCredentialStorage(bool);
 
 #if ENABLE(CONTEXT_MENUS)
     void didSelectItemFromActiveContextMenu(const WebContextMenuItemData&);
@@ -2632,7 +2632,7 @@ private:
 
     void cancelCurrentInteractionInformationRequest();
 
-    bool shouldDispatchUpdateAfterFocusingElement(const WebCore::Element&) const;
+    bool NODELETE shouldDispatchUpdateAfterFocusingElement(const WebCore::Element&) const;
 
     void updateMockAccessibilityElementAfterCommittingLoad();
 
@@ -2649,12 +2649,12 @@ private:
     void preferredBufferFormatsDidChange(Vector<RendererBufferFormat>&&);
 #endif
 
-    void platformDidScalePage();
+    void NODELETE platformDidScalePage();
 
     Vector<Ref<SandboxExtension>> consumeSandboxExtensions(Vector<SandboxExtensionHandle>&&);
     void revokeSandboxExtensions(Vector<Ref<SandboxExtension>>& sandboxExtensions);
 
-    bool hasPendingEditorStateUpdate() const;
+    bool NODELETE hasPendingEditorStateUpdate() const;
     bool shouldAvoidComputingPostLayoutDataForEditorState() const;
 
     void useRedirectionForCurrentNavigation(WebCore::ResourceResponse&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.h
@@ -46,7 +46,7 @@ public:
     const String& identifier() const { return m_data.identifier; }
     PageGroupIdentifier pageGroupID() const { return m_data.pageGroupID; }
     // Namespace IDs for local storage namespaces are currently equivalent to web page group IDs.
-    WebCore::PageGroup* corePageGroup() const;
+    WebCore::PageGroup* NODELETE corePageGroup() const;
 
 private:
     WebPageGroupProxy(WebPageGroupData&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -37,7 +37,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<WeakRef<PageOverlay>, WeakRef<WebPageOverlay>>& overlayMap()
+static HashMap<WeakRef<PageOverlay>, WeakRef<WebPageOverlay>>& NODELETE overlayMap()
 {
     static NeverDestroyed<HashMap<WeakRef<PageOverlay>, WeakRef<WebPageOverlay>>> map;
     return map;

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
@@ -78,7 +78,7 @@ public:
     };
 
     static Ref<WebPageOverlay> create(std::unique_ptr<Client>, WebCore::PageOverlay::OverlayType = WebCore::PageOverlay::OverlayType::View);
-    static WebPageOverlay* fromCoreOverlay(WebCore::PageOverlay&);
+    static WebPageOverlay* NODELETE fromCoreOverlay(WebCore::PageOverlay&);
     virtual ~WebPageOverlay();
 
     void setNeedsDisplay(const WebCore::IntRect& dirtyRect);

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.cpp
@@ -57,7 +57,7 @@ static uint64_t pageIDFromWebFrame(const RefPtr<WebFrame>& frame)
     return 0;
 }
 
-static uint64_t frameIDFromWebFrame(const RefPtr<WebFrame>& frame)
+static uint64_t NODELETE frameIDFromWebFrame(const RefPtr<WebFrame>& frame)
 {
     if (frame)
         return frame->frameID().toUInt64();

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -249,7 +249,7 @@ static String commandNameForSelectorName(const String& selectorName)
     return selectorName.left(selectorNameLength - 1);
 }
 
-static LocalFrame* frameForEvent(KeyboardEvent* event)
+static LocalFrame* NODELETE frameForEvent(KeyboardEvent* event)
 {
     ASSERT(event->target());
     ASSERT(downcast<Node>(event->target())->document().frame());

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1324,7 +1324,7 @@ void WebProcess::setInjectedBundleParameters(std::span<const uint8_t> value)
     injectedBundle->setBundleParameters(value);
 }
 
-[[noreturn]] inline void failedToGetNetworkProcessConnection()
+[[noreturn]] inline void NODELETE failedToGetNetworkProcessConnection()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     // GTK and WPE ports don't exit on send sync message failure.
@@ -2301,7 +2301,7 @@ void WebProcess::grantUserMediaDeviceSandboxExtensions(MediaDeviceSandboxExtensi
         machBootstrapExtension->consume();
 }
 
-static inline void checkDocumentsCaptureStateConsistency(const Vector<String>& extensionIDs)
+static inline void NODELETE checkDocumentsCaptureStateConsistency(const Vector<String>& extensionIDs)
 {
 #if ASSERT_ENABLED
     bool isCapturingAudio = std::ranges::any_of(Document::allDocumentsMap().values(), [](auto& document) {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -291,7 +291,7 @@ public:
 
     void networkProcessConnectionClosed(NetworkProcessConnection*);
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
-    WebLoaderStrategy& webLoaderStrategy();
+    WebLoaderStrategy& NODELETE webLoaderStrategy();
     WebFileSystemStorageConnection& fileSystemStorageConnection();
 
     RefPtr<WebTransportSession> webTransportSession(WebTransportSessionIdentifier);
@@ -465,16 +465,16 @@ public:
     void updatePageScreenProperties();
 #endif
 
-    void setChildProcessDebuggabilityEnabled(bool);
+    void NODELETE setChildProcessDebuggabilityEnabled(bool);
 
 #if ENABLE(GPU_PROCESS)
-    void setUseGPUProcessForCanvasRendering(bool);
-    void setUseGPUProcessForDOMRendering(bool);
+    void NODELETE setUseGPUProcessForCanvasRendering(bool);
+    void NODELETE setUseGPUProcessForDOMRendering(bool);
     void setUseGPUProcessForMedia(bool);
-    bool shouldUseRemoteRenderingFor(WebCore::RenderingPurpose);
+    bool NODELETE shouldUseRemoteRenderingFor(WebCore::RenderingPurpose);
 #if ENABLE(WEBGL)
-    void setUseGPUProcessForWebGL(bool);
-    bool shouldUseRemoteRenderingForWebGL() const;
+    void NODELETE setUseGPUProcessForWebGL(bool);
+    bool NODELETE shouldUseRemoteRenderingForWebGL() const;
 #endif
 #endif
 
@@ -577,7 +577,7 @@ private:
 
     void platformTerminate();
 
-    void setHasSuspendedPageProxy(bool);
+    void NODELETE setHasSuspendedPageProxy(bool);
     void setIsInProcessCache(bool, CompletionHandler<void()>&&);
     void markIsNoLongerPrewarmed();
 
@@ -607,7 +607,7 @@ private:
     void flushResourceLoadStatistics();
     void seedResourceLoadStatisticsForTesting(const WebCore::RegistrableDomain& firstPartyDomain, const WebCore::RegistrableDomain& thirdPartyDomain, bool shouldScheduleNotification, CompletionHandler<void()>&&);
     void userPreferredLanguagesChanged(const Vector<String>&) const;
-    void fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled);
+    void NODELETE fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled);
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     void setOptInCookiePartitioningEnabled(bool);
 #endif
@@ -645,7 +645,7 @@ private:
     void clearCachedPage(WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void()>&&);
 
 #if ENABLE(SERVICE_CONTROLS)
-    void setEnabledServices(bool hasImageServices, bool hasSelectionServices, bool hasRichContentServices);
+    void NODELETE setEnabledServices(bool hasImageServices, bool hasSelectionServices, bool hasRichContentServices);
 #endif
 
     void handleInjectedBundleMessage(const String& messageName, const UserData& messageBody);

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -88,7 +88,7 @@ private:
 
     void didSetItem(uint64_t mapSeed, const String& key, bool hasError, HashMap<String, String>&&);
     void didRemoveItem(uint64_t mapSeed, const String& key, bool hasError, HashMap<String, String>&&);
-    void didClear(uint64_t mapSeed);
+    void NODELETE didClear(uint64_t mapSeed);
 
     // Message handlers.
     void dispatchStorageEvent(const std::optional<StorageAreaImplIdentifier>& sourceStorageAreaID, const String& key, const String& oldValue, const String& newValue, const String& urlString, uint64_t messageIdentifier);

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
@@ -38,7 +38,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static WeakPtr<WebStorageNamespaceProvider>& existingStorageNameSpaceProvider()
+static WeakPtr<WebStorageNamespaceProvider>& NODELETE existingStorageNameSpaceProvider()
 {
     static NeverDestroyed<WeakPtr<WebStorageNamespaceProvider>> storageNameSpaceProvider;
     return storageNameSpaceProvider.get();

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -233,7 +233,7 @@ private:
     const Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "VideoPresentationManager"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakPtr<WebPage> m_page;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h
@@ -38,7 +38,7 @@ public:
     ~RemoteRealtimeAudioSource();
 
     void remoteAudioSamplesAvailable(const WTF::MediaTime&, const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t);
-    void setDescription(const WebCore::CAAudioStreamDescription&);
+    void NODELETE setDescription(const WebCore::CAAudioStreamDescription&);
 
 private:
     RemoteRealtimeAudioSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, const WebCore::MediaConstraints*, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, bool shouldCaptureInGPUProcess, std::optional<WebCore::PageIdentifier>);

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -86,7 +86,7 @@ private:
     class AudioFactory : public WebCore::AudioCaptureFactory {
     public:
         explicit AudioFactory(UserMediaCaptureManager& manager) : m_manager(manager) { }
-        void setShouldCaptureInGPUProcess(bool);
+        void NODELETE setShouldCaptureInGPUProcess(bool);
 
     private:
         WebCore::CaptureSourceOrError createAudioCaptureSource(const WebCore::CaptureDevice&, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints*, std::optional<WebCore::PageIdentifier>) final;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -149,7 +149,7 @@ public:
 
     void invalidate();
 
-    bool hasVideoPlayingInPictureInPicture() const;
+    bool NODELETE hasVideoPlayingInPictureInPicture() const;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -161,7 +161,7 @@ public:
     // Interface to WebChromeClient
     bool canEnterVideoFullscreen(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
     bool supportsVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
-    bool supportsVideoFullscreenStandby() const;
+    bool NODELETE supportsVideoFullscreenStandby() const;
     void enterVideoFullscreenForVideoElement(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool standby);
     void setPlayerIdentifierForVideoElement(WebCore::HTMLVideoElement&);
     void exitVideoFullscreenForVideoElement(WebCore::HTMLVideoElement&, WTF::CompletionHandler<void(bool)>&& = [](bool) { });
@@ -223,15 +223,15 @@ protected:
     void requestRouteSharingPolicyAndContextUID(WebCore::MediaPlayerClientIdentifier, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&&);
     void ensureUpdatedVideoDimensions(WebCore::MediaPlayerClientIdentifier, WebCore::FloatSize existingVideoDimensions);
 
-    void setCurrentVideoFullscreenMode(VideoPresentationInterfaceContext&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void NODELETE setCurrentVideoFullscreenMode(VideoPresentationInterfaceContext&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void setRequiresTextTrackRepresentation(WebCore::MediaPlayerClientIdentifier, bool);
     void setTextTrackRepresentationBounds(WebCore::MediaPlayerClientIdentifier, const WebCore::IntRect&);
 
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const;
-    uint64_t logIdentifier() const;
+    const Logger& NODELETE logger() const;
+    uint64_t NODELETE logIdentifier() const;
     ASCIILiteral logClassName() const;
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakPtr<WebPage> m_page;

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -217,8 +217,8 @@ public:
 
     virtual ASCIILiteral description() const = 0;
 
-    const PushSubscriptionSetIdentifier& subscriptionSetIdentifier() const { return m_identifier; }
-    const String& scope() const { return m_scope; };
+    const PushSubscriptionSetIdentifier& NODELETE subscriptionSetIdentifier() const { return m_identifier; }
+    const String& NODELETE scope() const { return m_scope; };
 
     virtual void start() = 0;
 
@@ -234,9 +234,9 @@ protected:
     {
     }
 
-    PushService& service() const { return m_service.get(); }
-    PushServiceConnection& connection() const { return m_connection.get(); }
-    PushDatabase& database() const { return m_database.get(); }
+    PushService& NODELETE service() const { return m_service.get(); }
+    PushServiceConnection& NODELETE connection() const { return m_connection.get(); }
+    PushDatabase& NODELETE database() const { return m_database.get(); }
 
     virtual void finish() = 0;
 

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -138,7 +138,7 @@ private:
     void releaseIncomingPushTransaction();
     void incomingPushTransactionTimerFired();
 
-    Seconds silentPushTimeout() const;
+    Seconds NODELETE silentPushTimeout() const;
     void rescheduleSilentPushTimer();
     void silentPushTimerFired();
     void didShowNotification(const WebCore::PushSubscriptionSetIdentifier&, const String& scope);


### PR DESCRIPTION
#### 26754ae6c969762943bfae08aae787c69c0bc70d
<pre>
Adopt `NODELETE` annotation in more places in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=308411">https://bugs.webkit.org/show_bug.cgi?id=308411</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelObjectHeap.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::categoryCanMixWithOthers):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::validateEncoderInitializationData):
(WebKit::toWebRTCVideoRotation):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
(WebKit::canCaptureFromMultipleCameras):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::hasBeenThirdParty):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm:
(WebKit::toCFHTTPCookieStorageAcceptPolicy):
* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(firstNetworkProcess):
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/Daemon/DaemonEntryPoint.h:
* Source/WebKit/NetworkProcess/NetworkActivityTracker.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::toBrowsingContextGroupSwitchDecision):
(WebKit::shouldTryToMatchRegistrationOnRedirection):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/PingLoad.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp:
(WebKit::PCM::managerPointer):
(WebKit::PCM::daemonManagerSingleton):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(WebKit::PCM::taskMap):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::allWorkers):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::cachePolicyAllowsExpired):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::dispatchQueueIdentifier):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::PreloadedEntry::revalidationRequest const):
(WebKit::NetworkCache::SpeculativeLoadManager::PreloadedEntry::wasRevalidated const):
(WebKit::NetworkCache::SpeculativeLoadManager::PendingFrameLoad::didReceiveMainResourceResponse const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::ReadOperation::identifier const):
(WebKit::NetworkCache::Storage::ReadOperation::key const):
(WebKit::NetworkCache::Storage::ReadOperation::priority const):
(WebKit::NetworkCache::Storage::ReadOperation::isCanceled const):
(WebKit::NetworkCache::Storage::ReadOperation::canFinish const):
(WebKit::NetworkCache::Storage::ReadOperation::setWaitsForBlob):
(WebKit::NetworkCache::Storage::WriteOperation::identifier const):
(WebKit::NetworkCache::Storage::WriteOperation::WTF_REQUIRES_CAPABILITY):
(WebKit::NetworkCache::Storage::WriteOperation::storeBlobInMemoryCache const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::toNSURLSessionTaskPriority):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(toNSURLSessionAuthChallengeDisposition):
(toPrivacyStance):
* Source/WebKit/NetworkProcess/mac/SecItemShim.mm:
(WebKit::globalNetworkProcess):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::activePaths):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::mode const):
(WebKit::OriginStorageManager::StorageBucket::setMode):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::pendingRegistrationRequestMap):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::markAsStopped):
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::isStopped const):
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::shouldLogMissingECN const):
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::didLogMissingECN):
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::hasPendingSend const):
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::incrementPendingSendCount):
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::decrementPendingSendCount):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::WTF_REQUIRES_LOCK):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/DaemonDecoder.h:
* Source/WebKit/Platform/IPC/Decoder.h:
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::roundUpToAlignment):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/MessageLog.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/cocoa/MachMessage.cpp:
(IPC::safeRoundMsg):
* Source/WebKit/Platform/IPC/cocoa/MachMessage.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toReadingImpl):
(WebKit::toWritingImpl):
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::toPKPaymentAuthorizationStatus):
(WebKit::toPKPaymentErrorCode):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::restrictedOpenerType):
(WebKit::TrackerAddressLookupInfo::owner const):
(WebKit::TrackerAddressLookupInfo::host const):
(WebKit::TrackerAddressLookupInfo::canBlock const):
(WebKit::TrackerDomainLookupInfo::owner const):
(WebKit::TrackerDomainLookupInfo::canBlock const):
* Source/WebKit/Platform/foundation/LoggingFoundation.mm:
(WebKit::logLevelString):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(generateReplyIdentifier):
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/Shared/APIWebArchive.h:
* Source/WebKit/Shared/APIWebArchiveResource.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp:
(WebKit::activePaymentCoordinatorProxy):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKShippingType):
(WebKit::toPKShippingContactEditingMode):
(WebKit::toPKApplePayLaterAvailability):
(WebKit::toAPIType):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h:
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::itpQueue):
* Source/WebKit/Shared/Cocoa/InteractionInformationRequest.h:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultCaptionDisplaySettingsEnabled):
(WebKit::defaultUseAppKitGestures):
(WebKit::defaultTextInputClientSelectionUpdatesEnabled):
(WebKit::defaultContentInsetBackgroundFillEnabled):
(WebKit::defaultIOSurfaceLosslessCompressionEnabled):
(WebKit::defaultUnifiedPDFEnabled):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::enterSandbox):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::overrideLanguagesFromBootstrap):
(WebKit::stageOverrideLanguagesForMainThread):
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h:
* Source/WebKit/Shared/RTCPacketOptions.cpp:
(WebKit::toDifferentiatedServicesCodePoint):
* Source/WebKit/Shared/RTCPacketOptions.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/SharedStringHashTable.h:
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
(WebKit::doubleHash):
* Source/WebKit/Shared/SharedStringHashTableReadOnly.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::useTagNameForTextFormControls const):
(WebKit::TextExtractionAggregator::includeRects const):
(WebKit::TextExtractionAggregator::includeURLs const):
(WebKit::TextExtractionAggregator::shortenURLs const):
(WebKit::TextExtractionAggregator::onlyIncludeText const):
(WebKit::TextExtractionAggregator::useHTMLOutput const):
(WebKit::TextExtractionAggregator::useMarkdownOutput const):
(WebKit::TextExtractionAggregator::useTextTreeOutput const):
(WebKit::TextExtractionAggregator::useJSONOutput const):
(WebKit::TextExtractionAggregator::currentURLString const):
(WebKit::TextExtractionAggregator::popURLString):
(WebKit::TextExtractionAggregator::pushSuperscript):
(WebKit::TextExtractionAggregator::superscriptLevel const):
(WebKit::TextExtractionAggregator::popSuperscript):
(WebKit::TextExtractionAggregator::pushStrikethrough):
(WebKit::TextExtractionAggregator::isInsideStrikethrough const):
(WebKit::TextExtractionAggregator::popStrikethrough):
(WebKit::TextExtractionAggregator::version const):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/Shared/WebCompiledContentRuleList.h:
* Source/WebKit/Shared/WebCompiledContentRuleListData.cpp:
(WebKit::ruleListDataSize):
* Source/WebKit/Shared/WebContextMenuItem.h:
* Source/WebKit/Shared/WebContextMenuItemData.h:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::forceForEvent):
* Source/WebKit/Shared/WebEventConversion.h:
* Source/WebKit/Shared/WebFoundTextRange.h:
* Source/WebKit/Shared/WebImage.h:
* Source/WebKit/Shared/WebKeyboardEvent.h:
* Source/WebKit/Shared/WebMemorySampler.h:
* Source/WebKit/Shared/WebMouseEvent.h:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/WebPreferencesStore.cpp:
(WebKit::boolTestRunnerOverridesMap):
* Source/WebKit/Shared/WebWheelEvent.h:
* Source/WebKit/Shared/WebWheelEventCoalescer.h:
* Source/WebKit/Shared/WebsiteAutoplayPolicy.h:
* Source/WebKit/Shared/WebsiteData/WebsiteData.h:
* Source/WebKit/Shared/cf/CoreIPCNumber.h:
* Source/WebKit/Shared/mac/WebEventFactory.h:
* Source/WebKit/UIProcess/API/APIContentRuleList.h:
* Source/WebKit/UIProcess/API/APIContentRuleListAction.h:
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::headerSize):
(API::ContentRuleListMetaData::fileSize const):
(API::compiledToFile):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::sharedWorldNameMap):
(API::sharedWorldIdentifierMap):
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/APIFormInfo.h:
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/APIInspectorConfiguration.h:
* Source/WebKit/UIProcess/API/APINavigation.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/APIScriptMessage.h:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(toWKErrorCode):
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(toHTTPCookieAcceptPolicy):
(toWKCookiePolicy):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(toWKNavigationType):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(toStorageBlockingPolicy):
(toAPI):
(toEditableLinkBehavior):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(processStateFromThrottleState):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(toAPI):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(toRectEdges):
(convertUserInterfaceDirectionPolicy):
(convertSystemLayoutDirection):
(toWKMediaPlaybackState):
(nsTextAlignment):
(selectionAttributes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(WebKit::upgradeToHTTPSPolicy):
(WebKit::httpsByDefaultMode):
(WebKit::mouseEventPolicy):
(WebKit::coreMouseEventPolicy):
(WebKit::modalContainerObservationPolicy):
(WebKit::coreModalContainerObservationPolicy):
(toDeviceOrientationOrMotionPermissionState):
(toWKWebsiteDeviceOrientationAndMotionAccessPolicy):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(toWKResourceLoadInfoResourceType):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(wkWebAuthenticationTransport):
(wkWebAuthenticationType):
(coreUserVerificationAvailability):
(authenticatorTransport):
(authenticatorAttachment):
(userVerification):
(toWebCore):
(attestationConveyancePreference):
(authenticatorAttachmentToWKAuthenticatorAttachment):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(toWKPermissionsState):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(toWKUnifiedOriginStorageLevel):
(toUnifiedOriginStorageLevel):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(coreBoxExtentsFromEdgeInsets):
* Source/WebKit/UIProcess/AboutSchemeHandler.h:
* Source/WebKit/UIProcess/Authentication/WebCredential.h:
* Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h:
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::browsingContextPresentationFromCreateType):
(WebKit::pageLoadStrategyFromReadinessState):
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::toProtocol):
(WebKit::toProtocolUserPromptType):
(WebKit::protocolStringToCoordinateSystem):
(WebKit::toProtocolSameSitePolicy):
(WebKit::toWebCoreSameSitePolicy):
(WebKit::toAuthenticatorTransport):
(WebKit::protocolModifierToWebEventModifier):
(WebKit::simulatedInputSourceTypeFromProtocolSourceType):
(WebKit::normalizedVirtualKey):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::nsEventButtonNumberFromAutomationMouseButton):
(WebKit::automationMouseButtonToPlatformMouseButton):
(WebKit::virtualKeyHasStickyModifier):
(WebKit::keyCodeForCharKey):
(WebKit::eventModifierFlagsForVirtualKey):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::connectionToProcessMap):
(WebKit::adjustedTimeoutForThermalState):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/Cocoa/CSPExtensionUtilities.h:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm:
(WebKit::toWKDiagnosticLoggingResultType):
(WebKit::toWKDiagnosticLoggingDomain):
* Source/WebKit/UIProcess/Cocoa/MediaUtilities.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::soAuthorizationLoadPolicy):
(WebKit::wkSOAuthorizationLoadPolicy):
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::WebCore::toString):
* Source/WebKit/UIProcess/Cocoa/SafeBrowsingUtilities.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::containerType):
(WebKit::eventListenerTypes):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::toWKFocusDirection):
(WebKit::toWKAutoplayEventFlags):
(WebKit::toWKAutoplayEvent):
(WebKit::webAuthenticationPanelResult):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::cachedLockdownModeEnabledGlobally):
(WebKit::NSAppSingleton):
(WebKit::isLockdownModeEnabledGloballyForTesting):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::mediaTypeCache):
* Source/WebKit/UIProcess/DisplayLink.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::enabledSitesMap):
(WebKit::reasonForEnhancedSecurity):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::isTestEventListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::toAPI):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::toImpl):
(WebKit::webExtensionContexts):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::webExtensionControllers):
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp:
(WebKit::patternCache):
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/UIProcess/FrameProcess.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::shouldCreateAppleCameraServiceSandboxExtension):
(WebKit::singleton):
(WebKit::keptAliveGPUProcessProxy):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::logChannel):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/ModelElementController.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::identifierForPagePointer):
* Source/WebKit/UIProcess/OverrideLanguages.cpp:
(WebKit::overrideLanguagesStorage):
* Source/WebKit/UIProcess/OverrideLanguages.h:
* Source/WebKit/UIProcess/PageLoadState.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::generatePrepareToSuspendRequestID):
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/TextCheckerCompletion.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::webUserContentControllerProxies):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::toWebCore):
(WebKit::UserMediaPermissionInfoGatherer::setCameraPermission):
(WebKit::UserMediaPermissionInfoGatherer::setMicrophonePermission):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::needsAppleCameraService):
* Source/WebKit/UIProcess/UserMediaProcessManager.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::viewGestureControllersForAllPages):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm:
(WebKit::deviceRemovedCallback):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::authDataFlags):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::wkWebAuthenticationPanelUpdate):
(WebKit::wkWebAuthenticationResult):
(WebKit::wkWebAuthenticationSource):
(WebKit::localAuthenticatorPolicy):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toExceptionCode):
(WebKit::fromASAuthorizationPublicKeyCredentialAttachment):
(WebKit::toASCResidentKeyPreference):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.h:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::setBackForwardItemIdentifier):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::allFrames):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebNavigationState.h:
* Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.h:
* Source/WebKit/UIProcess/WebPageGroup.cpp:
(WebKit::webPageGroupMap):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::openerInfoOfPageBeingOpened):
(WebKit::webPageProxyMap):
(WebKit::websitePoliciesAndProcess):
(WebKit::WebPageProxy::countStringMatches):
(WebKit::frameTreePropertyIsRestrictedToFrameOwningProcess):
(WebKit::frameSandboxAllowsOpeningExternalCustomProtocols):
(WebKit::applyWebAppDesiredMutedKinds):
(WebKit::updateMutedCaptureKindsDesiredByWebApp):
(WebKit::shouldReloadAfterProcessTermination):
(WebKit::shouldShowSwiftDemoLogo):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebPreferences.h:
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::generateAddRequestIdentifier):
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::processPools):
(WebKit::globalURLSchemesWithCustomProtocolHandlers):
(WebKit::shouldReportNetworkOrGPUProcessCrash):
(WebKit::WebProcessPool::countWebPagesInAllProcessesForTesting):
(WebKit::WebProcessPool::isJITDisabledInAllRemoteWorkerProcesses const):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::transformHandlesToObjects):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::managedDomains):
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::activeGeneralStorageDirectories):
(WebKit::allDataStores):
(WebKit::protectedGlobalDefaultDataStore):
(WebKit::globalDefaultDataStore):
(WebKit::defaultDataStoreIsPersistent):
(WebKit::computeWebProcessAccessTypeForDataFetch):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::computeWebProcessAccessTypeForDataRemovalWithRecords):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::toScreenCaptureKitPromptType):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataEncoder::finishEncoding):
(WebKit::HistoryEntryDataEncoder::capacity const):
(WebKit::HistoryEntryDataEncoder::mutableBuffer):
(WebKit::HistoryEntryDataEncoder::buffer const):
(WebKit::HistoryEntryDataDecoder::isValid const):
(WebKit::HistoryEntryDataDecoder::markInvalid):
(WebKit::HistoryEntryDataDecoder::finishDecoding):
(WebKit::HistoryEntryDataDecoder::alignBufferPosition):
(WebKit::HistoryEntryDataDecoder::alignedBuffer const):
(WebKit::HistoryEntryDataDecoder::bufferIsLargeEnoughToContain const):
(WebKit::HistoryEntryDataDecoder::alignedBufferIsLargeEnoughToContain const):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::toCorrectionResponse):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::flagsChangedEventMonitorTrackingAreaOptions):
(WebKit::coreTextCheckingType):
(WebKit::kit):
(WebKit::pasteboardNameForAccessCategory):
(WebKit::toWKRectEdge):
(WebKit::toRectEdges):
(WebKit::toUserInterfaceLayoutDirection):
(WebKit::nsTextAlignmentFromTextAlignment):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::isValidNodeHandle):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::PromiseConverter::convertError):
* Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp:
(WebKit::databaseProviders):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::toWebAPI):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::webExtensionPorts):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::toWebAPI):
(WebKit::toWindowTypeFilter):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::wrapperCache):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::webExtensionContextProxies):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::webExtensionControllerProxies):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxyFlushFence::renderingUpdateID const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::offsetOrSizeExceedsBounds):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::equalDescriptors):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::mimeCaches):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoderCallbacks::close):
(WebKit::RemoteVideoEncoderCallbacks::close):
(WebKit::shouldUseLocalDecoder):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::toVideoRotation):
(WebKit::toWebRTCCodecType):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
(toAutoFillButtonType):
(toWKAutoFillButtonType):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp:
(WebKit::domStyleDeclarationHandleCache):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::domRangeHandleCache):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::allExtensions):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp:
(WebKit::toWKInputFieldActionType):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::allWorlds):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.h:
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.h:
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:
(WebKit::sharedModelElementCacheDirectory):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::pageIDForLog):
(WebKit::frameIDForLog):
(WebKit::resourceIDForLog):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::convertToWebRTCEcnMarking):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h:
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::streamLoader):
(WebKit::ByteRangeRequest::position const):
(WebKit::ByteRangeRequest::count const):
(WebKit::ByteRangeRequest::accumulatedData const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::isContextMenuEvent):
(WebKit::compareOptionsForFindOptions):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerProvider.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::userContentControllers):
(WebKit::WebUserMessageHandlerDescriptorProxy::identifier):
* Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.cpp:
(WebKit::RemoteWebLockRegistry::LocksSnapshot::isEmpty const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::toInputFieldAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPasteboardOverrides.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::cachedImage):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::remainingCharacterRange):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemoteAsyncContentsDisplayDelegate::setDestinationLayerID):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::isEquivalentLayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp:
(WebKit::visitedLinkTableControllers):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::generateListenerID):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp:
(WebKit::overlayMap):
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.cpp:
(WebKit::frameIDFromWebFrame):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::frameForEvent):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::failedToGetNetworkProcessConnection):
(WebKit::checkDocumentsCaptureStateConsistency):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
(WebKit::existingStorageNameSpaceProvider):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushServiceRequest::subscriptionSetIdentifier const):
(WebPushD::PushServiceRequest::scope const):
(WebPushD::PushServiceRequest::service const):
(WebPushD::PushServiceRequest::connection const):
(WebPushD::PushServiceRequest::database const):
* Source/WebKit/webpushd/WebPushDaemon.h:

Canonical link: <a href="https://commits.webkit.org/308009@main">https://commits.webkit.org/308009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2f04dc1838d58b2fc23c6f0c168b184e331e43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99696 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112529 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80498 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93399 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2350 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157223 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120554 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130292 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74467 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7769 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18083 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18249 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->