### PR TITLE
[Swift in WebKit] Apply swift-format to WebKitSwift/LinearMediaKit and fix formatting

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -39,23 +39,31 @@ import AVKit_SPI
 import LinearMediaKit
 #endif
 
-private extension Logger {
-    static let linearMediaPlayer = Logger(subsystem: "com.apple.WebKit", category: "Fullscreen")
+extension Logger {
+    fileprivate static let linearMediaPlayer = Logger(subsystem: "com.apple.WebKit", category: "Fullscreen")
 }
 
 private class SwiftOnlyData: NSObject {
-    @Published var renderingConfiguration: RenderingConfiguration?
-    @Published var thumbnailMaterial: VideoMaterial?
-    @Published var videoMaterial: VideoMaterial?
-    @Published var peculiarEntity: PeculiarEntity?
+    @Published
+    var renderingConfiguration: RenderingConfiguration?
+    @Published
+    var thumbnailMaterial: VideoMaterial?
+    @Published
+    var videoMaterial: VideoMaterial?
+    @Published
+    var peculiarEntity: PeculiarEntity?
 
     // FIXME: It should be possible to store these directly on WKSLinearMediaPlayer since they are
     // bridged to NSDate, but a bug prevents that from compiling (rdar://121877511).
-    @Published var startDate: Date?
-    @Published var endDate: Date?
+    @Published
+    var startDate: Date?
+    @Published
+    var endDate: Date?
 
-    @Published var presentationMode: PresentationMode = .inline
-    @Published var presentationState: WKSLinearMediaPresentationState = .inline
+    @Published
+    var presentationMode: PresentationMode = .inline
+    @Published
+    var presentationState: WKSLinearMediaPresentationState = .inline
 
     // FIXME: Publish fullscreenSceneBehaviors once rdar://122435030 is resolved
     var fullscreenBehaviorsSubject = CurrentValueSubject<[FullscreenBehaviors], Never>(FullscreenBehaviors.default)
@@ -75,7 +83,9 @@ enum LinearMediaPlayerErrors: Error {
     case invalidStateError
 }
 
-@objc @implementation extension WKSLinearMediaPlayer {
+@objc
+@implementation
+extension WKSLinearMediaPlayer {
     weak var delegate: WKSLinearMediaPlayerDelegate?
 
     var selectedPlaybackRate = 1.0
@@ -146,7 +156,7 @@ enum LinearMediaPlayerErrors: Error {
             swiftOnlyData.isImmersiveVideo = newValue
             // FIXME: Should limit ContentTypePublisher to only publish changes to contentType if we have already created a default entity
             // rather than having to use a isImmersive attribute.
-            if !swiftOnlyData.enteredFromInline && swiftOnlyData.defaultEntity != nil && swiftOnlyData.presentationState != .external  {
+            if !swiftOnlyData.enteredFromInline && swiftOnlyData.defaultEntity != nil && swiftOnlyData.presentationState != .external {
                 contentType = newValue ? .immersive : .planar
             }
         }
@@ -169,16 +179,21 @@ enum LinearMediaPlayerErrors: Error {
         swiftOnlyData.presentationState
     }
 
-    @nonobjc private var enterFullscreenCompletionHandler: ((Bool, (any Error)?) -> Void)?
-    @nonobjc private var exitFullscreenCompletionHandler: ((Bool, (any Error)?) -> Void)?
+    @nonobjc
+    private var enterFullscreenCompletionHandler: ((Bool, (any Error)?) -> Void)?
+    @nonobjc
+    private var exitFullscreenCompletionHandler: ((Bool, (any Error)?) -> Void)?
 
     @nonobjc
     private var enterExternalCompletionHandler: ((Bool, (any Error)?) -> Void)?
 
-    @nonobjc private var swiftOnlyData: SwiftOnlyData
-    @nonobjc private var cancellables: [AnyCancellable] = []
+    @nonobjc
+    private var swiftOnlyData: SwiftOnlyData
+    @nonobjc
+    private var cancellables: [AnyCancellable] = []
 
-    @nonobjc private final var logIdentifier: String {
+    @nonobjc
+    private final var logIdentifier: String {
         String(delegate?.linearMediaPlayerLogIdentifier?(self) ?? 0, radix: 16, uppercase: true)
     }
 
@@ -238,7 +253,7 @@ enum LinearMediaPlayerErrors: Error {
         case .enteringExternal:
             contentType = .planar
             showsPlaybackControls = true
-            swiftOnlyData.fullscreenBehaviorsSubject.send([ .hostContentInline ])
+            swiftOnlyData.fullscreenBehaviorsSubject.send([.hostContentInline])
             swiftOnlyData.presentationState = .external
             contentOverlay = .init(frame: .zero)
             completionHandler?(true, nil)
@@ -277,7 +292,9 @@ enum LinearMediaPlayerErrors: Error {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         if let enterFullscreenCompletionHandler = enterFullscreenCompletionHandler {
-            Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): invalidating existing enterFullscreenCompletionHandler")
+            Logger.linearMediaPlayer.error(
+                "\(#function)(\(self.logIdentifier, privacy: .public)): invalidating existing enterFullscreenCompletionHandler"
+            )
             enterFullscreenCompletionHandler(false, LinearMediaPlayerErrors.invalidStateError)
             self.enterFullscreenCompletionHandler = nil
         }
@@ -301,7 +318,9 @@ enum LinearMediaPlayerErrors: Error {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         if let exitFullscreenCompletionHandler = exitFullscreenCompletionHandler {
-            Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): invalidating existing exitFullscreenCompletionHandler")
+            Logger.linearMediaPlayer.error(
+                "\(#function)(\(self.logIdentifier, privacy: .public)): invalidating existing exitFullscreenCompletionHandler"
+            )
             exitFullscreenCompletionHandler(false, LinearMediaPlayerErrors.invalidStateError)
             self.exitFullscreenCompletionHandler = nil
         }
@@ -343,43 +362,60 @@ extension WKSLinearMediaPlayer {
     private func maybeCreateSpatialOrImmersiveEntity() {
         if swiftOnlyData.peculiarEntity != nil || contentType == .immersive { return }
         if swiftOnlyData.isImmersiveVideo {
-            Logger.linearMediaPlayer.log("\(#function)\(self.logIdentifier, privacy: .public): isImmersiveVideo; setting contentType = .immersive")
+            Logger.linearMediaPlayer.log(
+                "\(#function)\(self.logIdentifier, privacy: .public): isImmersiveVideo; setting contentType = .immersive"
+            )
             contentType = .immersive
             return
         }
         if swiftOnlyData.enteredFromInline || swiftOnlyData.spatialVideoMetadata == nil {
             if swiftOnlyData.enteredFromInline {
-                Logger.linearMediaPlayer.log("\(#function)\(self.logIdentifier, privacy: .public): enteredFromInline; setting contentType = .planar")
+                Logger.linearMediaPlayer.log(
+                    "\(#function)\(self.logIdentifier, privacy: .public): enteredFromInline; setting contentType = .planar"
+                )
             } else {
-                Logger.linearMediaPlayer.log("\(#function)\(self.logIdentifier, privacy: .public): !spatialVideoMetadata; setting contentType = .planar")
+                Logger.linearMediaPlayer.log(
+                    "\(#function)\(self.logIdentifier, privacy: .public): !spatialVideoMetadata; setting contentType = .planar"
+                )
             }
 
             contentType = .planar
             return
         }
+
+        // FIXME: (rdar://170930694) There is no guarantee that `spatialVideoMetadata` is non-nil here, and therefore can cause a crash.
+        // swift-format-ignore: NeverForceUnwrap
         let metadata = swiftOnlyData.spatialVideoMetadata!
         swiftOnlyData.peculiarEntity = ContentType.makeSpatialEntity(videoMetadata: metadata.metadata, extruded: true)
-        Logger.linearMediaPlayer.log("\(#function)\(self.logIdentifier, privacy: .public): spatialVideoMetadata; making peculiar spatial entity")
+        Logger.linearMediaPlayer.log(
+            "\(#function)\(self.logIdentifier, privacy: .public): spatialVideoMetadata; making peculiar spatial entity"
+        )
 
         swiftOnlyData.peculiarEntity?.screenMode = spatialImmersive ? .immersive : .portal
-// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
-#if canImport(XPC)
-        swiftOnlyData.videoReceiverEndpointObserver = swiftOnlyData.peculiarEntity?.videoReceiverEndpointPublisher.sink {
-            [weak self] in guard let endpoint = $0 else { return }
-            self?.setVideoReceiverEndpoint(endpoint)
-        }
-#endif
+        // FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+        #if canImport(XPC)
+        swiftOnlyData.videoReceiverEndpointObserver = swiftOnlyData.peculiarEntity?.videoReceiverEndpointPublisher
+            .sink {
+                [weak self] in
+                guard let endpoint = $0 else { return }
+                self?.setVideoReceiverEndpoint(endpoint)
+            }
+        #endif
         contentType = .spatial
     }
 
     private func maybeClearSpatialOrImmersiveEntity() {
         if swiftOnlyData.isImmersiveVideo && contentType == .immersive {
-            Logger.linearMediaPlayer.log("\(#function)\(self.logIdentifier, privacy: .public): isImmersiveVideo; setting contentType = .none")
+            Logger.linearMediaPlayer.log(
+                "\(#function)\(self.logIdentifier, privacy: .public): isImmersiveVideo; setting contentType = .none"
+            )
             contentType = .none
             return
         }
         if swiftOnlyData.peculiarEntity == nil { return }
-        Logger.linearMediaPlayer.log("\(#function)\(self.logIdentifier, privacy: .public): clearing peculiarEntity; setting contentType = .none")
+        Logger.linearMediaPlayer.log(
+            "\(#function)\(self.logIdentifier, privacy: .public): clearing peculiarEntity; setting contentType = .none"
+        )
         swiftOnlyData.videoReceiverEndpointObserver = nil
         swiftOnlyData.peculiarEntity = nil
         contentType = .none // this causes a call to makeDefaultEntity
@@ -389,73 +425,107 @@ extension WKSLinearMediaPlayer {
 #endif // os(visionOS)
 
 #if os(visionOS)
-@_spi(Internal) extension WKSLinearMediaPlayer: @preconcurrency Playable {
+@_spi(Internal)
+extension WKSLinearMediaPlayer: @preconcurrency Playable {
 }
 #endif
 
 #if os(visionOS)
 
-@_spi(Internal) extension WKSLinearMediaPlayer {
+@_spi(Internal)
+extension WKSLinearMediaPlayer {
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var selectedPlaybackRatePublisher: AnyPublisher<Double, Never> {
         publisher(for: \.selectedPlaybackRate).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var presentationModePublisher: AnyPublisher<PresentationMode, Never> {
         swiftOnlyData.$presentationMode.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var errorPublisher: AnyPublisher<Error?, Never> {
         publisher(for: \.error).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var canTogglePlaybackPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.canTogglePlayback).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var requiresLinearPlaybackPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.requiresLinearPlayback).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var interstitialRangesPublisher: AnyPublisher<[Range<TimeInterval>], Never> {
         publisher(for: \.interstitialRanges).map { $0.map { $0.range } }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isInterstitialActivePublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isInterstitialActive).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var durationPublisher: AnyPublisher<TimeInterval, Never> {
         publisher(for: \.duration).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var currentTimePublisher: AnyPublisher<TimeInterval, Never> {
         publisher(for: \.currentTime).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var remainingTimePublisher: AnyPublisher<TimeInterval, Never> {
         publisher(for: \.remainingTime).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var playbackRatePublisher: AnyPublisher<Double, Never> {
         publisher(for: \.playbackRate).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var playbackRatesPublisher: AnyPublisher<[Double], Never> {
         publisher(for: \.playbackRates).map { $0.map { $0.doubleValue } }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isPlayingPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.playbackRate).map { $0 != 0.0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isLoadingPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isLoading).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isTrimmingPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isTrimming).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var forwardPlaybackEndTimePublisher: AnyPublisher<CMTime?, Never> {
         publisher(for: \.endTime)
             .dropFirst()
@@ -463,6 +533,8 @@ extension WKSLinearMediaPlayer {
             .eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var reversePlaybackEndTimePublisher: AnyPublisher<CMTime?, Never> {
         publisher(for: \.startTime)
             .dropFirst()
@@ -470,285 +542,423 @@ extension WKSLinearMediaPlayer {
             .eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var trimViewPublisher: AnyPublisher<UIView?, Never> {
         publisher(for: \.trimView).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var thumbnailLayerPublisher: AnyPublisher<CALayer?, Never> {
         publisher(for: \.thumbnailLayer).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var thumbnailMaterialPublisher: AnyPublisher<VideoMaterial?, Never> {
         swiftOnlyData.$thumbnailMaterial.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var captionLayerPublisher: AnyPublisher<CALayer?, Never> {
         Just(nil).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var captionContentInsetsPublisher: AnyPublisher<UIEdgeInsets, Never> {
         publisher(for: \.captionContentInsets).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var showsPlaybackControlsPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.showsPlaybackControls).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var canSeekPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.canSeek).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var seekableTimeRangesPublisher: AnyPublisher<[ClosedRange<TimeInterval>], Never> {
         publisher(for: \.seekableTimeRanges).map { $0.map { $0.closedRange } }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isSeekingPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isSeeking).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var canScanBackwardPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.canScanBackward).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var canScanForwardPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.canScanForward).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentInfoViewControllersPublisher: AnyPublisher<[UIViewController], Never> {
         publisher(for: \.contentInfoViewControllers).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contextualActionsPublisher: AnyPublisher<[UIAction], Never> {
         publisher(for: \.contextualActions).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contextualActionsInfoViewPublisher: AnyPublisher<UIView?, Never> {
         publisher(for: \.contextualActionsInfoView).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentDimensionsPublisher: AnyPublisher<CGSize, Never> {
         publisher(for: \.contentDimensions).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentModePublisher: AnyPublisher<ContentMode, Never> {
         publisher(for: \.contentMode).compactMap { $0.contentMode }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var videoLayerPublisher: AnyPublisher<CALayer?, Never> {
         publisher(for: \.videoLayer).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var videoMaterialPublisher: AnyPublisher<VideoMaterial?, Never> {
         swiftOnlyData.$videoMaterial.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var peculiarEntityPublisher: AnyPublisher<PeculiarEntity?, Never> {
         swiftOnlyData.$peculiarEntity.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var anticipatedViewingModePublisher: AnyPublisher<ViewingMode?, Never> {
         publisher(for: \.anticipatedViewingMode).compactMap { $0.viewingMode }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentOverlayPublisher: AnyPublisher<UIView?, Never> {
         publisher(for: \.contentOverlay).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentOverlayViewControllerPublisher: AnyPublisher<UIViewController?, Never> {
         publisher(for: \.contentOverlayViewController).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var volumePublisher: AnyPublisher<Double, Never> {
         publisher(for: \.volume).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isMutedPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isMuted).eraseToAnyPublisher()
     }
-#if !canImport(AVKit, _version: 1270)
+
+    #if !canImport(AVKit, _version: 1270)
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var sessionDisplayTitlePublisher: AnyPublisher<String?, Never> {
         publisher(for: \.sessionDisplayTitle).eraseToAnyPublisher()
     }
-#endif
+    #endif
+
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var sessionThumbnailPublisher: AnyPublisher<UIImage?, Never> {
         publisher(for: \.sessionThumbnail).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isSessionExtendedPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isSessionExtended).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var hasAudioContentPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.hasAudioContent).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var currentAudioTrackPublisher: AnyPublisher<Track?, Never> {
         publisher(for: \.currentAudioTrack).map { $0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var audioTracksPublisher: AnyPublisher<[Track]?, Never> {
         publisher(for: \.audioTracks).map { $0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var currentLegibleTrackPublisher: AnyPublisher<Track?, Never> {
         publisher(for: \.currentLegibleTrack).map { $0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var legibleTracksPublisher: AnyPublisher<[Track]?, Never> {
         publisher(for: \.legibleTracks).map { $0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentTypePublisher: AnyPublisher<ContentType?, Never> {
         publisher(for: \.contentType).map { $0.contentType }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var contentMetadataPublisher: AnyPublisher<ContentMetadataContainer, Never> {
         publisher(for: \.contentMetadata).map { $0.contentMetadata }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var transportBarIncludesTitleViewPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.transportBarIncludesTitleView).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var artworkPublisher: AnyPublisher<Data?, Never> {
         publisher(for: \.artwork).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isPlayableOfflinePublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isPlayableOffline).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var allowPipPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.allowPip).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var allowFullScreenFromInlinePublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.allowFullScreenFromInline).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var isLiveStreamPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isLiveStream).eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var startDatePublisher: AnyPublisher<Date, Never> {
         swiftOnlyData.$startDate.compactMap { $0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var endDatePublisher: AnyPublisher<Date, Never> {
         swiftOnlyData.$endDate.compactMap { $0 }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var recommendedViewingRatioPublisher: AnyPublisher<Double?, Never> {
         publisher(for: \.recommendedViewingRatio).compactMap { $0?.doubleValue }.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var fullscreenSceneBehaviorsPublisher: AnyPublisher<[FullscreenBehaviors], Never> {
         // FIXME: Publish fullscreenSceneBehaviors once rdar://122435030 is resolved
         swiftOnlyData.fullscreenBehaviorsSubject.eraseToAnyPublisher()
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func updateRenderingConfiguration(_ config: RenderingConfiguration) {
         swiftOnlyData.renderingConfiguration = config
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func play() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerPlay?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func pause() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerPause?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func togglePlayback() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerTogglePlayback?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setPlaybackRate(_ rate: Double) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(rate)")
         delegate?.linearMediaPlayer?(self, setPlaybackRate: rate)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func seek(to time: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, seekToTime: time)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func seek(delta: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(delta)")
         delegate?.linearMediaPlayer?(self, seekByDelta: delta)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func seek(to destination: TimeInterval, from source: TimeInterval, metadata: SeekMetadata) -> TimeInterval {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) destination=\(destination) source=\(source)")
         return delegate?.linearMediaPlayer?(self, seekToDestination: destination, fromSource: source) ?? TimeInterval.zero
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func completeTrimming(commitChanges: Bool) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(commitChanges)")
         delegate?.linearMediaPlayer?(self, completeTrimming: commitChanges)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func updateStartTime(_ time: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, updateStartTime: time)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func updateEndTime(_ time: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, updateEndTime: time)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func beginEditingVolume() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginEditingVolume?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func endEditingVolume() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndEditingVolume?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setAudioTrack(_ newTrack: Track?) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(newTrack?.localizedDisplayName ?? "nil")")
         delegate?.linearMediaPlayer?(self, setAudioTrack: newTrack as? WKSLinearMediaTrack)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setLegibleTrack(_ newTrack: Track?) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(newTrack?.localizedDisplayName ?? "nil")")
         delegate?.linearMediaPlayer?(self, setLegibleTrack: newTrack as? WKSLinearMediaTrack)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func skipActiveInterstitial() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerSkipActiveInterstitial?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setCaptionContentInsets(_ insets: UIEdgeInsets) {
-        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: insets), privacy: .public)")
+        Logger.linearMediaPlayer.log(
+            "\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: insets), privacy: .public)"
+        )
         delegate?.linearMediaPlayer?(self, setCaptionContentInsets: insets)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func updateVideoBounds(_ bounds: CGRect) {
-        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: bounds), privacy: .public)")
+        Logger.linearMediaPlayer.log(
+            "\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: bounds), privacy: .public)"
+        )
         delegate?.linearMediaPlayer?(self, updateVideoBounds: bounds)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func updateViewingMode(_ mode: ViewingMode?) {
         let viewingMode = WKSLinearMediaViewingMode(mode)
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(viewingMode)")
         delegate?.linearMediaPlayer?(self, update: viewingMode)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func togglePip() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerTogglePip?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func toggleInlineMode() {
-        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log(
+            "\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)"
+        )
 
         switch presentationState {
         case .inline:
@@ -762,8 +972,12 @@ extension WKSLinearMediaPlayer {
         }
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func willEnterFullscreen() {
-        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log(
+            "\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)"
+        )
 
         switch presentationState {
         case .inline:
@@ -776,6 +990,8 @@ extension WKSLinearMediaPlayer {
         }
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didCompleteEnterFullscreen(result: Result<Void, any Error>) {
         let completionHandler = enterFullscreenCompletionHandler
         enterFullscreenCompletionHandler = nil
@@ -790,8 +1006,12 @@ extension WKSLinearMediaPlayer {
         }
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func willExitFullscreen() {
-        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log(
+            "\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)"
+        )
 
         switch presentationState {
         case .fullscreen:
@@ -803,6 +1023,8 @@ extension WKSLinearMediaPlayer {
         }
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didCompleteExitFullscreen(result: Result<Void, any Error>) {
         let completionHandler = exitFullscreenCompletionHandler
         exitFullscreenCompletionHandler = nil
@@ -819,6 +1041,8 @@ extension WKSLinearMediaPlayer {
         }
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func makeDefaultEntity() -> Entity? {
         // This gets called from maybeCreateSpatialOrImmersiveEntity through the KVO when setting
         // peculiarEntity. As such, we can't check if the peculiarEntity is set or not.
@@ -839,78 +1063,106 @@ extension WKSLinearMediaPlayer {
             return entity
         }
 
-        Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): failed to find spatialVideoMetadata and captionLayer")
+        Logger.linearMediaPlayer.error(
+            "\(#function)(\(self.logIdentifier, privacy: .public)): failed to find spatialVideoMetadata and captionLayer"
+        )
         swiftOnlyData.defaultEntity = nil
         return nil
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setTimeResolverInterval(_ interval: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(interval)")
         delegate?.linearMediaPlayer?(self, setTimeResolverInterval: interval)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setTimeResolverResolution(_ resolution: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(resolution)")
         delegate?.linearMediaPlayer?(self, setTimeResolverResolution: resolution)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setThumbnailSize(_ size: CGSize) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: size), privacy: .public)")
         delegate?.linearMediaPlayer?(self, setThumbnailSize: size)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func seekThumbnail(to time: TimeInterval) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, seekThumbnailToTime: time)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func beginScrubbing() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginScrubbing?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func endScrubbing() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndScrubbing?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func beginScanningForward() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginScanningForward?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func endScanningForward() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndScanningForward?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func beginScanningBackward() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginScanningBackward?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func endScanningBackward() {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndScanningBackward?(self)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setVolume(_ volume: Double) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(volume)")
         delegate?.linearMediaPlayer?(self, setVolume: volume)
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setIsMuted(_ value: Bool) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(value)")
         delegate?.linearMediaPlayer?(self, setMuted: value)
     }
 
-// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
-#if canImport(XPC)
+    // FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+    #if canImport(XPC)
+    // FIXME: Objective-C interface type WKSLinearMediaPlayer should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setVideoReceiverEndpoint(_ endpoint: xpc_object_t) {
         Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayer?(self, setVideoReceiverEndpoint: endpoint)
     }
-#endif
+    #endif
 }
 
 #endif // os(visionOS)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -35,17 +35,21 @@ import AVKit_SPI
 
 // MARK: Objective-C Implementations
 
-@objc @implementation extension WKSLinearMediaContentMetadata {
+@objc
+@implementation
+extension WKSLinearMediaContentMetadata {
     let title: String?
     let subtitle: String?
-    
+
     init(title: String?, subtitle: String?) {
         self.title = title
         self.subtitle = subtitle
     }
 }
 
-@objc @implementation extension WKSLinearMediaTimeRange {
+@objc
+@implementation
+extension WKSLinearMediaTimeRange {
     let lowerBound: TimeInterval
     let upperBound: TimeInterval
 
@@ -55,7 +59,9 @@ import AVKit_SPI
     }
 }
 
-@objc @implementation extension WKSLinearMediaTrack {
+@objc
+@implementation
+extension WKSLinearMediaTrack {
     let localizedDisplayName: String
 
     init(localizedDisplayName: String) {
@@ -63,7 +69,9 @@ import AVKit_SPI
     }
 }
 
-@objc @implementation extension WKSLinearMediaSpatialVideoMetadata {
+@objc
+@implementation
+extension WKSLinearMediaSpatialVideoMetadata {
     let width: Int32
     let height: Int32
     let horizontalFieldOfView: Int32
@@ -79,8 +87,11 @@ import AVKit_SPI
     }
 }
 
-@objc @implementation extension WKSPlayableViewControllerHost {
-    @nonobjc private let base = PlayableViewController()
+@objc
+@implementation
+extension WKSPlayableViewControllerHost {
+    @nonobjc
+    private let base = PlayableViewController()
 
     var viewController: UIViewController {
         base
@@ -126,7 +137,6 @@ import AVKit_SPI
         set {
             base.playable = newValue
         }
-
     }
 }
 
@@ -198,20 +208,22 @@ extension WKSLinearMediaContentType {
 }
 
 extension WKSLinearMediaPresentationState: CustomStringConvertible {
+    // FIXME: Objective-C interface type WKSLinearMediaPresentationState should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var description: String {
         switch self {
         case .inline:
-            return "inline"
+            "inline"
         case .enteringFullscreen:
-            return "enteringFullscreen"
+            "enteringFullscreen"
         case .fullscreen:
-            return "fullscreen"
+            "fullscreen"
         case .exitingFullscreen:
-            return "exitingFullscreen"
+            "exitingFullscreen"
         case .enteringExternal:
-            return "enteringExternal"
+            "enteringExternal"
         case .external:
-            return "external"
+            "external"
         @unknown default:
             fatalError()
         }
@@ -235,7 +247,7 @@ extension WKSLinearMediaViewingMode: CustomStringConvertible {
             fatalError()
         }
     }
-    
+
     var viewingMode: ViewingMode? {
         switch self {
         case .none:
@@ -253,18 +265,20 @@ extension WKSLinearMediaViewingMode: CustomStringConvertible {
         }
     }
 
+    // FIXME: Objective-C interface type WKSLinearMediaViewingMode should not itself conform to a Swift protocol.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var description: String {
         switch self {
         case .none:
-            return "none"
+            "none"
         case .mono:
-            return "mono"
+            "mono"
         case .stereo:
-            return "stereo"
+            "stereo"
         case .immersive:
-            return "immersive"
+            "immersive"
         case .spatial:
-            return "spatial"
+            "spatial"
         @unknown default:
             fatalError()
         }
@@ -283,15 +297,16 @@ extension WKSLinearMediaFullscreenBehaviors {
 
 extension WKSLinearMediaTimeRange {
     var closedRange: ClosedRange<TimeInterval> {
-        return lowerBound...upperBound
+        lowerBound...upperBound
     }
 
     var range: Range<TimeInterval> {
-        return lowerBound..<upperBound
+        lowerBound..<upperBound
     }
 }
 
-@_spi(Internal) extension WKSLinearMediaTrack: Track {
+@_spi(Internal)
+extension WKSLinearMediaTrack: Track {
 }
 
 extension WKSLinearMediaSpatialVideoMetadata {


### PR DESCRIPTION
#### 198eeec79bb59d36e872a0b14743765061f30ac1
<pre>
[Swift in WebKit] Apply swift-format to WebKitSwift/LinearMediaKit and fix formatting
<a href="https://bugs.webkit.org/show_bug.cgi?id=308424">https://bugs.webkit.org/show_bug.cgi?id=308424</a>
<a href="https://rdar.apple.com/170908904">rdar://170908904</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(SwiftOnlyData.renderingConfiguration):
(SwiftOnlyData.thumbnailMaterial):
(SwiftOnlyData.videoMaterial):
(SwiftOnlyData.peculiarEntity):
(SwiftOnlyData.startDate):
(SwiftOnlyData.endDate):
(SwiftOnlyData.presentationMode):
(SwiftOnlyData.presentationState):
(WKSLinearMediaPlayer.isImmersiveVideo):
(WKSLinearMediaPlayer.enterFullscreenCompletionHandler):
(WKSLinearMediaPlayer.exitFullscreenCompletionHandler):
(WKSLinearMediaPlayer.swiftOnlyData):
(WKSLinearMediaPlayer.cancellables):
(WKSLinearMediaPlayer.logIdentifier):
(WKSLinearMediaPlayer.completeEnterExternalPlayback):
(WKSLinearMediaPlayer.enterFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.exitFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.maybeCreateSpatialOrImmersiveEntity):
(WKSLinearMediaPlayer.maybeClearSpatialOrImmersiveEntity):
(WKSLinearMediaPlayer.setCaptionContentInsets(_:)):
(WKSLinearMediaPlayer.updateVideoBounds(_:)):
(WKSLinearMediaPlayer.toggleInlineMode):
(WKSLinearMediaPlayer.willEnterFullscreen):
(WKSLinearMediaPlayer.willExitFullscreen):
(WKSLinearMediaPlayer.makeDefaultEntity):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSPlayableViewControllerHost.playable):
(WKSLinearMediaTimeRange.closedRange):
(WKSLinearMediaTimeRange.range):

Canonical link: <a href="https://commits.webkit.org/308021@main">https://commits.webkit.org/308021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5884382bf1af09e6ccfe067df44c2243745bd885

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99717 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01a5db19-89d7-48df-af68-54760ca3b4bb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112548 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80512 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/218f54dd-ccea-453b-ba5d-778c679666e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93418 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01da9ddb-cb99-4bb7-aa79-f2a10cdf7dd8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14169 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11927 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2372 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123736 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157247 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120575 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120875 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30960 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74499 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7845 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82125 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18105 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->