### PR TITLE
[MathML] Dynamic changes to mo attributes don't trigger relayout

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2074,7 +2074,6 @@ imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-marg
 imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-006.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/table-width-3.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-form-dynamic-002.html [ ImageOnlyFailure ]
 
 # This MathML test should be rewritten.
 webkit.org/b/201356 mathml/presentation/stretchy-depth-height-symmetric.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-stretch-properties-dynamic-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-stretch-properties-dynamic-001-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL minsize assert_approx_equals: modify expected 125 +/- 1 but got 75
-FAIL maxsize assert_approx_equals: attach expected 100 +/- 1 but got 150
-FAIL largeop assert_approx_equals: set true expected 50 +/- 1 but got 25
-FAIL symmetric assert_approx_equals: set true expected 150 +/- 1 but got 75
+PASS minsize
+PASS maxsize
+PASS largeop
+PASS symmetric
 PASS stretchy
 ⥯
 ⥯

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -324,7 +324,6 @@ loader/archive/cf/LegacyWebArchive.cpp
 [ Mac ] loader/cache/CachedResourceLoader.cpp
 mathml/MathMLElement.cpp
 mathml/MathMLMathElement.cpp
-mathml/MathMLOperatorElement.cpp
 mathml/MathMLPresentationElement.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -216,54 +216,64 @@ void MathMLOperatorElement::childrenChanged(const ChildChange& change)
 
 void MathMLOperatorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
+    bool affectsLayout = false;
     switch (name.nodeName()) {
     case AttributeNames::formAttr:
         m_dictionaryProperty = std::nullopt;
         m_properties.dirtyFlags = MathMLOperatorDictionary::allFlags;
+        affectsLayout = true;
         break;
     case AttributeNames::lspaceAttr:
         m_leadingSpace = std::nullopt;
-        if (renderer())
-            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        affectsLayout = true;
         break;
     case AttributeNames::rspaceAttr:
         m_trailingSpace = std::nullopt;
-        if (renderer())
-            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        affectsLayout = true;
         break;
     case AttributeNames::minsizeAttr:
         m_minSize = std::nullopt;
+        affectsLayout = true;
         break;
     case AttributeNames::maxsizeAttr:
         m_maxSize = std::nullopt;
+        affectsLayout = true;
         break;
     case AttributeNames::stretchyAttr:
         m_properties.dirtyFlags |= Stretchy;
-        if (renderer())
-            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        affectsLayout = true;
         break;
     case AttributeNames::movablelimitsAttr:
         m_properties.dirtyFlags |= MovableLimits;
-        if (renderer())
-            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        affectsLayout = true;
         break;
     case AttributeNames::accentAttr:
         m_properties.dirtyFlags |= Accent;
+        affectsLayout = true;
         break;
     case AttributeNames::fenceAttr:
         m_properties.dirtyFlags |= Fence;
         break;
     case AttributeNames::largeopAttr:
         m_properties.dirtyFlags |= LargeOp;
+        affectsLayout = true;
         break;
     case AttributeNames::separatorAttr:
         m_properties.dirtyFlags |= Separator;
         break;
     case AttributeNames::symmetricAttr:
         m_properties.dirtyFlags |= Symmetric;
+        affectsLayout = true;
         break;
     default:
         break;
+    }
+
+    if (affectsLayout) {
+        if (CheckedPtr renderOperator = dynamicDowncast<RenderMathMLOperator>(renderer())) {
+            renderOperator->updateFromElement();
+            renderOperator->setNeedsLayoutAndPreferredWidthsUpdate();
+        }
     }
 
     MathMLTokenElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -278,6 +278,7 @@ void RenderMathMLOperator::updateTokenContent()
 void RenderMathMLOperator::updateFromElement()
 {
     updateTokenContent();
+    resetStretchSize();
 }
 
 bool RenderMathMLOperator::useMathOperator() const


### PR DESCRIPTION
#### 709c3895afd71e0836f8c8be7393e44d41fab7e1
<pre>
[MathML] Dynamic changes to mo attributes don&apos;t trigger relayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=308418">https://bugs.webkit.org/show_bug.cgi?id=308418</a>
<a href="https://rdar.apple.com/170907029">rdar://170907029</a>

Reviewed by Frédéric Wang.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When minsize, maxsize, largeop, or symmetric attributes are changed
dynamically via JavaScript, the operator layout was not updated.

This patch:
1. Adds affectsLayout tracking for layout-affecting attributes in
    MathMLOperatorElement::attributeChanged()
2. Calls updateFromElement() and setNeedsLayoutAndPreferredWidthsUpdate()
    when these attributes change
3. Adds resetStretchSize() to updateFromElement() so the parent mrow
    can re-stretch the operator with new constraints

* LayoutTests/TestExpectations: Progression
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-stretch-properties-dynamic-001-expected.txt: Ditto
* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::attributeChanged):
* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::updateFromElement):
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/308014@main">https://commits.webkit.org/308014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59f08dd065dc309a917fb60cac197b3bb9fc561

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99690 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/624262bb-ada5-4d25-8659-ce9bce390241) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112523 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80493 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52740174-1a6f-4d93-b51b-3f8a0454ee37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93393 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cf95ee0-7a97-4f58-85c7-5ada90402ceb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14146 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11901 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2344 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157217 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/388 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120548 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30955 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74455 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7755 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82095 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18077 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->