### PR TITLE
[JSC] Reduce register pressure for TypeOfIsUndefined in DFG

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5163,17 +5163,23 @@ void SpeculativeJIT::compile(Node* node)
     case TypeOfIsUndefined: {
         JSValueOperand value(this, node->child1());
         GPRTemporary result(this);
-        GPRTemporary localGlobalObject(this);
-        GPRTemporary remoteGlobalObject(this);
+        std::optional<GPRTemporary> localGlobalObject;
+        std::optional<GPRTemporary> remoteGlobalObject;
+
+        bool watchpointValid = masqueradesAsUndefinedWatchpointSetIsStillValid();
+        if (!watchpointValid) {
+            localGlobalObject.emplace(this);
+            remoteGlobalObject.emplace(this);
+        }
 
         Jump isCell = branchIfCell(value.jsValueRegs());
 
         compare64(Equal, value.gpr(), TrustedImm32(JSValue::ValueUndefined), result.gpr());
         Jump done = jump();
-        
+
         isCell.link(this);
         Jump notMasqueradesAsUndefined;
-        if (masqueradesAsUndefinedWatchpointSetIsStillValid()) {
+        if (watchpointValid) {
             move(TrustedImm32(0), result.gpr());
             notMasqueradesAsUndefined = jump();
         } else {
@@ -5185,8 +5191,8 @@ void SpeculativeJIT::compile(Node* node)
             notMasqueradesAsUndefined = jump();
 
             isMasqueradesAsUndefined.link(this);
-            GPRReg localGlobalObjectGPR = localGlobalObject.gpr();
-            GPRReg remoteGlobalObjectGPR = remoteGlobalObject.gpr();
+            GPRReg localGlobalObjectGPR = localGlobalObject->gpr();
+            GPRReg remoteGlobalObjectGPR = remoteGlobalObject->gpr();
             loadLinkableConstant(LinkableConstant::globalObject(*this, node), localGlobalObjectGPR);
             emitLoadStructure(vm(), value.gpr(), result.gpr());
             loadPtr(Address(result.gpr(), Structure::globalObjectOffset()), remoteGlobalObjectGPR);


### PR DESCRIPTION
#### a9eb4a8d4cf518575e244fcb46353814bb542276
<pre>
[JSC] Reduce register pressure for TypeOfIsUndefined in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=308422">https://bugs.webkit.org/show_bug.cgi?id=308422</a>

Reviewed by NOBODY (OOPS!).

The localGlobalObject and remoteGlobalObject GPRTemporaries were
unconditionally allocated, but they are only used when the
masqueradesAsUndefined watchpoint is invalid. In the common case where
the watchpoint is still valid, these two registers were locked
unnecessarily, increasing register pressure for surrounding nodes.

Use std::optional&lt;GPRTemporary&gt; to defer allocation to the case where
the registers are actually needed, reducing locked GPRs from 4 to 2 in
the common path.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9eb4a8d4cf518575e244fcb46353814bb542276

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154888 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99680 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112514 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99680 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93384 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14132 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11892 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2334 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138190 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157207 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7011 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/378 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120538 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120838 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74445 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7739 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177518 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18335 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82086 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45554 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->