### PR TITLE
[Async scrolling] Clean up RequestedScrollData

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting-expected.txt
@@ -1,5 +1,0 @@
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT ScrollTimeline current time is updated after programmatic animated scroll. Test timed out
-

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -427,17 +427,22 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
     tracePoint(ProgrammaticScroll, scrollPosition.y(), frameView->frame().isMainFrame());
 
     auto requestedScrollData = RequestedScrollData {
-        .requestType = ScrollRequestType::PositionUpdate,
+        .requestType = (options.animated == ScrollIsAnimated::Yes) ? ScrollRequestType::AnimatedPositionUpdate : ScrollRequestType::PositionUpdate,
         .scrollPositionOrDelta = scrollPosition,
         .identifier = { },
         .scrollType = options.type,
         .clamping = options.clamping,
-        .animated = options.animated,
         .scrollbarRevealBehavior = scrollableArea.scrollbarRevealBehavior(),
     };
 
     if (options.originalScrollDelta) {
-        requestedScrollData.requestType = ScrollRequestType::DeltaUpdate;
+        if (options.animated == ScrollIsAnimated::Yes)
+            requestedScrollData.requestType = ScrollRequestType::AnimatedDeltaUpdate;
+        else if (options.interruptsAnimation == ScrollInterruptsAnimation::No)
+            requestedScrollData.requestType = ScrollRequestType::ImplicitDeltaUpdate;
+        else
+            requestedScrollData.requestType = ScrollRequestType::DeltaUpdate;
+
         requestedScrollData.scrollPositionOrDelta = *options.originalScrollDelta;
     }
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -617,12 +617,14 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 
     auto options = ScrollPositionChangeOptions::createProgrammatic();
     options.originalScrollDelta = adjustment;
+    options.interruptsAnimation = ScrollInterruptsAnimation::No;
 
     auto revealScope = ScrollbarRevealBehaviorScope(m_owningScrollableArea.get(), ScrollbarRevealBehavior::DontReveal);
 
     auto oldScrollType = m_owningScrollableArea->currentScrollType();
     m_owningScrollableArea->setCurrentScrollType(ScrollType::Programmatic);
 
+    // FIXME: This has to explicitly not stop animated scrolls (use ImplicitDeltaUpdate).
     if (!m_owningScrollableArea->requestScrollToPosition(newScrollPosition, options))
         m_owningScrollableArea->scrollToPositionWithoutAnimation(newScrollPosition);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -52,7 +52,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
 #if ENABLE(SCROLLING_THREAD)
     OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
 #endif
-    RequestedScrollData&& requestedScrollData,
+    ScrollRequestData&& requestedScrollData,
     FloatScrollSnapOffsetsInfo&& snapOffsetsInfo,
     std::optional<unsigned> currentHorizontalSnapPointIndex,
     std::optional<unsigned> currentVerticalSnapPointIndex,

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -149,7 +149,7 @@ private:
 #if ENABLE(SCROLLING_THREAD)
         OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
 #endif
-        RequestedScrollData&&,
+        ScrollRequestData&&,
         FloatScrollSnapOffsetsInfo&&,
         std::optional<unsigned> currentHorizontalSnapPointIndex,
         std::optional<unsigned> currentVerticalSnapPointIndex,

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
@@ -47,7 +47,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
 #if ENABLE(SCROLLING_THREAD)
     OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
 #endif
-    RequestedScrollData&& requestedScrollData,
+    ScrollRequestData&& requestedScrollData,
     FloatScrollSnapOffsetsInfo&& snapOffsetsInfo,
     std::optional<unsigned> currentHorizontalSnapPointIndex,
     std::optional<unsigned> currentVerticalSnapPointIndex,

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
@@ -56,7 +56,7 @@ private:
 #if ENABLE(SCROLLING_THREAD)
         OptionSet<SynchronousScrollingReason>,
 #endif
-        RequestedScrollData&&,
+        ScrollRequestData&&,
         FloatScrollSnapOffsetsInfo&&,
         std::optional<unsigned> currentHorizontalSnapPointIndex,
         std::optional<unsigned> currentVerticalSnapPointIndex,

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
@@ -47,7 +47,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
 #if ENABLE(SCROLLING_THREAD)
     OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
 #endif
-    RequestedScrollData&& requestedScrollData,
+    ScrollRequestData&& requestedScrollData,
     FloatScrollSnapOffsetsInfo&& snapOffsetsInfo,
     std::optional<unsigned> currentHorizontalSnapPointIndex,
     std::optional<unsigned> currentVerticalSnapPointIndex,

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
@@ -62,7 +62,7 @@ private:
 #if ENABLE(SCROLLING_THREAD)
         OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
 #endif
-        RequestedScrollData&&,
+        ScrollRequestData&&,
         FloatScrollSnapOffsetsInfo&&,
         std::optional<unsigned> currentHorizontalSnapPointIndex,
         std::optional<unsigned> currentVerticalSnapPointIndex,

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -108,10 +108,9 @@ public:
     const RequestedKeyboardScrollData& keyboardScrollData() const { return m_keyboardScrollData; }
     WEBCORE_EXPORT void setKeyboardScrollData(const RequestedKeyboardScrollData&);
 
-    const RequestedScrollData& requestedScrollData() const { return m_requestedScrollData; }
+    const ScrollRequestData& requestedScrollData() const { return m_requestedScrollData; }
 
-    enum class CanMergeScrollData : bool { No, Yes };
-    WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&, CanMergeScrollData = CanMergeScrollData::Yes);
+    WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&);
 
     WEBCORE_EXPORT bool NODELETE hasScrollPositionRequest() const;
 
@@ -185,7 +184,7 @@ protected:
 #if ENABLE(SCROLLING_THREAD)
         OptionSet<SynchronousScrollingReason>,
 #endif
-        RequestedScrollData&&,
+        ScrollRequestData&&,
         FloatScrollSnapOffsetsInfo&&,
         std::optional<unsigned> currentHorizontalSnapPointIndex,
         std::optional<unsigned> currentVerticalSnapPointIndex,
@@ -211,6 +210,8 @@ protected:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
 private:
+    void mergeOrAppendScrollRequest(RequestedScrollData&&);
+
     FloatSize m_scrollableAreaSize;
     FloatSize m_totalContentsSize;
     FloatSize m_reachableContentsSize;
@@ -240,7 +241,7 @@ private:
 
     std::optional<ScrollbarColor> m_scrollbarColor;
     ScrollableAreaParameters m_scrollableAreaParameters;
-    RequestedScrollData m_requestedScrollData;
+    ScrollRequestData m_requestedScrollData;
     RequestedKeyboardScrollData m_keyboardScrollData;
 #if ENABLE(SCROLLING_THREAD)
     OptionSet<SynchronousScrollingReason> m_synchronousScrollingReasons;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -102,7 +102,7 @@ public:
     void scrollTo(const FloatPoint&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped);
     void scrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped);
 
-    void handleScrollPositionRequest(const RequestedScrollData&);
+    void handleScrollPositionRequests(const ScrollRequestData&);
 
     void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&);
     void requestKeyboardScroll(const RequestedKeyboardScrollData&);
@@ -208,6 +208,8 @@ protected:
 
     bool shouldRubberBand(const PlatformWheelEvent&, EventTargeting) const;
     bool shouldRubberBandOnSide(BoxSide, RectEdges<bool> pinnedEdges) const;
+
+    void handleScrollPositionRequest(const RequestedScrollData&);
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -187,7 +187,7 @@ void ThreadedScrollingTree::didCommitTreeOnScrollingThread()
 
 bool ThreadedScrollingTree::scrollingTreeNodeRequestsScroll(ScrollingNodeID nodeID, const RequestedScrollData& request)
 {
-    if (request.animated == ScrollIsAnimated::Yes) {
+    if (isAnimatedUpdate(request.requestType)) {
         m_nodesWithPendingScrollAnimations.set(nodeID, request);
         return true;
     }

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -212,6 +212,7 @@ TextStream& operator<<(TextStream& ts, ScrollPositionChangeOptions options)
     ts.dumpProperty("animated"_s, options.animated == ScrollIsAnimated::Yes);
     ts.dumpProperty("snap point selection method"_s, options.snapPointSelectionMethod);
     ts.dumpProperty("original scroll delta"_s, options.originalScrollDelta ? *options.originalScrollDelta : FloatSize());
+    ts.dumpProperty("interrupts animation"_s, options.interruptsAnimation == ScrollInterruptsAnimation::Yes);
 
     return ts;
 }

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -329,6 +329,11 @@ enum class ScrollClamping : bool {
     Clamped
 };
 
+enum class ScrollInterruptsAnimation : bool {
+    No,
+    Yes
+};
+
 enum class ScrollBehaviorForFixedElements : bool {
     StickToDocumentBounds,
     StickToViewportBounds
@@ -368,10 +373,11 @@ using ScrollbarControlPartMask = unsigned;
 
 struct ScrollPositionChangeOptions {
     ScrollType type;
-    ScrollClamping clamping = ScrollClamping::Clamped;
-    ScrollIsAnimated animated = ScrollIsAnimated::No;
-    ScrollSnapPointSelectionMethod snapPointSelectionMethod = ScrollSnapPointSelectionMethod::Closest;
-    std::optional<FloatSize> originalScrollDelta = std::nullopt;
+    ScrollClamping clamping { ScrollClamping::Clamped };
+    ScrollIsAnimated animated { ScrollIsAnimated::No };
+    ScrollSnapPointSelectionMethod snapPointSelectionMethod { ScrollSnapPointSelectionMethod::Closest };
+    std::optional<FloatSize> originalScrollDelta { };
+    ScrollInterruptsAnimation interruptsAnimation { ScrollInterruptsAnimation::Yes };
 
     static ScrollPositionChangeOptions createProgrammatic()
     {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -79,7 +79,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
 #if ENABLE(SCROLLING_THREAD)
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ReasonsForSynchronousScrolling] OptionSet<WebCore::SynchronousScrollingReason> synchronousScrollingReasons()
 #endif
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::RequestedScrollData requestedScrollData()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::ScrollRequestData requestedScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::SnapOffsetsInfo] WebCore::FloatScrollSnapOffsetsInfo snapOffsetsInfo()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex] std::optional<unsigned> currentHorizontalSnapPointIndex()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex] std::optional<unsigned> currentVerticalSnapPointIndex()
@@ -137,7 +137,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
 #if ENABLE(SCROLLING_THREAD)
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ReasonsForSynchronousScrolling] OptionSet<WebCore::SynchronousScrollingReason> synchronousScrollingReasons()
 #endif
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::RequestedScrollData requestedScrollData()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::ScrollRequestData requestedScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::SnapOffsetsInfo] WebCore::FloatScrollSnapOffsetsInfo snapOffsetsInfo()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex] std::optional<unsigned> currentHorizontalSnapPointIndex()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex] std::optional<unsigned> currentVerticalSnapPointIndex()
@@ -179,7 +179,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
 #if ENABLE(SCROLLING_THREAD)
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ReasonsForSynchronousScrolling] OptionSet<WebCore::SynchronousScrollingReason> synchronousScrollingReasons()
 #endif
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::RequestedScrollData requestedScrollData()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::ScrollRequestData requestedScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::SnapOffsetsInfo] WebCore::FloatScrollSnapOffsetsInfo snapOffsetsInfo()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex] std::optional<unsigned> currentHorizontalSnapPointIndex()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex] std::optional<unsigned> currentVerticalSnapPointIndex()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4368,10 +4368,10 @@ enum class WebCore::ScrollType : bool;
     Markable<WebCore::ScrollRequestIdentifier> identifier;
     WebCore::ScrollType scrollType;
     WebCore::ScrollClamping clamping;
-    WebCore::ScrollIsAnimated animated;
     WebCore::ScrollbarRevealBehavior scrollbarRevealBehavior;
-    std::optional<std::tuple<WebCore::ScrollRequestType, Variant<WebCore::FloatPoint, WebCore::FloatSize>, WebCore::ScrollType, WebCore::ScrollClamping>> requestedDataBeforeAnimatedScroll;
 }
+
+using WebCore::ScrollRequestData = Vector<WebCore::RequestedScrollData, 2>;
 
 [Alias=struct ScrollSnapOffsetsInfo<float,WebCore::FloatRect>, CustomHeader] alias WebCore::FloatScrollSnapOffsetsInfo {
     std::optional<WebCore::ScrollSnapStrictness> strictness;
@@ -8068,7 +8068,10 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [Nested] enum class WebCore::ScrollRequestType : uint8_t {
     PositionUpdate,
+    AnimatedPositionUpdate,
     DeltaUpdate,
+    AnimatedDeltaUpdate,
+    ImplicitDeltaUpdate,
     CancelAnimatedScroll
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -466,7 +466,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         return;
 
     {
-        std::optional<RequestedScrollData> requestedScroll;
+        ScrollRequestData requestedScroll;
         CheckedRef scrollingCoordinatorProxy = *page->scrollingCoordinatorProxy();
 
         auto commitLayerAndScrollingTrees = [&] {
@@ -498,8 +498,8 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
 #endif
         // Handle requested scroll position updates from the scrolling tree transaction after didCommitLayerTree()
         // has updated the view size based on the content size.
-        if (requestedScroll)
-            scrollingCoordinatorProxy->adjustMainFrameDelegatedScrollPosition(WTF::move(*requestedScroll));
+        if (requestedScroll.size())
+            scrollingCoordinatorProxy->adjustMainFrameDelegatedScrollPosition(WTF::move(requestedScroll));
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
         if (layerTreeTransaction.changedLayerProperties().size() || layerTreeTransaction.destroyedLayers().size())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -120,8 +120,8 @@ public:
     virtual void scrollingTreeNodeWillBeRemoved(WebCore::ScrollingNodeID) { };
 #endif
 
-    std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(IPC::Connection&, const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
-    void adjustMainFrameDelegatedScrollPosition(WebCore::RequestedScrollData&&);
+    WebCore::ScrollRequestData commitScrollingTreeState(IPC::Connection&, const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
+    void adjustMainFrameDelegatedScrollPosition(WebCore::ScrollRequestData&&);
 
     bool hasFixedOrSticky() const;
     bool NODELETE hasScrollableMainFrame() const;
@@ -224,7 +224,7 @@ private:
     const Ref<RemoteScrollingTree> m_scrollingTree;
 
 protected:
-    std::optional<WebCore::RequestedScrollData> m_requestedScroll;
+    WebCore::ScrollRequestData m_scrollRequestData;
     RemoteScrollingUIState m_uiState;
     std::optional<unsigned> m_currentHorizontalSnapPointIndex;
     std::optional<unsigned> m_currentVerticalSnapPointIndex;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1097,7 +1097,8 @@ public:
 
     void setViewNeedsDisplay(const WebCore::Region&);
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated, WebCore::InterruptScrollAnimation);
-    
+
+    // FIXME: This is a scroll offset, unadjusted for content insets.
     WebCore::FloatPoint viewScrollPosition() const;
 
     void setNeedsScrollGeometryUpdates(bool);


### PR DESCRIPTION
#### 05c68b558872e9b3736f0c3dbf8d33af4d558288
<pre>
[Async scrolling] Clean up RequestedScrollData
<a href="https://bugs.webkit.org/show_bug.cgi?id=308436">https://bugs.webkit.org/show_bug.cgi?id=308436</a>
<a href="https://rdar.apple.com/170930785">rdar://170930785</a>

Reviewed by BJ Burg and Tim Horton.

`RequestedScrollData` encodes data required to handle programmatic scrolls (e.g. `scrollTo()`,
scrollBy()`, scroll anchoring adjustments etc). When multiple of these occur in sequence,
we have to determine how they reduce to the minimal set of instructions to the UI process
for async scrolling. For example:
    window.scrollTo(0, 100);
    window.scrollBy(0, 20);

reduces to
    window.scrollTo(0, 120);

and
    window.scrollTo({ top: 100, behavior: &apos;smooth&apos;});
    window.scrollTo(0, 20);

becomes
    window.scrollTo(0, 20);

because instantaneous scrolls abort any smooth scroll. However, some combinations do result in
a two-step operation:
    window.scrollTo(0, 100);
    window.scrollBy({ top: 20, behavior: &apos;smooth&apos;});

`RequestedScrollData` used `requestedDataBeforeAnimatedScroll` to represent step 1 here, but that
was unwieldy, and didn&apos;t preserve the `ScrollRequestIdentifier` on the first step. So instead use a
`Vector&lt;RequestedScrollData, 2&gt;` to represent the minimal set of operations for all the coalesced
requests in a given update. And it does always reduce to a maximum of two operations.

Most of the changes here are a mechanical switch from `RequestedScrollData` to `ScrollRequestData`.

The merging code is tricky, and used to live in `RequestedScrollData::merge()`. I moved it to
`ScrollingStateScrollingNode::mergeOrAppendScrollRequest()`, and made it a bit more long-winded, but
hopefully easier to follow. A couple of issues need care here; accumulating positions and deltas,
and ensuring that we keep track of the most recent `ScrollRequestIdentifier`.

To simplify this merging logic, it was easier to represent animated scrolls via new `ScrollRequestType`
values rather than using `ScrollIsAnimated` in `RequestedScrollData`. A new type, `ImplicitDeltaUpdate`,
was added to represent scrolls that don&apos;t interrupted running animated scrolls, for use by scroll
anchoring. Per spec[1], all the other types interrupt animations.

There are two places in the UI process that now have to handle the set of 1 or 2 requests:
`ScrollingTreeScrollingNode::handleScrollPositionRequests()` and
`RemoteScrollingCoordinatorProxy::adjustMainFrameDelegatedScrollPosition()` (the latter handles only
main frame scrolls on iOS). These can now just process the requests in turn (I believe this makes an
iOS test pass now).

[1] <a href="https://drafts.csswg.org/cssom-view/#scrolling">https://drafts.csswg.org/cssom-view/#scrolling</a>

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting-expected.txt: This test
now passes on iOS.
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::computeDestinationPosition):
(WebCore::operator&lt;&lt;):
(WebCore::RequestedScrollData::merge): Deleted.
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::isAnimatedUpdate):
(WebCore::RequestedScrollData::comparePositionOrDelta const):
(WebCore::RequestedScrollData::operator== const):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp:
(WebCore::ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::mergeOrAppendScrollRequest):
(WebCore::ScrollingStateScrollingNode::setRequestedScrollData):
(WebCore::ScrollingStateScrollingNode::hasScrollPositionRequest const):
(WebCore::ScrollingStateScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::requestedScrollData const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateAfterChildren):
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequests):
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeRequestsScroll):
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):
(WebKit::RemoteScrollingCoordinatorProxy::adjustMainFrameDelegatedScrollPosition):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeRequestsScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::startPendingScrollAnimations):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeRequestsScroll):
* Source/WebKit/UIProcess/WebPageProxy.h: viewScrollPosition() is not what it says on the tin.

Canonical link: <a href="https://commits.webkit.org/308102@main">https://commits.webkit.org/308102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62134d6a59c6d4009c68c16afea2083947e34335

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19135 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155126 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ee4f9ce-c596-44df-aea0-0c8004b50425) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19039 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0ab5e14-efca-43a9-91f4-3c3219679d87) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149425 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93580 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1570a199-3a67-49d7-902f-a318e84716e0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2571 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157450 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/607 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31006 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74745 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18563 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->