### PR TITLE
Fix CLANG_POINTER_CONVERSION annotation on wrapper so that we can remove suppressions

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -51,38 +51,37 @@ namespace WebKit {
 
 template<typename WrappedObjectClass> struct WrapperTraits;
 
-template<typename DestinationClass, typename SourceClass> inline CLANG_POINTER_CONVERSION DestinationClass *checkedObjCCast(SourceClass *source)
+template<typename DestinationClass, typename SourceClass> inline DestinationClass *CLANG_POINTER_CONVERSION checkedObjCCast(SourceClass *source)
 {
     return checked_objc_cast<DestinationClass>(source);
 }
 
-template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass& object)
+template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *CLANG_POINTER_CONVERSION wrapper(ObjectClass& object)
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return checkedObjCCast<typename WrapperTraits<ObjectClass>::WrapperClass>(object.wrapper());
+    return checkedObjCCast<typename WrapperTraits<ObjectClass>::WrapperClass>(object.wrapper());
 }
 
-template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass* object)
+template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *CLANG_POINTER_CONVERSION wrapper(ObjectClass* object)
 {
     return object ? wrapper(*object) : nil;
 }
 
-template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const Ref<ObjectClass>& object)
+template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *CLANG_POINTER_CONVERSION wrapper(const Ref<ObjectClass>& object)
 {
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline CLANG_POINTER_CONVERSION typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const RefPtr<ObjectClass>& object)
+template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *CLANG_POINTER_CONVERSION wrapper(const RefPtr<ObjectClass>& object)
 {
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline CLANG_POINTER_CONVERSION RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(Ref<ObjectClass>&& object)
+template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> CLANG_POINTER_CONVERSION wrapper(Ref<ObjectClass>&& object)
 {
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline CLANG_POINTER_CONVERSION RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(RefPtr<ObjectClass>&& object)
+template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> CLANG_POINTER_CONVERSION wrapper(RefPtr<ObjectClass>&& object)
 {
     return object ? wrapper(object.releaseNonNull()) : nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm
@@ -34,14 +34,12 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)targetFrame
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_formInfo)->targetFrame());
+    return wrapper(protect(*_formInfo)->targetFrame());
 }
 
 - (WKFrameInfo *)sourceFrame
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_formInfo)->sourceFrame());
+    return wrapper(protect(*_formInfo)->sourceFrame());
 }
 
 - (NSURL *)submissionURL

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm
@@ -54,8 +54,7 @@
 
 - (WKContentWorld *)world
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(API::ContentWorld::worldForIdentifier(_ref->info().worldIdentifier));
+    return wrapper(API::ContentWorld::worldForIdentifier(_ref->info().worldIdentifier));
 }
 
 - (void)windowProxyFrameInfo:(void (^)(WKFrameInfo *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -105,8 +105,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKFrameInfo *)sourceFrame
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_navigationAction)->sourceFrame());
+    return wrapper(protect(*_navigationAction)->sourceFrame());
 }
 
 - (WKFrameInfo *)targetFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -88,8 +88,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)_navigationInitiatingFrame
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(RefPtr { _navigationResponse.get() }->navigationInitiatingFrame());
+    return wrapper(RefPtr { _navigationResponse.get() }->navigationInitiatingFrame());
 }
 
 - (WKNavigation *)_navigation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -406,8 +406,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy NODELETE toWKWebsiteDevi
 
 - (WKWebsiteDataStore *)_websiteDataStore
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(_websitePolicies->websiteDataStore());
+    return wrapper(_websitePolicies->websiteDataStore());
 }
 
 - (void)_setWebsiteDataStore:(WKWebsiteDataStore *)websiteDataStore
@@ -417,8 +416,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy NODELETE toWKWebsiteDevi
 
 - (WKUserContentController *)_userContentController
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(_websitePolicies->userContentController());
+    return wrapper(_websitePolicies->userContentController());
 }
 
 - (void)_setUserContentController:(WKUserContentController *)userContentController

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -409,8 +409,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 + (WKWebsiteDataStore *)defaultDataStore
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(WebKit::WebsiteDataStore::defaultDataStore());
+    return wrapper(WebKit::WebsiteDataStore::defaultDataStore());
 }
 
 + (WKWebsiteDataStore *)nonPersistentDataStore
@@ -497,8 +496,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKHTTPCookieStore *)httpCookieStore
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_websiteDataStore)->cookieStore());
+    return wrapper(protect(*_websiteDataStore)->cookieStore());
 }
 
 static WallTime toSystemClockTime(NSDate *date)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -107,8 +107,7 @@ IGNORE_WARNINGS_END
 
 - (NSData *)resumeData
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return WebKit::wrapper(_download->_download->legacyResumeData());
+    return WebKit::wrapper(_download->_download->legacyResumeData());
 }
 
 - (WKFrameInfo *)originatingFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -69,8 +69,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 - (WKProcessPool *)processPool
 {
-    // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-    SUPPRESS_UNCOUNTED_ARG return wrapper(protect(*_configuration)->processPool());
+    return wrapper(protect(*_configuration)->processPool());
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -296,8 +296,7 @@ static WKURLRequestRef willSendRequestForFrame(WKBundlePageRef, WKBundleFrameRef
         if (substituteRequest != originalRequest.get())
             return substituteRequest ? WKURLRequestCreateWithNSURLRequest(substituteRequest.get()) : nullptr;
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequest:redirectResponse:)]) {
-        // Static analyzer false positive. CLANG_POINTER_CONVERSION should make this warning go away but doesn't.
-        SUPPRESS_UNCOUNTED_ARG RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
+        RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
         RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() willSendRequest:originalRequest.get()
             redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().protectedNSURLResponse().get()];
 


### PR DESCRIPTION
#### eb6bd744f25c039d28e938a8932394ec4d13a2ec
<pre>
Fix CLANG_POINTER_CONVERSION annotation on wrapper so that we can remove suppressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308421">https://bugs.webkit.org/show_bug.cgi?id=308421</a>

Reviewed by Wenson Hsieh.

The false positive was happening due to CLANG_POINTER_CONVERSION being placed before the return type
as opposed to after the return type like everywhere else. Fix that so that we can remove suppressions
added in 307994@main.

No new tests since there should be no behavioral changes.

* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::checkedObjCCast):
(WebKit::wrapper):
* Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm:
(-[WKFormInfo targetFrame]):
(-[WKFormInfo sourceFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKJSHandle.mm:
(-[WKJSHandle world]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction sourceFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _navigationInitiatingFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _websiteDataStore]):
(-[WKWebpagePreferences _userContentController]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore defaultDataStore]):
(-[WKWebsiteDataStore httpCookieStore]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload resumeData]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration processPool]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(willSendRequestForFrame):

Canonical link: <a href="https://commits.webkit.org/308015@main">https://commits.webkit.org/308015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2015de0b48148b4850e487142a9f612254d8a86b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcc8d2df-0b68-4850-abc0-e80b8ff3410d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112512 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80486 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f371f34f-3080-492b-90da-c4437466959f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2903ce74-1f20-4046-9b27-33bded29538f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11890 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123700 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157206 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120537 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120837 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74444 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22550 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16514 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7740 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18334 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82085 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->