### PR TITLE
[MathML] none and mprescripts should be laid out as mrow elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2052,8 +2052,6 @@ imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-movablel
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/op-dict-8.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/op-dict-9.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/mprescripts-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/none-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/underover-stretchy-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/display-with-overflow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/floating-inside-mathml-with-block-display.html [ ImageOnlyFailure ]

--- a/LayoutTests/accessibility/mac/mathml-multiscript-expected.txt
+++ b/LayoutTests/accessibility/mac/mathml-multiscript-expected.txt
@@ -93,11 +93,13 @@ Prescripts:
 
 Check multiscript with 'none' tags.
 Postscripts:
+	0. AXMathSuperscript = AXEmptyGroup
 	0. AXMathSubscript = AXMathNumber
 	1. AXMathSubscript = AXMathNumber
 
 Prescripts:
 	0. AXMathSuperscript = AXMathIdentifier
+	0. AXMathSubscript = AXEmptyGroup
 	1. AXMathSubscript = AXMathNumber
 
 PASS successfullyParsed is true

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy-expected.txt
@@ -9,8 +9,8 @@ PASS operator stretching inside Menclose
 PASS operator stretching inside Mpadded
 PASS operator stretching inside Unknown
 FAIL operator stretching inside Mtd assert_greater_than_equal: expected a number greater than or equal to 100 but got 10
-FAIL operator stretching inside None assert_greater_than_equal: expected a number greater than or equal to 100 but got 10
-FAIL operator stretching inside Mprescripts assert_greater_than_equal: expected a number greater than or equal to 100 but got 10
+PASS operator stretching inside None
+PASS operator stretching inside Mprescripts
 PASS operator stretching inside Mfenced
 PASS operator stretching inside A
 ↨

--- a/LayoutTests/platform/glib/accessibility/math-multiscript-attributes-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/math-multiscript-attributes-expected.txt
@@ -65,6 +65,24 @@ AXRequired: 0
 AXChecked: 0
 AXPlatformAttributes: multiscript-type:post, tag:mi
 ------------
+AXRole: AXGroup
+AXParent: AXSection
+AXChildren: 0
+AXPosition:  { 8.00000, -33.0000 }
+AXSize: { 32.0000, 10.0000 }
+AXTitle:
+AXDescription:
+AXFocusable: 0
+AXFocused: 0
+AXSelectable: 0
+AXSelected: 0
+AXMultiSelectable: 0
+AXEnabled: 1
+AXExpanded: 0
+AXRequired: 0
+AXChecked: 0
+AXPlatformAttributes: tag:mprescripts
+------------
 AXRole: AXSubscript
 AXParent: AXSection
 AXChildren: 0

--- a/LayoutTests/platform/mac/accessibility/math-multiscript-attributes-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/math-multiscript-attributes-expected.txt
@@ -102,6 +102,37 @@ AXElementBusy: 0
 
 ------------
 AXRole: AXGroup
+AXSubrole: AXEmptyGroup
+AXRoleDescription: group
+AXChildren:
+AXChildrenInNavigationOrder:
+AXHelp:
+AXParent:
+AXSize: NSSize: {27, 10}
+AXTitle:
+AXDescription:
+AXValue:
+AXFocused: 0
+AXEnabled: 1
+AXWindow:
+AXSelectedTextMarkerRange: (null)
+AXStartTextMarker:
+AXEndTextMarker:
+AXVisited: 0
+AXLinkedUIElements:
+AXSelected: 0
+AXBlockQuoteLevel: 0
+AXTopLevelUIElement:
+AXLanguage:
+AXDOMIdentifier:
+AXDOMClassList:
+AXFocusableAncestor:
+AXEditableAncestor: (null)
+AXHighestEditableAncestor: (null)
+AXElementBusy: 0
+
+------------
+AXRole: AXGroup
 AXSubrole: AXMathIdentifier
 AXRoleDescription: group
 AXChildren:

--- a/Source/WebCore/mathml/mathtags.in
+++ b/Source/WebCore/mathml/mathtags.in
@@ -33,9 +33,9 @@ mtable interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
 mtr interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
 mtd interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
 mmultiscripts interfaceName=MathMLScriptsElement, JSInterfaceName=MathMLElement
-mprescripts interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
+mprescripts interfaceName=MathMLRowElement, JSInterfaceName=MathMLElement
 menclose interfaceName=MathMLMencloseElement, JSInterfaceName=MathMLElement
-none interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
+none interfaceName=MathMLRowElement, JSInterfaceName=MathMLElement
 semantics interfaceName=MathMLSelectElement, JSInterfaceName=MathMLElement
 
 maligngroup interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement


### PR DESCRIPTION
#### 74250f489695d05f6bf66b319b175aecabf73b8a
<pre>
[MathML] none and mprescripts should be laid out as mrow elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=308442">https://bugs.webkit.org/show_bug.cgi?id=308442</a>
<a href="https://rdar.apple.com/170940035">rdar://170940035</a>

Reviewed by Frédéric Wang.

This patch aligns WeKit with Gecko / Firefox and Blink / Chromium.

Change none and mprescripts from MathMLPresentationElement to
MathMLRowElement in mathtags.in so they get RenderMathMLRow.

The spec [1] states:
&quot;The &lt;mprescripts&gt; element is laid out as an mrow element.&quot;

[1] <a href="https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts">https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts</a>

This consequently fixes stretchy operators inside these elements,
as RenderMathMLRow calls stretchVerticalOperatorsAndLayoutChildren().

This is safe because all code handling these elements in
RenderMathMLScripts.cpp uses tag name checks, not C++ type checks.

* LayoutTests/TestExpectations: Progressions
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy-expected.txt: Ditto
* Source/WebCore/mathml/mathtags.in:

&gt; Rebaselines:
* LayoutTests/platform/glib/accessibility/math-multiscript-attributes-expected.txt:
* LayoutTests/platform/mac/accessibility/math-multiscript-attributes-expected.txt:
* LayoutTests/accessibility/mac/mathml-multiscript-expected.txt:

Canonical link: <a href="https://commits.webkit.org/308050@main">https://commits.webkit.org/308050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/628aad3c20d55288f6749f2eb347a5603d52ff71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2d84168-e1fe-476d-8e11-0f771e89810c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112561 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80516 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77cfbf47-a256-4dcc-af2d-eff9dfccc921) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93431 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14189 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11945 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2389 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157264 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120589 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30979 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74534 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7901 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18288 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18179 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->