### PR TITLE
[MathML] Add support for multiple-char operators

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default-expected.txt
@@ -1,0 +1,19 @@
+
+PASS Default spacing for = + unsupported combining char U+0303
+PASS Default spacing for = + U+0338 + U+20D2 (too many characters)
+ 
+=̃
+ 
+
+ 
+=̃
+ 
+
+ 
+≠⃒
+ 
+
+ 
+≠⃒
+ 
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Default spacing for = + unsupported combining char U+0303
+PASS Default spacing for = + U+0338 + U+20D2 (too many characters)
+PASS Default spacing for ++ (two non-combining characters)
+ 
+=̃
+ 
+
+ 
+≠⃒
+ 
+
+ 
+++
+ 
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Operator dictionary (combining char, default category)</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="help" href="https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
+<link rel="help" href="https://w3c.github.io/mathml-core/#dictionary-based-attributes">
+<link rel="help" href="https://w3c.github.io/mathml-core/#operator-dictionary">
+<link rel="help" href="https://w3c.github.io/mathml-core/#layout-of-mrow">
+<link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
+<meta name="assert" content="Operators with unsupported combining characters or three or more characters fall back to Default category (lspace=rspace=0.2777777777777778em)">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<style>
+  mo {
+      color: blue;
+  }
+  mn {
+      background: black;
+  }
+</style>
+<script>
+  function spaceBetween(element, i, j) {
+      return element.children[j].getBoundingClientRect().left -
+          element.children[i].getBoundingClientRect().right;
+  }
+  window.addEventListener("load", () => {
+      var epsilon = 1;
+      // Default category spacing per https://w3c.github.io/mathml-core/#operator-dictionary-categories-values
+      var defaultSpaceEm = 0.2777777777777778;
+
+      Array.from(document.getElementsByClassName("test-group")).forEach(group => {
+          var ref = group.getElementsByClassName("reference")[0];
+          var def = group.getElementsByClassName("default")[0];
+          test(function() {
+              assert_true(MathMLFeatureDetection.has_operator_spacing());
+              var fontSize = parseFloat(getComputedStyle(def).fontSize);
+              var expected = 2 * defaultSpaceEm * fontSize;
+              var actual = spaceBetween(def, 0, 2) - spaceBetween(ref, 0, 2);
+              assert_approx_equals(actual, expected, epsilon, "lspace + rspace");
+          }, `Default spacing for ${group.dataset.description}`);
+      });
+  });
+</script>
+</head>
+<body>
+  <div id="log"></div>
+  <!-- U+0303 COMBINING TILDE is not a recognized combining overlay -->
+  <div class="test-group" data-description="= + unsupported combining char U+0303">
+    <p>
+      <math class="reference">
+        <mn>&nbsp;</mn>
+        <mo lspace="0" rspace="0">=&#x303;</mo>
+        <mn>&nbsp;</mn>
+      </math>
+    </p>
+    <p>
+      <math class="default">
+        <mn>&nbsp;</mn>
+        <mo>=&#x303;</mo>
+        <mn>&nbsp;</mn>
+      </math>
+    </p>
+  </div>
+  <!-- Three characters: base + two combining overlays -->
+  <div class="test-group" data-description="= + U+0338 + U+20D2 (too many characters)">
+    <p>
+      <math class="reference">
+        <mn>&nbsp;</mn>
+        <mo lspace="0" rspace="0">=&#x338;&#x20D2;</mo>
+        <mn>&nbsp;</mn>
+      </math>
+    </p>
+    <p>
+      <math class="default">
+        <mn>&nbsp;</mn>
+        <mo>=&#x338;&#x20D2;</mo>
+        <mn>&nbsp;</mn>
+      </math>
+    </p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Operator dictionary (combining char, default category)</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="help" href="https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
+<link rel="help" href="https://w3c.github.io/mathml-core/#dictionary-based-attributes">
+<link rel="help" href="https://w3c.github.io/mathml-core/#operator-dictionary">
+<link rel="help" href="https://w3c.github.io/mathml-core/#layout-of-mrow">
+<link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
+<meta name="assert" content="Operators with unsupported combining characters or multiple characters fall back to Default category">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<style>
+  mo {
+      color: blue;
+  }
+  mn {
+      background: black;
+  }
+</style>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("load", runTests);
+
+  function spaceBetween(element, i, j) {
+      return element.children[j].getBoundingClientRect().left -
+          element.children[i].getBoundingClientRect().right;
+  }
+  function runTests() {
+      var epsilon = 1;
+
+      // Operators with unsupported combining characters or multiple combining
+      // characters should fall back to Default category (0em spacing).
+      Array.from(document.getElementsByClassName("default")).forEach(element => {
+          test(function() {
+              assert_true(MathMLFeatureDetection.has_operator_spacing());
+              var lspace = spaceBetween(element, 0, 1);
+              var rspace = spaceBetween(element, 1, 2);
+              assert_approx_equals(lspace, 0, epsilon, "lspace");
+              assert_approx_equals(rspace, 0, epsilon, "rspace");
+          }, `Default spacing for ${element.getAttribute("data-description")}`);
+      });
+
+      done();
+  }
+</script>
+</head>
+<body>
+  <div id="log"></div>
+  <!-- U+0303 COMBINING TILDE is not a recognized combining overlay -->
+  <p>
+    <math class="default" data-description="= + unsupported combining char U+0303">
+      <mn>&nbsp;</mn>
+      <mo>=&#x303;</mo>
+      <mn>&nbsp;</mn>
+    </math>
+  </p>
+  <!-- Three characters: base + two combining overlays -->
+  <p>
+    <math class="default" data-description="= + U+0338 + U+20D2 (too many characters)">
+      <mn>&nbsp;</mn>
+      <mo>=&#x338;&#x20D2;</mo>
+      <mn>&nbsp;</mn>
+    </math>
+  </p>
+  <!-- Two regular (non-combining) characters -->
+  <p>
+    <math class="default" data-description="++ (two non-combining characters)">
+      <mn>&nbsp;</mn>
+      <mo>++</mo>
+      <mn>&nbsp;</mn>
+    </math>
+  </p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-expected.txt
@@ -1,12 +1,12 @@
 
 PASS Spacing around ≠
 PASS Spacing around =⃒
-FAIL Spacing around |̸ assert_approx_equals: expected 61.09375 +/- 1 but got 77.75
-FAIL Spacing around |⃒ assert_approx_equals: expected 61.09375 +/- 1 but got 77.75
-FAIL Spacing around ⋉̸ assert_approx_equals: expected 72.21875 +/- 1 but got 77.75
-FAIL Spacing around ⋉⃒ assert_approx_equals: expected 72.21875 +/- 1 but got 77.75
-FAIL Spacing around ∄ assert_approx_equals: expected 58.3125 +/- 1 but got 77.75
-FAIL Spacing around ∃⃒ assert_approx_equals: expected 58.3125 +/- 1 but got 77.75
+PASS Spacing around |̸
+PASS Spacing around |⃒
+PASS Spacing around ⋉̸
+PASS Spacing around ⋉⃒
+PASS Spacing around ∄
+PASS Spacing around ∃⃒
  
 =
  

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -59,16 +59,44 @@ Ref<MathMLOperatorElement> MathMLOperatorElement::create(const QualifiedName& ta
 MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(const String& string)
 {
     OperatorChar operatorChar;
-    StringView view = string;
-    // FIXME: This operator dictionary does not accept multiple characters (https://webkit.org/b/124828).
-    if (auto codePoint = view.trim(isASCIIWhitespaceWithoutFF<char16_t>).convertToSingleCodePoint()) {
-        auto character = codePoint.value();
-        // The minus sign renders better than the hyphen sign used in some MathML formulas.
-        if (character == hyphenMinus)
-            character = minusSign;
+    String trimmed = string.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    if (trimmed.isEmpty())
+        return operatorChar;
+
+    auto setOperatorChar = [&](char32_t character) {
         operatorChar.character = character;
         operatorChar.isVertical = isVertical(operatorChar.character);
+    };
+
+    // https://w3c.github.io/mathml-core/#dfn-algorithm-to-determine-the-category-of-an-operator
+    // Only operators with UTF-16 length 1 or 2 are recognized.
+    unsigned length = trimmed.length();
+    if (length == 1) {
+        char32_t character = trimmed[0];
+        // The minus sign renders better than the hyphen sign used in some MathML formulas.
+        // This is not in MathML Core, see https://github.com/w3c/mathml-core/issues/70
+        if (character == hyphenMinus)
+            character = minusSign;
+        setOperatorChar(character);
+        return operatorChar;
     }
+
+    if (length == 2) {
+        // A surrogate pair encoding a single code point (e.g. U+1EEF0, U+1EEF1).
+        if (auto codePoint = StringView(trimmed).convertToSingleCodePoint()) {
+            setOperatorChar(codePoint.value());
+            return operatorChar;
+        }
+        // Base character followed by U+0338 COMBINING LONG SOLIDUS OVERLAY
+        // or U+20D2 COMBINING LONG VERTICAL LINE OVERLAY. The base character
+        // is used for dictionary lookup and must not be substituted.
+        constexpr UChar combiningLongSolidusOverlay = 0x0338;
+        constexpr UChar combiningLongVerticalLineOverlay = 0x20D2;
+        UChar second = trimmed[1];
+        if (second == combiningLongSolidusOverlay || second == combiningLongVerticalLineOverlay)
+            setOperatorChar(trimmed[0]);
+    }
+
     return operatorChar;
 }
 

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -57,16 +57,42 @@ Ref<MathMLOperatorElement> MathMLOperatorElement::create(const QualifiedName& ta
 MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(const String& string)
 {
     OperatorChar operatorChar;
-    StringView view = string;
-    // FIXME: This operator dictionary does not accept multiple characters (https://webkit.org/b/124828).
-    if (auto codePoint = view.trim(isASCIIWhitespaceWithoutFF<char16_t>).convertToSingleCodePoint()) {
-        auto character = codePoint.value();
+    String trimmed = string.trim(isASCIIWhitespaceWithoutFF<UChar>);
+    if (trimmed.isEmpty())
+        return operatorChar;
+
+    auto setOperatorChar = [&](char32_t character, bool substituteHyphenMinus = true) {
         // The minus sign renders better than the hyphen sign used in some MathML formulas.
-        if (character == hyphenMinus)
+        // This is not in MathML Core, see https://github.com/w3c/mathml-core/issues/70
+        if (substituteHyphenMinus && character == hyphenMinus)
             character = minusSign;
         operatorChar.character = character;
         operatorChar.isVertical = isVertical(operatorChar.character);
+    };
+
+    // https://w3c.github.io/mathml-core/#dfn-algorithm-to-determine-the-category-of-an-operator
+    // Only operators with UTF-16 length 1 or 2 are recognized.
+    unsigned length = trimmed.length();
+    if (length == 1) {
+        setOperatorChar(trimmed[0]);
+        return operatorChar;
     }
+
+    if (length == 2) {
+        // A surrogate pair encoding a single code point (e.g. U+1EEF0, U+1EEF1).
+        if (auto codePoint = StringView(trimmed).convertToSingleCodePoint()) {
+            setOperatorChar(codePoint.value());
+            return operatorChar;
+        }
+        // Base character followed by U+0338 COMBINING LONG SOLIDUS OVERLAY
+        // or U+20D2 COMBINING LONG VERTICAL LINE OVERLAY.
+        constexpr UChar combiningLongSolidusOverlay = 0x0338;
+        constexpr UChar combiningLongVerticalLineOverlay = 0x20D2;
+        UChar second = trimmed[1];
+        if (second == combiningLongSolidusOverlay || second == combiningLongVerticalLineOverlay)
+            setOperatorChar(trimmed[0], false);
+    }
+
     return operatorChar;
 }
 


### PR DESCRIPTION
#### 4bb39a4d8cca917eb651c9481345be436f7fb75b
<pre>
[MathML] Add support for multiple-char operators
<a href="https://bugs.webkit.org/show_bug.cgi?id=124828">https://bugs.webkit.org/show_bug.cgi?id=124828</a>
<a href="https://rdar.apple.com/170907545">rdar://170907545</a>

Reviewed by Frédéric Wang Nélar.

Per the MathML Core specification [1], the algorithm to determine the
category of an operator only recognizes content with UTF-16 length 1 or
2. For length 2, if the second character is U+0338 COMBINING LONG SOLIDUS
OVERLAY or U+20D2 COMBINING LONG VERTICAL LINE OVERLAY, the first
character is used for dictionary lookup. These are the only two-character
combining forms in the operator dictionary.

Previously, parseOperatorChar() only handled single code points via
convertToSingleCodePoint(), which returned nullopt for two-character
operators like &quot;≠&quot; (&quot;=&quot; + U+0338), causing them to fall back to default
spacing instead of using the base character&apos;s dictionary properties.

Operators that are not recognized (unsupported combining character or
three or more characters) fall through to the Default category, whose
lspace and rspace are both 0.2777777777777778em (5/18em) [2]. This
matches WebKit&apos;s existing struct defaults in
MathMLOperatorDictionary::Property, so no implementation change was
needed; the new test asserts this spec-correct value by comparing the
total operator width against a reference with explicit lspace=&quot;0&quot;
rspace=&quot;0&quot;.

[1] <a href="https://w3c.github.io/mathml-core/#dfn-algorithm-to-determine-the-category-of-an-operator">https://w3c.github.io/mathml-core/#dfn-algorithm-to-determine-the-category-of-an-operator</a>
[2] <a href="https://w3c.github.io/mathml-core/#operator-dictionary-categories-values">https://w3c.github.io/mathml-core/#operator-dictionary-categories-values</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-combining-default.html: Added.
* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::parseOperatorChar):

Canonical link: <a href="https://commits.webkit.org/312867@main">https://commits.webkit.org/312867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/751bc3ca5c2356ec50aafcfefd75a1b26cf0e27f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34834 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170264 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fedb7cdf-60a6-41b1-bdc4-816fcfdad18c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7b52e4c-0511-4fb3-bbd8-f118948d07b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27460 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105771 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c53cbac6-fd09-4772-a00c-9c596c4295db) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17984 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/22712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172747 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19781 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34508 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36035 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34493 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96369 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28000 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101444 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33503 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->