### PR TITLE
[YARR] JIT non-greedy backreference should restore index on backtrack failure

### DIFF
--- a/JSTests/stress/regexp-non-greedy-backref-index-restore.js
+++ b/JSTests/stress/regexp-non-greedy-backref-index-restore.js
@@ -1,0 +1,42 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("FAIL: " + msg + " expected: " + JSON.stringify(expected) + " actual: " + JSON.stringify(actual));
+}
+
+function testRegExp(re, str, expectedMatch, expectedIndex) {
+    for (var i = 0; i < 200; i++) {
+        var result = re.exec(str);
+        if (expectedMatch === null) {
+            shouldBe(result, null, re + ".exec(" + JSON.stringify(str) + ")");
+        } else {
+            shouldBe(result !== null, true, re + ".exec(" + JSON.stringify(str) + ") should not be null");
+            for (var j = 0; j < expectedMatch.length; j++)
+                shouldBe(result[j], expectedMatch[j], re + ".exec(" + JSON.stringify(str) + ")[" + j + "]");
+            shouldBe(result.index, expectedIndex, re + ".exec(" + JSON.stringify(str) + ").index");
+        }
+    }
+}
+
+testRegExp(/(a)\1{0,2}?$/, "aaaa", ["aaa", "a"], 1);
+testRegExp(/(a)\1{0,2}?$/, "aaaaa", ["aaa", "a"], 2);
+testRegExp(/(a)\1??$/, "aaa", ["aa", "a"], 1);
+testRegExp(/(ab)\1{0,2}?$/, "abababab", ["ababab", "ab"], 2);
+testRegExp(/(.)\1{0,2}?$/, "xaaaa", ["aaa", "a"], 2);
+testRegExp(/(a)\1{0,1}?$/, "aaaaa", ["aa", "a"], 3);
+testRegExp(/(a)\1{0,3}?$/, "aaaaa", ["aaaa", "a"], 1);
+testRegExp(/(a)\1{0,2}?/, "aaaa", ["a", "a"], 0);
+testRegExp(/(a)\1{0,2}$/, "aaaa", ["aaa", "a"], 1);
+
+// Alternation: NonGreedy backreference fails, falls through to next alternative
+testRegExp(/(a)\1*?b|c/, "aac", ["c", undefined], 2);
+testRegExp(/(a)\1*?b|aac/, "aac", ["aac", undefined], 0);
+
+// Multiple backreferences
+testRegExp(/(a)(b)\2*?\1/, "abba", ["abba", "a", "b"], 0);
+
+// Undefined capture with NonGreedy
+testRegExp(/(a)?\1*?b/, "b", ["b", undefined], 0);
+testRegExp(/(a)?\1*?b/, "aab", ["aab", "a"], 0);
+
+// Nested group with NonGreedy backreference and anchor
+testRegExp(/(a)(b)\2*?\1$/, "abbbba", ["abbbba", "a", "b"], 0);


### PR DESCRIPTION
#### 2fb117dc7dcdb56ecdf3fb4568d01dd854bf1e10
<pre>
[YARR] JIT non-greedy backreference should restore index on backtrack failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=308425">https://bugs.webkit.org/show_bug.cgi?id=308425</a>

Reviewed by Yusuke Suzuki.

The interpreter restores the input position via input.setPos(backTrack-&gt;begin)
when a non-greedy backreference fails completely, but the JIT was missing the
equivalent restoration. This caused the index to remain at whatever position
the last retry reached, skipping valid start positions for subsequent
alternatives or backtracking.

The fix saves the initial index into the backReferenceSize frame slot (unused
by NonGreedy) and restores it on complete failure.

Test: JSTests/stress/regexp-non-greedy-backref-index-restore.js

* JSTests/stress/regexp-non-greedy-backref-index-restore.js: Added.
(shouldBe):
(testRegExp):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/308264@main">https://commits.webkit.org/308264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40532598645a57c7c9e67da69699bfd87c4ede62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99685 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112518 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80490 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11898 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2339 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138195 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157212 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7016 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120543 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120843 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74450 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7746 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82090 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->