### PR TITLE
[MathML] Update direction-overall-003.html to match spec-compliant symmetric prescript spacing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1996,7 +1996,6 @@ imported/w3c/web-platform-tests/html/browsers/windows/nested-browsing-contexts/f
 # These MathML WPT tests fail.
 webkit.org/b/180013 mathml/non-core/lengths-2.html [ ImageOnlyFailure ]
 webkit.org/b/194952 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-bar-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-bar-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-default-padding.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-2.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2193,7 +2193,6 @@ imported/w3c/web-platform-tests/html/browsers/windows/nested-browsing-contexts/f
 
 # These MathML WPT tests fail.
 webkit.org/b/180013 mathml/non-core/lengths-2.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-2.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-3.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-op-1-4.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003-expected.html
@@ -4,22 +4,22 @@
   <body>
 
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <div style="position: absolute; width: 70px; height: 200px;
                   left: 0px; background: red;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
                   left: 70px; background: green;"></div>
-      <div style="position: absolute; width: 70px; height: 200px;
+      <div style="position: absolute; width: 40px; height: 200px;
                   left: 140px; background: magenta;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
-                  left: 210px; background: blue;"></div>
+                  left: 180px; background: blue;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
-                  left: 280px; background: yellow;"></div>-->
+                  left: 250px; background: yellow;"></div>
     </div>
 
 
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <div style="position: absolute; width: 10px; height: 200px;
                   left: -5px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
@@ -27,11 +27,11 @@
       <div style="position: absolute; width: 10px; height: 200px;
                   left: 135px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 205px; background: black;"></div>
+                  left: 175px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 275px; background: black;"></div>
+                  left: 245px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 345px; background: black;"></div>
+                  left: 315px; background: black;"></div>
     </div>
 
   </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003-ref.html
@@ -4,22 +4,22 @@
   <body>
 
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <div style="position: absolute; width: 70px; height: 200px;
                   left: 0px; background: red;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
                   left: 70px; background: green;"></div>
-      <div style="position: absolute; width: 70px; height: 200px;
+      <div style="position: absolute; width: 40px; height: 200px;
                   left: 140px; background: magenta;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
-                  left: 210px; background: blue;"></div>
+                  left: 180px; background: blue;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
-                  left: 280px; background: yellow;"></div>-->
+                  left: 250px; background: yellow;"></div>
     </div>
 
 
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <div style="position: absolute; width: 10px; height: 200px;
                   left: -5px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
@@ -27,11 +27,11 @@
       <div style="position: absolute; width: 10px; height: 200px;
                   left: 135px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 205px; background: black;"></div>
+                  left: 175px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 275px; background: black;"></div>
+                  left: 245px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 345px; background: black;"></div>
+                  left: 315px; background: black;"></div>
     </div>
 
   </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003.html
@@ -30,19 +30,23 @@
          do not match perfectly, so we use an alternative == reftest here
          which is less strict. -->
 
-    <!-- five vertical bands: red, green, magenta, blue and yellow -->
+    <!-- Five vertical bands (red, green, magenta, blue, yellow) sized so
+         that, per MathML Core, the space-after-script sits before each
+         prescript pair and after each postscript pair. In dir=rtl this puts
+         the base and the inner prescript pair adjacent to each other, so the
+         magenta (base) band is only 40px wide. -->
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <div style="position: absolute; width: 70px; height: 200px;
                   left: 0px; background: red;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
                   left: 70px; background: green;"></div>
-      <div style="position: absolute; width: 70px; height: 200px;
+      <div style="position: absolute; width: 40px; height: 200px;
                   left: 140px; background: magenta;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
-                  left: 210px; background: blue;"></div>
+                  left: 180px; background: blue;"></div>
       <div style="position: absolute; width: 70px; height: 200px;
-                  left: 280px; background: yellow;"></div>-->
+                  left: 250px; background: yellow;"></div>
     </div>
 
     <!-- a mmultiscripts element whose children are squares of different
@@ -50,7 +54,7 @@
          the band over which the square is positioned. Hence, this
          mmultiscripts should not be visible. -->
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <math dir="rtl">
         <mmultiscripts>
           <mspace width="40px" height="40px" mathbackground="magenta"/>
@@ -75,7 +79,7 @@
     <!-- We add black vertical bands to cover spaces between the children of
          mmultiscripts. -->
     <div style="position: absolute;
-                top: 5px; left: 5px; width: 200px; height: 200px;">
+                top: 5px; left: 5px; width: 320px; height: 200px;">
       <div style="position: absolute; width: 10px; height: 200px;
                   left: -5px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
@@ -83,11 +87,11 @@
       <div style="position: absolute; width: 10px; height: 200px;
                   left: 135px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 205px; background: black;"></div>
+                  left: 175px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 275px; background: black;"></div>
+                  left: 245px; background: black;"></div>
       <div style="position: absolute; width: 10px; height: 200px;
-                  left: 345px; background: black;"></div>
+                  left: 315px; background: black;"></div>
     </div>
 
   </body>

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -457,10 +457,11 @@ void RenderMathMLScripts::layoutBlock(RelayoutChildren relayoutChildren, LayoutU
             LayoutUnit subSupPairWidth = std::max(subScript->logicalWidth() + subScript->marginLogicalWidth(), supScript->logicalWidth() + supScript->marginLogicalWidth());
             horizontalOffset += space + subSupPairWidth;
             LayoutUnit subAscent = ascentForChild(*subScript);
-            LayoutPoint subScriptLocation(mirrorIfNeeded(horizontalOffset - subScript->marginEnd() - subScript->logicalWidth(), *subScript), ascent + metrics.subShift - subAscent);
+            LayoutUnit prescriptSpaceOffset = writingMode().isBidiRTL() ? space : 0_lu;
+            LayoutPoint subScriptLocation(mirrorIfNeeded(horizontalOffset - prescriptSpaceOffset - subScript->marginEnd() - subScript->logicalWidth(), *subScript), ascent + metrics.subShift - subAscent);
             subScript->setLocation(subScriptLocation);
             LayoutUnit supAscent = ascentForChild(*supScript);
-            LayoutPoint supScriptLocation(mirrorIfNeeded(horizontalOffset - supScript->marginEnd() - supScript->logicalWidth(), *supScript), ascent - metrics.supShift - supAscent);
+            LayoutPoint supScriptLocation(mirrorIfNeeded(horizontalOffset - prescriptSpaceOffset - supScript->marginEnd() - supScript->logicalWidth(), *supScript), ascent - metrics.supShift - supAscent);
             supScript->setLocation(supScriptLocation);
             subScript = supScript->nextInFlowSiblingBox();
         }


### PR DESCRIPTION
#### 04b65f4f8bb6a63a4ca36371d6bc579e75ef0e8c
<pre>
[MathML] Update direction-overall-003.html to match spec-compliant symmetric prescript spacing
<a href="https://bugs.webkit.org/show_bug.cgi?id=308438">https://bugs.webkit.org/show_bug.cgi?id=308438</a>
<a href="https://rdar.apple.com/170932312">rdar://170932312</a>

Reviewed by Frédéric Wang Nélar.

The imported WPT reftest direction-overall-003.html was originally based
on Gecko&apos;s &quot;always-after-scripts&quot; spacing, where every script (prescript
and postscript) has the space-after-script on its inline-end side. Both
WebKit and Chromium implement the symmetric layout from MathML Core
instead: the space-after-script sits on the outer side of each script,
i.e. before each prescript pair and after each postscript pair. Under
that layout the base is adjacent to the inner prescript pair (no space
between them) and the prescript pairs shift inward by one
space-after-script compared to Gecko&apos;s rendering, so the existing
reference bands no longer line up with the squares in dir=rtl.

Update the test and its reference so the colored bands match WebKit&apos;s
(and Chromium&apos;s) symmetric output: widen the container to 320px, shrink
the magenta (base) band to 40px, shift the blue and yellow bands left
by one space-after-script (30px), and move the trailing black separator
stripes to the new band boundaries.

Refer to Specification Issue: <a href="https://github.com/w3c/mathml-core/issues/217">https://github.com/w3c/mathml-core/issues/217</a>

No change required; the rendering already matches the spec.

* LayoutTests/TestExpectations: Remove failing expectation.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003.html:
Resize and reposition the colored bands and black separators to match
the symmetric prescript layout.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003-ref.html:
Mirror the band changes in the reference.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/direction/direction-overall-003-expected.html:
Ditto

Canonical link: <a href="https://commits.webkit.org/314879@main">https://commits.webkit.org/314879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b089fd41250cf0c08535ff21189f013f6e55e302

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117730 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d99ba000-0ac7-4f06-a786-abf4ac14a134) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163228 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125173 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88199 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88a795a6-1ba4-4b8b-8ae7-463bdd6d7a30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27459 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144938 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.NavigateBackAfterNavigatingAwayFromCrossOriginOpenerPolicyUsingBackForwardCache2 (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105770 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bc96be0-9a1a-4566-af13-5d425e281720) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25019 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17982 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172745 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22197 "Build is in progress. Recent messages:") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133456 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37312 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96366 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21311 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34001 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33501 "Built successfully") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->