### PR TITLE
[MathML] Use unstretched size for minsize/maxsize default and percentages

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001-expected.txt
@@ -3,8 +3,8 @@ PASS minsize < 0 is treated as 0
 PASS maxsize < minsize is treated as maxsize = minsize
 PASS minsize < maxsize < 0 is treated as maxsize = minsize = 0
 PASS target size = 0 is treated as Tascent = Tdescent = minsize/2
-FAIL minsize/maxsize percentages are relative to the unstretched size assert_approx_equals: percent maxsize expected 75 +/- 1 but got 150
-FAIL default minsize/maxsize values assert_approx_equals: default minsize is not 1em expected 12.5 +/- 1 but got 25
+PASS minsize/maxsize percentages are relative to the unstretched size
+PASS default minsize/maxsize values
 ⥯
 
 ⥯

--- a/LayoutTests/platform/glib/mathml/opentype/vertical-expected.txt
+++ b/LayoutTests/platform/glib/mathml/opentype/vertical-expected.txt
@@ -141,7 +141,7 @@ layer at (0,0) size 800x363
             RenderBlock (anonymous) at (0,0) size 8x15
               RenderText {#text} at (0,-45) size 8x106
                 text run at (0,-45) width 8: "\x{2193}"
-          RenderMathMLOperator {mo} at (33,2) size 18x18
+          RenderMathMLOperator {mo} at (33,1) size 18x18
             RenderBlock (anonymous) at (0,0) size 8x18
               RenderText {#text} at (0,-44) size 8x106
                 text run at (0,-44) width 8: "\x{2195}"

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/size-and-position-of-stretchy-fences-with-default-font-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/size-and-position-of-stretchy-fences-with-default-font-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Inner binary operator should not affect position and size of outer fences.
-FAIL Fences are stretched symmetrically with respect to the math axis assert_approx_equals: expected 65.265625 +/- 2 but got 62.2421875
+FAIL Fences are stretched symmetrically with respect to the math axis assert_approx_equals: expected 66.15625 +/- 2 but got 63.1328125
 (
 (
 x

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -108,6 +108,7 @@ void MathOperator::reset(const RenderStyle& style)
     m_descent = 0;
     m_italicCorrection = 0;
     m_radicalVerticalScale = 1;
+    m_unstretchedSize = 0;
 
     // We use the base size for the calculation of the preferred width.
     GlyphData baseGlyph;
@@ -115,6 +116,11 @@ void MathOperator::reset(const RenderStyle& style)
         return;
     m_maxPreferredWidth = m_width = advanceWidthForGlyph(baseGlyph);
     getAscentAndDescentForGlyph(baseGlyph, m_ascent, m_descent);
+
+    // Store the unstretched size for minsize/maxsize percentage calculations.
+    // Per MathML Core, minsize/maxsize only apply to vertical (block axis) operators.
+    if (m_operatorType == Type::VerticalOperator)
+        m_unstretchedSize = m_ascent + m_descent;
 
     if (m_operatorType == Type::VerticalOperator)
         calculateStretchyData(style, true); // We also take into account the width of larger sizes for the calculation of the preferred width.

--- a/Source/WebCore/rendering/mathml/MathOperator.h
+++ b/Source/WebCore/rendering/mathml/MathOperator.h
@@ -50,6 +50,7 @@ public:
     LayoutUnit ascent() const { return m_ascent; }
     LayoutUnit descent() const { return m_descent; }
     LayoutUnit italicCorrection() const { return m_italicCorrection; }
+    LayoutUnit unstretchedSize() const { return m_unstretchedSize; }
 
     void stretchTo(const RenderStyle&, LayoutUnit width);
 
@@ -108,6 +109,7 @@ private:
     LayoutUnit m_ascent { 0 };
     LayoutUnit m_descent { 0 };
     LayoutUnit m_italicCorrection { 0 };
+    LayoutUnit m_unstretchedSize { 0 };
     float m_radicalVerticalScale { 1 };
 };
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -104,16 +104,21 @@ LayoutUnit RenderMathMLOperator::trailingSpace() const
 
 LayoutUnit RenderMathMLOperator::minSize() const
 {
-    LayoutUnit minSize { style().fontCascade().size() }; // Default minsize is "1em".
-    minSize = toUserUnits(element().minSize(), style(), minSize);
-    return std::max<LayoutUnit>(0, minSize);
+    // Per MathML Core, default minsize is 100% of the unstretched size and
+    // percentage values are relative to the unstretched size ("height of g").
+    // If the unstretched size is unavailable (e.g. base glyph not found),
+    // percentages and the default resolve to 0 (no constraint).
+    return toUserUnits(element().minSize(), style(), m_mathOperator.unstretchedSize());
 }
 
 LayoutUnit RenderMathMLOperator::maxSize() const
 {
-    LayoutUnit maxSize = intMaxForLayoutUnit; // Default maxsize is ∞.
-    maxSize = toUserUnits(element().maxSize(), style(), maxSize);
-    return std::max<LayoutUnit>(0, maxSize);
+    // Default maxsize is infinity. Percentages are relative to the unstretched size.
+    const auto& length = element().maxSize();
+    if (length.type == MathMLElement::LengthType::ParsingFailed)
+        return intMaxForLayoutUnit;
+
+    return toUserUnits(length, style(), m_mathOperator.unstretchedSize());
 }
 
 bool RenderMathMLOperator::isVertical() const
@@ -142,18 +147,17 @@ void RenderMathMLOperator::stretchTo(LayoutUnit heightAboveBaseline, LayoutUnit 
         m_stretchDepthBelowBaseline = halfStretchSize - axis;
     }
     // We try to honor the minsize/maxsize condition by increasing or decreasing both height and depth proportionately.
-    // The MathML specification does not indicate what to do when maxsize < minsize, so we follow Gecko and make minsize take precedence.
+    // Per MathML Core step 5 of https://w3c.github.io/mathml-core/#layout-of-operators:
+    // "If minsize < 0 then set minsize to 0. If maxsize < minsize then set maxsize to minsize."
     LayoutUnit size = stretchSize();
+    LayoutUnit minSizeValue = std::max(0_lu, minSize());
+    LayoutUnit maxSizeValue = std::max(minSizeValue, maxSize());
     float aspect = 1.0;
     if (size > 0) {
-        LayoutUnit minSizeValue = minSize();
         if (size < minSizeValue)
             aspect = minSizeValue.toFloat() / size;
-        else {
-            LayoutUnit maxSizeValue = maxSize();
-            if (maxSizeValue < size)
-                aspect = maxSizeValue.toFloat() / size;
-        }
+        else if (maxSizeValue < size)
+            aspect = maxSizeValue.toFloat() / size;
     }
     m_stretchHeightAboveBaseline *= aspect;
     m_stretchDepthBelowBaseline *= aspect;


### PR DESCRIPTION
#### e142f1f93ed0e1e5d9cc4868b880179cf0f5d07d
<pre>
[MathML] Use unstretched size for minsize/maxsize default and percentages
<a href="https://bugs.webkit.org/show_bug.cgi?id=308423">https://bugs.webkit.org/show_bug.cgi?id=308423</a>
<a href="https://rdar.apple.com/170908253">rdar://170908253</a>

Reviewed by Frédéric Wang.

Per MathML Core section 3.2.4.3 &quot;Layout of operators&quot;
(<a href="https://w3c.github.io/mathml-core/#layout-of-operators)">https://w3c.github.io/mathml-core/#layout-of-operators)</a>, under the
block (vertical) stretch axis path, the spec says:

&quot;Let minsize and maxsize be the minsize and maxsize properties on the
operator. Percentage values are interpreted relative to the height of g.&quot;

This says percentage values for minsize/maxsize are relative to the
height of the base glyph (the unstretched size). Store the unstretched
size in MathOperator during reset() and use it as the reference value
for minsize/maxsize calculations.

Per step 5 of the layout algorithm, the spec also says:

&quot;If minsize &lt; 0 then set minsize to 0. If maxsize &lt; minsize then set
maxsize to minsize.&quot;

This clamping is performed in stretchTo() to match the spec&apos;s algorithm
structure, where minSize()/maxSize() return unclamped values.

Note that minsize/maxsize only appear in the block (vertical) stretch
axis section of the spec. The inline (horizontal) stretch path has no
minsize/maxsize step, so we only compute the unstretched size for
vertical operators.

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/size-and-position-of-stretchy-fences-with-default-font-001-expected.txt: Rebaseline
* LayoutTests/platform/glib/mathml/opentype/vertical-expected.txt: Ditto
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/size-and-position-of-stretchy-fences-with-default-font-001-expected.txt: Platform Specific Expectation
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::reset):
* Source/WebCore/rendering/mathml/MathOperator.h:
(WebCore::MathOperator::unstretchedSize const):
* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::minSize const):
(WebCore::RenderMathMLOperator::maxSize const):
(WebCore::RenderMathMLOperator::stretchTo):

Canonical link: <a href="https://commits.webkit.org/309764@main">https://commits.webkit.org/309764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495acd98a282ea2bbba162bae6df7d852c6c11f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104906 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6af51e2-1ba4-4b5d-9f37-37216ab8fc38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83031 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02112ec1-ea5e-434d-b47d-ed8d5227c973) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97678 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8b5eaa5-ac49-4737-98b7-34a9e98bbbd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18197 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8044 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162671 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5804 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124976 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34011 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80567 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12389 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87947 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23345 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23499 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->