### PR TITLE
[MathML] Position mprescripts element in mmultiscripts layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL mprescripts coordinates and sizes (2 postscripts) assert_approx_equals: 2 postscripts, top expected 51 +/- 1 but got 16
-FAIL mprescripts coordinates and sizes (2 prescripts) assert_approx_equals: 2 prescripts, left expected 43 +/- 1 but got 8
-FAIL mprescripts coordinates and sizes (2 prescripts, 4 postscripts) assert_approx_equals: 2 prescripts, 4 postscripts, left expected 43 +/- 1 but got 8
-FAIL mprescripts coordinates and sizes (4 prescripts, 2 postscripts) assert_approx_equals: 4 prescripts, 2 postscripts, left expected 78 +/- 1 but got 8
-FAIL mprescripts coordinates and sizes (prescripts with padding/border/margin) assert_approx_equals: prescripts with padding/border/margin, left expected 43 +/- 1 but got 8
+PASS mprescripts coordinates and sizes (2 postscripts)
+PASS mprescripts coordinates and sizes (2 prescripts)
+PASS mprescripts coordinates and sizes (2 prescripts, 4 postscripts)
+PASS mprescripts coordinates and sizes (4 prescripts, 2 postscripts)
+PASS mprescripts coordinates and sizes (prescripts with padding/border/margin)
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl-expected.txt
@@ -1,0 +1,11 @@
+
+PASS mprescripts RTL coordinates and sizes (rtl 2 postscripts)
+PASS mprescripts RTL coordinates and sizes (rtl 2 prescripts)
+PASS mprescripts RTL coordinates and sizes (rtl 2 prescripts, 4 postscripts)
+PASS mprescripts RTL coordinates and sizes (rtl 4 prescripts, 2 postscripts)
+PASS mprescripts RTL coordinates and sizes (rtl prescripts with padding/border/margin)
+
+
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>mprescripts RTL</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup">
+<meta name="assert" content="Position and size of mprescripts in mmultiscript element with dir=rtl.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+  math, mspace {
+    font: 25px/1 Ahem;
+  }
+</style>
+<script>
+  /* This test verifies that mprescripts is correctly positioned in RTL
+     mmultiscripts. The right side of mprescripts should align with the
+     right side of the base, and it should be vertically centered. */
+
+  setup({ explicit_done: true });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
+
+  function runTests() {
+      Array.from(document.getElementsByTagName("mprescripts")).
+          forEach(prescript => {
+              let mmultiscripts = prescript.parentNode;
+              let name = mmultiscripts.getAttribute("data-name");
+              test(function() {
+                  assert_true(MathMLFeatureDetection.has_mspace());
+                  var e = 1;
+                  let base_box = mmultiscripts.firstElementChild.getBoundingClientRect();
+                  let prescript_box = prescript.getBoundingClientRect();
+                  assert_approx_equals(prescript_box.right, base_box.right, e, `${name}, right`);
+                  assert_approx_equals((prescript_box.top + prescript_box.bottom) / 2, (base_box.top + base_box.bottom) / 2, e, `${name}, vertical center`);
+
+                  if (name == "rtl prescripts with padding/border/margin") {
+                      assert_approx_equals(prescript_box.width, 2*(15 + 25), e, `${name}, width`);
+                      assert_approx_equals(prescript_box.height, 2*(10 + 20), e, `${name}, height`);
+                  } else {
+                      assert_approx_equals(prescript_box.width, 0, e, `${name}, width`);
+                      assert_approx_equals(prescript_box.height, 0, e, `${name}, height`);
+                  }
+              }, `mprescripts RTL coordinates and sizes (${name})`);
+          });
+
+      done();
+  }
+</script>
+</head>
+<body>
+  <div id="log"></div>
+  <p>
+    <math dir="rtl">
+      <mmultiscripts data-name="rtl 2 postscripts">
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mprescripts/>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math dir="rtl">
+      <mmultiscripts data-name="rtl 2 prescripts">
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mprescripts/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math dir="rtl">
+      <mmultiscripts data-name="rtl 2 prescripts, 4 postscripts">
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mprescripts/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math dir="rtl">
+      <mmultiscripts data-name="rtl 4 prescripts, 2 postscripts">
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mprescripts/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math dir="rtl">
+      <mmultiscripts data-name="rtl prescripts with padding/border/margin">
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mprescripts style="background: blue;
+                            padding-top: 10px; border-top: 20px solid green;
+                            padding-bottom: 10px; border-bottom: 20px solid green;
+                            padding-left: 15px; border-left: 25px solid green;
+                            padding-right: 15px; border-right: 25px solid green;
+                            margin-top: 50px;"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace width="30px" height="15px" depth="15px" style="background: black"/>
+      </mmultiscripts>
+    </math>
+  </p>
+</body>
+</html>

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -467,6 +467,20 @@ void RenderMathMLScripts::layoutBlock(RelayoutChildren relayoutChildren, LayoutU
         LayoutPoint baseLocation(mirrorIfNeeded(horizontalOffset + reference.base->marginStart(), *reference.base), ascent - baseAscent + reference.base->marginBefore());
         reference.base->setLocation(baseLocation);
         horizontalOffset += reference.base->logicalWidth() + reference.base->marginLogicalWidth();
+
+        // Position the prescriptDelimiter (mprescripts element) aligned with the base, vertically centered.
+        // In LTR, left edges align. In RTL, right edges align.
+        if (reference.prescriptDelimiter) {
+            LayoutUnit prescriptHeight = reference.prescriptDelimiter->logicalHeight();
+            LayoutUnit baseBorderBoxHeight = reference.base->logicalHeight();
+            LayoutUnit baseCenterY = baseLocation.y() + baseBorderBoxHeight / 2;
+            LayoutUnit prescriptX = baseLocation.x();
+            if (writingMode().isBidiRTL())
+                prescriptX += reference.base->logicalWidth() - reference.prescriptDelimiter->logicalWidth();
+            LayoutPoint prescriptLocation(prescriptX, baseCenterY - prescriptHeight / 2);
+            reference.prescriptDelimiter->setLocation(prescriptLocation);
+        }
+
         subScript = reference.firstPostScript;
         while (subScript && subScript != reference.prescriptDelimiter) {
             auto supScript = subScript->nextInFlowSiblingBox();


### PR DESCRIPTION
#### e03c39a3e5a6a64c9a48cb23646fb3cceb1b73b9
<pre>
[MathML] Position mprescripts element in mmultiscripts layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=308426">https://bugs.webkit.org/show_bug.cgi?id=308426</a>
<a href="https://rdar.apple.com/170909975">rdar://170909975</a>

Reviewed by Frédéric Wang.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The mprescripts element was never explicitly positioned during
mmultiscripts layout. It was only used as a loop boundary to
separate prescripts from postscripts, leaving it at its default
position. Position it aligned with the base (left edge in LTR,
right edge in RTL), vertically centered with the base.

Also fix RTL positioning of prescript pairs by placing the
space-after-script on the inline-end side of each pair, so
mirrorIfNeeded produces correct visual positions in RTL mode.

* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::layoutBlock):
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl.html: Added.

Canonical link: <a href="https://commits.webkit.org/308013@main">https://commits.webkit.org/308013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3984bf573c2619d8922f45d99ca689b6f4c7770e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99699 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c99e540a-0d9f-4227-b17b-00ccfbbf19f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112522 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80500 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aeaac8cb-3d9a-4f81-8143-5af90f3b658e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93392 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9a2d490-87f2-45f5-9910-3799e22f75fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14144 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11900 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2343 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157216 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/387 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120547 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120847 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30956 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74454 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7754 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82094 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18076 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->