### PR TITLE
[MathML] Symmetric non-stretchy largeop operators should center around math axis

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/symmetric-largeop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/symmetric-largeop-expected.txt
@@ -1,5 +1,5 @@
 ⫿
 ⫿
 
-FAIL Placement of operators assert_equals: symmetric largeop is centered around the math axis expected 75 but got 90
+PASS Placement of operators
 

--- a/LayoutTests/platform/glib/mathml/opentype/large-operators-expected.txt
+++ b/LayoutTests/platform/glib/mathml/opentype/large-operators-expected.txt
@@ -40,7 +40,7 @@ layer at (0,0) size 800x52
           RenderBlock (anonymous) at (0,0) size 22x18
             RenderText {#text} at (0,-44) size 22x106
               text run at (0,-44) width 22: "\x{2230}"
-        RenderMathMLOperator {mo} at (429,7) size 22x23
+        RenderMathMLOperator {mo} at (429,6) size 22x24
           RenderBlock (anonymous) at (0,0) size 13x17
             RenderText {#text} at (0,-45) size 13x106
               text run at (0,-45) width 13: "\x{22C3}"
@@ -52,7 +52,7 @@ layer at (0,0) size 800x52
           RenderBlock (anonymous) at (0,0) size 13x18
             RenderText {#text} at (0,-44) size 13x106
               text run at (0,-44) width 13: "\x{22C1}"
-        RenderMathMLOperator {mo} at (491,6) size 22x23
+        RenderMathMLOperator {mo} at (491,6) size 22x24
           RenderBlock (anonymous) at (0,0) size 13x17
             RenderText {#text} at (0,-44) size 13x106
               text run at (0,-44) width 13: "\x{22C2}"

--- a/LayoutTests/platform/glib/mathml/opentype/opentype-stretchy-expected.txt
+++ b/LayoutTests/platform/glib/mathml/opentype/opentype-stretchy-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x337
-  RenderBlock {HTML} at (0,0) size 800x337
-    RenderBody {BODY} at (8,16) size 784x305
+layer at (0,0) size 800x334
+  RenderBlock {HTML} at (0,0) size 800x334
+    RenderBody {BODY} at (8,16) size 784x302
       RenderBlock {P} at (0,0) size 784x34
         RenderMathMLMath {math} at (0,20) size 26x11
           RenderMathMLRow {mrow} at (0,0) size 26x11
@@ -35,7 +35,7 @@ layer at (0,0) size 800x337
                 RenderText {#text} at (0,-3) size 2x0
                   text run at (0,-3) width 2: "\x{219F}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,219) size 784x86
+      RenderBlock {P} at (0,219) size 784x83
         RenderMathMLMath {math} at (0,0) size 84x82
           RenderMathMLRow {mrow} at (0,0) size 84x82
             RenderMathMLOperator {mo} at (0,0) size 84x82

--- a/LayoutTests/platform/ios/mathml/opentype/opentype-stretchy-expected.txt
+++ b/LayoutTests/platform/ios/mathml/opentype/opentype-stretchy-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x340
-  RenderBlock {HTML} at (0,0) size 800x340
-    RenderBody {BODY} at (8,16) size 784x308
+layer at (0,0) size 800x335
+  RenderBlock {HTML} at (0,0) size 800x336
+    RenderBody {BODY} at (8,16) size 784x304
       RenderBlock {P} at (0,0) size 784x35
         RenderMathMLMath {math} at (0,20) size 26x11
           RenderMathMLRow {mrow} at (0,0) size 26x11
@@ -35,7 +35,7 @@ layer at (0,0) size 800x340
                 RenderText {#text} at (0,-4) size 3x1
                   text run at (0,-3) width 3: "\x{219F}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,221) size 784x87
+      RenderBlock {P} at (0,221) size 784x83
         RenderMathMLMath {math} at (0,0) size 84x82
           RenderMathMLRow {mrow} at (0,0) size 84x82
             RenderMathMLOperator {mo} at (0,0) size 84x82

--- a/LayoutTests/platform/mac/mathml/opentype/opentype-stretchy-expected.txt
+++ b/LayoutTests/platform/mac/mathml/opentype/opentype-stretchy-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x338
-  RenderBlock {HTML} at (0,0) size 800x339
-    RenderBody {BODY} at (8,16) size 784x307
+layer at (0,0) size 800x334
+  RenderBlock {HTML} at (0,0) size 800x335
+    RenderBody {BODY} at (8,16) size 784x303
       RenderBlock {P} at (0,0) size 784x35
         RenderMathMLMath {math} at (0,20) size 26x11
           RenderMathMLRow {mrow} at (0,0) size 26x11
@@ -35,7 +35,7 @@ layer at (0,0) size 800x338
                 RenderText {#text} at (0,-4) size 3x1
                   text run at (0,-3) width 3: "\x{219F}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,220) size 784x87
+      RenderBlock {P} at (0,220) size 784x83
         RenderMathMLMath {math} at (0,0) size 84x82
           RenderMathMLRow {mrow} at (0,0) size 84x82
             RenderMathMLOperator {mo} at (0,0) size 84x82

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -316,7 +316,19 @@ LayoutUnit RenderMathMLOperator::verticalStretchedOperatorShift() const
 std::optional<LayoutUnit> RenderMathMLOperator::firstLineBaseline() const
 {
     if (useMathOperator()) {
-        auto baseline = settings().subpixelInlineLayoutEnabled() ? m_mathOperator.ascent() - verticalStretchedOperatorShift() : LayoutUnit(roundf(m_mathOperator.ascent() - verticalStretchedOperatorShift()));
+        LayoutUnit shift;
+        if (isVertical() && hasOperatorFlag(MathMLOperatorDictionary::Stretchy)) {
+            // If the operator has the stretchy property.
+            // If the stretch axis of the operator is block.
+            // https://w3c.github.io/mathml-core/#layout-of-operators
+            shift = verticalStretchedOperatorShift();
+        } else if (isLargeOperatorInDisplayStyle() && hasOperatorFlag(MathMLOperatorDictionary::Symmetric)) {
+            // If the operator has the largeop property and if math-style on the mo element is normal.
+            // If the operator has the symmetric property.
+            // https://w3c.github.io/mathml-core/#layout-of-operators
+            shift = (m_mathOperator.ascent() - m_mathOperator.descent() - 2 * mathAxisHeight()) / 2;
+        }
+        auto baseline = settings().subpixelInlineLayoutEnabled() ? m_mathOperator.ascent() - shift : LayoutUnit(roundf(m_mathOperator.ascent() - shift));
         return { borderAndPaddingBefore() + baseline };
     }
     return RenderMathMLToken::firstLineBaseline();


### PR DESCRIPTION
#### 883d57d213040747f441fc61e3f86c4fa65401d5
<pre>
[MathML] Symmetric non-stretchy largeop operators should center around math axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=308413">https://bugs.webkit.org/show_bug.cgi?id=308413</a>
<a href="https://rdar.apple.com/170905663">rdar://170905663</a>

Reviewed by Frédéric Wang.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Non-stretchy large operators with symmetric=&quot;true&quot; were incorrectly placed
on the baseline instead of being centered around the math axis. The
verticalStretchedOperatorShift() only computed shifts for stretchy operators.

This patch restructures the baseline shift logic in firstLineBaseline() to
follow the spec structure from <a href="https://w3c.github.io/mathml-core/#layout-of-operators">https://w3c.github.io/mathml-core/#layout-of-operators</a>:
first handling stretchy vertical operators, then largeop symmetric operators.
The shift formula uses the spec&apos;s definition directly:
shift = (ascent - descent - 2 * axisHeight) / 2.

* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::firstLineBaseline const):
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/symmetric-largeop-expected.txt: Progression
* LayoutTests/platform/glib/mathml/opentype/large-operators-expected.txt: Rebaseline
* LayoutTests/platform/glib/mathml/opentype/opentype-stretchy-expected.txt: Ditto
* LayoutTests/platform/ios/mathml/opentype/opentype-stretchy-expected.txt: Ditto
* LayoutTests/platform/mac/mathml/opentype/opentype-stretchy-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/309778@main">https://commits.webkit.org/309778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b15d8e5552e49c4df69c57f6500381e693fe315b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151721 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/24502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160461 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eac86394-b658-4650-a34a-4ce948c22acb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24795 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f6931ad-fb67-48e4-85d6-888f37b05fa1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154681 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3146bf82-96fd-48fd-be38-1314e901b6bd) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18417 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/8298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162927 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/6076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15635 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/24301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34017 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/24302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135840 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/24302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23918 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/88203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->