### PR TITLE
Drop unnecessary usage of ternary operator in WebKit/

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -173,8 +173,8 @@ public:
     PAL::SessionID sessionID() const { return m_sessionID; }
 
     bool isLockdownModeEnabled() const { return m_isLockdownModeEnabled; }
-    bool isLockdownSafeFontParserEnabled() const { return sharedPreferencesForWebProcess() ? sharedPreferencesForWebProcess()->lockdownFontParserEnabled : false; }
-    bool isForceLockdownSafeFontParserEnabled() const { return sharedPreferencesForWebProcess() ? sharedPreferencesForWebProcess()->forceLockdownFontParserEnabled : false; }
+    bool isLockdownSafeFontParserEnabled() const { return sharedPreferencesForWebProcess() && sharedPreferencesForWebProcess()->lockdownFontParserEnabled; }
+    bool isForceLockdownSafeFontParserEnabled() const { return sharedPreferencesForWebProcess() && sharedPreferencesForWebProcess()->forceLockdownFontParserEnabled; }
 
     Logger& logger();
 

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -829,7 +829,7 @@ void UserMediaCaptureManagerProxy::setIsInBackground(RealtimeMediaSourceIdentifi
 void UserMediaCaptureManagerProxy::isPowerEfficient(WebCore::RealtimeMediaSourceIdentifier sourceID, CompletionHandler<void(bool)>&& callback)
 {
     RefPtr proxy = m_proxies.get(sourceID);
-    callback(proxy ? proxy->isPowerEfficient() : false);
+    callback(proxy && proxy->isPowerEfficient());
 }
 
 void UserMediaCaptureManagerProxy::clear()

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -307,7 +307,7 @@ void WebResourceLoadStatisticsStore::statisticsDatabaseHasAllTables(CompletionHa
             return;
         }
         auto missingTables = statisticsStore->checkForMissingTablesInSchema();
-        postTaskReply([hasAllTables = missingTables ? false : true, completionHandler = WTF::move(completionHandler)] () mutable {
+        postTaskReply([hasAllTables = !missingTables, completionHandler = WTF::move(completionHandler)] () mutable {
             completionHandler(hasAllTables);
         });
     });

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -171,7 +171,7 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
     }
     soup_message_set_flags(m_soupMessage.get(), static_cast<SoupMessageFlags>(soup_message_get_flags(m_soupMessage.get()) | messageFlags));
 
-    bool shouldBlockCookies = wasBlockingCookies == WasBlockingCookies::Yes ? true : m_storedCredentialsPolicy == StoredCredentialsPolicy::EphemeralStateless;
+    bool shouldBlockCookies = wasBlockingCookies == WasBlockingCookies::Yes || m_storedCredentialsPolicy == StoredCredentialsPolicy::EphemeralStateless;
     if (!shouldBlockCookies) {
         if (auto* networkStorageSession = m_session->networkStorageSession())
             shouldBlockCookies = networkStorageSession->shouldBlockCookies(m_currentRequest, m_frameID, m_pageID, WebCore::ShouldRelaxThirdPartyCookieBlocking::No, WebCore::IsKnownCrossSiteTracker::No);

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
@@ -41,7 +41,7 @@ SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferenc
 #if <%= @pref.condition %>
 <%- end -%>
 <%- if @pref.opts["disableInLockdownMode"] -%>
-    sharedPreferences.<%= @pref.nameLower %> = isLockdownModeEnabled ? false : preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
+    sharedPreferences.<%= @pref.nameLower %> = !isLockdownModeEnabled && preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 <%- else -%>
     sharedPreferences.<%= @pref.nameLower %> = preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 <%- end -%>

--- a/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
+++ b/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
@@ -41,7 +41,7 @@ namespace AXPreferenceHelpers {
 static bool shouldUseDefault()
 {
     RetainPtr forceDefault = [[NSUserDefaults standardUserDefaults] objectForKey:@"ForceDefaultAccessibilitySettings"];
-    return forceDefault ? [forceDefault boolValue] : false;
+    return forceDefault && [forceDefault boolValue];
 }
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)

--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
@@ -86,7 +86,7 @@ WebContextMenuItemGlib::WebContextMenuItemGlib(GAction* action, const String& ti
 #if PLATFORM(GTK) && !USE(GTK4)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 WebContextMenuItemGlib::WebContextMenuItemGlib(GtkAction* action)
-    : WebContextMenuItemData(GTK_IS_TOGGLE_ACTION(action) ? ContextMenuItemType::CheckableAction : ContextMenuItemType::Action, ContextMenuItemBaseApplicationTag, String::fromUTF8(gtk_action_get_label(action)), gtk_action_get_sensitive(action), GTK_IS_TOGGLE_ACTION(action) ? gtk_toggle_action_get_active(GTK_TOGGLE_ACTION(action)) : false)
+    : WebContextMenuItemData(GTK_IS_TOGGLE_ACTION(action) ? ContextMenuItemType::CheckableAction : ContextMenuItemType::Action, ContextMenuItemBaseApplicationTag, String::fromUTF8(gtk_action_get_label(action)), gtk_action_get_sensitive(action), GTK_IS_TOGGLE_ACTION(action) && gtk_toggle_action_get_active(GTK_TOGGLE_ACTION(action)))
 {
     m_gtkAction = action;
     createActionIfNeeded();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -457,12 +457,12 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (BOOL)_hasServiceWorkerBackgroundActivityForTesting
 {
-    return _page ? protect(_page->configuration().processPool())->hasServiceWorkerBackgroundActivityForTesting() : false;
+    return _page && protect(_page->configuration().processPool())->hasServiceWorkerBackgroundActivityForTesting();
 }
 
 - (BOOL)_hasServiceWorkerForegroundActivityForTesting
 {
-    return _page ? protect(_page->configuration().processPool())->hasServiceWorkerForegroundActivityForTesting() : false;
+    return _page && protect(_page->configuration().processPool())->hasServiceWorkerForegroundActivityForTesting();
 }
 
 - (void)_denyNextUserMediaRequest

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1464,7 +1464,7 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
         GdkDevice* device = gdk_event_get_source_device(event);
         GdkInputSource source = gdk_device_get_source(device);
 
-        bool isEnd = gdk_event_is_scroll_stop_event(event) ? true : false;
+        bool isEnd = !!gdk_event_is_scroll_stop_event(event);
 
         PlatformGtkScrollData scrollData = { .delta = delta, .eventTime = eventTime, .source = source, .isEnd = isEnd };
         if (controller->handleScrollWheelEvent(&scrollData))

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -233,7 +233,7 @@ static WebCore::FloatBoxExtent NODELETE coreBoxExtentsFromEdgeInsets(NSEdgeInset
 
 - (void)_setSemanticContext:(NSViewSemanticContext)semanticContext
 {
-    auto wasUsingFormSemanticContext = _impl ? _impl->useFormSemanticContext() : false;
+    auto wasUsingFormSemanticContext = _impl && _impl->useFormSemanticContext();
 
     [super _setSemanticContext:semanticContext];
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1507,7 +1507,7 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
         callback({ { WTF::move(rectObject), WTF::move(inViewCenterPointObject), isObscured } });
     };
 
-    bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
+    bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded && *optionalScrollIntoViewIfNeeded;
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, coordinateSystem.value()), WTF::move(completionHandler));
 }
 
@@ -2829,8 +2829,8 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
     bool frameNotFound = false;
     auto frameID = webFrameIDForHandle(frameHandle, frameNotFound);
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(frameNotFound, WindowNotFound);
-    bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
-    bool clipToViewport = optionalClipToViewport ? *optionalClipToViewport : false;
+    bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded && *optionalScrollIntoViewIfNeeded;
+    bool clipToViewport = optionalClipToViewport && *optionalClipToViewport;
 
 #if PLATFORM(COCOA) || (!PLATFORM(GTK) && !PLATFORM(WPE))
     auto ipcCompletionHandler = [] (CommandCallback<String>&& callback) mutable {

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -152,7 +152,7 @@ private:
 #if ENABLE(DEVICE_ORIENTATION)
         void shouldAllowDeviceOrientationAndMotionAccess(WebKit::WebPageProxy&, WebFrameProxy&, FrameInfoData&&, CompletionHandler<void(bool)>&&) final;
 #endif
-        bool needsFontAttributes() const final { return m_uiDelegate ? m_uiDelegate->m_delegateMethods.webViewDidChangeFontAttributes : false; }
+        bool needsFontAttributes() const final { return m_uiDelegate && m_uiDelegate->m_delegateMethods.webViewDidChangeFontAttributes; }
         void didChangeFontAttributes(const WebCore::FontAttributes&) final;
         void decidePolicyForUserMediaPermissionRequest(WebPageProxy&, WebFrameProxy&, API::SecurityOrigin&, API::SecurityOrigin&, UserMediaPermissionRequestProxy&) final;
         void decidePolicyForScreenCaptureUnmuting(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, WebKit::FrameInfoData&&, API::SecurityOrigin&, API::SecurityOrigin&, CompletionHandler<void(bool isAllowed)>&&) final;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3219,7 +3219,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
         if (!allJSONData.get().allKeys.count) {
             removeDeclarativeNetRequestRules();
             API::ContentRuleListStore::defaultStoreSingleton().removeContentRuleListFile(declarativeNetRequestContentRuleListFilePath(), [completionHandler = WTF::move(completionHandler)](std::error_code error) mutable {
-                completionHandler(error ? false : true);
+                completionHandler(!error);
             });
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -381,7 +381,7 @@ bool WebExtensionTab::isActive() const
         return false;
 
     RefPtr window = this->window();
-    return window ? window->activeTab() == this : false;
+    return window && window->activeTab() == this;
 }
 
 bool WebExtensionTab::isSelected() const

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -205,7 +205,7 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
 
 - (BOOL)inspectorViewControllerInspectorIsUnderTest:(WKInspectorViewController *)inspectorViewController
 {
-    return _inspectorProxy ? _inspectorProxy->isUnderTest() : false;
+    return _inspectorProxy && _inspectorProxy->isUnderTest();
 }
 
 - (BOOL)inspectorViewControllerInspectorIsHorizontallyAttached:(WKInspectorViewController *)inspectorViewController

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -212,7 +212,7 @@ static inline void performEnterpriseAttestation(const WebCore::PublicKeyCredenti
 
 static inline bool emptyTransportsOrContain(const Vector<AuthenticatorTransport>& transports, AuthenticatorTransport target)
 {
-    return transports.isEmpty() ? true : transports.contains(target);
+    return transports.isEmpty() || transports.contains(target);
 }
 
 // A Base64 encoded string of the Credential ID is used as the key of the hash set.

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -172,7 +172,7 @@ void WebAuthenticatorCoordinatorProxy::handleRequest(WebAuthenticationRequestDat
 #if HAVE(WEB_AUTHN_AS_MODERN)
             afterConsent(consented ? *consented : protectedThis->removeMatchingAutofillEventForUsername(username, origin));
 #else
-            afterConsent(consented ? *consented : false);
+            afterConsent(consented && *consented);
 #endif
         });
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12725,7 +12725,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.shouldRelaxThirdPartyCookieBlocking = m_configuration->shouldRelaxThirdPartyCookieBlocking();
     parameters.canUseCredentialStorage = m_canUseCredentialStorage;
 
-    parameters.httpsUpgradeEnabled = preferences->upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
+    parameters.httpsUpgradeEnabled = preferences->upgradeKnownHostsToHTTPSEnabled() && m_configuration->httpsUpgradeEnabled();
     parameters.allowPostingLegacySynchronousMessages = m_configuration->allowPostingLegacySynchronousMessages();
     parameters.backgroundTextExtractionEnabled = m_configuration->backgroundTextExtractionEnabled();
 
@@ -13969,7 +13969,7 @@ void WebPageProxy::setCanRunModal(bool canRunModal)
 
 bool WebPageProxy::canRunModal()
 {
-    return hasRunningProcess() ? m_canRunModal : false;
+    return hasRunningProcess() && m_canRunModal;
 }
 
 void WebPageProxy::beginPrinting(WebFrameProxy* frame, const PrintInfo& printInfo)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -3141,7 +3141,7 @@ void WebProcessProxy::setResourceMonitorRuleLists(RefPtr<WebCompiledContentRuleL
 std::optional<SandboxExtension::Handle> WebProcessProxy::sandboxExtensionForFile(const String& fileName) const
 {
     auto handle = m_fileSandboxExtensions.getOptional(fileName);
-    WEBPROCESSPROXY_RELEASE_LOG(Sandbox, "sandboxExtensionForFile: %" PRIVATE_LOG_STRING ", has cached extension: %d", fileName.utf8().data(), handle ? true : false);
+    WEBPROCESSPROXY_RELEASE_LOG(Sandbox, "sandboxExtensionForFile: %" PRIVATE_LOG_STRING ", has cached extension: %d", fileName.utf8().data(), !!handle);
     return handle;
 }
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -348,7 +348,7 @@ void OpenXRCoordinator::scheduleAnimationFrame(WebPageProxy& page, std::optional
             }
 
             active.renderQueue->dispatch([this, renderState = active.renderState, requestData = WTF::move(requestData), onFrameUpdateCallback = WTF::move(onFrameUpdateCallback)]() mutable {
-                renderState->passthroughFullyObscured = requestData ? requestData->isPassthroughFullyObscured : false;
+                renderState->passthroughFullyObscured = requestData && requestData->isPassthroughFullyObscured;
                 renderState->onFrameUpdate = WTF::move(onFrameUpdateCallback);
                 renderLoop(renderState);
             });

--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -145,7 +145,7 @@ bool SystemSettingsManagerProxy::cursorBlink() const
 {
     gboolean cursorBlinkSetting;
     g_object_get(m_settings, "gtk-cursor-blink", &cursorBlinkSetting, nullptr);
-    return cursorBlinkSetting ? true : false;
+    return !!cursorBlinkSetting;
 }
 
 int SystemSettingsManagerProxy::cursorBlinkTime() const
@@ -159,21 +159,21 @@ bool SystemSettingsManagerProxy::primaryButtonWarpsSlider() const
 {
     gboolean buttonSetting;
     g_object_get(m_settings, "gtk-primary-button-warps-slider", &buttonSetting, nullptr);
-    return buttonSetting ? true : false;
+    return !!buttonSetting;
 }
 
 bool SystemSettingsManagerProxy::overlayScrolling() const
 {
     gboolean overlayScrollingSetting;
     g_object_get(m_settings, "gtk-overlay-scrolling", &overlayScrollingSetting, nullptr);
-    return overlayScrollingSetting ? true : false;
+    return !!overlayScrollingSetting;
 }
 
 bool SystemSettingsManagerProxy::enableAnimations() const
 {
     gboolean enableAnimationsSetting;
     g_object_get(m_settings, "gtk-enable-animations", &enableAnimationsSetting, nullptr);
-    return enableAnimationsSetting ? true : false;
+    return !!enableAnimationsSetting;
 }
 
 void SystemSettingsManagerProxy::updateFontProperties(const String& fontName, WebCore::SystemSettingsState& changedState)

--- a/Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm
+++ b/Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm
@@ -56,7 +56,7 @@
         return;
 
     auto page = [_webViewToTrack.get() _page];
-    RELEASE_LOG(ViewState, "%p - WKApplicationStateTrackingView: View with page [%p, pageProxyID=%" PRIu64 "] was removed from a window, _lastObservedStateWasBackground=%d", self, page.get(), page ? page->identifier().toUInt64() : 0, page ? page->lastObservedStateWasBackground() : false);
+    RELEASE_LOG(ViewState, "%p - WKApplicationStateTrackingView: View with page [%p, pageProxyID=%" PRIu64 "] was removed from a window, _lastObservedStateWasBackground=%d", self, page.get(), page ? page->identifier().toUInt64() : 0, page && page->lastObservedStateWasBackground());
     protect(*_applicationStateTracker)->setWindow(nil);
 }
 
@@ -66,7 +66,7 @@
         return;
 
     auto page = [_webViewToTrack.get() _page];
-    bool lastObservedStateWasBackground = page ? page->lastObservedStateWasBackground() : false;
+    bool lastObservedStateWasBackground = page && page->lastObservedStateWasBackground();
 
     protect(*_applicationStateTracker)->setWindow(self._contentView.window);
     RELEASE_LOG(ViewState, "%p - WKApplicationStateTrackingView: View with page [%p, pageProxyID=%" PRIu64 "] was added to a window, _lastObservedStateWasBackground=%d, isNowBackground=%d", self, page.get(), page ? page->identifier().toUInt64() : 0, lastObservedStateWasBackground, [self isBackground]);

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -240,7 +240,7 @@ bool wpeDisplayCheckEGLExtension(WPEDisplay* display, const char* extensionName)
 {
     auto addResult = display->priv->extensionsMap.ensure(ASCIILiteral::fromLiteralUnsafe(extensionName), [&] {
         auto* eglDisplay = wpe_display_get_egl_display(display, nullptr);
-        return eglDisplay ? epoxy_has_egl_extension(eglDisplay, extensionName) : false;
+        return eglDisplay && epoxy_has_egl_extension(eglDisplay, extensionName);
     });
     return addResult.iterator->value;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -309,7 +309,7 @@ void WebExtensionAPICookies::set(NSDictionary *details, Ref<WebExtensionCallback
 
     cookie.name = details[@"name"] ?: @"";
     cookie.value = details[valueKey] ?: @"";
-    cookie.secure = details[secureKey] ? objectForKey<NSNumber>(details, secureKey).boolValue : false;
+    cookie.secure = details[secureKey] && objectForKey<NSNumber>(details, secureKey).boolValue;
     auto *domain = dynamic_objc_cast<NSString>(details[domainKey]);
     cookie.domain = domain ? String(domain) : normalizeDomain(url.host().toString());
     auto *path = dynamic_objc_cast<NSString>(details[pathKey]);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
@@ -1194,7 +1194,7 @@ gboolean webkit_dom_document_exec_command(WebKitDOMDocument* self, const gchar* 
     WTF::String convertedCommand = WTF::String::fromUTF8(command);
     WTF::String convertedValue = WTF::String::fromUTF8(value);
     auto result = item->execCommand(convertedCommand, userInterface, convertedValue);
-    return result.hasException() ? false : result.returnValue();
+    return !result.hasException() && result.returnValue();
 }
 
 gboolean webkit_dom_document_query_command_enabled(WebKitDOMDocument* self, const gchar* command)
@@ -1205,7 +1205,7 @@ gboolean webkit_dom_document_query_command_enabled(WebKitDOMDocument* self, cons
     WebCore::Document* item = WebKit::core(self);
     WTF::String convertedCommand = WTF::String::fromUTF8(command);
     auto result = item->queryCommandEnabled(convertedCommand);
-    return result.hasException() ? false : result.returnValue();
+    return !result.hasException() && result.returnValue();
 }
 
 gboolean webkit_dom_document_query_command_indeterm(WebKitDOMDocument* self, const gchar* command)
@@ -1216,7 +1216,7 @@ gboolean webkit_dom_document_query_command_indeterm(WebKitDOMDocument* self, con
     WebCore::Document* item = WebKit::core(self);
     WTF::String convertedCommand = WTF::String::fromUTF8(command);
     auto result = item->queryCommandIndeterm(convertedCommand);
-    return result.hasException() ? false : result.returnValue();
+    return !result.hasException() && result.returnValue();
 }
 
 gboolean webkit_dom_document_query_command_state(WebKitDOMDocument* self, const gchar* command)
@@ -1227,7 +1227,7 @@ gboolean webkit_dom_document_query_command_state(WebKitDOMDocument* self, const 
     WebCore::Document* item = WebKit::core(self);
     WTF::String convertedCommand = WTF::String::fromUTF8(command);
     auto result = item->queryCommandState(convertedCommand);
-    return result.hasException() ? false : result.returnValue();
+    return !result.hasException() && result.returnValue();
 }
 
 gboolean webkit_dom_document_query_command_supported(WebKitDOMDocument* self, const gchar* command)
@@ -1238,7 +1238,7 @@ gboolean webkit_dom_document_query_command_supported(WebKitDOMDocument* self, co
     WebCore::Document* item = WebKit::core(self);
     WTF::String convertedCommand = WTF::String::fromUTF8(command);
     auto result = item->queryCommandSupported(convertedCommand);
-    return result.hasException() ? false : result.returnValue();
+    return !result.hasException() && result.returnValue();
 }
 
 gchar* webkit_dom_document_query_command_value(WebKitDOMDocument* self, const gchar* command)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -389,7 +389,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
     Ref mainFrame = frame->mainFrame();
     RefPtr policySourceDocumentLoader = policySourceDocumentLoaderForFrame(*frame, isMainFrameNavigation);
 
-    parameters.allowPrivacyProxy = policySourceDocumentLoader ? policySourceDocumentLoader->allowPrivacyProxy() : true;
+    parameters.allowPrivacyProxy = !policySourceDocumentLoader || policySourceDocumentLoader->allowPrivacyProxy();
 
     if (RefPtr framePolicySourceDocumentLoader = frame->loader().loaderForWebsitePolicies(isMainFrameNavigation ? FrameLoader::CanIncludeCurrentDocumentLoader::No : FrameLoader::CanIncludeCurrentDocumentLoader::Yes)) {
         if (String referrer = framePolicySourceDocumentLoader->preferences().overrideReferrerForAllRequests; !referrer.isNull())
@@ -565,7 +565,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         RefPtr coreFrame = webFrame ? webFrame->coreFrame() : nullptr;
         RefPtr openerFrame = coreFrame ? coreFrame->opener() : nullptr;
         RefPtr openerDocumentSecurityOrigin = openerFrame ? openerFrame->frameDocumentSecurityOrigin() : nullptr;
-        bool openerDocumentIsSameOriginAsTopDocument = openerDocumentSecurityOrigin ? openerDocumentSecurityOrigin->isSameOriginAs(protect(openerFrame->topOrigin())) : false;
+        bool openerDocumentIsSameOriginAsTopDocument = openerDocumentSecurityOrigin && openerDocumentSecurityOrigin->isSameOriginAs(protect(openerFrame->topOrigin()));
         auto openerDocumentSecurityPolicy = openerFrame ? openerFrame->frameDocumentSecurityPolicy() : std::nullopt;
         if (!document->haveInitializedSecurityOrigin() && openerDocumentSecurityPolicy && openerDocumentIsSameOriginAsTopDocument)
             loadParameters.sourceCrossOriginOpenerPolicy = openerDocumentSecurityPolicy->crossOriginOpenerPolicy;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -72,7 +72,7 @@ auto PDFDocumentLayout::lastPageIndex() const -> PageIndex
 
 bool PDFDocumentLayout::isFirstPageOfRow(PageIndex pageIndex) const
 {
-    return isTwoUpDisplayMode() ? isLeftPageIndex(pageIndex) : true;
+    return !isTwoUpDisplayMode() || isLeftPageIndex(pageIndex);
 }
 
 RetainPtr<PDFPage> PDFDocumentLayout::pageAtIndex(PageIndex index) const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -760,7 +760,7 @@ void UnifiedPDFPlugin::notifyFlushRequired(const GraphicsLayer*)
 bool UnifiedPDFPlugin::isInWindow() const
 {
     RefPtr page = this->page();
-    return page ? page->isInWindow() : false;
+    return page && page->isInWindow();
 }
 
 void UnifiedPDFPlugin::didChangeIsInWindow()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
@@ -47,7 +47,7 @@ WebDocumentSyncClient::WebDocumentSyncClient(WebPage& webPage)
 bool WebDocumentSyncClient::siteIsolationEnabled()
 {
     RefPtr corePage = protect(m_page)->corePage();
-    return corePage ? corePage->settings().siteIsolationEnabled() : false;
+    return corePage && corePage->settings().siteIsolationEnabled();
 }
 
 void WebDocumentSyncClient::broadcastDocumentSyncDataToOtherProcesses(const WebCore::DocumentSyncSerializationData& data)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -75,19 +75,19 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebEditorClient);
 bool WebEditorClient::shouldDeleteRange(const std::optional<SimpleRange>& range)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldDeleteRange(*page, range) : false;
+    return page && page->injectedBundleEditorClient().shouldDeleteRange(*page, range);
 }
 
 bool WebEditorClient::smartInsertDeleteEnabled()
 {
     RefPtr page = m_page.get();
-    return page ? page->isSmartInsertDeleteEnabled() : false;
+    return page && page->isSmartInsertDeleteEnabled();
 }
 
 bool WebEditorClient::isSelectTrailingWhitespaceEnabled() const
 {
     RefPtr page = m_page.get();
-    return page ? page->isSelectTrailingWhitespaceEnabled() : false;
+    return page && page->isSelectTrailingWhitespaceEnabled();
 }
 
 bool WebEditorClient::isContinuousSpellCheckingEnabled()
@@ -119,37 +119,37 @@ int WebEditorClient::spellCheckerDocumentTag()
 bool WebEditorClient::shouldBeginEditing(const SimpleRange& range)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldBeginEditing(*page, range) : false;
+    return page && page->injectedBundleEditorClient().shouldBeginEditing(*page, range);
 }
 
 bool WebEditorClient::shouldEndEditing(const SimpleRange& range)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldEndEditing(*page, range) : false;
+    return page && page->injectedBundleEditorClient().shouldEndEditing(*page, range);
 }
 
 bool WebEditorClient::shouldInsertNode(Node& node, const std::optional<SimpleRange>& rangeToReplace, EditorInsertAction action)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldInsertNode(*page, node, rangeToReplace, action) : false;
+    return page && page->injectedBundleEditorClient().shouldInsertNode(*page, node, rangeToReplace, action);
 }
 
 bool WebEditorClient::shouldInsertText(const String& text, const std::optional<SimpleRange>& rangeToReplace, EditorInsertAction action)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldInsertText(*page, text, rangeToReplace, action) : false;
+    return page && page->injectedBundleEditorClient().shouldInsertText(*page, text, rangeToReplace, action);
 }
 
 bool WebEditorClient::shouldChangeSelectedRange(const std::optional<SimpleRange>& fromRange, const std::optional<SimpleRange>& toRange, Affinity affinity, bool stillSelecting)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldChangeSelectedRange(*page, fromRange, toRange, affinity, stillSelecting) : false;
+    return page && page->injectedBundleEditorClient().shouldChangeSelectedRange(*page, fromRange, toRange, affinity, stillSelecting);
 }
 
 bool WebEditorClient::shouldApplyStyle(const StyleProperties& style, const std::optional<SimpleRange>& range)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().shouldApplyStyle(*page, style, range) : false;
+    return page && page->injectedBundleEditorClient().shouldApplyStyle(*page, style, range);
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -324,7 +324,7 @@ void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& 
 bool WebEditorClient::performTwoStepDrop(DocumentFragment& fragment, const SimpleRange& destination, bool isMove)
 {
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleEditorClient().performTwoStepDrop(*page, fragment, destination, isMove) : false;
+    return page && page->injectedBundleEditorClient().performTwoStepDrop(*page, fragment, destination, isMove);
 }
 
 void WebEditorClient::registerUndoStep(UndoStep& step)
@@ -512,7 +512,7 @@ void WebEditorClient::subFrameScrollPositionChanged()
 bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
 {
     RefPtr page = m_page.get();
-    return page ? page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection) : false;
+    return page && page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection);
 }
 
 #endif // PLATFORM(COCOA)
@@ -576,7 +576,7 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     ASSERT(webFrame);
 
     RefPtr page = m_page.get();
-    return page ? page->injectedBundleFormClient().shouldPerformActionInTextField(page.get(), *inputElement, toInputFieldAction(actionType), webFrame.get()) : false;
+    return page && page->injectedBundleFormClient().shouldPerformActionInTextField(page.get(), *inputElement, toInputFieldAction(actionType), webFrame.get());
 }
 
 void WebEditorClient::textWillBeDeletedInTextField(Element& element)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -104,8 +104,8 @@ void WebSpeechSynthesisClient::speak(RefPtr<WebCore::PlatformSpeechSynthesisUtte
     auto voiceURI = voice ? voice->voiceURI() : emptyString();
     auto name = voice ? voice->name() : emptyString();
     auto lang = voice ? voice->lang() : emptyString();
-    auto localService = voice ? voice->localService() : false;
-    auto isDefault = voice ? voice->isDefault() : false;
+    auto localService = voice && voice->localService();
+    auto isDefault = voice && voice->isDefault();
 
     RefPtr page = m_page.get();
     if (!page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
@@ -67,7 +67,7 @@ void WebEditorClient::stopDelayingAndCoalescingContentChangeNotifications()
 bool WebEditorClient::hasRichlyEditableSelection()
 {
     RefPtr page = m_page.get();
-    return page ? page->hasRichlyEditableSelection() : false;
+    return page && page->hasRichlyEditableSelection();
 }
 
 int WebEditorClient::getPasteboardItemsCount()
@@ -109,25 +109,25 @@ void WebEditorClient::subFrameScrollPositionChanged()
 bool WebEditorClient::shouldRevealCurrentSelectionAfterInsertion() const
 {
     RefPtr page = m_page.get();
-    return page ? page->shouldRevealCurrentSelectionAfterInsertion() : false;
+    return page && page->shouldRevealCurrentSelectionAfterInsertion();
 }
 
 bool WebEditorClient::shouldSuppressPasswordEcho() const
 {
     RefPtr page = m_page.get();
-    return page ? (page->screenIsBeingCaptured() || page->hardwareKeyboardIsAttached()) : false;
+    return page && (page->screenIsBeingCaptured() || page->hardwareKeyboardIsAttached());
 }
 
 bool WebEditorClient::shouldRemoveDictationAlternativesAfterEditing() const
 {
     RefPtr page = m_page.get();
-    return page ? page->shouldRemoveDictationAlternativesAfterEditing() : false;
+    return page && page->shouldRemoveDictationAlternativesAfterEditing();
 }
 
 bool WebEditorClient::shouldDrawVisuallyContiguousBidiSelection() const
 {
     RefPtr page = m_page.get();
-    return page ? page->shouldDrawVisuallyContiguousBidiSelection() : false;
+    return page && page->shouldDrawVisuallyContiguousBidiSelection();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -677,7 +677,7 @@ void WebPage::updateMockAccessibilityElementAfterCommittingLoad()
 {
     RefPtr mainFrame = dynamicDowncast<WebCore::LocalFrame>(this->mainFrame());
     RefPtr document = mainFrame ? mainFrame->document() : nullptr;
-    [m_mockAccessibilityElement setHasMainFramePlugin:document ? document->isPluginDocument() : false];
+    [m_mockAccessibilityElement setHasMainFramePlugin:document && document->isPluginDocument()];
 }
 
 void WebPage::getProcessDisplayName(CompletionHandler<void(String&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -315,7 +315,7 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
         withCertificateInfo == WithCertificateInfo::Yes ? certificateInfo() : CertificateInfo(),
         getCurrentProcessID(),
         isFocused(),
-        coreLocalFrame ? coreLocalFrame->loader().errorOccurredInLoading() : false,
+        coreLocalFrame && coreLocalFrame->loader().errorOccurredInLoading(),
         WTF::move(metrics)
     };
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2511,7 +2511,7 @@ void WebPage::drawRect(GraphicsContext& graphicsContext, const IntRect& rect)
     if (!localMainFrame)
         return;
     RefPtr mainFrameView = localMainFrame->view();
-    LocalDefaultSystemAppearance localAppearance(mainFrameView ? mainFrameView->useDarkAppearance() : false);
+    LocalDefaultSystemAppearance localAppearance(mainFrameView && mainFrameView->useDarkAppearance());
 #endif
 
     GraphicsContextStateSaver stateSaver(graphicsContext);

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -166,7 +166,7 @@ namespace ax = WebCore::Accessibility;
         [self setSize:webPage->size()];
 #endif
         RefPtr frame = dynamicDowncast<WebCore::LocalFrame>(webPage->mainFrame());
-        m_hasMainFramePlugin = frame && frame->document() ? frame->document()->isPluginDocument() : false;
+        m_hasMainFramePlugin = frame && frame->document() && frame->document()->isPluginDocument();
     } else {
         m_pageID = std::nullopt;
         m_hasMainFramePlugin = false;


### PR DESCRIPTION
#### dfb367b623e3322f80b93f8cafad767cef561b71
<pre>
Drop unnecessary usage of ternary operator in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=308428">https://bugs.webkit.org/show_bug.cgi?id=308428</a>
<a href="https://rdar.apple.com/170912631">rdar://170912631</a>

Reviewed by Chris Dumez.

This improves readability and enforces more idiomatic C++ by resorting to
equivalent binary boolean operations.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::isLockdownSafeFontParserEnabled const):
(WebKit::GPUConnectionToWebProcess::isForceLockdownSafeFontParserEnabled const):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::isPowerEfficient):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::statisticsDatabaseHasAllTables):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::createRequest):
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb:
* Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm:
(AXPreferenceHelpers::shouldUseDefault):
* Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp:
(WebKit::WebContextMenuItemGlib::WebContextMenuItemGlib):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _hasServiceWorkerBackgroundActivityForTesting]):
(-[WKWebView _hasServiceWorkerForegroundActivityForTesting]):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseScrollEvent):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setSemanticContext:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::isActive const):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerInspectorIsUnderTest:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::emptyTransportsOrContain):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
(WebKit::WebAuthenticatorCoordinatorProxy::handleRequest):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::canRunModal):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::sandboxExtensionForFile const):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::scheduleAnimationFrame):
* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::cursorBlink const):
(WebKit::SystemSettingsManagerProxy::primaryButtonWarpsSlider const):
(WebKit::SystemSettingsManagerProxy::overlayScrolling const):
(WebKit::SystemSettingsManagerProxy::enableAnimations const):
* Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm:
(-[WKApplicationStateTrackingView willMoveToWindow:]):
(-[WKApplicationStateTrackingView didMoveToWindow]):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpeDisplayCheckEGLExtension):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::WebExtensionAPICookies::set):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp:
(webkit_dom_document_exec_command):
(webkit_dom_document_query_command_enabled):
(webkit_dom_document_query_command_indeterm):
(webkit_dom_document_query_command_state):
(webkit_dom_document_query_command_supported):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::isFirstPageOfRow const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::isInWindow const):
* Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp:
(WebKit::WebDocumentSyncClient::siteIsolationEnabled):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::shouldDeleteRange):
(WebKit::WebEditorClient::smartInsertDeleteEnabled):
(WebKit::WebEditorClient::isSelectTrailingWhitespaceEnabled const):
(WebKit::WebEditorClient::shouldBeginEditing):
(WebKit::WebEditorClient::shouldEndEditing):
(WebKit::WebEditorClient::shouldInsertNode):
(WebKit::WebEditorClient::shouldInsertText):
(WebKit::WebEditorClient::shouldChangeSelectedRange):
(WebKit::WebEditorClient::shouldApplyStyle):
(WebKit::WebEditorClient::performTwoStepDrop):
(WebKit::WebEditorClient::shouldAllowSingleClickToChangeSelection const):
(WebKit::WebEditorClient::doTextFieldCommandFromEvent):
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
(WebKit::WebSpeechSynthesisClient::speak):
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm:
(WebKit::WebEditorClient::hasRichlyEditableSelection):
(WebKit::WebEditorClient::shouldRevealCurrentSelectionAfterInsertion const):
(WebKit::WebEditorClient::shouldSuppressPasswordEcho const):
(WebKit::WebEditorClient::shouldRemoveDictationAlternativesAfterEditing const):
(WebKit::WebEditorClient::shouldDrawVisuallyContiguousBidiSelection const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::updateMockAccessibilityElementAfterCommittingLoad):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::info const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawRect):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase setWebPage:]):

Canonical link: <a href="https://commits.webkit.org/308012@main">https://commits.webkit.org/308012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42412572292f2de917690b6dbf465925b6516e0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99697 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112530 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93400 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/145562 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14150 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123716 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157224 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120555 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30954 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74468 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7763 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82102 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->