### PR TITLE
[EvaluationTimeZoom] Convert `border-radius` property to evaluation time zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius-expected.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 10px;
+  margin: 10px;
+  width: max-content;
+}
+
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  border: solid black 1px;
+}
+
+#container-zoomed {
+  display: inline-block;
+  width: 400px;
+  height: 200px;
+  border: solid black 2px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching border radii.</p> 
+<div class="group">
+  <div id="container" style="border-radius: 20px;">
+  </div>
+  <div style="display: inline-block; border-radius: 20px;">
+    <div id="container" style="border-radius: 20px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div id="container-zoomed" style="border-radius: 40px;">
+  </div>
+  <div style="display: inline-block;">
+    <div id="container-zoomed" style="border-radius: 40px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to border-radius</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/border-radius-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 10px;
+  margin: 10px;
+  width: max-content;
+}
+
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  border: solid black 1px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching border radii.</p> 
+<div class="group">
+  <div id="container" style="border-radius: 20px; zoom: 1;">
+  </div>
+  <div style="display: inline-block; border-radius: 20px;">
+    <div id="container" style="border-radius: inherit; zoom: 1;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div id="container" style="border-radius: 20px; zoom: 2;">
+  </div>
+  <div style="display: inline-block; border-radius: 20px;">
+    <div id="container" style="border-radius: inherit; zoom: 2;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-radius-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-radius-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 10px;
+  margin: 10px;
+  width: max-content;
+}
+
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  border: solid black 1px;
+}
+
+#container-zoomed {
+  display: inline-block;
+  width: 400px;
+  height: 200px;
+  border: solid black 2px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two boxes with matching border radii.</p> 
+<div class="group">
+  <div id="container" style="border-radius: 20px;">
+  </div>
+  <div style="display: inline-block; border-radius: 20px;">
+    <div id="container" style="border-radius: 20px;">
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div id="container-zoomed" style="border-radius: 40px;">
+  </div>
+  <div style="display: inline-block;">
+    <div id="container-zoomed" style="border-radius: 40px;">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -76,12 +76,12 @@ template<SupportWebKitBorderRadiusQuirk supportQuirk> static std::optional<CSS::
     // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
     // https://drafts.csswg.org/css-backgrounds/#propdef-border-radius
 
-    using OptionalRadiiForAxis = std::array<std::optional<CSS::LengthPercentage<CSS::Nonnegative>>, 4>;
+    using OptionalRadiiForAxis = std::array<std::optional<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>, 4>;
 
     OptionalRadiiForAxis horizontalRadii;
     unsigned i = 0;
     for (; i < 4 && !range.atEnd() && range.peek().type() != DelimiterToken; ++i) {
-        horizontalRadii[i] = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(range, state);
+        horizontalRadii[i] = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state);
         if (!horizontalRadii[i])
             return { };
     }
@@ -117,7 +117,7 @@ template<SupportWebKitBorderRadiusQuirk supportQuirk> static std::optional<CSS::
 
     OptionalRadiiForAxis verticalRadii;
     for (unsigned i = 0; i < 4 && !range.atEnd(); ++i) {
-        verticalRadii[i] = MetaConsumer<CSS::LengthPercentage<CSS::Nonnegative>>::consume(range, state);
+        verticalRadii[i] = MetaConsumer<CSS::LengthPercentage<CSS::NonnegativeUnzoomed>>::consume(range, state);
         if (!verticalRadii[i])
             return { };
     }

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -1263,7 +1263,7 @@ template<typename T, typename... Ts>
     requires (WTF::all<std::convertible_to<Ts, T>...>)
 SpaceSeparatedArray(T, Ts...) -> SpaceSeparatedArray<T, 1 + sizeof...(Ts)>;
 
-template<size_t I, typename T, size_t N> decltype(auto) get(const SpaceSeparatedArray<T, N>& array)
+template<size_t I, typename T, size_t N> constexpr decltype(auto) get(const SpaceSeparatedArray<T, N>& array)
 {
     return std::get<I>(array.value);
 }
@@ -1273,6 +1273,16 @@ template<typename T, size_t N> inline constexpr auto SerializationSeparator<Spac
 
 // Convenience for representing a two element array.
 template<typename T> using SpaceSeparatedPair = SpaceSeparatedArray<T, 2>;
+
+template<typename T> constexpr void transpose(SpaceSeparatedPair<T>& value)
+{
+    std::swap(value.value[0], value.value[1]);
+}
+
+template<typename T> constexpr SpaceSeparatedPair<T> transposed(const SpaceSeparatedPair<T>& value)
+{
+    return { value.value[1], value.value[0] };
+}
 
 // Wraps a pair of elements of a single type, semantically marking them as serializing as "space separated" and "minimally serializing".
 template<typename T> struct MinimallySerializingSpaceSeparatedPair {
@@ -1294,10 +1304,13 @@ template<typename T> struct MinimallySerializingSpaceSeparatedPair {
     constexpr const T& first() const { return get<0>(value); }
     constexpr const T& second() const { return get<1>(value); }
 
+    constexpr void transpose() { WebCore::transpose(value); }
+    constexpr MinimallySerializingSpaceSeparatedPair<T> transposed() const { return WebCore::transposed(value); }
+
     SpaceSeparatedPair<T> value;
 };
 
-template<size_t I, typename T> decltype(auto) get(const MinimallySerializingSpaceSeparatedPair<T>& size)
+template<size_t I, typename T> constexpr decltype(auto) get(const MinimallySerializingSpaceSeparatedPair<T>& size)
 {
     return get<I>(size.value);
 }
@@ -1425,13 +1438,16 @@ template<typename T> struct SpaceSeparatedPoint {
 
     constexpr bool operator==(const SpaceSeparatedPoint<T>&) const = default;
 
-    const T& x() const { return get<0>(value); }
-    const T& y() const { return get<1>(value); }
+    constexpr const T& x() const { return get<0>(value); }
+    constexpr const T& y() const { return get<1>(value); }
+
+    constexpr void transpose() { WebCore::transpose(value); }
+    constexpr SpaceSeparatedPoint<T> transposed() const { return WebCore::transposed(value); }
 
     SpaceSeparatedPair<T> value;
 };
 
-template<size_t I, typename T> decltype(auto) get(const SpaceSeparatedPoint<T>& point)
+template<size_t I, typename T> constexpr decltype(auto) get(const SpaceSeparatedPoint<T>& point)
 {
     return get<I>(point.value);
 }
@@ -1456,13 +1472,16 @@ template<typename T> struct SpaceSeparatedSize {
 
     constexpr bool operator==(const SpaceSeparatedSize<T>&) const = default;
 
-    const T& width() const { return get<0>(value); }
-    const T& height() const { return get<1>(value); }
+    constexpr const T& width() const { return get<0>(value); }
+    constexpr const T& height() const { return get<1>(value); }
+
+    constexpr void transpose() { WebCore::transpose(value); }
+    constexpr SpaceSeparatedSize<T> transposed() const { return WebCore::transposed(value); }
 
     SpaceSeparatedPair<T> value;
 };
 
-template<size_t I, typename T> decltype(auto) get(const SpaceSeparatedSize<T>& size)
+template<size_t I, typename T> constexpr decltype(auto) get(const SpaceSeparatedSize<T>& size)
 {
     return get<I>(size.value);
 }
@@ -1492,13 +1511,16 @@ template<typename T> struct MinimallySerializingSpaceSeparatedPoint {
 
     constexpr bool operator==(const MinimallySerializingSpaceSeparatedPoint<T>&) const = default;
 
-    const T& x() const { return get<0>(value); }
-    const T& y() const { return get<1>(value); }
+    constexpr const T& x() const { return get<0>(value); }
+    constexpr const T& y() const { return get<1>(value); }
+
+    constexpr void transpose() { WebCore::transpose(value); }
+    constexpr MinimallySerializingSpaceSeparatedPoint<T> transposed() const { return WebCore::transposed(value); }
 
     SpaceSeparatedPair<T> value;
 };
 
-template<size_t I, typename T> decltype(auto) get(const MinimallySerializingSpaceSeparatedPoint<T>& point)
+template<size_t I, typename T> constexpr decltype(auto) get(const MinimallySerializingSpaceSeparatedPoint<T>& point)
 {
     return get<I>(point.value);
 }
@@ -1532,10 +1554,13 @@ template<typename T> struct MinimallySerializingSpaceSeparatedSize {
     constexpr const T& width() const { return get<0>(value); }
     constexpr const T& height() const { return get<1>(value); }
 
+    constexpr void transpose() { WebCore::transpose(value); }
+    constexpr MinimallySerializingSpaceSeparatedSize<T> transposed() const { return WebCore::transposed(value); }
+
     SpaceSeparatedPair<T> value;
 };
 
-template<size_t I, typename T> decltype(auto) get(const MinimallySerializingSpaceSeparatedSize<T>& size)
+template<size_t I, typename T> constexpr decltype(auto) get(const MinimallySerializingSpaceSeparatedSize<T>& size)
 {
     return get<I>(size.value);
 }

--- a/Source/WebCore/css/values/borders/CSSBorderRadius.cpp
+++ b/Source/WebCore/css/values/borders/CSSBorderRadius.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 namespace CSS {
 
-static bool hasDefaultValueForAxis(const SpaceSeparatedArray<LengthPercentage<Nonnegative>, 4>& values)
+static bool hasDefaultValueForAxis(const SpaceSeparatedArray<LengthPercentage<NonnegativeUnzoomed>, 4>& values)
 {
     return values.value[3] == values.value[1]
         && values.value[2] == values.value[0]
@@ -44,11 +44,11 @@ bool hasDefaultValue(const BorderRadius& borderRadius)
     return hasDefaultValueForAxis(borderRadius.horizontal) && hasDefaultValueForAxis(borderRadius.vertical);
 }
 
-static std::pair<SpaceSeparatedVector<LengthPercentage<Nonnegative>, 4>, bool> gatherSerializableRadiiForAxis(const SpaceSeparatedArray<LengthPercentage<Nonnegative>, 4>& values)
+static std::pair<SpaceSeparatedVector<LengthPercentage<NonnegativeUnzoomed>, 4>, bool> gatherSerializableRadiiForAxis(const SpaceSeparatedArray<LengthPercentage<NonnegativeUnzoomed>, 4>& values)
 {
     bool isDefaultValue = false;
 
-    SpaceSeparatedVector<LengthPercentage<Nonnegative>, 4>::Container result;
+    SpaceSeparatedVector<LengthPercentage<NonnegativeUnzoomed>, 4>::Container result;
     result.append(values.value[0]);
 
     if (values.value[3] != values.value[1]) {

--- a/Source/WebCore/css/values/borders/CSSBorderRadius.h
+++ b/Source/WebCore/css/values/borders/CSSBorderRadius.h
@@ -32,8 +32,8 @@ namespace CSS {
 // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
 // https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius
 struct BorderRadius {
-    using Axis = SpaceSeparatedArray<LengthPercentage<Nonnegative>, 4>;
-    using Corner = MinimallySerializingSpaceSeparatedSize<LengthPercentage<Nonnegative>>;
+    using Axis = SpaceSeparatedArray<LengthPercentage<NonnegativeUnzoomed>, 4>;
+    using Corner = MinimallySerializingSpaceSeparatedSize<LengthPercentage<NonnegativeUnzoomed>>;
 
     static BorderRadius defaultValue();
 

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -557,7 +557,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(const Render
 
     if (auto basicShapePath = style->clipPath().tryBasicShape(); !hasRotationOrShear && originalElement && basicShapePath) {
         auto size = boundingSize(regionRenderer, transform);
-        auto path = Style::tryPath(*basicShapePath, TransformOperationData(FloatRect(FloatPoint(), size)));
+        auto path = Style::tryPath(*basicShapePath, TransformOperationData(FloatRect(FloatPoint(), size)), style->usedZoomForLength());
 
         if (path && !clipOffset.isZero())
             path->translate(clipOffset);

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -121,7 +121,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
     rotate = Style::toPlatform(style.rotate(), borderBoxSize);
 
     if (!style.offsetPath().isNone() && transformOperationData) {
-        if (auto path = Style::tryPath(style.offsetPath(), *transformOperationData)) {
+        if (auto path = Style::tryPath(style.offsetPath(), *transformOperationData, style.usedZoomForLength())) {
             transformOrigin = { .value = Style::TransformResolver::computeTransformOrigin(style, transformOperationData->boundingBox).xy() };
             offsetPath = Style::toPlatform(style.offsetPath());
             offsetDistance = Style::evaluate<AcceleratedEffectOffsetDistance>(style.offsetDistance(), path->length(), Style::ZoomNeeded { });
@@ -163,7 +163,8 @@ TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const
 
     // 6. Translate and rotate by the transform specified by offset.
     if (transformOperationData && offsetPath) {
-        if (auto path = Style::tryPath(Style::OffsetPath { *offsetPath }, *transformOperationData)) {
+        // Passing the special `none` zoom factor is correct here as zoom was previously applied when `offsetPath` was initialized.
+        if (auto path = Style::tryPath(Style::OffsetPath { *offsetPath }, *transformOperationData, Style::ZoomFactor::none())) {
             // FIXME: This transform of `transformOrigin` is not present in the overload of MotionPath::applyMotionPathTransform() that takes a `RenderStyle`.
             auto computedTransformOrigin = boundingBox.location() + transformOrigin.value;
 

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -60,7 +60,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
     };
 
     if (style.border().hasBorderRadius()) {
-        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
+        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
         radii.scale(calcBorderRadiiConstraintScaleFor(borderRect, radii));
 
         if (!closedEdges.top()) {
@@ -100,7 +100,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
     };
 
     if (style.border().hasBorderRadius()) {
-        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
+        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
 
         auto leftOutset = std::max(borderRect.x() - outlineBoxRect.x(), 0_lu);
         auto topOutset = std::max(borderRect.y() - outlineBoxRect.y(), 0_lu);
@@ -139,7 +139,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
 BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
 {
     if (style.border().hasBorderRadius()) {
-        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
+        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
 
         auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);
         auto topInset = std::max(insetRect.y()- borderRect.y(), 0_lu);

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -221,7 +221,7 @@ static FloatPoint currentOffsetForData(const MotionPathData& data)
     return FloatPoint(data.usedStartingPosition - data.offsetFromContainingBlock);
 }
 
-std::optional<Path> MotionPath::computePathForRay(const RayPathOperation& rayPathOperation, const TransformOperationData& transformData)
+std::optional<Path> MotionPath::computePathForRay(const RayPathOperation& rayPathOperation, const TransformOperationData& transformData, Style::ZoomFactor)
 {
     auto motionPathData = transformData.motionPathData;
     if (!motionPathData || motionPathData->containingBlockBoundingRect.rect().isZero())
@@ -250,7 +250,7 @@ static FloatRoundedRect offsetRectForData(const MotionPathData& data)
     return rect;
 }
 
-std::optional<Path> MotionPath::computePathForBox(const BoxPathOperation&, const TransformOperationData& transformData)
+std::optional<Path> MotionPath::computePathForBox(const BoxPathOperation&, const TransformOperationData& transformData, Style::ZoomFactor)
 {
     if (auto motionPathData = transformData.motionPathData) {
         Path path;
@@ -260,7 +260,7 @@ std::optional<Path> MotionPath::computePathForBox(const BoxPathOperation&, const
     return std::nullopt;
 }
 
-std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pathOperation, const TransformOperationData& transformData)
+std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pathOperation, const TransformOperationData& transformData, Style::ZoomFactor zoom)
 {
     if (auto motionPathData = transformData.motionPathData) {
         auto containingBlockRect = offsetRectForData(*motionPathData).rect();
@@ -268,14 +268,14 @@ std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pa
             [&]<Style::ShapeWithCenterCoordinate T>(const T& shape) -> std::optional<Path> {
                 if (!shape->position)
                     return Style::pathForCenterCoordinate(*shape, containingBlockRect, motionPathData->usedStartingPosition);
-                return Style::path(shape, containingBlockRect);
+                return Style::path(shape, containingBlockRect, zoom);
             },
             [&](const auto& shape) -> std::optional<Path> {
-                return Style::path(shape, containingBlockRect);
+                return Style::path(shape, containingBlockRect, zoom);
             }
         );
     }
-    return pathOperation.pathForReferenceRect(transformData.boundingBox);
+    return pathOperation.pathForReferenceRect(transformData.boundingBox, zoom);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -38,6 +38,10 @@ class ShapePathOperation;
 
 struct TransformOperationData;
 
+namespace Style {
+struct ZoomFactor;
+}
+
 struct MotionPathData {
     FloatRoundedRect containingBlockBoundingRect;
     FloatPoint offsetFromContainingBlock;
@@ -51,9 +55,9 @@ public:
 
     static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, FloatPoint transformOrigin, TransformBox, const Path&, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto);
 
-    static std::optional<Path> computePathForBox(const BoxPathOperation&, const TransformOperationData&);
-    static std::optional<Path> computePathForShape(const ShapePathOperation&, const TransformOperationData&);
-    static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&);
+    static std::optional<Path> computePathForBox(const BoxPathOperation&, const TransformOperationData&, Style::ZoomFactor);
+    static std::optional<Path> computePathForShape(const ShapePathOperation&, const TransformOperationData&, Style::ZoomFactor);
+    static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&, Style::ZoomFactor);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/OutlinePainter.h
+++ b/Source/WebCore/rendering/OutlinePainter.h
@@ -56,7 +56,7 @@ private:
     static void collectFocusRingRectsForInlineChildren(const RenderBlockFlow&, Vector<LayoutRect>&, const LayoutPoint&, const RenderLayerModelObject*);
     static void collectFocusRingRectsForChildBox(const RenderBox&, Vector<LayoutRect>&, const LayoutPoint&, const RenderLayerModelObject*);
 
-    static Path pathWithShrinkWrappedRects(const Vector<FloatRect>&, const Style::BorderRadius&, float outlineOffset, WritingMode, float deviceScaleFactor);
+    static Path pathWithShrinkWrappedRects(const Vector<FloatRect>&, const Style::BorderRadius&, float outlineOffset, WritingMode, Style::ZoomFactor, float deviceScaleFactor);
 
     void addPDFURLAnnotationForLink(const RenderElement&, const LayoutPoint& paintOffset) const;
 

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -98,9 +98,9 @@ RefPtr<PathOperation> ShapePathOperation::blend(const PathOperation* to, const B
     return ShapePathOperation::create(WebCore::Style::blend(m_shape, toShapePathOperation->m_shape, context));
 }
 
-std::optional<Path> ShapePathOperation::getPath(const TransformOperationData& data) const
+std::optional<Path> ShapePathOperation::getPath(const TransformOperationData& data, Style::ZoomFactor zoom) const
 {
-    return MotionPath::computePathForShape(*this, data);
+    return MotionPath::computePathForShape(*this, data, zoom);
 }
 
 // MARK: - BoxPathOperation
@@ -115,9 +115,9 @@ Ref<PathOperation> BoxPathOperation::clone() const
     return adoptRef(*new BoxPathOperation(referenceBox()));
 }
 
-std::optional<Path> BoxPathOperation::getPath(const TransformOperationData& data) const
+std::optional<Path> BoxPathOperation::getPath(const TransformOperationData& data, Style::ZoomFactor zoom) const
 {
-    return MotionPath::computePathForBox(*this, data);
+    return MotionPath::computePathForBox(*this, data, zoom);
 }
 
 // MARK: - RayPathOperation
@@ -149,9 +149,9 @@ RefPtr<PathOperation> RayPathOperation::blend(const PathOperation* to, const Ble
     return RayPathOperation::create(Style::blend(m_ray, toRayPathOperation->m_ray, context), m_referenceBox);
 }
 
-std::optional<Path> RayPathOperation::getPath(const TransformOperationData& data) const
+std::optional<Path> RayPathOperation::getPath(const TransformOperationData& data, Style::ZoomFactor zoom) const
 {
-    return MotionPath::computePathForRay(*this, data);
+    return MotionPath::computePathForRay(*this, data, zoom);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -62,7 +62,7 @@ public:
 
     virtual bool canBlend(const PathOperation&) const { return false; }
     virtual RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const { return nullptr; }
-    virtual std::optional<Path> getPath(const TransformOperationData&) const = 0;
+    virtual std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const = 0;
 
     Type type() const { return m_type; }
 
@@ -96,7 +96,7 @@ public:
     const Style::URL& url() const { return m_url; }
     const AtomString& fragment() const { return m_fragment; }
 
-    std::optional<Path> getPath(const TransformOperationData&) const final { return m_path; }
+    std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final { return m_path; }
     std::optional<Path> path() const { return m_path; }
 
     bool operator==(const ReferencePathOperation& other) const
@@ -131,9 +131,9 @@ public:
 
     const Style::BasicShape& shape() const { return m_shape; }
     WindRule windRule() const { return Style::windRule(m_shape); }
-    Path pathForReferenceRect(const FloatRect& boundingRect) const { return Style::path(m_shape, boundingRect); }
+    Path pathForReferenceRect(const FloatRect& boundingRect, Style::ZoomFactor zoom) const { return Style::path(m_shape, boundingRect, zoom); }
 
-    std::optional<Path> getPath(const TransformOperationData&) const final;
+    std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final;
 
     bool operator==(const ShapePathOperation& other) const
     {
@@ -164,7 +164,7 @@ public:
 
     Ref<PathOperation> clone() const final;
 
-    std::optional<Path> getPath(const TransformOperationData&) const final;
+    std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final;
 
     bool operator==(const BoxPathOperation& other) const
     {
@@ -199,7 +199,7 @@ public:
 
     double lengthForPath() const;
     double lengthForContainPath(const FloatRect& elementRect, double computedPathLength) const;
-    std::optional<Path> getPath(const TransformOperationData&) const final;
+    std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final;
 
     bool operator==(const RayPathOperation& other) const
     {

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1609,9 +1609,7 @@ bool RenderBox::hitTestClipPath(const HitTestLocation& hitTestLocation, const La
 
     return WTF::switchOn(style().clipPath(),
         [&](const Style::BasicShapePath& clipPath) {
-            auto& shape = clipPath.shape();
-            auto path = Style::path(shape, referenceBoxRect(clipPath.referenceBox()));
-            return path.contains(hitTestLocationInLocalCoordinates, Style::windRule(shape));
+            return Style::path(clipPath.shape(), referenceBoxRect(clipPath.referenceBox()), style().usedZoomForLength()).contains(hitTestLocationInLocalCoordinates, Style::windRule(clipPath.shape()));
         },
         [&](const Style::ReferencePath& clipPath) {
             RefPtr element = document().getElementById(clipPath.fragment());

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1522,8 +1522,11 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
     // It's not really correct to do math here with oldOutlineBoundsRect/newOutlineBoundsRect and local shadow/radius values, since
     // oldOutlineBoundsRect/newOutlineBoundsRect are in the coordinate space of the repaint container, and have been mapped through ancestor transforms.
 
-    const RenderStyle& outlineStyle = outlineStyleForRepaint();
+    auto& outlineStyle = outlineStyleForRepaint();
+
     auto& style = this->style();
+    auto zoom = style.usedZoomForLength();
+
     auto outlineWidth = LayoutUnit { outlineStyle.usedOutlineSize() };
     auto insetShadowExtent = Style::shadowInsetExtent(style.boxShadow(), style.usedZoomForLength());
     auto sizeDelta = LayoutSize { absoluteValue(newOutlineBoundsRect.width() - oldOutlineBoundsRect.width()), absoluteValue(newOutlineBoundsRect.height() - oldOutlineBoundsRect.height()) };
@@ -1539,8 +1542,8 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxWidth = renderBox->width();
                 return std::max({
                     renderBox->borderRight(),
-                    Style::evaluate<LayoutUnit>(style.borderTopRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
-                    Style::evaluate<LayoutUnit>(style.borderBottomRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
+                    Style::evaluate<LayoutUnit>(style.borderTopRightRadius().width(), borderBoxWidth, zoom),
+                    Style::evaluate<LayoutUnit>(style.borderBottomRightRadius().width(), borderBoxWidth, zoom),
                 });
             };
             auto outlineRightInsetExtent = [&] -> LayoutUnit {
@@ -1583,8 +1586,8 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxHeight = renderBox->height();
                 return std::max({
                     renderBox->borderBottom(),
-                    Style::evaluate<LayoutUnit>(style.borderBottomLeftRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
-                    Style::evaluate<LayoutUnit>(style.borderBottomRightRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
+                    Style::evaluate<LayoutUnit>(style.borderBottomLeftRadius().height(), borderBoxHeight, zoom),
+                    Style::evaluate<LayoutUnit>(style.borderBottomRightRadius().height(), borderBoxHeight, zoom),
                 });
             };
             auto outlineBottomInsetExtent = [&] -> LayoutUnit {

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3502,7 +3502,7 @@ std::pair<Path, WindRule> RenderLayer::computeClipPath(const LayoutSize& offsetF
         [&](const Style::BasicShapePath& clipPath) -> std::pair<Path, WindRule> {
             auto referenceBoxRect = referenceBoxRectForClipPath(clipPath.referenceBox(), offsetFromRoot, rootRelativeBoundsForNonBoxes);
             auto snappedReferenceBoxRect = snapRectToDevicePixelsIfNeeded(referenceBoxRect, renderer());
-            return { Style::path(clipPath.shape(), snappedReferenceBoxRect), Style::windRule(clipPath.shape()) };
+            return { Style::path(clipPath.shape(), snappedReferenceBoxRect, style.usedZoomForLength()), Style::windRule(clipPath.shape()) };
         },
         [&](const Style::BoxPath& clipPath) -> std::pair<Path, WindRule> {
             CheckedPtr box = dynamicDowncast<RenderBox>(renderer());

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -653,7 +653,7 @@ bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) con
             auto referenceBox = clipPathReferenceBox(clipPath.referenceBox());
             if (!referenceBox.contains(point))
                 return false;
-            return Style::path(clipPath.shape(), referenceBox).contains(point, Style::windRule(clipPath.shape()));
+            return Style::path(clipPath.shape(), referenceBox, style().usedZoomForLength()).contains(point, Style::windRule(clipPath.shape()));
         },
         [&](const Style::BoxPath& clipPath) {
             auto referenceBox = clipPathReferenceBox(clipPath.referenceBox());

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -329,7 +329,7 @@ void RenderThemeCocoa::adjustApplePayButtonStyle(RenderStyle& style, const Eleme
     style.setMinHeight(Style::MinimumSize::Fixed { applePayButtonMinimumHeight });
 
     if (!style.hasExplicitlySetBorderRadius()) {
-        auto radius = Style::LengthPercentage<CSS::Nonnegative>::Dimension { static_cast<float>(PKApplePayButtonDefaultCornerRadius) };
+        auto radius = Style::LengthPercentage<CSS::NonnegativeUnzoomed>::Dimension { static_cast<float>(PKApplePayButtonDefaultCornerRadius) };
         style.setBorderRadius({ radius, radius });
     }
 }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1417,11 +1417,13 @@ void RenderThemeMac::adjustMenuListButtonStyle(RenderStyle& style, const Element
 #else
     UNUSED_PARAM(element);
 #endif
-    float fontScale = style.computedFontSize() / baseFontSize;
+
+    auto usedZoom = style.usedZoomForLength();
+    float fontScale = style.computedFontSize() / baseFontSize / usedZoom.value;
 
     style.resetPadding();
 
-    auto radius = Style::LengthPercentage<CSS::Nonnegative>::Dimension { std::trunc(baseBorderRadius + fontScale - 1) }; // FIXME: Round up?
+    auto radius = Style::LengthPercentage<CSS::NonnegativeUnzoomed>::Dimension { std::trunc(baseBorderRadius + fontScale - 1) }; // FIXME: Round up?
     style.setBorderRadius({ radius, radius });
 
     style.setMinHeight(18_css_px);

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -91,7 +91,7 @@ static inline FloatSize physicalSizeToLogical(const FloatSize& size, WritingMode
     return size.transposedSize();
 }
 
-Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicShape, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode writingMode, float logicalMargin)
+Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicShape, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode writingMode, float logicalMargin, Style::ZoomFactor zoom)
 {
     bool horizontalWritingMode = writingMode.isHorizontal();
     float boxWidth = horizontalWritingMode ? logicalBoxSize.width() : logicalBoxSize.height();
@@ -136,10 +136,10 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
 
             auto boxSize = FloatSize(boxWidth, boxHeight);
             auto isBlockLeftToRight = writingMode.isBlockLeftToRight();
-            auto topLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto topRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto topLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, zoom), writingMode);
+            auto topRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, zoom), writingMode);
+            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, zoom), writingMode);
+            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, zoom), writingMode);
             auto cornerRadii = CornerRadii(topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius);
             if (shouldFlipStartAndEndPoints(writingMode))
                 cornerRadii = { cornerRadii.topRight(), cornerRadii.topLeft(), cornerRadii.bottomRight(), cornerRadii.bottomLeft() };

--- a/Source/WebCore/rendering/shapes/LayoutShape.h
+++ b/Source/WebCore/rendering/shapes/LayoutShape.h
@@ -37,6 +37,13 @@
 
 namespace WebCore {
 
+namespace Style {
+struct ZoomFactor;
+}
+
+class Image;
+class LayoutRoundedRect;
+
 struct LineSegment {
     LineSegment() = default;
 
@@ -52,9 +59,6 @@ struct LineSegment {
     bool isValid { false };
 };
 
-class Image;
-class LayoutRoundedRect;
-
 // A representation of a BasicShape that enables layout code to determine how to break a line up into segments
 // that will fit within or around a shape. The line is defined by a pair of logical Y coordinates and the
 // computed segments are returned as pairs of logical X coordinates. The BasicShape itself is defined in
@@ -67,7 +71,7 @@ public:
         Path marginShape;
     };
 
-    static Ref<const LayoutShape> createShape(const Style::BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float logicalMargin);
+    static Ref<const LayoutShape> createShape(const Style::BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float logicalMargin, Style::ZoomFactor);
     static Ref<const LayoutShape> createRasterShape(Image*, float threshold, const LayoutRect& logicalImageRect, const LayoutRect& logicalMarginRect, WritingMode, float logicalMargin);
     static Ref<const LayoutShape> createBoxShape(const LayoutRoundedRect&, WritingMode, float logicalMargin);
 

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -264,11 +264,11 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
     return WTF::switchOn(shapeOutside,
         [&](const Style::ShapeOutside::Shape& shape) {
             auto offset = LayoutPoint { logicalLeftOffset(renderer), logicalTopOffset(renderer) };
-            return LayoutShape::createShape(shape, offset, boxSize, writingMode, logicalMargin);
+            return LayoutShape::createShape(shape, offset, boxSize, writingMode, logicalMargin, style.usedZoomForLength());
         },
         [&](const Style::ShapeOutside::ShapeAndShapeBox& shapeAndShapeBox) {
             auto offset = LayoutPoint { logicalLeftOffset(renderer), logicalTopOffset(renderer) };
-            return LayoutShape::createShape(shapeAndShapeBox.shape, offset, boxSize, writingMode, logicalMargin);
+            return LayoutShape::createShape(shapeAndShapeBox.shape, offset, boxSize, writingMode, logicalMargin, style.usedZoomForLength());
         },
         [&](const Style::ShapeOutside::Image& shapeImage) {
             ASSERT(shapeImage.isValid());

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -458,7 +458,7 @@ inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatP
             auto referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
             if (!referenceBox.contains(point))
                 return false;
-            return Style::path(clipPath.shape(), referenceBox).contains(point, Style::windRule(clipPath.shape()));
+            return Style::path(clipPath.shape(), referenceBox, renderer.style().usedZoomForLength()).contains(point, Style::windRule(clipPath.shape()));
         },
         [&](const Style::BoxPath& clipPath) {
             auto referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
@@ -481,7 +481,7 @@ void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, co
             auto referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
             referenceBox = localToParentTransform.mapRect(referenceBox);
 
-            auto path = Style::path(clipPath.shape(), referenceBox);
+            auto path = Style::path(clipPath.shape(), referenceBox, renderer.style().usedZoomForLength());
             path.transform(valueOrDefault(localToParentTransform.inverse()));
 
             context.clipPath(path, Style::windRule(clipPath.shape()));

--- a/Source/WebCore/style/StyleTransformResolver.cpp
+++ b/Source/WebCore/style/StyleTransformResolver.cpp
@@ -156,7 +156,7 @@ void TransformResolver::applyCSSTransform(const TransformOperationData& transfor
 
     // 6. Translate and rotate by the transform specified by offset.
     if (options.contains(Option::Offset))
-        applyMotionPathTransform(transformData);
+        applyMotionPathTransform(transformData, m_style->usedZoomForLength());
 
     // 7. Multiply by each of the transform functions in transform from left to right.
     m_style->transform().apply(m_transform, boundingBox.size());
@@ -202,9 +202,9 @@ TransformationMatrix TransformResolver::computeTransform(const RenderStyle& styl
     return computeTransform(computedStyle, transformData, options);
 }
 
-void TransformResolver::applyMotionPathTransform(const TransformOperationData& transformData)
+void TransformResolver::applyMotionPathTransform(const TransformOperationData& transformData, ZoomFactor zoom)
 {
-    auto offsetPath = tryPath(m_style->offsetPath(), transformData);
+    auto offsetPath = tryPath(m_style->offsetPath(), transformData, zoom);
     if (!offsetPath)
         return;
 

--- a/Source/WebCore/style/StyleTransformResolver.h
+++ b/Source/WebCore/style/StyleTransformResolver.h
@@ -89,7 +89,7 @@ public:
     static TransformationMatrix computeTransform(const RenderStyle&, const TransformOperationData&, OptionSet<Option> = allTransformOperations);
 
 private:
-    void applyMotionPathTransform(const TransformOperationData&);
+    void applyMotionPathTransform(const TransformOperationData&, ZoomFactor);
 
     TransformationMatrix& m_transform;
     const CheckedRef<const ComputedStyle> m_style;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -409,7 +409,7 @@ template<typename> struct Shadows;
 
 using Animations = CoordinatedValueList<Animation>;
 using BackgroundLayers = CoordinatedValueList<BackgroundLayer>;
-using BorderRadiusValue = MinimallySerializingSpaceSeparatedSize<LengthPercentage<CSS::Nonnegative>>;
+using BorderRadiusValue = MinimallySerializingSpaceSeparatedSize<LengthPercentage<CSS::NonnegativeUnzoomed>>;
 using BoxShadows = Shadows<BoxShadow>;
 using FlexGrow = Number<CSS::Nonnegative, float>;
 using FlexShrink = Number<CSS::Nonnegative, float>;

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
@@ -78,30 +78,30 @@ auto CSSValueConversion<BorderRadiusValue>::operator()(BuilderState& state, cons
         return { 0_css_px, 0_css_px };
 
     return {
-        toStyleFromCSSValue<LengthPercentage<CSS::Nonnegative>>(state, pair->first),
-        toStyleFromCSSValue<LengthPercentage<CSS::Nonnegative>>(state, pair->second)
+        toStyleFromCSSValue<LengthPercentage<CSS::NonnegativeUnzoomed>>(state, pair->first),
+        toStyleFromCSSValue<LengthPercentage<CSS::NonnegativeUnzoomed>>(state, pair->second)
     };
 }
 
 // MARK: - Evaluation
 
-auto Evaluation<BorderRadius, CornerRadii>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomNeeded token) -> CornerRadii
+auto Evaluation<BorderRadius, CornerRadii>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomFactor zoom) -> CornerRadii
 {
     return {
-        evaluate<FloatSize>(value.topLeft(), referenceSize, token),
-        evaluate<FloatSize>(value.topRight(), referenceSize, token),
-        evaluate<FloatSize>(value.bottomLeft(), referenceSize, token),
-        evaluate<FloatSize>(value.bottomRight(), referenceSize, token),
+        evaluate<FloatSize>(value.topLeft(), referenceSize, zoom),
+        evaluate<FloatSize>(value.topRight(), referenceSize, zoom),
+        evaluate<FloatSize>(value.bottomLeft(), referenceSize, zoom),
+        evaluate<FloatSize>(value.bottomRight(), referenceSize, zoom),
     };
 }
 
-auto Evaluation<BorderRadius, LayoutRoundedRect::Radii>::operator()(const BorderRadius& value, LayoutSize referenceSize, ZoomNeeded token) -> LayoutRoundedRect::Radii
+auto Evaluation<BorderRadius, LayoutRoundedRect::Radii>::operator()(const BorderRadius& value, LayoutSize referenceSize, ZoomFactor zoom) -> LayoutRoundedRect::Radii
 {
     return {
-        evaluate<LayoutSize>(value.topLeft(), referenceSize, token),
-        evaluate<LayoutSize>(value.topRight(), referenceSize, token),
-        evaluate<LayoutSize>(value.bottomLeft(), referenceSize, token),
-        evaluate<LayoutSize>(value.bottomRight(), referenceSize, token),
+        evaluate<LayoutSize>(value.topLeft(), referenceSize, zoom),
+        evaluate<LayoutSize>(value.topRight(), referenceSize, zoom),
+        evaluate<LayoutSize>(value.bottomLeft(), referenceSize, zoom),
+        evaluate<LayoutSize>(value.bottomRight(), referenceSize, zoom),
     };
 }
 

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.h
@@ -35,7 +35,7 @@ class LayoutSize;
 
 namespace Style {
 
-using BorderRadiusValue = MinimallySerializingSpaceSeparatedSize<LengthPercentage<CSS::Nonnegative>>;
+using BorderRadiusValue = MinimallySerializingSpaceSeparatedSize<LengthPercentage<CSS::NonnegativeUnzoomed>>;
 
 // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
 // https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius
@@ -80,10 +80,10 @@ template<> struct CSSValueConversion<BorderRadiusValue> { auto operator()(Builde
 // MARK: - Evaluation
 
 template<> struct Evaluation<BorderRadius, CornerRadii> {
-    auto operator()(const BorderRadius&, FloatSize, ZoomNeeded) -> CornerRadii;
+    auto operator()(const BorderRadius&, FloatSize, ZoomFactor) -> CornerRadii;
 };
 template<> struct Evaluation<BorderRadius, LayoutRoundedRect::Radii> {
-    auto operator()(const BorderRadius&, LayoutSize, ZoomNeeded) -> LayoutRoundedRect::Radii;
+    auto operator()(const BorderRadius&, LayoutSize, ZoomFactor) -> LayoutRoundedRect::Radii;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/masking/StyleClipPath.h
+++ b/Source/WebCore/style/values/masking/StyleClipPath.h
@@ -68,7 +68,7 @@ struct ClipPath {
 private:
     friend struct Blending<ClipPath>;
     friend CSSBoxType referenceBox(const ClipPath&);
-    friend std::optional<WebCore::Path> tryPath(const ClipPath&, const TransformOperationData&);
+    friend std::optional<WebCore::Path> tryPath(const ClipPath&, const TransformOperationData&, ZoomFactor);
 
     static bool isValid(RefPtr<PathOperation> operation)
     {
@@ -78,12 +78,12 @@ private:
     RefPtr<PathOperation> operation;
 };
 
-inline std::optional<WebCore::Path> tryPath(const ClipPath& clipPath, const TransformOperationData& data)
+inline std::optional<WebCore::Path> tryPath(const ClipPath& clipPath, const TransformOperationData& data, ZoomFactor zoom)
 {
     RefPtr operation = clipPath.operation;
     if (!operation)
         return { };
-    return operation->getPath(data);
+    return operation->getPath(data, zoom);
 }
 
 template<typename T> bool ClipPath::holdsAlternative() const

--- a/Source/WebCore/style/values/motion/StyleOffsetPath.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetPath.h
@@ -72,17 +72,17 @@ struct OffsetPath {
 private:
     friend struct Blending<OffsetPath>;
     friend struct ToPlatform<OffsetPath>;
-    friend std::optional<WebCore::Path> tryPath(const OffsetPath&, const TransformOperationData&);
+    friend std::optional<WebCore::Path> tryPath(const OffsetPath&, const TransformOperationData&, ZoomFactor);
 
     RefPtr<PathOperation> operation;
 };
 
-inline std::optional<WebCore::Path> tryPath(const OffsetPath& offsetPath, const TransformOperationData& data)
+inline std::optional<WebCore::Path> tryPath(const OffsetPath& offsetPath, const TransformOperationData& data, ZoomFactor zoom)
 {
     RefPtr operation = offsetPath.operation;
     if (!operation)
         return { };
-    return operation->getPath(data);
+    return operation->getPath(data, zoom);
 }
 
 template<typename T> bool OffsetPath::holdsAlternative() const

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -128,28 +128,41 @@ using AngleAllFloat = Angle<CSS::All, float>;
 
 // Standard Lengths
 using LengthAll = Length<CSS::All>;
+using LengthAllUnzoomed = Length<CSS::AllUnzoomed>;
 using LengthNonnegative = Length<CSS::Nonnegative>;
+using LengthNonnegativeUnzoomed = Length<CSS::NonnegativeUnzoomed>;
 
 // Standard LengthPercentages
 using LengthPercentageAll = LengthPercentage<CSS::All>;
+using LengthPercentageAllUnzoomed = LengthPercentage<CSS::AllUnzoomed>;
 using LengthPercentageNonnegative = LengthPercentage<CSS::Nonnegative>;
+using LengthPercentageNonnegativeUnzoomed = LengthPercentage<CSS::NonnegativeUnzoomed>;
 
 // Standard Percentages
 using PercentageAll = Percentage<CSS::All>;
+using PercentageAllUnzoomed = Percentage<CSS::AllUnzoomed>;
 using PercentageNonnegative = Percentage<CSS::Nonnegative>;
+using PercentageNonnegativeUnzoomed = Percentage<CSS::NonnegativeUnzoomed>;
 using PercentageAllFloat = Percentage<CSS::All, float>;
+using PercentageAllUnzoomedFloat = Percentage<CSS::AllUnzoomed, float>;
 using PercentageNonnegativeFloat = Percentage<CSS::Nonnegative, float>;
-using Percentage0To100 = LengthPercentage<CSS::Range{0,100}>;
+using PercentageNonnegativeUnzoomedFloat = Percentage<CSS::NonnegativeUnzoomed, float>;
 
 // Standard Points
 using LengthPercentageSpaceSeparatedPointAll = SpaceSeparatedPoint<LengthPercentageAll>;
+using LengthPercentageSpaceSeparatedPointAllUnzoomed = SpaceSeparatedPoint<LengthPercentageAllUnzoomed>;
 using LengthPercentageSpaceSeparatedPointNonnegative = SpaceSeparatedPoint<LengthPercentageNonnegative>;
+using LengthPercentageSpaceSeparatedPointNonnegativeUnzoomed = SpaceSeparatedPoint<LengthPercentageNonnegativeUnzoomed>;
 
 // Standard Sizes
 using LengthPercentageSpaceSeparatedSizeAll = SpaceSeparatedSize<LengthPercentageAll>;
+using LengthPercentageSpaceSeparatedSizeAllUnzoomed = SpaceSeparatedSize<LengthPercentageAllUnzoomed>;
 using LengthPercentageSpaceSeparatedSizeNonnegative = SpaceSeparatedSize<LengthPercentageNonnegative>;
+using LengthPercentageSpaceSeparatedSizeNonnegativeUnzoomed = SpaceSeparatedSize<LengthPercentageNonnegativeUnzoomed>;
 using LengthPercentageMinimallySerializingSpaceSeparatedSizeAll = MinimallySerializingSpaceSeparatedSize<LengthPercentageAll>;
+using LengthPercentageMinimallySerializingSpaceSeparatedSizeAllUnzoomed = MinimallySerializingSpaceSeparatedSize<LengthPercentageAllUnzoomed>;
 using LengthPercentageMinimallySerializingSpaceSeparatedSizeNonnegative = MinimallySerializingSpaceSeparatedSize<LengthPercentageNonnegative>;
+using LengthPercentageMinimallySerializingSpaceSeparatedSizeNonnegativeUnzoomed = MinimallySerializingSpaceSeparatedSize<LengthPercentageNonnegativeUnzoomed>;
 
 // MARK: CSS -> Style
 

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
@@ -116,9 +116,9 @@ auto Blending<BasicShape>::blend(const BasicShape& a, const BasicShape& b, const
 
 // MARK: - Path
 
-WebCore::Path PathComputation<BasicShape>::operator()(const BasicShape& shape, const FloatRect& rect)
+WebCore::Path PathComputation<BasicShape>::operator()(const BasicShape& shape, const FloatRect& rect, ZoomFactor zoom)
 {
-    return WTF::switchOn(shape, [&](const auto& shape) { return WebCore::Style::path(shape, rect); });
+    return WTF::switchOn(shape, [&](const auto& shape) { return WebCore::Style::path(shape, rect, zoom); });
 }
 
 // MARK: - Winding

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.h
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.h
@@ -73,7 +73,7 @@ template<> struct Blending<BasicShape> {
 
 // MARK: - Path
 
-template<> struct PathComputation<BasicShape> { WebCore::Path operator()(const BasicShape&, const FloatRect&); };
+template<> struct PathComputation<BasicShape> { WebCore::Path operator()(const BasicShape&, const FloatRect&, ZoomFactor); };
 
 // MARK: - Winding
 

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -104,7 +104,7 @@ WebCore::Path pathForCenterCoordinate(const Circle& value, const FloatRect& boun
     return cachedCirclePath(bounding);
 }
 
-WebCore::Path PathComputation<Circle>::operator()(const Circle& value, const FloatRect& boundingBox)
+WebCore::Path PathComputation<Circle>::operator()(const Circle& value, const FloatRect& boundingBox, ZoomFactor)
 {
     return pathForCenterCoordinate(value, boundingBox, resolvePosition(value, boundingBox.size()));
 }

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.h
@@ -58,7 +58,7 @@ FloatPoint resolvePosition(const Circle& value, FloatSize boxSize);
 float resolveRadius(const Circle& value, FloatSize boxSize, FloatPoint center);
 WebCore::Path pathForCenterCoordinate(const Circle&, const FloatRect&, FloatPoint);
 
-template<> struct PathComputation<Circle> { WebCore::Path operator()(const Circle&, const FloatRect&); };
+template<> struct PathComputation<Circle> { WebCore::Path operator()(const Circle&, const FloatRect&, ZoomFactor); };
 
 template<> struct Blending<Circle> {
     auto canBlend(const Circle&, const Circle&) -> bool;

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -112,7 +112,7 @@ WebCore::Path pathForCenterCoordinate(const Ellipse& value, const FloatRect& bou
     return cachedEllipsePath(bounding);
 }
 
-WebCore::Path PathComputation<Ellipse>::operator()(const Ellipse& value, const FloatRect& boundingBox)
+WebCore::Path PathComputation<Ellipse>::operator()(const Ellipse& value, const FloatRect& boundingBox, ZoomFactor)
 {
     return pathForCenterCoordinate(value, boundingBox, resolvePosition(value, boundingBox.size()));
 }

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.h
@@ -58,7 +58,7 @@ FloatPoint resolvePosition(const Ellipse& value, FloatSize boxSize);
 FloatSize resolveRadii(const Ellipse&, FloatSize boxSize, FloatPoint center);
 WebCore::Path pathForCenterCoordinate(const Ellipse&, const FloatRect&, FloatPoint);
 
-template<> struct PathComputation<Ellipse> { WebCore::Path operator()(const Ellipse&, const FloatRect&); };
+template<> struct PathComputation<Ellipse> { WebCore::Path operator()(const Ellipse&, const FloatRect&, ZoomFactor); };
 
 template<> struct Blending<Ellipse> {
     auto canBlend(const Ellipse&, const Ellipse&) -> bool;

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
@@ -59,7 +59,7 @@ static const WebCore::Path& cachedRoundedInsetPath(const FloatRoundedRect& rect)
 
 // MARK: - Path
 
-WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const FloatRect& boundingBox)
+WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const FloatRect& boundingBox, ZoomFactor zoom)
 {
     auto boundingSize = boundingBox.size();
 
@@ -72,7 +72,7 @@ WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const Float
         std::max<float>(boundingSize.height() - top - evaluate<float>(value.insets.bottom(), boundingSize.height(), Style::ZoomNeeded { }), 0)
     };
 
-    auto radii = evaluate<CornerRadii>(value.radii, boundingSize, Style::ZoomNeeded { });
+    auto radii = evaluate<CornerRadii>(value.radii, boundingSize, zoom);
     radii.scale(calcBorderRadiiConstraintScaleFor(rect, radii));
 
     return cachedRoundedInsetPath(FloatRoundedRect { rect, radii });

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.h
@@ -55,7 +55,7 @@ template<size_t I> const auto& get(const Inset& value)
 
 DEFINE_TYPE_MAPPING(CSS::Inset, Inset)
 
-template<> struct PathComputation<Inset> { WebCore::Path operator()(const Inset&, const FloatRect&); };
+template<> struct PathComputation<Inset> { WebCore::Path operator()(const Inset&, const FloatRect&, ZoomFactor); };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StylePathComputation.h
+++ b/Source/WebCore/style/values/shapes/StylePathComputation.h
@@ -27,6 +27,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/Path.h>
 #include <WebCore/StyleValueTypes.h>
+#include <WebCore/StyleZoomPrimitives.h>
 
 namespace WebCore {
 namespace Style {
@@ -34,24 +35,24 @@ namespace Style {
 // All types that want to expose a generated WebCore::Path must specialize PathComputation the following member function:
 //
 //    template<> struct WebCore::Style::PathComputation<StyleType> {
-//        WebCore::Path operator()(const StyleType&, const FloatRect&);
+//        WebCore::Path operator()(const StyleType&, const FloatRect&, ZoomFactor);
 //    };
 
 template<typename StyleType> struct PathComputation;
 
 struct PathComputationInvoker {
-    template<typename StyleType, typename Reference> WebCore::Path operator()(const StyleType& value, const Reference& reference) const
+    template<typename StyleType, typename Reference> WebCore::Path operator()(const StyleType& value, const Reference& reference, ZoomFactor zoom) const
     {
-        return PathComputation<StyleType>{}(value, reference);
+        return PathComputation<StyleType>{}(value, reference, zoom);
     }
 };
 inline constexpr PathComputationInvoker path{};
 
 // Specialization for `FunctionNotation`.
 template<CSSValueID Name, typename StyleType> struct PathComputation<FunctionNotation<Name, StyleType>> {
-    template<typename Reference> WebCore::Path operator()(const FunctionNotation<Name, StyleType>& value, const Reference& reference)
+    template<typename Reference> WebCore::Path operator()(const FunctionNotation<Name, StyleType>& value, const Reference& reference, ZoomFactor zoom)
     {
-        return WebCore::Style::path(value.parameters, reference);
+        return WebCore::Style::path(value.parameters, reference, zoom);
     }
 };
 

--- a/Source/WebCore/style/values/shapes/StylePathFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.cpp
@@ -136,7 +136,7 @@ void Serialize<Path>::operator()(StringBuilder& builder, const CSS::Serializatio
 
 // MARK: - Path
 
-WebCore::Path PathComputation<Path>::operator()(const Path& value, const FloatRect& boundingBox)
+WebCore::Path PathComputation<Path>::operator()(const Path& value, const FloatRect& boundingBox, ZoomFactor)
 {
     return cachedTransformedByteStreamPath(value.data.byteStream, value.zoom, boundingBox.location());
 }

--- a/Source/WebCore/style/values/shapes/StylePathFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.h
@@ -79,7 +79,7 @@ template<> struct Serialize<Path> { void operator()(StringBuilder&, const CSS::S
 
 // MARK: - Path
 
-template<> struct PathComputation<Path> { WebCore::Path operator()(const Path&, const FloatRect&); };
+template<> struct PathComputation<Path> { WebCore::Path operator()(const Path&, const FloatRect&, ZoomFactor); };
 
 // MARK: - Wind Rule
 

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.h
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.h
@@ -61,7 +61,7 @@ struct RayPath {
 private:
     friend ClipPath;
     friend OffsetPath;
-    friend std::optional<WebCore::Path> tryPath(const RayPath&, const TransformOperationData&);
+    friend std::optional<WebCore::Path> tryPath(const RayPath&, const TransformOperationData&, ZoomFactor);
     friend WTF::TextStream& operator<<(WTF::TextStream&, const RayPath&);
 
     Ref<RayPathOperation> operation;
@@ -93,7 +93,7 @@ struct ReferencePath {
 private:
     friend ClipPath;
     friend OffsetPath;
-    friend std::optional<WebCore::Path> tryPath(const ReferencePath&, const TransformOperationData&);
+    friend std::optional<WebCore::Path> tryPath(const ReferencePath&, const TransformOperationData&, ZoomFactor);
     friend WTF::TextStream& operator<<(WTF::TextStream&, const ReferencePath&);
 
     Ref<ReferencePathOperation> operation;
@@ -124,7 +124,7 @@ struct BasicShapePath {
 private:
     friend ClipPath;
     friend OffsetPath;
-    friend std::optional<WebCore::Path> tryPath(const BasicShapePath&, const TransformOperationData&);
+    friend std::optional<WebCore::Path> tryPath(const BasicShapePath&, const TransformOperationData&, ZoomFactor);
     friend WTF::TextStream& operator<<(WTF::TextStream&, const BasicShapePath&);
 
     Ref<ShapePathOperation> operation;
@@ -151,33 +151,33 @@ struct BoxPath {
 private:
     friend ClipPath;
     friend OffsetPath;
-    friend std::optional<WebCore::Path> tryPath(const BoxPath&, const TransformOperationData&);
+    friend std::optional<WebCore::Path> tryPath(const BoxPath&, const TransformOperationData&, ZoomFactor);
 
     Ref<BoxPathOperation> operation;
 };
 
-inline std::optional<WebCore::Path> tryPath(const RayPath& rayPath, const TransformOperationData& data)
+inline std::optional<WebCore::Path> tryPath(const RayPath& rayPath, const TransformOperationData& data, ZoomFactor zoom)
 {
     Ref operation = rayPath.operation;
-    return operation->getPath(data);
+    return operation->getPath(data, zoom);
 }
 
-inline std::optional<WebCore::Path> tryPath(const ReferencePath& referencePath, const TransformOperationData& data)
+inline std::optional<WebCore::Path> tryPath(const ReferencePath& referencePath, const TransformOperationData& data, ZoomFactor zoom)
 {
     Ref operation = referencePath.operation;
-    return operation->getPath(data);
+    return operation->getPath(data, zoom);
 }
 
-inline std::optional<WebCore::Path> tryPath(const BasicShapePath& basicShapePath, const TransformOperationData& data)
+inline std::optional<WebCore::Path> tryPath(const BasicShapePath& basicShapePath, const TransformOperationData& data, ZoomFactor zoom)
 {
     Ref operation = basicShapePath.operation;
-    return operation->getPath(data);
+    return operation->getPath(data, zoom);
 }
 
-inline std::optional<WebCore::Path> tryPath(const BoxPath& boxPath, const TransformOperationData& data)
+inline std::optional<WebCore::Path> tryPath(const BoxPath& boxPath, const TransformOperationData& data, ZoomFactor zoom)
 {
     Ref operation = boxPath.operation;
-    return operation->getPath(data);
+    return operation->getPath(data, zoom);
 }
 
 // MARK: - Conversion

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -58,7 +58,7 @@ static const WebCore::Path& cachedPolygonPath(const Vector<FloatPoint>& points)
 
 // MARK: - Path
 
-WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const FloatRect& boundingBox)
+WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const FloatRect& boundingBox, ZoomFactor)
 {
     auto boundingLocation = boundingBox.location();
     auto boundingSize = boundingBox.size();

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.h
@@ -56,7 +56,7 @@ template<size_t I> const auto& get(const Polygon& value)
 
 DEFINE_TYPE_MAPPING(CSS::Polygon, Polygon)
 
-template<> struct PathComputation<Polygon> { WebCore::Path operator()(const Polygon&, const FloatRect&); };
+template<> struct PathComputation<Polygon> { WebCore::Path operator()(const Polygon&, const FloatRect&, ZoomFactor); };
 template<> struct WindRuleComputation<Polygon> { WebCore::WindRule operator()(const Polygon&); };
 
 template<> struct Blending<Polygon> {

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -591,7 +591,7 @@ auto Blending<ArcCommand>::blend(const ArcCommand& a, const ArcCommand& b, const
 
 // MARK: - Shape (path conversion)
 
-WebCore::Path PathComputation<Shape>::operator()(const Shape& value, const FloatRect& boundingBox)
+WebCore::Path PathComputation<Shape>::operator()(const Shape& value, const FloatRect& boundingBox, ZoomFactor)
 {
     // FIXME: We should do some caching here.
     auto pathSource = ShapeSVGPathSource(value.startingPoint, value, boundingBox.size());

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -397,7 +397,7 @@ template<size_t I> const auto& get(const Shape& value)
 
 DEFINE_TYPE_MAPPING(CSS::Shape, Shape)
 
-template<> struct PathComputation<Shape> { WebCore::Path operator()(const Shape&, const FloatRect&); };
+template<> struct PathComputation<Shape> { WebCore::Path operator()(const Shape&, const FloatRect&, ZoomFactor); };
 template<> struct WindRuleComputation<Shape> { WebCore::WindRule operator()(const Shape&); };
 
 template<> struct Blending<Shape> {

--- a/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
@@ -39,7 +39,10 @@ struct ZoomNeeded { };
 struct ZoomFactor {
     float value;
 
-    constexpr explicit ZoomFactor(float v) : value(v) { }
+    constexpr explicit ZoomFactor(float v) : value { v } { }
+
+    // Special zoom factor to use when zoom has already been applied to a value.
+    static constexpr ZoomFactor none() { return ZoomFactor { 1 }; }
 };
 
 // Map from computed style values (which take zoom into account) to web-exposed values, which are zoom-independent.

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -252,8 +252,9 @@ Path SVGPathElement::path() const
 {
     if (document().settings().cssDPropertyEnabled()) {
         if (CheckedPtr renderer = this->renderer()) {
-            if (auto& pathFunction = renderer->style().d().tryPath())
-                return Style::path(pathFunction->parameters, FloatRect { });
+            CheckedRef style = renderer->style();
+            if (auto& pathFunction = style->d().tryPath())
+                return Style::path(pathFunction->parameters, FloatRect { }, style->usedZoomForLength());
             return { };
         }
     }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2994,34 +2994,61 @@ header: <WebCore/StylePrimitiveNumericTypes.h>
 [CustomHeader, Nested] struct WebCore::Style::PercentageNonnegativeFloat {
     float value;
 };
+[CustomHeader, Nested] struct WebCore::Style::PercentageNonnegativeUnzoomedFloat {
+    float value;
+};
 
 [CustomHeader, Nested] struct WebCore::Style::PercentageAllFloat {
+    float value;
+};
+[CustomHeader, Nested] struct WebCore::Style::PercentageAllUnzoomedFloat {
     float value;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthNonnegative {
     float unresolvedValue();
 };
+[CustomHeader, Nested] struct WebCore::Style::LengthNonnegativeUnzoomed {
+    float unresolvedValue();
+};
 using WebCore::Style::LengthAll = WebCore::Style::Length<WebCore::CSS::All>;
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::All> {
+    float unresolvedValue();
+};
+using WebCore::Style::LengthAllUnzoomed = WebCore::Style::Length<WebCore::CSS::AllUnzoomed>;
+[CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::AllUnzoomed> {
     float unresolvedValue();
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::All> {
     Variant<WebCore::Style::LengthAll, WebCore::Style::PercentageAllFloat> ipcData()
 };
+[CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::AllUnzoomed> {
+    Variant<WebCore::Style::LengthAllUnzoomed, WebCore::Style::PercentageAllUnzoomedFloat> ipcData()
+};
 [CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::Nonnegative> {
     Variant<WebCore::Style::LengthNonnegative, WebCore::Style::PercentageNonnegativeFloat> ipcData();
 };
+[CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::NonnegativeUnzoomed> {
+    Variant<WebCore::Style::LengthNonnegativeUnzoomed, WebCore::Style::PercentageNonnegativeUnzoomedFloat> ipcData();
+};
 
 using WebCore::Style::LengthPercentageNonnegative = WebCore::Style::LengthPercentage<WebCore::CSS::Nonnegative>;
+using WebCore::Style::LengthPercentageNonnegativeUnzoomed = WebCore::Style::LengthPercentage<WebCore::CSS::NonnegativeUnzoomed>;
 using WebCore::Style::LengthPercentageAll = WebCore::Style::LengthPercentage<WebCore::CSS::All>;
+using WebCore::Style::LengthPercentageAllUnzoomed = WebCore::Style::LengthPercentage<WebCore::CSS::AllUnzoomed>;
 
 [CustomHeader, Nested] struct WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegative> {
     std::array<WebCore::Style::LengthPercentageNonnegative, 2> value;
 };
+[CustomHeader, Nested] struct WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegativeUnzoomed> {
+    std::array<WebCore::Style::LengthPercentageNonnegativeUnzoomed, 2> value;
+};
 [CustomHeader, Nested] struct WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAll> {
     std::array<WebCore::Style::LengthPercentageAll, 2> value;
+};
+[CustomHeader, Nested] struct WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAllUnzoomed> {
+    std::array<WebCore::Style::LengthPercentageAllUnzoomed, 2> value;
 };
 [CustomHeader, Nested] struct WebCore::SpaceSeparatedPair<WebCore::Style::CoordinatePair> {
     std::array<WebCore::Style::CoordinatePair, 2> value;
@@ -3030,25 +3057,45 @@ using WebCore::Style::LengthPercentageAll = WebCore::Style::LengthPercentage<Web
 [CustomHeader, Nested] struct WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageNonnegative> {
     WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegative> value;
 };
+[CustomHeader, Nested] struct WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageNonnegativeUnzoomed> {
+    WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegativeUnzoomed> value;
+};
 [CustomHeader, Nested] struct WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageAll> {
     WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAll> value;
+};
+[CustomHeader, Nested] struct WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageAllUnzoomed> {
+    WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAllUnzoomed> value;
 };
 
 [CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> {
     WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegative> value;
 };
+[CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegativeUnzoomed> {
+    WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegativeUnzoomed> value;
+};
 [CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageAll> {
     WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAll> value;
 };
+[CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageAllUnzoomed> {
+    WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAllUnzoomed> value;
+};
 
 using WebCore::Style::LengthPercentageSpaceSeparatedPointAll = WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageAll>;
+using WebCore::Style::LengthPercentageSpaceSeparatedPointAllUnzoomed = WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageAllUnzoomed>;
 using WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegative = WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageNonnegative>;
+using WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegativeUnzoomed = WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageNonnegativeUnzoomed>;
 
 [CustomHeader, Nested] struct WebCore::CommaSeparatedVector<WebCore::Style::LengthPercentageSpaceSeparatedPointAll> {
     Vector<WebCore::Style::LengthPercentageSpaceSeparatedPointAll> value;
 };
+[CustomHeader, Nested] struct WebCore::CommaSeparatedVector<WebCore::Style::LengthPercentageSpaceSeparatedPointAllUnzoomed> {
+    Vector<WebCore::Style::LengthPercentageSpaceSeparatedPointAllUnzoomed> value;
+};
 [CustomHeader, Nested] struct WebCore::CommaSeparatedVector<WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegative> {
     Vector<WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegative> value;
+};
+[CustomHeader, Nested] struct WebCore::CommaSeparatedVector<WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegativeUnzoomed> {
+    Vector<WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegativeUnzoomed> value;
 };
 
 [CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedRectEdges<WebCore::Style::LengthPercentageAll> {
@@ -3056,6 +3103,12 @@ using WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegative = WebCore::
     WebCore::Style::LengthPercentageAll right();
     WebCore::Style::LengthPercentageAll bottom();
     WebCore::Style::LengthPercentageAll left();
+};
+[CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedRectEdges<WebCore::Style::LengthPercentageAllUnzoomed> {
+    WebCore::Style::LengthPercentageAllUnzoomed top();
+    WebCore::Style::LengthPercentageAllUnzoomed right();
+    WebCore::Style::LengthPercentageAllUnzoomed bottom();
+    WebCore::Style::LengthPercentageAllUnzoomed left();
 };
 
 using WebCore::Style::ShapeCommand = Variant<WebCore::Style::MoveCommand, WebCore::Style::LineCommand, WebCore::Style::HLineCommand, WebCore::Style::VLineCommand, WebCore::Style::CurveCommand, WebCore::Style::SmoothCommand, WebCore::Style::ArcCommand, WebCore::Style::CloseCommand>;
@@ -3290,10 +3343,10 @@ using WebCore::Style::LengthPercentageMinimallySerializingSpaceSeparatedSizeAll 
 
 header: <WebCore/StyleBorderRadius.h>
 [CustomHeader, Nested] struct WebCore::Style::BorderRadius {
-    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> topLeft();
-    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> topRight();
-    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> bottomRight();
-    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> bottomLeft();
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegativeUnzoomed> topLeft();
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegativeUnzoomed> topRight();
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegativeUnzoomed> bottomRight();
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegativeUnzoomed> bottomLeft();
 };
 
 header: <WebCore/StyleRayFunction.h>


### PR DESCRIPTION
#### ed5ce070c41d611cabe36fc6f6b82186de5cdfa7
<pre>
[EvaluationTimeZoom] Convert `border-radius` property to evaluation time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=308433">https://bugs.webkit.org/show_bug.cgi?id=308433</a>

Reviewed by Darin Adler.

Implement support for evaluation time zoom for the `border-radius` property
and use of the border-radius value in CSS shape functions.  The progression
is evident in the new `border-radius.html` test as inherited values are now
correctly zoomed.

A large part of this change is piping zoom through shape resolution and path
construction, which is needed for border-radius value usage.

Additionally, the set of standard length related style types used for IPC
definitions in StylePrimitiveNumericTypes.h/WebCoreArgumentCoders.serialization.in
was extended to include &quot;unzoomed&quot; versions for each type. While not all are
being utilized yet, this will make future changes easier, as these serializer
types can be tricky to get right, so doing them all at once makes sense.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-radius-ref.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-radius.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/border-radius-ref.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/borders/CSSBorderRadius.cpp:
* Source/WebCore/css/values/borders/CSSBorderRadius.h:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/rendering/BorderShape.cpp:
* Source/WebCore/rendering/MotionPath.cpp:
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/OutlinePainter.cpp:
* Source/WebCore/rendering/OutlinePainter.h:
* Source/WebCore/rendering/PathOperation.cpp:
* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
* Source/WebCore/rendering/shapes/LayoutShape.h:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/style/StyleTransformResolver.cpp:
* Source/WebCore/style/StyleTransformResolver.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/values/borders/StyleBorderRadius.cpp:
* Source/WebCore/style/values/borders/StyleBorderRadius.h:
* Source/WebCore/style/values/masking/StyleClipPath.h:
* Source/WebCore/style/values/motion/StyleOffsetPath.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/shapes/StyleBasicShape.cpp:
* Source/WebCore/style/values/shapes/StyleBasicShape.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
* Source/WebCore/style/values/shapes/StyleCircleFunction.h:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.h:
* Source/WebCore/style/values/shapes/StyleInsetFunction.cpp:
* Source/WebCore/style/values/shapes/StyleInsetFunction.h:
* Source/WebCore/style/values/shapes/StylePathComputation.h:
* Source/WebCore/style/values/shapes/StylePathFunction.cpp:
* Source/WebCore/style/values/shapes/StylePathFunction.h:
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.h:
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
* Source/WebCore/style/values/shapes/StylePolygonFunction.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:
* Source/WebCore/svg/SVGPathElement.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/308055@main">https://commits.webkit.org/308055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2d5f2f8cf0e6f97ee27896daf3b5b95b439ab7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146354 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155021 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99799 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112633 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99799 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14256 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157342 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/513 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120662 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120960 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30981 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74652 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16637 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18469 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->