### PR TITLE
[AutoFill Debugging] Add a heuristic to prioritize buttons and links when handling text-based click interactions

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -1,5 +1,7 @@
-PASS clickError is ""
-PASS clickCount.textContent is "1"
+PASS firstClickError is ""
+PASS secondClickError is ""
+PASS clickCount1.textContent is "1"
+PASS clickCount2.textContent is "1"
 PASS textInputError is ""
 PASS textField.value is "bar"
 PASS selectMenuItemError is ""
@@ -24,11 +26,15 @@ PASS disabledSelect.value is "Beta"
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Test  Disabled
+Test
+1
+
+Disabled
 Subject
 
 Hello world.
 
+Hello World: more options  Hello World
 1
 
 Foo bar

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -21,6 +21,7 @@
 </head>
 <body>
     <button id="test-button" aria-label="Click Me">Test</button>
+    <h1 class="click-count-1">0</h1>
     <button id="disabled-button" aria-label="Disabled Button" disabled>Disabled</button>
     <input type="email" placeholder="Enter some text" value="foo" />
     <input type="text" placeholder="Readonly field" value="readonly" readonly />
@@ -38,7 +39,11 @@
         <h3 aria-label="Heading">Subject</h3>
         <p>Hello world.</p>
     </div>
-    <h1 class="click-count">0</h1>
+    <form>
+        <a href="#">Hello World: more options</a>
+        <button id="hello-button">Hello World</button>
+        <h1 class="click-count-2">0</h1>
+    </form>
     <div class="scroller" aria-label="Child scroller">
         <div class="tall">Foo bar</div>
         <p>Hidden in scroller</p>
@@ -53,10 +58,17 @@
         readonlyField = document.querySelector("input[readonly]");
         select = document.querySelector("select");
         disabledSelect = document.querySelector("select[disabled]");
-        clickCount = document.querySelector(".click-count");
+        clickCount1 = document.querySelector(".click-count-1");
+        clickCount2 = document.querySelector(".click-count-2");
         childScroller = document.querySelector(".scroller");
+
         document.getElementById("test-button").addEventListener("click", () => {
-            clickCount.textContent = parseInt(clickCount.textContent) + 1;
+            clickCount1.textContent = parseInt(clickCount1.textContent) + 1;
+        });
+
+        document.getElementById("hello-button").addEventListener("click", event => {
+            clickCount2.textContent = parseInt(clickCount2.textContent) + 1;
+            event.preventDefault();
         });
 
         if (!window.testRunner)
@@ -68,8 +80,12 @@
             includeAccessibilityAttributes: true,
         });
 
-        clickError = await UIHelper.performTextExtractionInteraction("click", {
+        firstClickError = await UIHelper.performTextExtractionInteraction("click", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Click Me")
+        });
+
+        secondClickError = await UIHelper.performTextExtractionInteraction("click", {
+            text: "Hello World"
         });
 
         textInputError = await UIHelper.performTextExtractionInteraction("textinput", {
@@ -154,8 +170,10 @@
             text: "Gamma"
         });
 
-        shouldBeEqualToString("clickError", "");
-        shouldBeEqualToString("clickCount.textContent", "1");
+        shouldBeEqualToString("firstClickError", "");
+        shouldBeEqualToString("secondClickError", "")
+        shouldBeEqualToString("clickCount1.textContent", "1");
+        shouldBeEqualToString("clickCount2.textContent", "1");
         shouldBeEqualToString("textInputError", "");
         shouldBeEqualToString("textField.value", "bar");
         shouldBeEqualToString("selectMenuItemError", "");


### PR DESCRIPTION
#### 46334f674a96c704eabffdc76013c8bf0754c142
<pre>
[AutoFill Debugging] Add a heuristic to prioritize buttons and links when handling text-based click interactions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308441">https://bugs.webkit.org/show_bug.cgi?id=308441</a>
<a href="https://rdar.apple.com/170939635">rdar://170939635</a>

Reviewed by Aditya Keerthi.

When handling a click interaction with search text, we currently simulate a click over the first
matching run of text in the document. We can make this smarter by prioritizing both:

- Matching text in clickable elements
- Elements where the search text matches exactly

* LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:

Augment an existing test to exercise these enhancements.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::searchForClickTarget):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::textDescription):
(WebCore::TextExtraction::interactionDescription):

Canonical link: <a href="https://commits.webkit.org/308053@main">https://commits.webkit.org/308053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/926fde7d56089b087f6b1923485672e3cb5ca51f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154937 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99728 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63c73778-e531-4808-8b92-9982b6fc1c1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112557 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99728 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/431d2ecd-db59-4474-b9af-86e9b20482c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93427 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/869818b7-f766-424d-b0bc-af85db21aad2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14182 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11939 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2383 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157258 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/429 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120585 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120885 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30984 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74522 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7880 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82137 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18116 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18173 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->