### PR TITLE
[threaded-animations] remote timeline may not get preserved in update where a new animation uses it

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2500,4 +2500,6 @@ webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.ht
 
 webkit.org/b/308326 [ Debug ] imported/w3c/web-platform-tests/fetch/api/basic/error-after-response.any.html [ Pass Failure ]
 
+webkit.org/b/308430 webanimations/threaded-animations/accelerated-timeline-preservation-during-update.html [ Pass Crash ]
+
 webkit.org/b/308334 [ Tahoe Debug ] http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration.html [ Skip ]

--- a/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Removing an animation and creating an animation that both used the same timeline in the same update preserves the shared timeline.
+

--- a/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update.html
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+.target {
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div class="target" id="a"></div>
+<div class="target" id="b"></div>
+<div class="target" id="c"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const duration = 1000 * 1000;
+const animate = id => document.getElementById(id).animate({ opacity: 0 }, { duration, id });
+
+const assertRemoteAnimationExists = async animation => {
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(animation.effect.target);
+    assert_equals(remoteAnimationStack.animations.length, 1, `We have a remote animation for the target of animation ${animation.id}`);
+};
+
+promise_test(async t => {
+    const a = animate("a");
+    await animationAcceleration(a);
+    await assertRemoteAnimationExists(a);
+
+    // Create an update where the existing animation will first be removed and a new animation
+    // will be started, both using the same timeline (the default document timeline).
+    a.cancel();
+    const b = animate("b");
+    await animationAcceleration(b);
+    await assertRemoteAnimationExists(b);
+}, "Removing an animation and creating an animation that both used the same timeline in the same update preserves the shared timeline.");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -44,7 +44,7 @@ public:
     const AcceleratedEffects& backdropLayerEffects() const { return m_backdropLayerEffects; }
     void setEffects(AcceleratedEffects&&);
 
-    const AcceleratedEffectValues& baseValues() { return m_baseValues; }
+    const AcceleratedEffectValues& baseValues() const { return m_baseValues; }
     void setBaseValues(AcceleratedEffectValues&&);
 
     virtual ~AcceleratedEffectStack() = default;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -542,7 +542,7 @@ public:
     virtual void markFrontBufferVolatileForTesting() { }
 
 #if ENABLE(THREADED_ANIMATIONS)
-    AcceleratedEffectStack* acceleratedEffectStack() const { return m_effectStack.get(); }
+    const AcceleratedEffectStack* acceleratedEffectStack() const { return m_effectStack.get(); }
     WEBCORE_EXPORT virtual void setAcceleratedEffectsAndBaseValues(AcceleratedEffects&&, AcceleratedEffectValues&&);
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4517,6 +4517,11 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const GraphicsLayerAn
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
+const AcceleratedEffectStack* RenderLayerBacking::acceleratedEffectStack() const
+{
+    return m_graphicsLayer->acceleratedEffectStack();
+}
+
 void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<AcceleratedTimeline>>& timelines)
 {
     auto& renderer = this->renderer();

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -48,6 +48,7 @@ class TiledBacking;
 class TransformationMatrix;
 
 #if ENABLE(THREADED_ANIMATIONS)
+class AcceleratedEffectStack;
 class AcceleratedTimeline;
 #endif
 
@@ -196,6 +197,7 @@ public:
     void resumeAnimations();
 
 #if ENABLE(THREADED_ANIMATIONS)
+    const AcceleratedEffectStack* acceleratedEffectStack() const;
     void updateAcceleratedEffectsAndBaseValues(HashSet<Ref<AcceleratedTimeline>>&);
 #endif
 


### PR DESCRIPTION
#### 9fe876d63d4a51281d610347cbc2c9a4de04368b
<pre>
[threaded-animations] remote timeline may not get preserved in update where a new animation uses it
<a href="https://bugs.webkit.org/show_bug.cgi?id=308429">https://bugs.webkit.org/show_bug.cgi?id=308429</a>
<a href="https://rdar.apple.com/170365106">rdar://170365106</a>

Reviewed by Simon Fraser.

We update threaded animations once per page rendering update. This process involves a list of target
Styleable instances that have been marked as dirty during when animations last updated. That list is
processed in `AcceleratedEffectStackUpdater::update()` where we create a current list of accelerated
effects for this styleable&apos;s associated graphics layer, replacing the existing list of accelerated
effects by creating a new `AcceleratedEffectStack`.

The `AcceleratedEffectStack` keeps a strong reference to its `AcceleratedEffect` instances, which in
turn keep a strong reference to its `AcceleratedTimeline` instance.

This means that during the call to `AcceleratedEffectStackUpdater::update()`, as accelerated effect
stacks are replaced, accelerated effects and their associated timelines may get destroyed. Then, when
layer tree commit will occur, `AcceleratedTimelinesUpdater::takeTimelinesUpdate()` will identify
which `AcceleratedTimeline` instances are no longer in use and mark them for deletion when the remote
layer tree processes that update.

Consider the case where an existing animation A is running on target A. In a later page rendering update,
that animation A will have been canceled as a new animation B will be started on target B. Both animations
may be associated with the same timeline, as is common with monotonic animations which will use the
default document timeline. During the call to `AcceleratedEffectStackUpdater::update()`, target A may be
processed first, causing its accelerated effect stack to be cleared and its accelerated effect – and associated
timeline – to be destroyed. During that same function, as target B gets processed, a new accelerated effect
is created and a new `AcceleratedTimeline` will be created, using the same identifier as the accelerated
timeline that was just destroyed because they are the accelerated representation of the same, persistent
`DocumentTimeline`.

As a result, that timeline identifier will be marked for deletion and we will fail the timeline lookup in
`RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues()`, causing a crash.

We fix this issue by keeping a list of strong references to all effects previously associated with the targets
processed during a call to `AcceleratedEffectStackUpdater::update()`. This way, the accelerated effects that are
no longer current will be destroyed in a batch as that function ends, making sure in the scenario described above
that when we process target B, the accelerated timeline that was used for target A remains alive. As a result,
during this update, no timeline is marked for either creation or destruction.

To support this, we need to expose the `AcceleratedEffectStack` through `RenderLayerBacking`. Doing so made it
clear that existing accessors on `GraphicsLayer` should have return a const pointer, so we make those changes
as well.

This uncovered a reproducible deadlock when running this new test over multiple iterations, covered by bug 308430,
which we will address separately.

Test: webanimations/threaded-animations/accelerated-timeline-preservation-during-update.html

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update.html: Added.
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::update):
* Source/WebCore/platform/animation/AcceleratedEffectStack.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::acceleratedEffectStack const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::acceleratedEffectStack const):
* Source/WebCore/rendering/RenderLayerBacking.h:

Canonical link: <a href="https://commits.webkit.org/308011@main">https://commits.webkit.org/308011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c54144086e3f991b9a5b1bb6d2f4bef6bb4173a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146244 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99704 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4d9384e-f896-468e-9d67-cf7970171496) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112534 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/806f54e4-d4e0-44ee-9c8b-5c2d50198533) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14894 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93404 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd64acb8-da31-45dc-90db-8d00b36af887) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11910 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2357 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157232 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120561 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120861 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74482 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7804 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82110 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18090 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->