### PR TITLE
Make 272 WebCore files Project-scoped, take 2

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -302,7 +302,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/InternalAPI/WebGPUTextureView.h
     Modules/WebGPU/InternalAPI/WebGPUTextureViewDescriptor.h
     Modules/WebGPU/InternalAPI/WebGPUTextureViewDimension.h
-    Modules/WebGPU/InternalAPI/WebGPUUncapturedErrorEvent.h
     Modules/WebGPU/InternalAPI/WebGPUUncapturedErrorEventInit.h
     Modules/WebGPU/InternalAPI/WebGPUValidationError.h
     Modules/WebGPU/InternalAPI/WebGPUVertexAttribute.h
@@ -332,7 +331,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/applepay/ApplePayError.h
     Modules/applepay/ApplePayErrorCode.h
     Modules/applepay/ApplePayErrorContactField.h
-    Modules/applepay/ApplePayFeature.h
     Modules/applepay/ApplePayInstallmentConfigurationWebCore.h
     Modules/applepay/ApplePayInstallmentItem.h
     Modules/applepay/ApplePayInstallmentItemType.h
@@ -351,7 +349,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/applepay/ApplePaySetupConfiguration.h
     Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
     Modules/applepay/ApplePaySetupFeatureWebCore.h
-    Modules/applepay/ApplePaySetupWebCore.h
     Modules/applepay/ApplePayShippingContactEditingMode.h
     Modules/applepay/ApplePayShippingContactUpdate.h
     Modules/applepay/ApplePayShippingMethod.h
@@ -392,11 +389,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/contact-picker/ContactInfo.h
     Modules/contact-picker/ContactProperty.h
     Modules/contact-picker/ContactsRequestData.h
-    Modules/contact-picker/ContactsSelectOptions.h
 
     Modules/cookie-store/CookieChangeSubscription.h
     Modules/cookie-store/CookieStoreGetOptions.h
-    Modules/cookie-store/CookieStoreManager.h
 
     Modules/credentialmanagement/BasicCredential.h
     Modules/credentialmanagement/CredentialRequestOptions.h
@@ -419,13 +414,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/fetch/FetchIdentifier.h
     Modules/fetch/FetchLoader.h
     Modules/fetch/FetchLoaderClient.h
-    Modules/fetch/FetchReferrerPolicy.h
-    Modules/fetch/FetchRequestCache.h
     Modules/fetch/FetchRequestCredentials.h
     Modules/fetch/FetchRequestDestination.h
     Modules/fetch/FetchRequestInit.h
     Modules/fetch/FetchRequestMode.h
-    Modules/fetch/FetchRequestRedirect.h
     Modules/fetch/FetchResponse.h
     Modules/fetch/IPAddressSpace.h
     Modules/fetch/RequestPriority.h
@@ -436,11 +428,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/filesystem/FileSystemHandleCloseScope.h
     Modules/filesystem/FileSystemHandleIdentifier.h
     Modules/filesystem/FileSystemStorageConnection.h
-    Modules/filesystem/FileSystemSyncAccessHandle.h
     Modules/filesystem/FileSystemSyncAccessHandleIdentifier.h
-    Modules/filesystem/FileSystemWritableFileStream.h
     Modules/filesystem/FileSystemWritableFileStreamIdentifier.h
-    Modules/filesystem/FileSystemWritableFileStreamSink.h
     Modules/filesystem/FileSystemWriteCloseReason.h
     Modules/filesystem/FileSystemWriteCommandType.h
     Modules/filesystem/StorageManagerFileSystem.h
@@ -451,7 +440,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/gamepad/GamepadHapticEffectType.h
     Modules/gamepad/NavigatorGamepad.h
 
-    Modules/geolocation/GeoNotifier.h
     Modules/geolocation/Geolocation.h
     Modules/geolocation/GeolocationClient.h
     Modules/geolocation/GeolocationController.h
@@ -471,7 +459,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/highlight/HighlightRegistry.h
     Modules/highlight/HighlightVisibility.h
 
-    Modules/identity/CredentialRequestCoordinator.h
     Modules/identity/CredentialRequestCoordinatorClient.h
     Modules/identity/DigitalCredential.h
     Modules/identity/DigitalCredentialGetRequest.h
@@ -480,7 +467,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/DigitalCredentialsMobileDocumentRequestData.h
     Modules/identity/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h
     Modules/identity/DigitalCredentialsRequestData.h
-    Modules/identity/DigitalCredentialsRequestDataBuilder.h
     Modules/identity/DigitalCredentialsResponseData.h
     Modules/identity/DigitalCredentialsSecurityOriginData.h
 
@@ -499,7 +485,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/indexeddb/IDBActiveDOMObject.h
     Modules/indexeddb/IDBActiveDOMObjectInlines.h
     Modules/indexeddb/IDBCursor.h
-    Modules/indexeddb/IDBDatabase.h
     Modules/indexeddb/IDBDatabaseIdentifier.h
     Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
     Modules/indexeddb/IDBGetAllResult.h
@@ -581,18 +566,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/mediastream/LongRange.h
     Modules/mediastream/MediaAccessDenialReason.h
     Modules/mediastream/MediaDeviceHashSalts.h
-    Modules/mediastream/MediaDeviceInfo.h
-    Modules/mediastream/MediaDevices.h
     Modules/mediastream/MediaStreamTrack.h
-    Modules/mediastream/MediaStreamTrackEvent.h
     Modules/mediastream/MediaStreamTrackHandle.h
     Modules/mediastream/MediaTrackCapabilities.h
     Modules/mediastream/MediaTrackConstraints.h
-    Modules/mediastream/RTCController.h
-    Modules/mediastream/RTCDTMFSender.h
-    Modules/mediastream/RTCDTMFToneChangeEvent.h
     Modules/mediastream/RTCDataChannel.h
-    Modules/mediastream/RTCDataChannelEvent.h
     Modules/mediastream/RTCDataChannelRemoteHandler.h
     Modules/mediastream/RTCDataChannelRemoteSource.h
     Modules/mediastream/RTCError.h
@@ -606,7 +584,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/mediastream/RTCIceServerTransportProtocol.h
     Modules/mediastream/RTCIceTcpCandidateType.h
     Modules/mediastream/RTCNetworkManager.h
-    Modules/mediastream/RTCPeerConnectionIceEvent.h
     Modules/mediastream/RTCRtpSFrameTransformer.h
     Modules/mediastream/RTCRtpScriptTransformer.h
     Modules/mediastream/RTCRtpTransceiver.h
@@ -632,7 +609,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/model-element/ModelPlayerProvider.h
     Modules/model-element/ModelPlayerTransformState.h
 
-    Modules/model-element/dummy/DummyModelPlayer.h
     Modules/model-element/dummy/DummyModelPlayerProvider.h
 
     Modules/model-element/scenekit/SceneKitModelLoaderClient.h
@@ -650,7 +626,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/notifications/NotificationPermission.h
     Modules/notifications/NotificationPermissionCallback.h
     Modules/notifications/NotificationResources.h
-    Modules/notifications/NotificationResourcesLoader.h
 
     Modules/paymentrequest/PaymentSessionBase.h
 
@@ -664,10 +639,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/permissions/PermissionState.h
     Modules/permissions/Permissions.h
 
-    Modules/pictureinpicture/DocumentPictureInPicture.h
-    Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
-    Modules/pictureinpicture/PictureInPictureEvent.h
-    Modules/pictureinpicture/PictureInPictureWindow.h
 
     Modules/plugins/PluginReplacement.h
     Modules/plugins/YouTubePluginReplacement.h
@@ -675,9 +646,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/push-api/PushCrypto.h
     Modules/push-api/PushDatabase.h
     Modules/push-api/PushEncryptionKeyName.h
-    Modules/push-api/PushEvent.h
     Modules/push-api/PushEventInit.h
-    Modules/push-api/PushManager.h
     Modules/push-api/PushMessageCrypto.h
     Modules/push-api/PushPermissionState.h
     Modules/push-api/PushStrategy.h
@@ -688,7 +657,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/push-api/PushSubscriptionOptionsInit.h
     Modules/push-api/PushSubscriptionOwner.h
 
-    Modules/remoteplayback/RemotePlayback.h
 
     Modules/reporting/DeprecationReportBody.h
     Modules/reporting/Report.h
@@ -720,7 +688,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/storage/StorageEstimate.h
     Modules/storage/StorageManager.h
     Modules/storage/StorageProvider.h
-    Modules/storage/WorkerStorageConnection.h
 
     Modules/streams/ReadableStreamSource.h
     Modules/streams/ReadableStreamToSharedBufferSink.h
@@ -759,13 +726,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webauthn/CurrentUserDetailsOptions.h
     Modules/webauthn/PublicKeyCredential.h
     Modules/webauthn/PublicKeyCredentialCreationOptions.h
-    Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h
     Modules/webauthn/PublicKeyCredentialDescriptor.h
     Modules/webauthn/PublicKeyCredentialDescriptorJSON.h
     Modules/webauthn/PublicKeyCredentialEntity.h
     Modules/webauthn/PublicKeyCredentialParameters.h
     Modules/webauthn/PublicKeyCredentialRequestOptions.h
-    Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.h
     Modules/webauthn/PublicKeyCredentialRpEntity.h
     Modules/webauthn/PublicKeyCredentialType.h
     Modules/webauthn/PublicKeyCredentialUserEntity.h
@@ -791,13 +756,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webauthn/fido/FidoConstants.h
     Modules/webauthn/fido/FidoHidMessage.h
     Modules/webauthn/fido/FidoHidPacket.h
-    Modules/webauthn/fido/FidoParsingUtils.h
     Modules/webauthn/fido/Pin.h
     Modules/webauthn/fido/U2fCommandConstructor.h
     Modules/webauthn/fido/U2fResponseConverter.h
 
     Modules/webcodecs/VideoColorSpaceInit.h
-    Modules/webcodecs/VideoMatrixCoefficients.h
     Modules/webcodecs/WebCodecsAlphaOption.h
     Modules/webcodecs/WebCodecsAudioData.h
     Modules/webcodecs/WebCodecsAudioInternalData.h
@@ -811,7 +774,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webcodecs/WebCodecsVideoFrame.h
     Modules/webcodecs/WebCodecsVideoFrameData.h
 
-    Modules/webdatabase/DatabaseContext.h
     Modules/webdatabase/DatabaseDetails.h
     Modules/webdatabase/DatabaseManager.h
     Modules/webdatabase/DatabaseManagerClient.h
@@ -819,7 +781,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webdatabase/OriginLock.h
 
     Modules/websockets/ThreadableWebSocketChannel.h
-    Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
     Modules/websockets/WebSocketChannelClient.h
     Modules/websockets/WebSocketChannelInspector.h
     Modules/websockets/WebSocketDeflateFramer.h
@@ -841,7 +802,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webtransport/WebTransportReceiveStreamStats.h
     Modules/webtransport/WebTransportReliabilityMode.h
     Modules/webtransport/WebTransportSendGroup.h
-    Modules/webtransport/WebTransportSendStreamSink.h
     Modules/webtransport/WebTransportSendStreamStats.h
     Modules/webtransport/WebTransportSession.h
     Modules/webtransport/WebTransportSessionClient.h
@@ -868,7 +828,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AXObjectRareData.h
     accessibility/AXSearchManager.h
     accessibility/AXStitchGroup.h
-    accessibility/AXStitchUtilities.h
     accessibility/AXTextMarker.h
     accessibility/AXTextRun.h
     accessibility/AXTextStateChangeIntent.h
@@ -879,7 +838,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AccessibilityMockObject.h
     accessibility/AccessibilityNodeObject.h
     accessibility/AccessibilityObject.h
-    accessibility/AccessibilityObjectInlines.h
     accessibility/AccessibilityRenderObject.h
     accessibility/AccessibilityRole.h
     accessibility/AccessibilityScrollView.h
@@ -895,7 +853,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/AnimationEventBase.h
     animation/AnimationFrameRatePreset.h
     animation/AnimationMalloc.h
-    animation/AnimationPlaybackEvent.h
     animation/AnimationPlaybackEventInit.h
     animation/AnimationTimeline.h
     animation/AnimationTimelinesController.h
@@ -905,13 +862,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/CompositeOperationOrAuto.h
     animation/ComputedEffectTiming.h
     animation/CustomAnimationOptions.h
-    animation/DocumentTimeline.h
     animation/DocumentTimelineOptions.h
     animation/EffectTiming.h
-    animation/ElementAnimationRareData.h
     animation/FillMode.h
     animation/FrameRateAligner.h
-    animation/GetAnimationsOptions.h
     animation/IterationCompositeOperation.h
     animation/KeyframeAnimationOptions.h
     animation/KeyframeEffect.h
@@ -924,7 +878,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/ScrollTimeline.h
     animation/ScrollTimelineOptions.h
     animation/StyleOriginatedAnimation.h
-    animation/StyleOriginatedTimelinesController.h
     animation/TimelineRangeOffset.h
     animation/TimelineRangeValue.h
     animation/ViewTimeline.h
@@ -941,19 +894,14 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/CachedModuleScriptLoader.h
     bindings/js/CachedScriptFetcher.h
     bindings/js/CommonVM.h
-    bindings/js/DOMPromiseProxy.h
     bindings/js/DOMWrapperWorld.h
     bindings/js/ExceptionDetails.h
     bindings/js/GarbageCollectionController.h
     bindings/js/IDBBindingUtilities.h
     bindings/js/JSCSSRuleCustom.h
     bindings/js/JSCSSStyleDeclarationCustom.h
-    bindings/js/JSDOMAbstractOperations.h
-    bindings/js/JSDOMAsyncIterator.h
-    bindings/js/JSDOMAttribute.h
     bindings/js/JSDOMBinding.h
     bindings/js/JSDOMBindingSecurity.h
-    bindings/js/JSDOMBindingSecurityInlines.h
     bindings/js/JSDOMCastThisValue.h
     bindings/js/JSDOMConvert.h
     bindings/js/JSDOMConvertAny.h
@@ -972,7 +920,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSDOMConvertNullable.h
     bindings/js/JSDOMConvertNumbers.h
     bindings/js/JSDOMConvertObject.h
-    bindings/js/JSDOMConvertPromise.h
     bindings/js/JSDOMConvertRecord.h
     bindings/js/JSDOMConvertResult.h
     bindings/js/JSDOMConvertSequences.h
@@ -980,15 +927,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSDOMConvertStrings.h
     bindings/js/JSDOMConvertUndefined.h
     bindings/js/JSDOMConvertUnion.h
-    bindings/js/JSDOMConvertVariadic.h
-    bindings/js/JSDOMConvertWebGL.h
     bindings/js/JSDOMConvertXPathNSResolver.h
     bindings/js/JSDOMExceptionHandling.h
     bindings/js/JSDOMGlobalObject.h
     bindings/js/JSDOMGuardedObject.h
     bindings/js/JSDOMIterator.h
     bindings/js/JSDOMOperation.h
-    bindings/js/JSDOMOperationReturningPromise.h
     bindings/js/JSDOMPromise.h
     bindings/js/JSDOMPromiseDeferred.h
     bindings/js/JSDOMPromiseDeferredForward.h
@@ -1005,17 +949,13 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSNodeCustom.h
     bindings/js/JSNodeCustomInlines.h
     bindings/js/JSNodeListCustom.h
-    bindings/js/JSPluginElementFunctions.h
     bindings/js/JSShadowRealmGlobalScopeBase.h
     bindings/js/JSStyleSheetCustom.h
     bindings/js/JSValueInWrappedObject.h
     bindings/js/JSWindowProxy.h
-    bindings/js/ModuleFetchFailureKind.h
     bindings/js/ModuleScriptLoader.h
-    bindings/js/ModuleScriptLoaderClient.h
     bindings/js/ReadableStreamDefaultController.h
     bindings/js/RunJavaScriptParameters.h
-    bindings/js/ScheduledAction.h
     bindings/js/ScriptCachedFrameData.h
     bindings/js/ScriptController.h
     bindings/js/ScriptWrappable.h
@@ -1029,12 +969,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/WebCoreOpaqueRootInlines.h
     bindings/js/WebCoreTypedArrayController.h
     bindings/js/WindowProxy.h
-    bindings/js/WorkerScriptFetcher.h
 
     bridge/jsc/BridgeJSC.h
 
-    bridge/runtime_method.h
-    bridge/runtime_object.h
     bridge/runtime_root.h
 
     contentextensions/CombinedFiltersAlphabet.h
@@ -1057,7 +994,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     contentextensions/DFABytecodeCompiler.h
     contentextensions/DFABytecodeInterpreter.h
     contentextensions/DFACombiner.h
-    contentextensions/DFAMinimizer.h
     contentextensions/DFANode.h
     contentextensions/ImmutableNFA.h
     contentextensions/ImmutableNFANodeBuilder.h
@@ -1095,42 +1031,26 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/keys/CryptoKeyAlgorithm.h
     crypto/keys/CryptoKeyEC.h
     crypto/keys/CryptoKeyHMAC.h
-    crypto/keys/CryptoKeyOKP.h
-    crypto/keys/CryptoKeyRSAComponents.h
     crypto/keys/CryptoRsaHashedKeyAlgorithm.h
     crypto/keys/CryptoRsaKeyAlgorithm.h
 
     crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
     crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
-    crypto/parameters/CryptoAlgorithmAesCtrParams.h
     crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h
-    crypto/parameters/CryptoAlgorithmAesGcmParams.h
     crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h
-    crypto/parameters/CryptoAlgorithmAesKeyParams.h
     crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h
-    crypto/parameters/CryptoAlgorithmEcKeyParams.h
     crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h
-    crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
     crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h
-    crypto/parameters/CryptoAlgorithmEcdsaParams.h
     crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h
-    crypto/parameters/CryptoAlgorithmHkdfParams.h
     crypto/parameters/CryptoAlgorithmHkdfParamsInit.h
-    crypto/parameters/CryptoAlgorithmHmacKeyParams.h
     crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h
-    crypto/parameters/CryptoAlgorithmPbkdf2Params.h
     crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h
-    crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
     crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h
-    crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
     crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h
     crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
     crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h
-    crypto/parameters/CryptoAlgorithmRsaOaepParams.h
     crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h
-    crypto/parameters/CryptoAlgorithmRsaPssParams.h
     crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
-    crypto/parameters/CryptoAlgorithmX25519Params.h
     crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
 
     css/CSSAttrValue.h
@@ -1300,7 +1220,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ActiveDOMObject.h
     dom/AddEventListenerOptions.h
     dom/AsyncNodeDeletionQueue.h
-    dom/AsyncNodeDeletionQueueInlines.h
     dom/Attr.h
     dom/Attribute.h
     dom/BoundaryPoint.h
@@ -1333,7 +1252,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/DOMRectInit.h
     dom/DOMRectList.h
     dom/DOMRectReadOnly.h
-    dom/DOMStringList.h
     dom/DataTransfer.h
     dom/DeviceOrientationClient.h
     dom/DeviceOrientationData.h
@@ -1344,7 +1262,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/DocumentEnums.h
     dom/DocumentEventLoop.h
     dom/DocumentEventTiming.h
-    dom/DocumentFontLoader.h
     dom/DocumentFragment.h
     dom/DocumentFullscreen.h
     dom/DocumentImmersive.h
@@ -1362,7 +1279,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/DocumentType.h
     dom/DocumentView.h
     dom/DocumentWindow.h
-    dom/DragEvent.h
     dom/Element.h
     dom/ElementAncestorIterator.h
     dom/ElementAncestorIteratorInlines.h
@@ -1395,40 +1311,30 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ExtensionStyleSheets.h
     dom/FindRevealAlgorithms.h
     dom/FocusOptions.h
-    dom/FragmentDirectiveGenerator.h
     dom/FragmentDirectiveParser.h
     dom/FragmentDirectiveRangeFinder.h
     dom/FragmentDirectiveUtilities.h
     dom/FullscreenOptions.h
     dom/GCReachableRef.h
-    dom/IdTargetObserver.h
-    dom/IdTargetObserverRegistry.h
     dom/ImageOverlay.h
     dom/ImportNodeOptions.h
-    dom/InlineClassicScript.h
     dom/InlineStyleSheetOwner.h
-    dom/InputEvent.h
     dom/KeyboardEvent.h
     dom/LiveNodeList.h
     dom/LiveNodeListInlines.h
     dom/LoadableClassicScript.h
-    dom/LoadableModuleScript.h
-    dom/LoadableSpeculationRules.h
     dom/LoadableScript.h
     dom/LoadableScriptClient.h
     dom/LoadableScriptError.h
     dom/MessagePort.h
     dom/MessagePortIdentifier.h
-    dom/Microtasks.h
     dom/ModuleFetchParameters.h
     dom/MouseEvent.h
     dom/MouseEventInit.h
     dom/MouseEventTypes.h
     dom/MouseRelatedEvent.h
     dom/MutationEvent.h
-    dom/MutationObserver.h
     dom/MutationObserverOptions.h
-    dom/NameNodeList.h
     dom/NamedNodeMap.h
     dom/NativeNodeFilter.h
     dom/Node.h
@@ -1443,7 +1349,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/NodeRenderStyle.h
     dom/NodeTraversal.h
     dom/ParserContentPolicy.h
-    dom/PendingScript.h
     dom/PointerEvent.h
     dom/PointerEventTypeNames.h
     dom/PointerLockOptions.h
@@ -1460,7 +1365,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/RangeBoundaryPoint.h
     dom/RangeBoundaryPointInlines.h
     dom/RegisteredEventListener.h
-    dom/RejectedPromiseTracker.h
     dom/RenderedDocumentMarker.h
     dom/SandboxFlags.h
     dom/ScriptDisallowedScope.h
@@ -1483,7 +1387,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/SlotAssignmentMode.h
     dom/SpaceSplitString.h
     dom/SpatialBackdropSource.h
-    dom/SpeculationRulesMatcher.h
     dom/StartViewTransitionOptions.h
     dom/StaticRange.h
     dom/StyledElement.h
@@ -1515,7 +1418,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ViewTransitionTypeSet.h
     dom/ViewTransitionUpdateCallback.h
     dom/ViewportArguments.h
-    dom/VisibilityAdjustment.h
     dom/VisibilityChangeClient.h
     dom/VisibilityState.h
     dom/WheelEvent.h
@@ -1529,9 +1431,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/messageports/MessageWithMessagePorts.h
     dom/messageports/TransferredMessagePort.h
 
-    domjit/DOMJITIDLConvert.h
-    domjit/DOMJITIDLType.h
-    domjit/DOMJITIDLTypeFilter.h
 
     editing/CharacterRange.h
     editing/ClipboardAccessPolicy.h
@@ -1565,7 +1464,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     editing/SmartReplace.h
     editing/SpellChecker.h
     editing/TextAffinity.h
-    editing/TextCheckingHelper.h
     editing/TextGranularity.h
     editing/TextIterator.h
     editing/TextIteratorBehavior.h
@@ -1585,7 +1483,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     fileapi/AsyncFileStream.h
     fileapi/Blob.h
-    fileapi/BlobLoader.h
     fileapi/BlobPropertyBag.h
     fileapi/BlobURL.h
     fileapi/EndingType.h
@@ -1616,7 +1513,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/CachedHTMLCollectionInlines.h
     html/CanvasBase.h
     html/CanvasNoiseInjection.h
-    html/CanvasObserver.h
     html/CaptionDisplaySettingsClient.h
     html/CaptionDisplaySettingsOptions.h
     html/CollectionTraversal.h
@@ -1627,12 +1523,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/DOMTokenList.h
     html/DataListSuggestionInformation.h
     html/EnterKeyHint.h
-    html/FormAssociatedCustomElement.h
     html/FormAssociatedElement.h
     html/FormController.h
     html/FormListedElement.h
     html/HTMLAnchorElement.h
-    html/HTMLAnchorElementInlines.h
     html/HTMLAreaElement.h
     html/HTMLArticleElement.h
     html/HTMLAttachmentElement.h
@@ -1665,7 +1559,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/HTMLHtmlElement.h
     html/HTMLIFrameElement.h
     html/HTMLImageElement.h
-    html/HTMLImageLoader.h
     html/HTMLInputElement.h
     html/HTMLLIElement.h
     html/HTMLLabelElement.h
@@ -1719,11 +1612,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/LinkIconCollector.h
     html/LinkIconType.h
     html/LinkRelAttribute.h
-    html/MediaController.h
     html/MediaControllerInterface.h
     html/MediaDocument.h
     html/MediaElementSession.h
-    html/MediaEncryptedEvent.h
     html/MediaEncryptedEventInit.h
     html/MediaError.h
     html/OffscreenCanvas.h
@@ -1734,7 +1625,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/PluginDocument.h
     html/ResolvedCaptionDisplaySettingsOptions.h
     html/ResolvedCaptionDisplaySettingsOptionsWrapper.h
-    html/StepRange.h
     html/SwitchTrigger.h
     html/TimeRanges.h
     html/TypeAhead.h
@@ -1742,11 +1632,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/URLRegistry.h
     html/ValidatedFormListedElement.h
     html/ValidationMessage.h
-    html/ValidityState.h
     html/VideoFrameRequestCallback.h
     html/VoidCallback.h
 
-    html/canvas/ImageBitmapRenderingContextSettings.h
     html/canvas/PredefinedColorSpace.h
     html/canvas/WebGLAny.h
     html/canvas/WebGLBuffer.h
@@ -1767,7 +1655,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/canvas/WebGLVertexArrayObjectOES.h
 
     html/closewatcher/CloseWatcher.h
-    html/closewatcher/CloseWatcherManager.h
 
     html/forms/FileIconLoader.h
 
@@ -1781,17 +1668,13 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/track/AudioTrack.h
     html/track/AudioTrackClient.h
     html/track/BufferedLineReader.h
-    html/track/DataCue.h
     html/track/TextTrack.h
     html/track/TextTrackClient.h
     html/track/TextTrackCue.h
-    html/track/TextTrackCueGeneric.h
     html/track/TrackBase.h
     html/track/VTTCue.h
     html/track/VTTRegion.h
-    html/track/VideoTrack.h
     html/track/VideoTrackClient.h
-    html/track/WebVTTParser.h
 
     inspector/FrameInspectorController.h
     inspector/InspectorBackendClient.h
@@ -1807,18 +1690,15 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/InspectorOverlayLabel.h
     inspector/InspectorWebAgentBase.h
     inspector/LegacyWebSocketInspectorInstrumentation.h
-    inspector/PageDebugger.h
     inspector/PageInspectorController.h
 
     inspector/agents/InspectorPageAgent.h
 
     layout/FormattingState.h
-    layout/LayoutContext.h
     layout/LayoutState.h
     layout/LayoutUnits.h
     layout/MarginTypes.h
 
-    layout/floats/FloatAvoider.h
     layout/floats/FloatingContext.h
     layout/floats/PlacedFloats.h
 
@@ -1832,7 +1712,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/formattingContexts/block/BlockFormattingQuirks.h
     layout/formattingContexts/block/BlockFormattingState.h
     layout/formattingContexts/block/BlockLayoutState.h
-    layout/formattingContexts/block/BlockMarginCollapse.h
 
     layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h
     layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingQuirks.h
@@ -1847,10 +1726,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/formattingContexts/grid/FreeSpaceScenario.h
     layout/formattingContexts/grid/GridAreaLines.h
     layout/formattingContexts/grid/GridFormattingContext.h
-    layout/formattingContexts/grid/GridItemRect.h
-    layout/formattingContexts/grid/GridLayoutState.h
     layout/formattingContexts/grid/GridTypeAliases.h
-    layout/formattingContexts/grid/ImplicitGrid.h
 
     layout/formattingContexts/inline/AbstractLineBuilder.h
     layout/formattingContexts/inline/AvailableLineWidthOverride.h
@@ -1871,7 +1747,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/formattingContexts/inline/InlineLineTypes.h
     layout/formattingContexts/inline/InlineQuirks.h
     layout/formattingContexts/inline/InlineRect.h
-    layout/formattingContexts/inline/InlineSoftLineBreakItem.h
     layout/formattingContexts/inline/InlineTextItem.h
     layout/formattingContexts/inline/IntrinsicWidthHandler.h
     layout/formattingContexts/inline/LineLayoutResult.h
@@ -1888,11 +1763,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     layout/formattingContexts/inline/ruby/RubyFormattingContext.h
 
-    layout/formattingContexts/inline/text/TextBreakingPositionCache.h
     layout/formattingContexts/inline/text/TextBreakingPositionContext.h
     layout/formattingContexts/inline/text/TextUtil.h
 
-    layout/formattingContexts/table/TableFormattingConstraints.h
     layout/formattingContexts/table/TableFormattingGeometry.h
     layout/formattingContexts/table/TableFormattingQuirks.h
 
@@ -1920,13 +1793,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/layouttree/LayoutBoxGeometry.h
     layout/layouttree/LayoutChildIterator.h
     layout/layouttree/LayoutContainingBlockChainIterator.h
-    layout/layouttree/LayoutDescendantIterator.h
     layout/layouttree/LayoutElementBox.h
     layout/layouttree/LayoutGeometryRect.h
     layout/layouttree/LayoutInitialContainingBlock.h
     layout/layouttree/LayoutInlineTextBox.h
     layout/layouttree/LayoutIterator.h
-    layout/layouttree/LayoutTreeBuilder.h
 
     loader/AttributionSecondsUntilSendData.h
     loader/AttributionTimeToSendData.h
@@ -1945,7 +1816,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/CustomHeaderFields.h
     loader/DocumentLoadTiming.h
     loader/DocumentLoader.h
-    loader/DocumentPrefetcher.h
     loader/DocumentWriter.h
     loader/EmptyClients.h
     loader/EmptyFrameLoaderClient.h
@@ -2005,8 +1875,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/ResourceLoaderTypes.h
     loader/ResourceMonitor.h
     loader/ResourceMonitorChecker.h
-    loader/ResourceMonitorPersistence.h
-    loader/ResourceMonitorThrottler.h
     loader/ResourceMonitorThrottlerHolder.h
     loader/ResourceTimingInformation.h
     loader/ShouldTreatAsContinuingLoad.h
@@ -2023,8 +1891,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/archive/ArchiveResource.h
     loader/archive/ArchiveResourceCollection.h
     loader/archive/mhtml/MHTMLArchive.h
-    loader/cache/CachePolicy.h
-    loader/cache/CachedApplicationManifest.h
     loader/cache/CachedCSSStyleSheet.h
     loader/cache/CachedFontLoadRequest.h
     loader/cache/CachedImage.h
@@ -2036,7 +1902,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/cache/CachedResourceHandle.h
     loader/cache/CachedResourceLoader.h
     loader/cache/CachedResourceRequest.h
-    loader/cache/CachedResourceRequestInitiatorTypes.h
     loader/cache/CachedSVGDocument.h
     loader/cache/CachedSVGDocumentClient.h
     loader/cache/CachedSVGDocumentReference.h
@@ -2074,7 +1939,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/DebugPageOverlays.h
     page/DeprecatedGlobalSettings.h
     page/DeviceClient.h
-    page/DeviceController.h
     page/DiagnosticLoggingClient.h
     page/DiagnosticLoggingDomain.h
     page/DiagnosticLoggingKeys.h
@@ -2083,19 +1947,16 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/DragActions.h
     page/DragClient.h
     page/DragController.h
-    page/DragState.h
     page/DummySpeechRecognitionProvider.h
     page/EditorClient.h
     page/ElementTargetingController.h
     page/ElementTargetingTypes.h
-    page/EmptyAttachmentElementClient.h
     page/EventHandler.h
     page/EventTimingInteractionID.h
     page/FocusController.h
     page/FocusControllerTypes.h
     page/FocusDirection.h
     page/FocusEventData.h
-    page/FragmentDirective.h
     page/Frame.h
     page/FrameConsoleClient.h
     page/FrameDestructionObserver.h
@@ -2111,7 +1972,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/HandleUserInputEventResult.h
     page/ImageAnalysisQueue.h
     page/ImmediateActionStage.h
-    page/IntelligenceTextEffectsSupport.h
     page/InteractionRegion.h
     page/IntersectionObserverMarginBox.h
     page/IsLoggedIn.h
@@ -2131,7 +1991,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/MemoryRelease.h
     page/ModalContainerTypes.h
     page/NavigationActivation.h
-    page/NavigationHistoryEntry.h
     page/NavigationNavigationType.h
     page/Navigator.h
     page/NavigatorBase.h
@@ -2153,7 +2012,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/PointerCaptureController.h
     page/PointerCharacteristics.h
     page/PointerLockController.h
-    page/PopupOpeningObserver.h
     page/PrewarmInformation.h
     page/PrintContext.h
     page/ProcessWarming.h
@@ -2166,7 +2024,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/RemoteFrameGeometryTransformer.h
     page/RemoteFrameView.h
     page/RemoteUserInputEventData.h
-    page/RenderingUpdateScheduler.h
     page/ScreenOrientationLockType.h
     page/ScreenOrientationType.h
     page/ScriptTrackingPrivacyCategory.h
@@ -2174,7 +2031,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/ScrollIntoViewOptions.h
     page/ScrollLogicalPosition.h
     page/ScrollOptions.h
-    page/ScrollToOptions.h
     page/SecurityOrigin.h
     page/SecurityOriginData.h
     page/SecurityOriginHash.h
@@ -2183,7 +2039,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/ShadowRealmGlobalScope.h
     page/ShareData.h
     page/SocketProvider.h
-    page/SpatialNavigation.h
     page/SpeechRecognitionProvider.h
     page/SpeechSynthesisClient.h
     page/StageModeOperations.h
@@ -2222,11 +2077,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/WheelEventDeltaFilter.h
     page/WheelEventTestMonitor.h
     page/WindowFeatures.h
-    page/WindowFocusAllowedIndicator.h
     page/WindowOrWorkerGlobalScope.h
     page/WindowPostMessageOptions.h
     page/WorkerClient.h
-    page/WorkerNavigator.h
 
     page/csp/CSPViolationReportBody.h
     page/csp/ContentSecurityPolicy.h
@@ -2235,7 +2088,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/csp/ContentSecurityPolicyResponseHeaders.h
 
     page/scrolling/AsyncScrollingCoordinator.h
-    page/scrolling/ScrollAnchoringController.h
     page/scrolling/ScrollSnapOffsetsInfo.h
     page/scrolling/ScrollingConstraints.h
     page/scrolling/ScrollingCoordinator.h
@@ -2312,7 +2164,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/EventTrackingRegions.h
     platform/FileChooser.h
     platform/FileMonitor.h
-    platform/FileStream.h
     platform/FileStreamClient.h
     platform/FixedContainerEdges.h
     platform/FloatConversion.h
@@ -2403,7 +2254,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/ScrollAnimation.h
     platform/ScrollAnimationMomentum.h
     platform/ScrollAnimator.h
-    platform/ScrollExtents.h
     platform/ScrollSnapAnimatorState.h
     platform/ScrollTypes.h
     platform/ScrollView.h
@@ -2425,12 +2275,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/SharedMemory.h
     platform/SharedStringHash.h
     platform/SharedTimer.h
-    platform/SimpleCaretAnimator.h
     platform/Site.h
     platform/SleepDisabler.h
     platform/SleepDisablerClient.h
     platform/SleepDisablerIdentifier.h
-    platform/StaticPasteboard.h
     platform/StringEntropyHelpers.h
     platform/StyleAppearance.h
     platform/SuddenTermination.h
@@ -2505,7 +2353,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/PushPullFIFO.h
     platform/audio/RealtimeAudioThread.h
     platform/audio/SharedAudioDestination.h
-    platform/audio/SincResampler.h
 
     platform/encryptedmedia/CDMEncryptionScheme.h
     platform/encryptedmedia/CDMFactory.h
@@ -2518,7 +2365,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/encryptedmedia/CDMMediaCapability.h
     platform/encryptedmedia/CDMMessageType.h
     platform/encryptedmedia/CDMPrivate.h
-    platform/encryptedmedia/CDMProxy.h
     platform/encryptedmedia/CDMRequirement.h
     platform/encryptedmedia/CDMRestrictions.h
     platform/encryptedmedia/CDMSessionType.h
@@ -2533,7 +2379,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/generic/ScrollbarsControllerGeneric.h
 
-    platform/graphics/AV1Utilities.h
     platform/graphics/AlphaPremultiplication.h
     platform/graphics/AnimationFrameRate.h
     platform/graphics/AudioTrackPrivate.h
@@ -2550,7 +2395,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ColorHash.h
     platform/graphics/ColorInterpolation.h
     platform/graphics/ColorInterpolationMethod.h
-    platform/graphics/ColorLuminance.h
     platform/graphics/ColorMatrix.h
     platform/graphics/ColorModels.h
     platform/graphics/ColorNormalization.h
@@ -2631,7 +2475,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/GraphicsContextGLActiveInfo.h
     platform/graphics/GraphicsContextGLAttributes.h
     platform/graphics/GraphicsContextGLEnums.h
-    platform/graphics/GraphicsContextGLImageExtractor.h
     platform/graphics/GraphicsContextGLState.h
     platform/graphics/GraphicsContextState.h
     platform/graphics/GraphicsContextStateSaver.h
@@ -2642,7 +2485,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/GraphicsLayerContentsDisplayDelegate.h
     platform/graphics/GraphicsLayerEnums.h
     platform/graphics/GraphicsLayerFactory.h
-    platform/graphics/GraphicsLayerFilterAnimationValue.h
     platform/graphics/GraphicsLayerFloatAnimationValue.h
     platform/graphics/GraphicsLayerKeyframeValueList.h
     platform/graphics/GraphicsLayerTransform.h
@@ -2655,14 +2497,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/Icon.h
     platform/graphics/Image.h
     platform/graphics/ImageAdapter.h
-    platform/graphics/ImageBackingStore.h
     platform/graphics/ImageBuffer.h
     platform/graphics/ImageBufferAllocator.h
     platform/graphics/ImageBufferBackend.h
     platform/graphics/ImageBufferBackendParameters.h
     platform/graphics/ImageBufferDisplayListBackend.h
     platform/graphics/ImageBufferFormat.h
-    platform/graphics/ImageBufferPlatformBackend.h
     platform/graphics/ImageBufferResourceLimits.h
     platform/graphics/ImageDecoder.h
     platform/graphics/ImageDecoderIdentifier.h
@@ -2720,7 +2560,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/PathImpl.h
     platform/graphics/PathSegment.h
     platform/graphics/PathSegmentData.h
-    platform/graphics/PathStream.h
     platform/graphics/PathUtilities.h
     platform/graphics/Pattern.h
     platform/graphics/PixelBuffer.h
@@ -2769,7 +2608,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/TabSize.h
     platform/graphics/TextMeasurementCache.h
     platform/graphics/TextRun.h
-    platform/graphics/TextRunHash.h
     platform/graphics/TextTrackRepresentation.h
     platform/graphics/TileGridIdentifier.h
     platform/graphics/TiledBacking.h
@@ -2818,7 +2656,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/cv/CVUtilities.h
     platform/graphics/cv/GraphicsContextGLCV.h
-    platform/graphics/cv/GraphicsContextGLCVCocoa.h
     platform/graphics/cv/ImageRotationSessionVT.h
     platform/graphics/cv/ImageTransferSessionVT.h
     platform/graphics/cv/PixelBufferConformerCV.h
@@ -2882,9 +2719,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/iso/ISOTrackEncryptionBox.h
     platform/graphics/iso/ISOVTTCue.h
 
-    platform/graphics/opentype/OpenTypeCG.h
     platform/graphics/opentype/OpenTypeMathData.h
-    platform/graphics/opentype/OpenTypeTypes.h
     platform/graphics/opentype/OpenTypeVerticalData.h
 
     platform/graphics/re/DynamicContentScalingResourceCache.h
@@ -2905,8 +2740,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/transforms/TransformationMatrix.h
     platform/graphics/transforms/TranslateTransformOperation.h
 
-    platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
-    platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
 
     platform/mediacapabilities/PlatformMediaCapabilitiesAudioConfiguration.h
     platform/mediacapabilities/PlatformMediaCapabilitiesColorGamut.h
@@ -2923,9 +2756,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediacapabilities/PlatformMediaEncodingType.h
     platform/mediacapabilities/PlatformMediaEngineConfigurationFactory.h
 
-    platform/mediarecorder/MediaRecorderPrivate.h
     platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
-    platform/mediarecorder/MediaRecorderPrivateEncoder.h
     platform/mediarecorder/MediaRecorderPrivateOptions.h
     platform/mediarecorder/MediaRecorderPrivateWriter.h
 
@@ -2956,15 +2787,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/RTCDataChannelRemoteHandlerConnection.h
     platform/mediastream/RTCDataChannelRemoteSourceConnection.h
     platform/mediastream/RTCDataChannelState.h
-    platform/mediastream/RTCIceCandidateDescriptor.h
     platform/mediastream/RTCIceConnectionState.h
     platform/mediastream/RTCPeerConnectionHandlerClient.h
     platform/mediastream/RTCPriorityType.h
     platform/mediastream/RTCRtpCapabilities.h
     platform/mediastream/RTCRtpCodecCapability.h
-    platform/mediastream/RTCSessionDescriptionDescriptor.h
-    platform/mediastream/RTCSessionDescriptionRequest.h
-    platform/mediastream/RTCVoidRequest.h
     platform/mediastream/RealtimeIncomingVideoSource.h
     platform/mediastream/RealtimeMediaSource.h
     platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -3052,7 +2879,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/SocketStreamError.h
     platform/network/StorageSessionProvider.h
     platform/network/StoredCredentialsPolicy.h
-    platform/network/SynchronousLoaderClient.h
     platform/network/TimingAllowOrigin.h
 
     platform/sql/SQLValue.h
@@ -3066,9 +2892,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/sql/SQLiteTransaction.h
 
     platform/text/BidiContext.h
-    platform/text/BidiResolver.h
     platform/text/BidiRunList.h
-    platform/text/DateTimeFormat.h
     platform/text/LocaleToScriptMapping.h
     platform/text/PlatformLocale.h
     platform/text/SegmentedString.h
@@ -3103,7 +2927,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/FloatingObjects.h
     rendering/GapRects.h
     rendering/GlyphDisplayListCacheRemoval.h
-    rendering/RenderGridLayoutState.h
     rendering/HitTestLocation.h
     rendering/HitTestRequest.h
     rendering/HitTestResult.h
@@ -3126,7 +2949,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/PaintInfo.h
     rendering/PaintPhase.h
     rendering/PathOperation.h
-    rendering/PositionedLayoutConstraints.h
     rendering/RegionContext.h
     rendering/RenderAttachment.h
     rendering/RenderBlock.h
@@ -3154,7 +2976,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderLayerScrollableArea.h
     rendering/RenderLayoutState.h
     rendering/RenderLineBoxList.h
-    rendering/RenderLineBreak.h
     rendering/RenderListItem.h
     rendering/RenderMedia.h
     rendering/RenderMediaInlines.h
@@ -3175,34 +2996,26 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderTextLineBoxes.h
     rendering/RenderTheme.h
     rendering/RenderTreeAsText.h
-    rendering/RenderTreeMutationDisallowedScope.h
     rendering/RenderVideo.h
     rendering/RenderVideoInlines.h
     rendering/RenderView.h
-    rendering/RenderViewTransitionCapture.h
     rendering/RenderWidget.h
-    rendering/RenderWidgetInlines.h
     rendering/RepaintRectCalculation.h
     rendering/TextBoxSelectableRange.h
-    rendering/TextBoxTrimmer.h
     rendering/TransformOperationData.h
     rendering/VisibleRectContext.h
 
     rendering/line/LineWidth.h
     rendering/line/TrailingObjects.h
 
-    rendering/shapes/BoxLayoutShape.h
     rendering/shapes/LayoutShape.h
     rendering/shapes/PolygonLayoutShape.h
-    rendering/shapes/RasterLayoutShape.h
-    rendering/shapes/RectangleLayoutShape.h
     rendering/shapes/ShapeInterval.h
     rendering/shapes/ShapeOutsideInfo.h
 
     rendering/style/AutosizeStatus.h
     rendering/style/BorderData.h
     rendering/style/BorderValue.h
-    rendering/style/CollapsedBorderValue.h
     rendering/style/CounterDirectives.h
     rendering/style/GridArea.h
     rendering/style/GridSpan.h
@@ -3243,15 +3056,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/StyleContainmentCheckerInlines.h
     style/StyleCustomProperty.h
     style/StyleDifference.h
-    style/StyleForVisitedLink.h
     style/StyleInterpolationClient.h
-    style/StyleInterpolationContext.h
     style/StyleNameScope.h
     style/StyleScope.h
     style/StyleScopeIdentifier.h
     style/StyleScopeOrdinal.h
     style/StyleTreeResolver.h
-    style/StyleUpdate.h
     style/StyleValidity.h
     style/Styleable.h
 
@@ -3292,7 +3102,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/computed/data/StyleSVGLayoutData.h
     style/computed/data/StyleSVGMarkerResourceData.h
     style/computed/data/StyleSVGNonInheritedMiscData.h
-    style/computed/data/StyleSVGShadowData.h
     style/computed/data/StyleSVGStopData.h
     style/computed/data/StyleSVGStrokeData.h
     style/computed/data/StyleTransformData.h
@@ -3429,7 +3238,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/grid/StyleGridOrderedNamedLinesMap.h
     style/values/grid/StyleGridPosition.h
     style/values/grid/StyleGridPositionSide.h
-    style/values/grid/StyleGridPositionsResolver.h
     style/values/grid/StyleGridTemplateAreas.h
     style/values/grid/StyleGridTemplateList.h
     style/values/grid/StyleGridTrackBreadth.h
@@ -3443,7 +3251,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/images/StyleImageWrapper.h
     style/values/images/StyleObjectPosition.h
 
-    style/values/images/kinds/StyleCachedImage.h
     style/values/images/kinds/StyleImage.h
 
     style/values/inline/StyleLineFitEdge.h
@@ -3510,11 +3317,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/primitives/StyleCoordinatedValueList.h
     style/values/primitives/StyleCoordinatedValueListValue.h
-    style/values/primitives/StyleLengthWrapper+Blending.h
     style/values/primitives/StyleLengthWrapper.h
     style/values/primitives/StyleLengthWrapperData.h
     style/values/primitives/StylePosition.h
-    style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h
     style/values/primitives/StylePrimitiveKeyword+Serialization.h
     style/values/primitives/StylePrimitiveKeyword+ValueRepresentationNeeded.h
     style/values/primitives/StylePrimitiveNumeric+Forward.h
@@ -3614,12 +3419,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/text-decoration/StyleTextUnderlinePosition.h
 
     style/values/transforms/functions/StyleTransformFunctionWrapper.h
-    style/values/transforms/functions/StyleMatrix3DTransformFunction.h
-    style/values/transforms/functions/StyleMatrixTransformFunction.h
-    style/values/transforms/functions/StylePerspectiveTransformFunction.h
     style/values/transforms/functions/StyleRotateTransformFunction.h
     style/values/transforms/functions/StyleScaleTransformFunction.h
-    style/values/transforms/functions/StyleSkewTransformFunction.h
     style/values/transforms/functions/StyleTransformFunctionBase.h
     style/values/transforms/functions/StyleTransformFunctionWrapper.h
     style/values/transforms/functions/StyleTranslateTransformFunction.h
@@ -3655,12 +3456,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     svg/SVGAngle.h
     svg/SVGDocument.h
-    svg/SVGDocumentExtensions.h
     svg/SVGElement.h
-    svg/SVGLengthContext.h
     svg/SVGLengthList.h
     svg/SVGLengthValue.h
-    svg/SVGLocatable.h
     svg/SVGNumberList.h
     svg/SVGParserUtilities.h
     svg/SVGParsingError.h
@@ -3669,12 +3467,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     svg/SVGPathUtilities.h
     svg/SVGPreserveAspectRatio.h
     svg/SVGPreserveAspectRatioValue.h
-    svg/SVGStringList.h
     svg/SVGTests.h
     svg/SVGUnitTypes.h
-    svg/SVGZoomAndPanType.h
 
-    svg/animation/SMILTime.h
 
     svg/graphics/SVGImage.h
     svg/graphics/SVGImageCache.h
@@ -3689,7 +3484,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     svg/properties/SVGPropertyOwner.h
     svg/properties/SVGPropertyTraits.h
 
-    testing/MockContentFilter.h
     testing/MockContentFilterManager.h
     testing/MockContentFilterSettings.h
     testing/MockContentFilterSettingsClient.h
@@ -3704,7 +3498,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/WorkerAnimationController.h
     workers/WorkerDebuggerProxy.h
     workers/WorkerFetchResult.h
-    workers/WorkerFontLoadRequest.h
     workers/WorkerGlobalScope.h
     workers/WorkerInitializationData.h
     workers/WorkerLoaderProxy.h
@@ -3728,7 +3521,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/service/InstallEvent.h
     workers/service/NavigationPreloadState.h
     workers/service/RouterCondition.h
-    workers/service/RouterRule.h
     workers/service/RouterSourceDict.h
     workers/service/RouterSourceEnum.h
     workers/service/RunningStatus.h
@@ -3778,10 +3570,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/service/server/SWOriginStore.h
     workers/service/server/SWRegistrationDatabase.h
     workers/service/server/SWRegistrationStore.h
-    workers/service/server/SWScriptStorage.h
     workers/service/server/SWServer.h
     workers/service/server/SWServerDelegate.h
-    workers/service/server/SWServerJobQueue.h
     workers/service/server/SWServerRegistration.h
     workers/service/server/SWServerToContextConnection.h
     workers/service/server/SWServerWorker.h
@@ -3809,7 +3599,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/CSSSelectorEnums.h
     ${WebCore_DERIVED_SOURCES_DIR}/CSSSelectorInlines.h
     ${WebCore_DERIVED_SOURCES_DIR}/CSSValueKeywords.h
-    ${WebCore_DERIVED_SOURCES_DIR}/CommandLineAPIModuleSourceBuiltins.h
     ${WebCore_DERIVED_SOURCES_DIR}/DocumentSyncData.h
     ${WebCore_DERIVED_SOURCES_DIR}/DocumentSyncClient.h
     ${WebCore_DERIVED_SOURCES_DIR}/EventInterfaces.h
@@ -3825,7 +3614,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/JSCSSRule.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSCSSRuleList.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSCSSStyleDeclaration.h
-    ${WebCore_DERIVED_SOURCES_DIR}/JSDOMBindingInternalsBuiltins.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSDOMImplementation.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSDOMWindow.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSDeprecatedCSSOMCounter.h
@@ -3838,7 +3626,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/JSEventTarget.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSFile.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSHTMLCollection.h
-    ${WebCore_DERIVED_SOURCES_DIR}/JSHTMLElement.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSHTMLOptionsCollection.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSMediaList.h
     ${WebCore_DERIVED_SOURCES_DIR}/JSNamedNodeMap.h
@@ -3858,22 +3645,18 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/MathMLNames.h
     ${WebCore_DERIVED_SOURCES_DIR}/Namespace.h
     ${WebCore_DERIVED_SOURCES_DIR}/NodeName.h
-    ${WebCore_DERIVED_SOURCES_DIR}/ReadableStreamInternalsBuiltins.h
     ${WebCore_DERIVED_SOURCES_DIR}/RenderStyleProperties.h
     ${WebCore_DERIVED_SOURCES_DIR}/RenderStyleProperties+GettersInlines.h
     ${WebCore_DERIVED_SOURCES_DIR}/SVGNames.h
     ${WebCore_DERIVED_SOURCES_DIR}/Settings.h
-    ${WebCore_DERIVED_SOURCES_DIR}/StreamInternalsBuiltins.h
     ${WebCore_DERIVED_SOURCES_DIR}/StyleComputedStyleProperties.h
     ${WebCore_DERIVED_SOURCES_DIR}/StyleComputedStyleProperties+GettersInlines.h
     ${WebCore_DERIVED_SOURCES_DIR}/StyleComputedStyleProperties+InitialInlines.h
     ${WebCore_DERIVED_SOURCES_DIR}/TagName.h
-    ${WebCore_DERIVED_SOURCES_DIR}/TransformStreamInternalsBuiltins.h
     ${WebCore_DERIVED_SOURCES_DIR}/UserAgentParts.h
     ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheets.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreJSBuiltinInternals.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreVirtualLogFunctions.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebKitFontFamilyNames.h
-    ${WebCore_DERIVED_SOURCES_DIR}/WritableStreamInternalsBuiltins.h
 )

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUUncapturedErrorEvent.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUUncapturedErrorEvent.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/WebGPUError.h>
-#include <WebCore/WebGPUUncapturedErrorEventInit.h>
+#include "WebGPUError.h"
+#include "WebGPUUncapturedErrorEventInit.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
@@ -27,10 +27,10 @@
 
 #if ENABLE(APPLE_PAY)
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/ApplePaySetupConfiguration.h>
-#include <WebCore/JSDOMPromiseDeferred.h>
-#include <WebCore/JSDOMPromiseDeferredForward.h>
+#include "ActiveDOMObject.h"
+#include "ApplePaySetupConfiguration.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySessionType.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySessionType.h
@@ -30,7 +30,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include <WebCore/CDMSessionType.h>
+#include "CDMSessionType.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchReferrerPolicy.h
+++ b/Source/WebCore/Modules/fetch/FetchReferrerPolicy.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/ReferrerPolicy.h>
+#include "ReferrerPolicy.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchRequestCache.h
+++ b/Source/WebCore/Modules/fetch/FetchRequestCache.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FetchOptions.h>
+#include "FetchOptions.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchRequestRedirect.h
+++ b/Source/WebCore/Modules/fetch/FetchRequestRedirect.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FetchOptions.h>
+#include "FetchOptions.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/BufferSource.h>
-#include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
-#include <WebCore/IDLTypes.h>
+#include "ActiveDOMObject.h"
+#include "BufferSource.h"
+#include "FileSystemSyncAccessHandleIdentifier.h"
+#include "IDLTypes.h"
 #include <wtf/Deque.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStream.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStream.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "Blob.h"
+#include "FileSystemWriteCommandType.h"
+#include "WritableStream.h"
 #include <JavaScriptCore/ArrayBufferView.h>
-#include <WebCore/Blob.h>
-#include <WebCore/FileSystemWriteCommandType.h>
-#include <WebCore/WritableStream.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/FileSystemWritableFileStreamIdentifier.h>
-#include <WebCore/WritableStreamSink.h>
+#include "FileSystemWritableFileStreamIdentifier.h"
+#include "WritableStreamSink.h"
 
 namespace WebCore {
 class FileSystemFileHandle;

--- a/Source/WebCore/Modules/geolocation/GeoNotifier.h
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.h
@@ -28,8 +28,8 @@
 
 #if ENABLE(GEOLOCATION)
 
-#include <WebCore/PositionOptions.h>
-#include <WebCore/Timer.h>
+#include "PositionOptions.h"
+#include "Timer.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -27,10 +27,10 @@
 
 #if ENABLE(WEB_AUTHN)
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/DigitalCredentialsProtocols.h>
-#include <WebCore/JSDOMPromiseDeferred.h>
-#include <WebCore/UnvalidatedDigitalCredentialRequest.h>
+#include "ActiveDOMObject.h"
+#include "DigitalCredentialsProtocols.h"
+#include "JSDOMPromiseDeferred.h"
+#include "UnvalidatedDigitalCredentialRequest.h"
 #include <optional>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/Noncopyable.h>

--- a/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.h
@@ -25,18 +25,18 @@
 
 #pragma once
 
-#include <WebCore/DigitalCredentialsRequestData.h>
-#include <WebCore/Document.h>
-#include <WebCore/ExceptionOr.h>
-#include <WebCore/ISO18013DocumentRequest.h>
+#include "DigitalCredentialsRequestData.h"
+#include "Document.h"
+#include "ExceptionOr.h"
+#include "ISO18013DocumentRequest.h"
 
 #if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
-#include <WebCore/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h>
-#include <WebCore/ISO18013DocumentRequestInfo.h>
+#include "DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h"
+#include "ISO18013DocumentRequestInfo.h"
 #endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 
-#include <WebCore/SecurityOriginData.h>
-#include <WebCore/ValidatedMobileDocumentRequest.h>
+#include "SecurityOriginData.h"
+#include "ValidatedMobileDocumentRequest.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -25,15 +25,15 @@
 
 #pragma once
 
-#include <WebCore/EventNames.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/IDBActiveDOMObject.h>
-#include <WebCore/IDBConnectionProxy.h>
-#include <WebCore/IDBDatabaseConnectionIdentifier.h>
-#include <WebCore/IDBDatabaseInfo.h>
-#include <WebCore/IDBKeyPath.h>
-#include <WebCore/IDBTransactionMode.h>
+#include "EventNames.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "IDBActiveDOMObject.h"
+#include "IDBConnectionProxy.h"
+#include "IDBDatabaseConnectionIdentifier.h"
+#include "IDBDatabaseInfo.h"
+#include "IDBKeyPath.h"
+#include "IDBTransactionMode.h"
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.h
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include <WebCore/CaptureDevice.h>
-#include <WebCore/ContextDestructionObserver.h>
-#include <WebCore/ScriptWrappable.h>
+#include "CaptureDevice.h"
+#include "ContextDestructionObserver.h"
+#include "ScriptWrappable.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -33,14 +33,14 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/EventNames.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/IDLTypes.h>
-#include <WebCore/MediaTrackConstraints.h>
-#include <WebCore/RealtimeMediaSourceCenter.h>
-#include <WebCore/UserMediaClient.h>
+#include "ActiveDOMObject.h"
+#include "EventNames.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "IDLTypes.h"
+#include "MediaTrackConstraints.h"
+#include "RealtimeMediaSourceCenter.h"
+#include "UserMediaClient.h"
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h
@@ -26,7 +26,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include <WebCore/Event.h>
+#include "Event.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCController.h
+++ b/Source/WebCore/Modules/mediastream/RTCController.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include <WebCore/EventTarget.h>
-#include <WebCore/SecurityOrigin.h>
+#include "EventTarget.h"
+#include "SecurityOrigin.h"
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -27,11 +27,11 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/ScriptWrappable.h>
-#include <WebCore/Timer.h>
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "ScriptWrappable.h"
+#include "Timer.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <WebCore/Event.h>
+#include "Event.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <WebCore/Event.h>
-#include <WebCore/RTCDataChannel.h>
+#include "Event.h"
+#include "RTCDataChannel.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
@@ -26,7 +26,7 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <WebCore/Event.h>
+#include "Event.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <WebCore/ModelPlayer.h>
-#include <WebCore/ModelPlayerClient.h>
-#include <WebCore/ModelPlayerIdentifier.h>
+#include "ModelPlayer.h"
+#include "ModelPlayerClient.h"
+#include "ModelPlayerIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(NOTIFICATIONS)
 
-#include <WebCore/Notification.h>
-#include <WebCore/SharedBuffer.h>
-#include <WebCore/ThreadableLoader.h>
+#include "Notification.h"
+#include "SharedBuffer.h"
+#include "ThreadableLoader.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.h
@@ -28,7 +28,7 @@
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
 
-#include <WebCore/Supplementable.h>
+#include "Supplementable.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -28,8 +28,8 @@
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
 
-#include <WebCore/PictureInPictureObserver.h>
-#include <WebCore/Supplementable.h>
+#include "PictureInPictureObserver.h"
+#include "Supplementable.h"
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h
@@ -28,7 +28,7 @@
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
 
-#include <WebCore/Event.h>
+#include "Event.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -28,10 +28,10 @@
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/IntSize.h>
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "IntSize.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/push-api/PushEvent.h
+++ b/Source/WebCore/Modules/push-api/PushEvent.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/ExtendableEvent.h>
-#include <WebCore/Notification.h>
-#include <WebCore/NotificationData.h>
-#include <WebCore/PushEventInit.h>
+#include "ExtendableEvent.h"
+#include "Notification.h"
+#include "NotificationData.h"
+#include "PushEventInit.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/push-api/PushManager.h
+++ b/Source/WebCore/Modules/push-api/PushManager.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/JSDOMPromiseDeferredForward.h>
-#include <WebCore/PushPermissionState.h>
-#include <WebCore/PushSubscription.h>
-#include <WebCore/PushSubscriptionOptionsInit.h>
+#include "JSDOMPromiseDeferredForward.h"
+#include "PushPermissionState.h"
+#include "PushSubscription.h"
+#include "PushSubscriptionOptionsInit.h"
 #include <optional>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -27,10 +27,10 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/WebCoreOpaqueRoot.h>
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "WebCoreOpaqueRoot.h"
 #include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.h
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/StorageConnection.h>
+#include "StorageConnection.h"
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.h
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/ExceptionOr.h>
+#include "ExceptionOr.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h
@@ -26,10 +26,10 @@
 #pragma once
 
 #if ENABLE(WEB_AUTHN)
-#include <WebCore/AuthenticationExtensionsClientInputsJSON.h>
-#include <WebCore/AuthenticatorSelectionCriteria.h>
-#include <WebCore/PublicKeyCredentialRpEntity.h>
-#include <WebCore/PublicKeyCredentialUserEntityJSON.h>
+#include "AuthenticationExtensionsClientInputsJSON.h"
+#include "AuthenticatorSelectionCriteria.h"
+#include "PublicKeyCredentialRpEntity.h"
+#include "PublicKeyCredentialUserEntityJSON.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #if ENABLE(WEB_AUTHN)
-#include <WebCore/AuthenticationExtensionsClientInputsJSON.h>
-#include <WebCore/PublicKeyCredentialDescriptorJSON.h>
+#include "AuthenticationExtensionsClientInputsJSON.h"
+#include "PublicKeyCredentialDescriptorJSON.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webcodecs/VideoMatrixCoefficients.h
+++ b/Source/WebCore/Modules/webcodecs/VideoMatrixCoefficients.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(VIDEO)
 
-#include <WebCore/PlatformVideoMatrixCoefficients.h>
+#include "PlatformVideoMatrixCoefficients.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -27,8 +27,8 @@
 
 #pragma once
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/Document.h>
+#include "ActiveDOMObject.h"
+#include "Document.h"
 #include <wtf/Platform.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
@@ -30,10 +30,10 @@
 
 #pragma once
 
-#include <WebCore/ScriptExecutionContext.h>
-#include <WebCore/ThreadableWebSocketChannel.h>
-#include <WebCore/WebSocketChannelClient.h>
-#include <WebCore/WorkerThreadableWebSocketChannel.h>
+#include "ScriptExecutionContext.h"
+#include "ThreadableWebSocketChannel.h"
+#include "WebSocketChannelClient.h"
+#include "WorkerThreadableWebSocketChannel.h"
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakPtr.h>

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/WritableStreamSink.h>
+#include "WritableStreamSink.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AXTableHelpers.h
+++ b/Source/WebCore/accessibility/AXTableHelpers.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/AccessibilityRole.h>
+#include "AccessibilityRole.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -25,22 +25,22 @@
 
 #pragma once
 
-#include <WebCore/AXObjectCache.h>
-#include <WebCore/AXObjectRareData.h>
-#include <WebCore/AXTextMarker.h>
-#include <WebCore/AXUtilities.h>
-#include <WebCore/AccessibilityObject.h>
-#include <WebCore/Color.h>
-#include <WebCore/Document.h>
-#include <WebCore/Element.h>
-#include <WebCore/FrameDestructionObserverInlines.h>
-#include <WebCore/HTMLParserIdioms.h>
-#include <WebCore/LocalFrame.h>
-#include <WebCore/NodeDocument.h>
-#include <WebCore/RenderInline.h>
-#include <WebCore/RenderLayer.h>
-#include <WebCore/SimpleRange.h>
-#include <WebCore/TextIterator.h>
+#include "AXObjectCache.h"
+#include "AXObjectRareData.h"
+#include "AXTextMarker.h"
+#include "AXUtilities.h"
+#include "AccessibilityObject.h"
+#include "Color.h"
+#include "Document.h"
+#include "Element.h"
+#include "FrameDestructionObserverInlines.h"
+#include "HTMLParserIdioms.h"
+#include "LocalFrame.h"
+#include "NodeDocument.h"
+#include "RenderInline.h"
+#include "RenderLayer.h"
+#include "SimpleRange.h"
+#include "TextIterator.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/AnimationEventBase.h>
-#include <WebCore/AnimationPlaybackEventInit.h>
-#include <WebCore/WebAnimationTypes.h>
+#include "AnimationEventBase.h"
+#include "AnimationPlaybackEventInit.h"
+#include "WebAnimationTypes.h"
 #include <wtf/Markable.h>
 
 namespace WebCore {

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/AnimationFrameRate.h>
-#include <WebCore/AnimationTimeline.h>
-#include <WebCore/DocumentTimelineOptions.h>
-#include <WebCore/Timer.h>
+#include "AnimationFrameRate.h"
+#include "AnimationTimeline.h"
+#include "DocumentTimelineOptions.h"
+#include "Timer.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/animation/ElementAnimationRareData.h
+++ b/Source/WebCore/animation/ElementAnimationRareData.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/KeyframeEffectStack.h>
-#include <WebCore/PseudoElementIdentifier.h>
-#include <WebCore/WebAnimationTypes.h>
+#include "KeyframeEffectStack.h"
+#include "PseudoElementIdentifier.h"
+#include "WebAnimationTypes.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/CSSAnimation.h>
-#include <WebCore/ScrollAxis.h>
-#include <WebCore/StyleNameScope.h>
-#include <WebCore/Styleable.h>
+#include "CSSAnimation.h"
+#include "ScrollAxis.h"
+#include "StyleNameScope.h"
+#include "Styleable.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/AtomStringHash.h>

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/ExceptionOr.h>
-#include <WebCore/JSDOMGuardedObject.h>
+#include "ExceptionOr.h"
+#include "JSDOMGuardedObject.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/DOMPromiseProxy.h
+++ b/Source/WebCore/bindings/js/DOMPromiseProxy.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/ExceptionOr.h>
-#include <WebCore/JSDOMGlobalObject.h>
-#include <WebCore/JSDOMPromiseDeferred.h>
+#include "ExceptionOr.h"
+#include "JSDOMGlobalObject.h"
+#include "JSDOMPromiseDeferred.h"
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/bindings/js/JSDOMAbstractOperations.h
+++ b/Source/WebCore/bindings/js/JSDOMAbstractOperations.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/JSDOMConvertStrings.h>
-#include <WebCore/JSDOMExceptionHandling.h>
+#include "JSDOMConvertStrings.h"
+#include "JSDOMExceptionHandling.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -25,15 +25,15 @@
 
 #pragma once
 
+#include "JSDOMConvert.h"
+#include "JSDOMIterator.h"
+#include "JSDOMPromise.h"
+#include "JSDOMPromiseDeferred.h"
 #include <JavaScriptCore/AsyncIteratorPrototype.h>
 #include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/JSBoundFunction.h>
 #include <JavaScriptCore/JSPromiseConstructor.h>
 #include <JavaScriptCore/PropertySlot.h>
-#include <WebCore/JSDOMConvert.h>
-#include <WebCore/JSDOMIterator.h>
-#include <WebCore/JSDOMPromise.h>
-#include <WebCore/JSDOMPromiseDeferred.h>
 #include <type_traits>
 #include <wtf/CompletionHandler.h>
 

--- a/Source/WebCore/bindings/js/JSDOMAttribute.h
+++ b/Source/WebCore/bindings/js/JSDOMAttribute.h
@@ -23,9 +23,9 @@
 
 #pragma once
 
+#include "JSDOMCastThisValue.h"
+#include "JSDOMExceptionHandling.h"
 #include <JavaScriptCore/Error.h>
-#include <WebCore/JSDOMCastThisValue.h>
-#include <WebCore/JSDOMExceptionHandling.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurityInlines.h
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurityInlines.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/JSDOMBindingSecurity.h>
-#include <WebCore/JSDOMWindow.h>
+#include "JSDOMBindingSecurity.h"
+#include "JSDOMWindow.h"
 
 namespace WebCore {
 namespace BindingSecurity {

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/IDLTypes.h>
-#include <WebCore/JSDOMConvertBase.h>
-#include <WebCore/JSDOMPromise.h>
-#include <WebCore/WorkerGlobalScope.h>
+#include "IDLTypes.h"
+#include "JSDOMConvertBase.h"
+#include "JSDOMPromise.h"
+#include "WorkerGlobalScope.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMConvertVariadic.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertVariadic.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/IDLTypes.h>
-#include <WebCore/JSDOMConvertBase.h>
+#include "IDLTypes.h"
+#include "JSDOMConvertBase.h"
 #include <wtf/FixedVector.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(WEBGL)
 
-#include <WebCore/IDLTypes.h>
-#include <WebCore/JSDOMConvertBase.h>
+#include "IDLTypes.h"
+#include "JSDOMConvertBase.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include <WebCore/JSDOMOperation.h>
-#include <WebCore/JSDOMPromiseDeferred.h>
+#include "JSDOMOperation.h"
+#include "JSDOMPromiseDeferred.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSPluginElementFunctions.h
+++ b/Source/WebCore/bindings/js/JSPluginElementFunctions.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <WebCore/JSDOMBinding.h>
+#include "JSDOMBinding.h"
 
 namespace JSC {
 namespace Bindings {

--- a/Source/WebCore/bindings/js/WorkerScriptFetcher.h
+++ b/Source/WebCore/bindings/js/WorkerScriptFetcher.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#include "FetchOptions.h"
+#include "LoadableScript.h"
+#include "LoadableScriptError.h"
+#include "ModuleFetchParameters.h"
 #include <JavaScriptCore/ScriptFetcher.h>
-#include <WebCore/FetchOptions.h>
-#include <WebCore/LoadableScript.h>
-#include <WebCore/LoadableScriptError.h>
-#include <WebCore/ModuleFetchParameters.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/bridge/runtime_method.h
+++ b/Source/WebCore/bridge/runtime_method.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "BridgeJSC.h"
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSGlobalObject.h>
-#include <WebCore/BridgeJSC.h>
 
 namespace JSC {
 

--- a/Source/WebCore/bridge/runtime_object.h
+++ b/Source/WebCore/bridge/runtime_object.h
@@ -23,14 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#ifndef KJS_RUNTIME_OBJECT_H
-#define KJS_RUNTIME_OBJECT_H
+#pragma once
 
+#include "BridgeJSC.h"
 #include <JavaScriptCore/JSGlobalObject.h>
-#include <WebCore/BridgeJSC.h>
 
-namespace JSC {
-namespace Bindings {
+namespace JSC::Bindings {
 
 Exception* throwRuntimeObjectInvalidAccessError(JSGlobalObject*, ThrowScope&);
 
@@ -92,6 +90,3 @@ private:
 };
     
 }
-}
-
-#endif

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CryptoKey.h>
-#include <WebCore/CryptoKeyPair.h>
+#include "CryptoKey.h"
+#include "CryptoKeyPair.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/BufferSource.h>
-#include <WebCore/CryptoAlgorithmAesCtrParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
+#include "BufferSource.h"
+#include "CryptoAlgorithmAesCtrParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/BufferSource.h>
-#include <WebCore/CryptoAlgorithmAesGcmParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
+#include "BufferSource.h"
+#include "CryptoAlgorithmAesGcmParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CryptoAlgorithmAesKeyParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
+#include "CryptoAlgorithmAesKeyParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CryptoAlgorithmEcKeyParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
+#include "CryptoAlgorithmEcKeyParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CryptoAlgorithmEcdhKeyDeriveParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
+#include "CryptoAlgorithmEcdhKeyDeriveParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "CryptoAlgorithmEcdsaParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/CryptoAlgorithmEcdsaParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#include "BufferSource.h"
+#include "CryptoAlgorithmHkdfParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/BufferSource.h>
-#include <WebCore/CryptoAlgorithmHkdfParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "CryptoAlgorithmHmacKeyParamsInit.h"
+#include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/CryptoAlgorithmHmacKeyParamsInit.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#include "BufferSource.h"
+#include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmPbkdf2ParamsInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/BufferSource.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
-#include <WebCore/CryptoAlgorithmPbkdf2ParamsInit.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaHashedImportParamsInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
-#include <WebCore/CryptoAlgorithmRsaHashedImportParamsInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "CryptoAlgorithmRsaHashedKeyGenParamsInit.h"
+#include "CryptoAlgorithmRsaKeyGenParams.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/CryptoAlgorithmRsaHashedKeyGenParamsInit.h>
-#include <WebCore/CryptoAlgorithmRsaKeyGenParams.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/BufferSource.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
-#include <WebCore/CryptoAlgorithmRsaOaepParamsInit.h>
+#include "BufferSource.h"
+#include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaOaepParamsInit.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CryptoAlgorithmParameters.h>
-#include <WebCore/CryptoAlgorithmRsaPssParamsInit.h>
+#include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaPssParamsInit.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
+#include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmX25519ParamsInit.h"
+#include "CryptoKey.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/CryptoAlgorithmParameters.h>
-#include <WebCore/CryptoAlgorithmX25519ParamsInit.h>
-#include <WebCore/CryptoKey.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CSSCounterStyle.h>
+#include "CSSCounterStyle.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/AtomStringHash.h>

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/CSSCounterStyle.h>
-#include <WebCore/CSSRule.h>
-#include <WebCore/StyleProperties.h>
-#include <WebCore/StyleRule.h>
+#include "CSSCounterStyle.h"
+#include "CSSRule.h"
+#include "StyleProperties.h"
+#include "StyleRule.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -20,10 +20,10 @@
 
 #pragma once
 
-#include <WebCore/CSSURL.h>
-#include <WebCore/CSSValue.h>
-#include <WebCore/CSSValuePair.h>
-#include <WebCore/IntPoint.h>
+#include "CSSURL.h"
+#include "CSSValue.h"
+#include "CSSValuePair.h"
+#include "IntPoint.h"
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/CSSURL.h>
-#include <WebCore/CSSValue.h>
-#include <WebCore/CachedResourceHandle.h>
-#include <WebCore/ResourceLoaderOptions.h>
+#include "CSSURL.h"
+#include "CSSValue.h"
+#include "CachedResourceHandle.h"
+#include "ResourceLoaderOptions.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSFontFeatureValue.h
+++ b/Source/WebCore/css/CSSFontFeatureValue.h
@@ -26,8 +26,8 @@
 
 #pragma once
 
-#include <WebCore/CSSValue.h>
-#include <WebCore/FontTaggedSettings.h>
+#include "CSSValue.h"
+#include "FontTaggedSettings.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSFunctionValue.h
+++ b/Source/WebCore/css/CSSFunctionValue.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CSSValueList.h>
+#include "CSSValueList.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CSSGradient.h>
-#include <WebCore/StyleImage.h>
+#include "CSSGradient.h"
+#include "StyleImage.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSImageSetValue.h
+++ b/Source/WebCore/css/CSSImageSetValue.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CSSValueList.h>
+#include "CSSValueList.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
-#include <WebCore/CSSURL.h>
-#include <WebCore/CSSValue.h>
-#include <WebCore/CachedImage.h>
-#include <WebCore/CachedResourceHandle.h>
-#include <WebCore/ResourceLoaderOptions.h>
+#include "CSSURL.h"
+#include "CSSValue.h"
+#include "CachedImage.h"
+#include "CachedResourceHandle.h"
+#include "ResourceLoaderOptions.h"
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
 

--- a/Source/WebCore/css/CSSNamedImageValue.h
+++ b/Source/WebCore/css/CSSNamedImageValue.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CSSValue.h>
+#include "CSSValue.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSNamespaceRule.h
+++ b/Source/WebCore/css/CSSNamespaceRule.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CSSRule.h>
+#include "CSSRule.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSNestedDeclarations.h
+++ b/Source/WebCore/css/CSSNestedDeclarations.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <WebCore/CSSRule.h>
+#include "CSSRule.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSPositionTryDescriptors.h
+++ b/Source/WebCore/css/CSSPositionTryDescriptors.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/PropertySetCSSDescriptors.h>
+#include "PropertySetCSSDescriptors.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSPropertySourceData.h
+++ b/Source/WebCore/css/CSSPropertySourceData.h
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include <WebCore/StyleRuleType.h>
+#include "StyleRuleType.h"
 #include <utility>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/css/CSSReflectValue.h
+++ b/Source/WebCore/css/CSSReflectValue.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CSSPrimitiveValue.h>
-#include <WebCore/CSSValue.h>
+#include "CSSPrimitiveValue.h"
+#include "CSSValue.h"
 #include <wtf/Function.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSTransformListValue.h
+++ b/Source/WebCore/css/CSSTransformListValue.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <WebCore/CSSValueList.h>
+#include "CSSValueList.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -28,8 +28,8 @@
 
 #pragma once
 
-#include <WebCore/CSSPrimitiveValue.h>
-#include <WebCore/RenderStyleConstants.h>
+#include "CSSPrimitiveValue.h"
+#include "RenderStyleConstants.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/calc/CSSCalcRandomCachingKeyMap.h
+++ b/Source/WebCore/css/calc/CSSCalcRandomCachingKeyMap.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/CSSCalcRandomCachingKey.h>
+#include "CSSCalcRandomCachingKey.h"
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CSSValueKeywords.h>
+#include "CSSValueKeywords.h"
 #include <optional>
 #include <wtf/HashMap.h>
 

--- a/Source/WebCore/css/parser/CSSPropertyParserResult.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserResult.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/CSSProperty.h>
+#include "CSSProperty.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -24,10 +24,10 @@
 
 #pragma once
 
-#include <WebCore/CSSProperty.h>
-#include <WebCore/CSSPropertyNames.h>
-#include <WebCore/CSSValuePool.h>
-#include <WebCore/StyleRuleType.h>
+#include "CSSProperty.h"
+#include "CSSPropertyNames.h"
+#include "CSSValuePool.h"
+#include "StyleRuleType.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -29,13 +29,13 @@
 
 #pragma once
 
-#include <WebCore/CSSParserContext.h>
-#include <WebCore/CSSParserEnum.h>
-#include <WebCore/CSSParserTokenRange.h>
-#include <WebCore/CSSSelectorList.h>
-#include <WebCore/CSSSelectorParserContext.h>
-#include <WebCore/MutableCSSSelector.h>
-#include <WebCore/StyleSheetContents.h>
+#include "CSSParserContext.h"
+#include "CSSParserEnum.h"
+#include "CSSParserTokenRange.h"
+#include "CSSSelectorList.h"
+#include "CSSSelectorParserContext.h"
+#include "MutableCSSSelector.h"
+#include "StyleSheetContents.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/values/borders/CSSBoxShadowProperty.h
+++ b/Source/WebCore/css/values/borders/CSSBoxShadowProperty.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/CSSBoxShadow.h>
+#include "CSSBoxShadow.h"
 
 namespace WebCore {
 namespace CSS {

--- a/Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h
@@ -28,12 +28,12 @@
 
 #pragma once
 
-#include <WebCore/AsyncNodeDeletionQueue.h>
-#include <WebCore/ContainerNode.h>
-#include <WebCore/Element.h>
-#include <WebCore/HTMLElement.h>
-#include <WebCore/HTMLNames.h>
-#include <WebCore/NodeName.h>
+#include "AsyncNodeDeletionQueue.h"
+#include "ContainerNode.h"
+#include "Element.h"
+#include "HTMLElement.h"
+#include "HTMLNames.h"
+#include "NodeName.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <WebCore/CachedResourceHandle.h>
-#include <WebCore/Document.h>
-#include <WebCore/Timer.h>
+#include "CachedResourceHandle.h"
+#include "Document.h"
+#include "Timer.h"
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/dom/DragEvent.h
+++ b/Source/WebCore/dom/DragEvent.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/MouseEvent.h>
-#include <WebCore/MouseEventInit.h>
+#include "MouseEvent.h"
+#include "MouseEventInit.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/InlineClassicScript.h
+++ b/Source/WebCore/dom/InlineClassicScript.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/ScriptElementCachedScriptFetcher.h>
+#include "ScriptElementCachedScriptFetcher.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/StaticRange.h>
-#include <WebCore/UIEvent.h>
+#include "StaticRange.h"
+#include "UIEvent.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/LoadableScript.h>
-#include <WebCore/LoadableScriptError.h>
+#include "LoadableScript.h"
+#include "LoadableScriptError.h"
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/LoadableSpeculationRules.h
+++ b/Source/WebCore/dom/LoadableSpeculationRules.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include <WebCore/CachedResourceClient.h>
-#include <WebCore/CachedResourceHandle.h>
-#include <WebCore/FetchOptionsDestination.h>
-#include <WebCore/ResourceLoaderOptions.h>
-#include <WebCore/ResourceRequest.h>
+#include "CachedResourceClient.h"
+#include "CachedResourceHandle.h"
+#include "FetchOptionsDestination.h"
+#include "ResourceLoaderOptions.h"
+#include "ResourceRequest.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URL.h>

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include "EventLoop.h"
 #include <JavaScriptCore/MicrotaskQueue.h>
-#include <WebCore/EventLoop.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -31,8 +31,8 @@
 
 #pragma once
 
-#include <WebCore/GCReachableRef.h>
-#include <WebCore/MutationObserverOptions.h>
+#include "GCReachableRef.h"
+#include "MutationObserverOptions.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/dom/NameNodeList.h
+++ b/Source/WebCore/dom/NameNodeList.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <WebCore/LiveNodeList.h>
+#include "LiveNodeList.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/PendingScript.h
+++ b/Source/WebCore/dom/PendingScript.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/LoadableScript.h>
-#include <WebCore/LoadableScriptClient.h>
+#include "LoadableScript.h"
+#include "LoadableScriptClient.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "CustomElementRegistry.h"
+#include "ShadowRootMode.h"
+#include "SlotAssignmentMode.h"
 #include <JavaScriptCore/JSCJSValue.h>
-#include <WebCore/CustomElementRegistry.h>
-#include <WebCore/ShadowRootMode.h>
-#include <WebCore/SlotAssignmentMode.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/SpeculationRulesMatcher.h
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/SpeculationRules.h>
+#include "SpeculationRules.h"
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/domjit/DOMJITIDLConvert.h
+++ b/Source/WebCore/domjit/DOMJITIDLConvert.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/IDLTypes.h>
+#include "IDLTypes.h"
 
 namespace WebCore { namespace DOMJIT {
 

--- a/Source/WebCore/domjit/DOMJITIDLType.h
+++ b/Source/WebCore/domjit/DOMJITIDLType.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/IDLTypes.h>
+#include "IDLTypes.h"
 
 namespace WebCore { namespace DOMJIT {
 

--- a/Source/WebCore/domjit/DOMJITIDLTypeFilter.h
+++ b/Source/WebCore/domjit/DOMJITIDLTypeFilter.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "IDLTypes.h"
 #include <JavaScriptCore/SpeculatedType.h>
-#include <WebCore/IDLTypes.h>
 
 namespace WebCore { namespace DOMJIT {
 

--- a/Source/WebCore/editing/TextCheckingHelper.h
+++ b/Source/WebCore/editing/TextCheckingHelper.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#include <WebCore/SimpleRange.h>
-#include <WebCore/TextChecking.h>
+#include "SimpleRange.h"
+#include "TextChecking.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -25,14 +25,14 @@
 
 #pragma once
 
+#include "Blob.h"
+#include "Document.h"
+#include "ExceptionCode.h"
+#include "FileReaderLoader.h"
+#include "FileReaderLoaderClient.h"
+#include "Logging.h"
+#include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
-#include <WebCore/Blob.h>
-#include <WebCore/Document.h>
-#include <WebCore/ExceptionCode.h>
-#include <WebCore/FileReaderLoader.h>
-#include <WebCore/FileReaderLoaderClient.h>
-#include <WebCore/Logging.h>
-#include <WebCore/SharedBuffer.h>
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/CustomElementFormValue.h>
-#include <WebCore/HTMLMaybeFormAssociatedCustomElement.h>
-#include <WebCore/ValidatedFormListedElement.h>
-#include <WebCore/ValidityStateFlags.h>
+#include "CustomElementFormValue.h"
+#include "HTMLMaybeFormAssociatedCustomElement.h"
+#include "ValidatedFormListedElement.h"
+#include "ValidityStateFlags.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLAnchorElementInlines.h
+++ b/Source/WebCore/html/HTMLAnchorElementInlines.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/ElementInlines.h>
-#include <WebCore/HTMLAnchorElement.h>
+#include "ElementInlines.h"
+#include "HTMLAnchorElement.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/HTMLImageLoader.h
+++ b/Source/WebCore/html/HTMLImageLoader.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <WebCore/ImageLoader.h>
+#include "ImageLoader.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/HTMLInputElementInlines.h
+++ b/Source/WebCore/html/HTMLInputElementInlines.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/Document.h>
-#include <WebCore/HTMLInputElement.h>
-#include <WebCore/InputType.h>
+#include "Document.h"
+#include "HTMLInputElement.h"
+#include "InputType.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/HTMLSelectedContentElement.h
+++ b/Source/WebCore/html/HTMLSelectedContentElement.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/HTMLElement.h>
+#include "HTMLElement.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -27,12 +27,12 @@
 
 #if ENABLE(VIDEO)
 
-#include <WebCore/ContextDestructionObserver.h>
-#include <WebCore/Event.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/MediaControllerInterface.h>
-#include <WebCore/Timer.h>
+#include "ContextDestructionObserver.h"
+#include "Event.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "MediaControllerInterface.h"
+#include "Timer.h"
 #include <wtf/Vector.h>
 
 namespace PAL {

--- a/Source/WebCore/html/MediaEncryptedEvent.h
+++ b/Source/WebCore/html/MediaEncryptedEvent.h
@@ -30,8 +30,8 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include <WebCore/Event.h>
-#include <WebCore/MediaEncryptedEventInit.h>
+#include "Event.h"
+#include "MediaEncryptedEventInit.h"
 
 namespace JSC {
 class ArrayBuffer;

--- a/Source/WebCore/html/StepRange.h
+++ b/Source/WebCore/html/StepRange.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <WebCore/Decimal.h>
+#include "Decimal.h"
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/html/ValidityState.h
+++ b/Source/WebCore/html/ValidityState.h
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include <WebCore/FormListedElement.h>
-#include <WebCore/HTMLElement.h>
+#include "FormListedElement.h"
+#include "HTMLElement.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CloseWatcher.h>
+#include "CloseWatcher.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/track/DataCue.h
+++ b/Source/WebCore/html/track/DataCue.h
@@ -28,9 +28,9 @@
 
 #if ENABLE(VIDEO)
 
+#include "SerializedPlatformDataCue.h"
+#include "TextTrackCue.h"
 #include <JavaScriptCore/Strong.h>
-#include <WebCore/SerializedPlatformDataCue.h>
-#include <WebCore/TextTrackCue.h>
 #include <wtf/MediaTime.h>
 #include <wtf/TypeCasts.h>
 

--- a/Source/WebCore/html/track/TextTrackCueGeneric.h
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(VIDEO)
 
-#include <WebCore/Color.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/VTTCue.h>
+#include "Color.h"
+#include "EventTargetInterfaces.h"
+#include "VTTCue.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -28,8 +28,8 @@
 
 #if ENABLE(VIDEO)
 
-#include <WebCore/TrackBase.h>
-#include <WebCore/VideoTrackPrivateClient.h>
+#include "TrackBase.h"
+#include "VideoTrackPrivateClient.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -34,11 +34,11 @@
 
 #if ENABLE(VIDEO)
 
-#include <WebCore/BufferedLineReader.h>
-#include <WebCore/DocumentFragment.h>
-#include <WebCore/HTMLNames.h>
-#include <WebCore/TextResourceDecoder.h>
-#include <WebCore/VTTRegion.h>
+#include "BufferedLineReader.h"
+#include "DocumentFragment.h"
+#include "HTMLNames.h"
+#include "TextResourceDecoder.h"
+#include "VTTRegion.h"
 #include <memory>
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/layout/floats/FloatAvoider.h
+++ b/Source/WebCore/layout/floats/FloatAvoider.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/LayoutBox.h>
-#include <WebCore/LayoutBoxGeometry.h>
-#include <WebCore/LayoutPoint.h>
-#include <WebCore/LayoutUnits.h>
+#include "LayoutBox.h"
+#include "LayoutBoxGeometry.h"
+#include "LayoutPoint.h"
+#include "LayoutUnits.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/MarginTypes.h>
+#include "MarginTypes.h"
 #include <wtf/CheckedRef.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemRect.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemRect.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/GridAreaLines.h>
+#include "GridAreaLines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/FreeSpaceScenario.h>
-#include <WebCore/GridFormattingContext.h>
-#include <WebCore/GridTypeAliases.h>
-#include <WebCore/StyleGridTrackBreadth.h>
+#include "FreeSpaceScenario.h"
+#include "GridFormattingContext.h"
+#include "GridTypeAliases.h"
+#include "StyleGridTrackBreadth.h"
 
 namespace WebCore {
 class RenderStyle;

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/GridTypeAliases.h>
+#include "GridTypeAliases.h"
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/FreeSpaceScenario.h>
-#include <WebCore/GridTypeAliases.h>
-#include <WebCore/LayoutUnit.h>
+#include "FreeSpaceScenario.h"
+#include "GridTypeAliases.h"
+#include "LayoutUnit.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/StyleGridTrackBreadth.h>
+#include "StyleGridTrackBreadth.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/StyleGridPosition.h>
+#include "StyleGridPosition.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h
@@ -24,7 +24,7 @@
  */
 #pragma once
 
-#include <WebCore/GridTypeAliases.h>
+#include "GridTypeAliases.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineSoftLineBreakItem.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineSoftLineBreakItem.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/InlineItem.h>
+#include "InlineItem.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/Document.h>
-#include <WebCore/SecurityOriginData.h>
-#include <WebCore/TextBreakingPositionContext.h>
-#include <WebCore/Timer.h>
+#include "Document.h"
+#include "SecurityOriginData.h"
+#include "TextBreakingPositionContext.h"
+#include "Timer.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingConstraints.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingConstraints.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/FormattingConstraints.h>
+#include "FormattingConstraints.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/layouttree/LayoutDescendantIterator.h
+++ b/Source/WebCore/layout/layouttree/LayoutDescendantIterator.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/LayoutIterator.h>
+#include "LayoutIterator.h"
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.h
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/LayoutElementBox.h>
+#include "LayoutElementBox.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/CachedResourceClient.h>
-#include <WebCore/CachedResourceHandle.h>
+#include "CachedResourceClient.h"
+#include "CachedResourceHandle.h"
 #include <optional>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/loader/ResourceMonitorPersistence.h
+++ b/Source/WebCore/loader/ResourceMonitorPersistence.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/SQLiteDatabase.h>
+#include "SQLiteDatabase.h"
 #include <wtf/ContinuousApproximateTime.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.h
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(APPLICATION_MANIFEST)
 
-#include <WebCore/ApplicationManifest.h>
-#include <WebCore/CachedResource.h>
+#include "ApplicationManifest.h"
+#include "CachedResource.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/LoaderMalloc.h>
-#include <WebCore/ThreadGlobalData.h>
+#include "LoaderMalloc.h"
+#include "ThreadGlobalData.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/ResourceRequest.h>
+#include "ResourceRequest.h"
 #include <pal/SessionID.h>
 
 typedef const struct _CFCachedURLResponse* CFCachedURLResponseRef;

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -26,10 +26,10 @@
 
 #pragma once
 
-#include <WebCore/Event.h>
-#include <WebCore/LocalDOMWindow.h>
-#include <WebCore/Supplementable.h>
-#include <WebCore/Timer.h>
+#include "Event.h"
+#include "LocalDOMWindow.h"
+#include "Supplementable.h"
+#include "Timer.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/page/DragState.h
+++ b/Source/WebCore/page/DragState.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <WebCore/DataTransfer.h>
-#include <WebCore/DragActions.h>
-#include <WebCore/Element.h>
+#include "DataTransfer.h"
+#include "DragActions.h"
+#include "Element.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/page/EmptyAttachmentElementClient.h
+++ b/Source/WebCore/page/EmptyAttachmentElementClient.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-#include <WebCore/AttachmentElementClient.h>
+#include "AttachmentElementClient.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include <WebCore/ActiveDOMObject.h>
-#include <WebCore/EventTarget.h>
-#include <WebCore/EventTargetInterfaces.h>
-#include <WebCore/ReferrerPolicy.h>
-#include <WebCore/ScriptExecutionContextIdentifier.h>
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "ReferrerPolicy.h"
+#include "ScriptExecutionContextIdentifier.h"
 #include <wtf/RefCounted.h>
 
 namespace JSC {

--- a/Source/WebCore/page/RenderingUpdateScheduler.h
+++ b/Source/WebCore/page/RenderingUpdateScheduler.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/AnimationFrameRate.h>
-#include <WebCore/DisplayRefreshMonitorClient.h>
+#include "AnimationFrameRate.h"
+#include "DisplayRefreshMonitorClient.h"
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/page/ScrollToOptions.h
+++ b/Source/WebCore/page/ScrollToOptions.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <WebCore/ScrollOptions.h>
+#include "ScrollOptions.h"
 #include <cmath>
 
 namespace WebCore {

--- a/Source/WebCore/page/SpatialNavigation.h
+++ b/Source/WebCore/page/SpatialNavigation.h
@@ -20,10 +20,10 @@
 
 #pragma once
 
-#include <WebCore/FocusDirection.h>
-#include <WebCore/HTMLFrameOwnerElement.h>
-#include <WebCore/LayoutRect.h>
-#include <WebCore/NodeDocument.h>
+#include "FocusDirection.h"
+#include "HTMLFrameOwnerElement.h"
+#include "LayoutRect.h"
+#include "NodeDocument.h"
 #include <limits>
 
 namespace WebCore {

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/JSDOMPromiseDeferredForward.h>
-#include <WebCore/NavigatorBase.h>
-#include <WebCore/Supplementable.h>
+#include "JSDOMPromiseDeferredForward.h"
+#include "NavigatorBase.h"
+#include "Supplementable.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/mac/WheelEventDeltaFilterMac.h
+++ b/Source/WebCore/page/mac/WheelEventDeltaFilterMac.h
@@ -28,7 +28,7 @@
 #include <wtf/Platform.h>
 #if PLATFORM(MAC)
 
-#include <WebCore/WheelEventDeltaFilter.h>
+#include "WheelEventDeltaFilter.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/FloatRect.h>
-#include <WebCore/ScrollTypes.h>
+#include "FloatRect.h"
+#include "ScrollTypes.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/platform/ScrollExtents.h
+++ b/Source/WebCore/platform/ScrollExtents.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/FloatPoint.h>
-#include <WebCore/IntPoint.h>
+#include "FloatPoint.h"
+#include "IntPoint.h"
 #include <cstdint>
 
 namespace WebCore {

--- a/Source/WebCore/platform/SimpleCaretAnimator.h
+++ b/Source/WebCore/platform/SimpleCaretAnimator.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CaretAnimator.h>
+#include "CaretAnimator.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/StaticPasteboard.h
+++ b/Source/WebCore/platform/StaticPasteboard.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/Pasteboard.h>
+#include "Pasteboard.h"
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>

--- a/Source/WebCore/platform/audio/SincResampler.h
+++ b/Source/WebCore/platform/audio/SincResampler.h
@@ -29,8 +29,8 @@
 #ifndef SincResampler_h
 #define SincResampler_h
 
-#include <WebCore/AudioArray.h>
-#include <WebCore/AudioSourceProvider.h>
+#include "AudioArray.h"
+#include "AudioSourceProvider.h"
 #include <span>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
@@ -28,9 +28,9 @@
 #include <wtf/Platform.h>
 #if ENABLE(WEB_AUDIO)
 
+#include "AudioDestinationResampler.h"
+#include "AudioOutputUnitAdaptor.h"
 #include <AudioUnit/AudioUnit.h>
-#include <WebCore/AudioDestinationResampler.h>
-#include <WebCore/AudioOutputUnitAdaptor.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -28,7 +28,7 @@
 #include <wtf/Platform.h>
 #if USE(AUDIO_SESSION) && PLATFORM(IOS_FAMILY)
 
-#include <WebCore/AudioSessionCocoa.h>
+#include "AudioSessionCocoa.h"
 #include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WebInterruptionObserverHelper;

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.h
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.h
@@ -23,10 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef KeyedDecoderCF_h
-#define KeyedDecoderCF_h
+#pragma once
 
-#include <WebCore/KeyedCoding.h>
+#include "KeyedCoding.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -66,5 +65,3 @@ private:
 };
 
 } // namespace WebCore
-
-#endif // KeyedDecoderCF_h

--- a/Source/WebCore/platform/cf/KeyedEncoderCF.h
+++ b/Source/WebCore/platform/cf/KeyedEncoderCF.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/KeyedCoding.h>
+#include "KeyedCoding.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -30,10 +30,10 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-#include <WebCore/CDMInstance.h>
-#include <WebCore/CDMInstanceSession.h>
-#include <WebCore/CDMKeyID.h>
-#include <WebCore/SharedBuffer.h>
+#include "CDMInstance.h"
+#include "CDMInstanceSession.h"
+#include "CDMKeyID.h"
+#include "SharedBuffer.h"
 #include <wtf/BoxPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Condition.h>

--- a/Source/WebCore/platform/graphics/AV1Utilities.h
+++ b/Source/WebCore/platform/graphics/AV1Utilities.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#include "FloatSize.h"
+#include "PlatformExportMacros.h"
+#include "PlatformVideoColorSpace.h"
+#include "SharedBuffer.h"
 #include <JavaScriptCore/DataView.h>
-#include <WebCore/FloatSize.h>
-#include <WebCore/PlatformExportMacros.h>
-#include <WebCore/PlatformVideoColorSpace.h>
-#include <WebCore/SharedBuffer.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/StringView.h>

--- a/Source/WebCore/platform/graphics/ColorLuminance.h
+++ b/Source/WebCore/platform/graphics/ColorLuminance.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/ColorConversion.h>
+#include "ColorConversion.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(WEBGL)
 
-#include <WebCore/GraphicsContextGL.h>
-#include <WebCore/PlatformImage.h>
+#include "GraphicsContextGL.h"
+#include "PlatformImage.h"
 #include <wtf/MallocSpan.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/GraphicsLayerFilterAnimationValue.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerFilterAnimationValue.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/GraphicsLayerAnimationValue.h>
+#include "GraphicsLayerAnimationValue.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/ImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/ImageBackingStore.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include <WebCore/Color.h>
-#include <WebCore/IntRect.h>
-#include <WebCore/IntSize.h>
-#include <WebCore/NativeImage.h>
-#include <WebCore/SharedBuffer.h>
+#include "Color.h"
+#include "IntRect.h"
+#include "IntSize.h"
+#include "NativeImage.h"
+#include "SharedBuffer.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/ParsingUtilities.h>

--- a/Source/WebCore/platform/graphics/ImageBufferPlatformBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferPlatformBackend.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #if USE(CG)
-#include <WebCore/ImageBufferCGBitmapBackend.h>
+#include "ImageBufferCGBitmapBackend.h"
 #elif USE(CAIRO)
 #include "ImageBufferCairoImageSurfaceBackend.h"
 #elif USE(SKIA)

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/PathImpl.h>
-#include <WebCore/PathSegment.h>
+#include "PathImpl.h"
+#include "PathSegment.h"
 #include <wtf/DataRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/platform/graphics/TextRunHash.h
+++ b/Source/WebCore/platform/graphics/TextRunHash.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/TextRun.h>
+#include "TextRun.h"
 #include <wtf/HashFunctions.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Hasher.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 
-#include <WebCore/InbandTextTrackPrivateAVF.h>
+#include "InbandTextTrackPrivateAVF.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
-#include <WebCore/Logging.h>
-#include <WebCore/MediaSourceConfiguration.h>
-#include <WebCore/SourceBufferParser.h>
+#include "Logging.h"
+#include "MediaSourceConfiguration.h"
+#include "SourceBufferParser.h"
 #include <wtf/Box.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -28,9 +28,9 @@
 #include <wtf/Platform.h>
 #if PLATFORM(COCOA)
 
+#include "CAAudioStreamDescription.h"
+#include "TrackInfo.h"
 #include <CoreAudio/CoreAudioTypes.h>
-#include <WebCore/CAAudioStreamDescription.h>
-#include <WebCore/TrackInfo.h>
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>

--- a/Source/WebCore/platform/graphics/cocoa/FontCascadeCocoaInlines.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCascadeCocoaInlines.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <WebCore/FontCascade.h>
+#include "FontCascade.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/cocoa/MultiRepresentationHEICMetrics.h
+++ b/Source/WebCore/platform/graphics/cocoa/MultiRepresentationHEICMetrics.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
 
-#include <WebCore/FloatSize.h>
+#include "FloatSize.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -25,10 +25,9 @@
 
 #pragma once
 
-
+#include "MediaPromiseTypes.h"
+#include "ProcessIdentity.h"
 #include <CoreMedia/CMTime.h>
-#include <WebCore/MediaPromiseTypes.h>
-#include <WebCore/ProcessIdentity.h>
 #include <atomic>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(WEBGL) && ENABLE(VIDEO) && USE(AVFOUNDATION)
 
-#include <WebCore/GraphicsContextGLCV.h>
-#include <WebCore/GraphicsContextGLCocoa.h>
-#include <WebCore/ImageOrientation.h>
+#include "GraphicsContextGLCV.h"
+#include "GraphicsContextGLCocoa.h"
+#include "ImageOrientation.h"
 #include <memory>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
@@ -22,18 +22,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OpenTypeTypes_h
-#define OpenTypeTypes_h
+#pragma once
 
 #if ENABLE(OPENTYPE_MATH)
-#include <WebCore/Glyph.h>
+#include "Glyph.h"
 #endif
 
-#include <WebCore/SharedBuffer.h>
+#include "SharedBuffer.h"
 #include <wtf/StdLibExtras.h>
 
-namespace WebCore {
-namespace OpenType {
+namespace WebCore::OpenType {
 
 struct BigEndianShort {
     operator short() const { return (v & 0x00ff) << 8 | v >> 8; }
@@ -198,7 +196,4 @@ protected:
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
-} // namespace OpenType
-} // namespace WebCore
-
-#endif // OpenTypeTypes_h
+} // namespace WebCore::OpenType

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -27,7 +27,7 @@
 
 #if USE(LIBWEBRTC)
 
-#include <WebCore/VideoDecoder.h>
+#include "VideoDecoder.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -27,7 +27,7 @@
 
 #if USE(LIBWEBRTC)
 
-#include <WebCore/VideoEncoder.h>
+#include "VideoEncoder.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 

--- a/Source/WebCore/platform/mac/ScrollbarMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarMac.h
@@ -28,7 +28,7 @@
 #include <wtf/Platform.h>
 #if PLATFORM(MAC)
 
-#include <WebCore/Scrollbar.h>
+#include "Scrollbar.h"
 
 OBJC_CLASS NSScrollerImp;
 

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
@@ -28,9 +28,9 @@
 #include <wtf/Platform.h>
 #if PLATFORM(MAC)
 
-#include <WebCore/IntRect.h>
-#include <WebCore/ScrollbarsController.h>
-#include <WebCore/Timer.h>
+#include "IntRect.h"
+#include "ScrollbarsController.h"
+#include "Timer.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(VIDEO) && ENABLE(DATACUE_VALUE)
 
-#include <WebCore/SerializedPlatformDataCue.h>
-#include <WebCore/SerializedPlatformDataCueValue.h>
+#include "SerializedPlatformDataCue.h"
+#include "SerializedPlatformDataCueValue.h"
 #include <wtf/HashSet.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -28,7 +28,7 @@
 #include <wtf/Platform.h>
 #if PLATFORM(MAC)
 
-#include <WebCore/ThemeCocoa.h>
+#include "ThemeCocoa.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mac/WebCoreFullScreenWarningView.h
+++ b/Source/WebCore/platform/mac/WebCoreFullScreenWarningView.h
@@ -23,12 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #import <wtf/Platform.h>
 
 #if PLATFORM(MAC) && ENABLE(FULLSCREEN_API)
 
+#import "PlatformExportMacros.h"
 #import <AppKit/NSBox.h>
-#import <WebCore/PlatformExportMacros.h>
 #import <wtf/RetainPtr.h>
 
 @class NSTextField;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include <WebCore/ExceptionOr.h>
-#include <WebCore/MediaRecorderPrivateOptions.h>
-#include <WebCore/RealtimeMediaSource.h>
+#include "ExceptionOr.h"
+#include "MediaRecorderPrivateOptions.h"
+#include "RealtimeMediaSource.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -26,10 +26,10 @@
 
 #if ENABLE(MEDIA_RECORDER)
 
-#include <WebCore/CAAudioStreamDescription.h>
-#include <WebCore/MediaRecorderPrivateWriter.h>
-#include <WebCore/SharedBuffer.h>
-#include <WebCore/VideoEncoder.h>
+#include "CAAudioStreamDescription.h"
+#include "MediaRecorderPrivateWriter.h"
+#include "SharedBuffer.h"
+#include "VideoEncoder.h"
 #include <atomic>
 #include <span>
 #include <wtf/Deque.h>

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
@@ -26,7 +26,7 @@
 
 #if ENABLE(MEDIA_RECORDER)
 
-#include <WebCore/MediaRecorderPrivateWriter.h>
+#include "MediaRecorderPrivateWriter.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(MEDIA_STREAM) && USE(AVFOUNDATION)
 
-#include <WebCore/CaptureDeviceManager.h>
-#include <WebCore/RealtimeMediaSource.h>
-#include <WebCore/RealtimeMediaSourceSupportedConstraints.h>
+#include "CaptureDeviceManager.h"
+#include "RealtimeMediaSource.h"
+#include "RealtimeMediaSourceSupportedConstraints.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/WorkQueue.h>

--- a/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include <WebCore/CoreAudioCaptureUnit.h>
+#include "CoreAudioCaptureUnit.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/network/SynchronousLoaderClient.h
+++ b/Source/WebCore/platform/network/SynchronousLoaderClient.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/ResourceError.h>
-#include <WebCore/ResourceHandleClient.h>
-#include <WebCore/ResourceResponse.h>
+#include "ResourceError.h"
+#include "ResourceHandleClient.h"
+#include "ResourceResponse.h"
 #include <wtf/Function.h>
 #include <wtf/MessageQueue.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <WebCore/BidiContext.h>
-#include <WebCore/BidiRunList.h>
-#include <WebCore/WritingMode.h>
+#include "BidiContext.h"
+#include "BidiRunList.h"
+#include "WritingMode.h"
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.h
+++ b/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/CoreTextCompositionEngine.h>
+#include "CoreTextCompositionEngine.h"
 #include <pal/spi/cf/CoreTextSPI.h>
 
 class ChineseCompositionRules {

--- a/Source/WebCore/rendering/LayoutScope.h
+++ b/Source/WebCore/rendering/LayoutScope.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/RenderElement.h>
+#include "RenderElement.h"
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <WebCore/BoxSides.h>
-#include <WebCore/LayoutRange.h>
-#include <WebCore/RenderBox.h>
-#include <WebCore/StyleInset.h>
-#include <WebCore/StyleMargin.h>
-#include <WebCore/StyleSelfAlignmentData.h>
+#include "BoxSides.h"
+#include "LayoutRange.h"
+#include "RenderBox.h"
+#include "StyleInset.h"
+#include "StyleMargin.h"
+#include "StyleSelfAlignmentData.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderGridLayoutState.h
+++ b/Source/WebCore/rendering/RenderGridLayoutState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/RenderBox.h>
+#include "RenderBox.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/rendering/RenderLineBreak.h
+++ b/Source/WebCore/rendering/RenderLineBreak.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <WebCore/RenderBoxModelObject.h>
+#include "RenderBoxModelObject.h"
 #include <wtf/Platform.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/ImageBuffer.h>
-#include <WebCore/RenderReplaced.h>
+#include "ImageBuffer.h"
+#include "RenderReplaced.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderWidgetInlines.h
+++ b/Source/WebCore/rendering/RenderWidgetInlines.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/RenderObjectNode.h>
-#include <WebCore/RenderWidget.h>
+#include "RenderObjectNode.h"
+#include "RenderWidget.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/TextBoxTrimmer.h
+++ b/Source/WebCore/rendering/TextBoxTrimmer.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/LocalFrameViewLayoutContext.h>
+#include "LocalFrameViewLayoutContext.h"
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.h
@@ -29,9 +29,9 @@
 
 #pragma once
 
-#include <WebCore/FloatRoundedRect.h>
-#include <WebCore/LayoutShape.h>
-#include <WebCore/RenderStyleConstants.h>
+#include "FloatRoundedRect.h"
+#include "LayoutShape.h"
+#include "RenderStyleConstants.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/shapes/RasterLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/RasterLayoutShape.h
@@ -29,9 +29,9 @@
 
 #pragma once
 
-#include <WebCore/FloatRect.h>
-#include <WebCore/LayoutShape.h>
-#include <WebCore/ShapeInterval.h>
+#include "FloatRect.h"
+#include "LayoutShape.h"
+#include "ShapeInterval.h"
 #include <wtf/Assertions.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/rendering/shapes/RectangleLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/RectangleLayoutShape.h
@@ -29,9 +29,9 @@
 
 #pragma once
 
-#include <WebCore/FloatRect.h>
-#include <WebCore/FloatSize.h>
-#include <WebCore/LayoutShape.h>
+#include "FloatRect.h"
+#include "FloatSize.h"
+#include "LayoutShape.h"
 #include <wtf/Assertions.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/BorderValue.h>
-#include <WebCore/LayoutUnit.h>
+#include "BorderValue.h"
+#include "LayoutUnit.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/style/StylableInlines.h
+++ b/Source/WebCore/style/StylableInlines.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/ElementInlines.h>
-#include <WebCore/Styleable.h>
+#include "ElementInlines.h"
+#include "Styleable.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/style/StyleExtractorState.h
+++ b/Source/WebCore/style/StyleExtractorState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/PseudoElementIdentifier.h>
+#include "PseudoElementIdentifier.h"
 #include <wtf/Ref.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/StyleInterpolationContext.h
+++ b/Source/WebCore/style/StyleInterpolationContext.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include <WebCore/AnimationUtilities.h>
-#include <WebCore/WebAnimationTypes.h>
+#include "AnimationUtilities.h"
+#include "WebAnimationTypes.h"
 
 namespace WebCore::Style::Interpolation {
 

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/Node.h>
-#include <WebCore/StyleChange.h>
+#include "Node.h"
+#include "StyleChange.h"
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/style/TreeResolutionState.h
+++ b/Source/WebCore/style/TreeResolutionState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/AnchorPositionEvaluator.h>
+#include "AnchorPositionEvaluator.h"
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/computed/data/StyleSVGShadowData.h
+++ b/Source/WebCore/style/computed/data/StyleSVGShadowData.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-#include <WebCore/StyleBoxShadow.h>
+#include "StyleBoxShadow.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/style/values/images/kinds/StyleCachedImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCachedImage.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include <WebCore/CachedImage.h>
-#include <WebCore/CachedResourceHandle.h>
-#include <WebCore/StyleImage.h>
+#include "CachedImage.h"
+#include "CachedResourceHandle.h"
+#include "StyleImage.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include <WebCore/AnimationUtilities.h>
-#include <WebCore/StyleCalculationValue.h>
-#include <WebCore/StyleLengthWrapper.h>
+#include "AnimationUtilities.h"
+#include "StyleCalculationValue.h"
+#include "StyleLengthWrapper.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeyword+CSSValueCreation.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include <WebCore/CSSValuePool.h>
-#include <WebCore/StylePrimitiveKeyword+ValueRepresentationNeeded.h>
-#include <WebCore/StyleValueTypes.h>
+#include "CSSValuePool.h"
+#include "StylePrimitiveKeyword+ValueRepresentationNeeded.h"
+#include "StyleValueTypes.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericTypes.h>
-#include <WebCore/StyleTransformFunctionBase.h>
-#include <WebCore/TransformationMatrix.h>
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleTransformFunctionBase.h"
+#include "TransformationMatrix.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericTypes.h>
-#include <WebCore/StyleTransformFunctionBase.h>
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleTransformFunctionBase.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <WebCore/StylePerspective.h>
-#include <WebCore/StylePrimitiveNumericTypes.h>
-#include <WebCore/StyleTransformFunctionBase.h>
+#include "StylePerspective.h"
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleTransformFunctionBase.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericTypes.h>
-#include <WebCore/StyleTransformFunctionBase.h>
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleTransformFunctionBase.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -20,9 +20,9 @@
 
 #pragma once
 
-#include <WebCore/FloatRect.h>
-#include <WebCore/SVGLengthValue.h>
-#include <WebCore/SVGUnitTypes.h>
+#include "FloatRect.h"
+#include "SVGLengthValue.h"
+#include "SVGUnitTypes.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGLocatable.h
+++ b/Source/WebCore/svg/SVGLocatable.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <WebCore/AffineTransform.h>
+#include "AffineTransform.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/svg/SVGStringList.h
+++ b/Source/WebCore/svg/SVGStringList.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/SVGParserUtilities.h>
-#include <WebCore/SVGPrimitiveList.h>
+#include "SVGParserUtilities.h"
+#include "SVGPrimitiveList.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGZoomAndPanType.h
+++ b/Source/WebCore/svg/SVGZoomAndPanType.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/SVGPropertyTraits.h>
+#include "SVGPropertyTraits.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/testing/MockContentFilter.h
+++ b/Source/WebCore/testing/MockContentFilter.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <WebCore/MockContentFilterSettings.h>
-#include <WebCore/PlatformContentFilter.h>
+#include "MockContentFilterSettings.h"
+#include "PlatformContentFilter.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -26,10 +26,10 @@
 
 #pragma once
 
-#include <WebCore/FontLoadRequest.h>
-#include <WebCore/ResourceLoaderOptions.h>
-#include <WebCore/SharedBuffer.h>
-#include <WebCore/ThreadableLoaderClient.h>
+#include "FontLoadRequest.h"
+#include "ResourceLoaderOptions.h"
+#include "SharedBuffer.h"
+#include "ThreadableLoaderClient.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/workers/service/RouterRule.h
+++ b/Source/WebCore/workers/service/RouterRule.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include <WebCore/RouterCondition.h>
-#include <WebCore/RouterSourceDict.h>
-#include <WebCore/RouterSourceEnum.h>
+#include "RouterCondition.h"
+#include "RouterSourceDict.h"
+#include "RouterSourceEnum.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include <WebCore/SWServer.h>
-#include <WebCore/ServiceWorkerJobData.h>
-#include <WebCore/Timer.h>
-#include <WebCore/WorkerFetchResult.h>
+#include "SWServer.h"
+#include "ServiceWorkerJobData.h"
+#include "Timer.h"
+#include "WorkerFetchResult.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/TZoneMalloc.h>


### PR DESCRIPTION
#### c6d63835221893173aca3fa1cee6552519cce887
<pre>
Make 272 WebCore files Project-scoped, take 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=308415">https://bugs.webkit.org/show_bug.cgi?id=308415</a>

Reviewed by Ryosuke Niwa.

272 headers changed from Private to Project in project.pbxproj, with
217 of those also removed from Headers.cmake.

This originally landed as 307989@main but broke ASan builds so got
backed out in 308004@main. The reason it broke ASan builds is because
those apparently require the &quot;correct&quot; style of includes to be used,
so this corrects 229 files out of the total 300 that were recently made
Project-scoped (307977@main &amp; 307978@main).

This has been locally tested with an ASan release build.

Canonical link: <a href="https://commits.webkit.org/308035@main">https://commits.webkit.org/308035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebf676f6da6f859a3aef90ea2cbdb823b4ac3567

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99751 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1aecceed-d97f-45d6-a79a-0cc9d5bfc6da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112587 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80526 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69c01fb8-dc82-44b8-847f-cde62ac716d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93456 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61d796bf-72d5-47b2-8d77-22116f28b2cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14206 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11963 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2415 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157290 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/461 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120616 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120914 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130890 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74582 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22557 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7950 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82169 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->