### PR TITLE
counters evaluation with style containment

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5874,8 +5874,6 @@ imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visib
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-hidden-scrollTop-left-width-height.html [ Failure ]
 
 # Style containment
-imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-002.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/CounterNode.cpp
+++ b/Source/WebCore/rendering/CounterNode.cpp
@@ -32,10 +32,11 @@
 
 namespace WebCore {
 
-CounterNode::CounterNode(RenderElement& owner, OptionSet<CounterNode::Type> type, int value)
+CounterNode::CounterNode(RenderElement& owner, OptionSet<CounterNode::Type> type, int value, std::optional<Plan> plan)
     : m_type(type)
     , m_value(value)
     , m_owner(owner)
+    , m_plan(plan)
 {
 }
 
@@ -92,9 +93,9 @@ RenderElement& CounterNode::owner() const
     return m_owner.get();
 }
 
-Ref<CounterNode> CounterNode::create(RenderElement& owner, OptionSet<CounterNode::Type> type, int value)
+Ref<CounterNode> CounterNode::create(RenderElement& owner, OptionSet<CounterNode::Type> type, int value, std::optional<Plan> plan)
 {
-    return adoptRef(*new CounterNode(owner, type, value));
+    return adoptRef(*new CounterNode(owner, type, value, plan));
 }
 
 CounterNode* CounterNode::nextInPreOrderAfterChildren(const CounterNode* stayWithin) const
@@ -337,6 +338,15 @@ void CounterNode::removeChild(CounterNode& oldChild)
 
     if (next)
         next->recount();
+}
+
+bool CounterNode::shouldShowZero() const
+{
+    for (auto* node = this; node; node = node->parent()) {
+        if (node->m_plan.has_value())
+            return true;
+    }
+    return false;
 }
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/rendering/CounterNode.h
+++ b/Source/WebCore/rendering/CounterNode.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <optional>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
@@ -44,12 +45,17 @@ class RenderElement;
 class CounterNode : public RefCounted<CounterNode>, public CanMakeSingleThreadWeakPtr<CounterNode> {
 public:
     enum class Type : uint8_t { Increment, Reset, Set };
+    struct Plan {
+        OptionSet<Type> type;
+        int value { 0 };
+    };
 
-    static Ref<CounterNode> create(RenderElement&, OptionSet<Type>, int value);
+    static Ref<CounterNode> create(RenderElement&, OptionSet<Type>, int value, std::optional<Plan>);
     ~CounterNode();
     bool actsAsReset() const { return hasResetType() || !m_parent; }
     bool hasResetType() const { return m_type.contains(Type::Reset); }
     bool hasSetType() const { return m_type.contains(Type::Set); }
+    bool shouldShowZero() const;
     int value() const { return m_value; }
     int countInParent() const { return m_countInParent; }
     RenderElement& NODELETE owner() const;
@@ -74,7 +80,7 @@ public:
     void removeChild(CounterNode&);
 
 private:
-    CounterNode(RenderElement&, OptionSet<Type>, int value);
+    CounterNode(RenderElement&, OptionSet<Type>, int value, std::optional<Plan>);
     int NODELETE computeCountInParent() const;
     // Invalidates the text in the renderer of this counter, if any,
     // and in the renderers of all descendants of this counter, if any.
@@ -92,6 +98,7 @@ private:
     SingleThreadWeakPtr<CounterNode> m_nextSibling;
     SingleThreadWeakPtr<CounterNode> m_firstChild;
     SingleThreadWeakPtr<CounterNode> m_lastChild;
+    std::optional<Plan> m_plan;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -30,6 +30,7 @@
 #include "HTMLNames.h"
 #include "HTMLOListElement.h"
 #include "RenderChildIterator.h"
+#include "RenderElement.h"
 #include "RenderElementStyleInlines.h"
 #include "RenderElementInlines.h"
 #include "RenderListItem.h"
@@ -37,6 +38,7 @@
 #include "RenderStyle.h"
 #include "RenderView.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/AtomString.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(TREE_DEBUGGING)
@@ -58,6 +60,16 @@ static CounterMaps& counterMaps()
 {
     static NeverDestroyed<CounterMaps> staticCounterMaps;
     return staticCounterMaps;
+}
+
+static RenderElement* ancestorStyleContainmentObject(const RenderElement& element)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto* ancestor = element.parent();
+    for (; ancestor; ancestor = ancestor->parent()) {
+        if (ancestor->shouldApplyStyleContainment())
+            break;
+    }
+    return ancestor;
 }
 
 // Descend into a subtree to find its last RenderElement in pre-order, stopping at style containment boundaries.
@@ -175,12 +187,7 @@ static CounterDirectives listItemCounterDirectives(RenderElement& renderer)
     return { };
 }
 
-struct CounterPlan {
-    OptionSet<CounterNode::Type> type;
-    int value;
-};
-
-static std::optional<CounterPlan> planCounter(RenderElement& renderer, const AtomString& identifier)
+static std::optional<CounterNode::Plan> planCounter(RenderElement& renderer, const AtomString& identifier)
 {
     // We must have a generating node or else we cannot have a counter.
     RefPtr generatingElement = renderer.generatingElement();
@@ -217,11 +224,11 @@ static std::optional<CounterPlan> planCounter(RenderElement& renderer, const Ato
         type.add(CounterNode::Type::Increment);
 
     if (directives.setValue)
-        return CounterPlan { type, *directives.setValue };
+        return CounterNode::Plan { type, *directives.setValue };
     if (directives.resetValue)
-        return CounterPlan { type, saturatedSum<int>(*directives.resetValue, directives.incrementValue.value_or(0)) };
+        return CounterNode::Plan { type, saturatedSum<int>(*directives.resetValue, directives.incrementValue.value_or(0)) };
     if (directives.incrementValue)
-        return CounterPlan { type, *directives.incrementValue };
+        return CounterNode::Plan { type, *directives.incrementValue };
     return std::nullopt;
 }
 
@@ -374,7 +381,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
     auto& maps = counterMaps();
 
     auto type = plan ? plan->type : OptionSet<CounterNode::Type> { };
-    auto newNode = CounterNode::create(renderer, type, plan ? plan->value : 0);
+    auto newNode = CounterNode::create(renderer, plan ? plan->type : OptionSet<CounterNode::Type> { }, plan ? plan->value : 0, plan);
 
     auto place = findPlaceForCounter(renderer, identifier, type);
     if (place.parent)
@@ -439,22 +446,42 @@ String RenderCounter::originalText() const
     if (!m_counterNode)
         return emptyString();
 
-    RefPtr counterNode = m_counterNode.get();
-    int value = counterNode->actsAsReset() ? counterNode->value() : counterNode->countInParent();
+    String text;
+    for (RefPtr current = m_counterNode; current; ) {
+        RefPtr child = current;
+        int value = child->actsAsReset() ? child->value() : child->countInParent();
 
-    auto counterText = [&](int value) {
-        return counterStyle()->text(value, writingMode());
-    };
-    auto text = counterText(value);
-    if (!m_counter.separator.isNull()) {
-        if (!counterNode->actsAsReset())
-            counterNode = counterNode->parent();
-        while (RefPtr parent = counterNode->parent()) {
-            text = makeString(counterText(counterNode->countInParent()), m_counter.separator, text);
-            counterNode = parent;
+        auto counterText = [&](int value) {
+            return counterStyle()->text(value, writingMode());
+        };
+        auto newText = counterText(value);
+        if (!m_counter.separator.isNull()) {
+            if (!child->actsAsReset())
+                child = child->parent();
+            while (RefPtr parent = child->parent()) {
+                newText = makeString(counterText(child->countInParent()), m_counter.separator, newText);
+                child = parent;
+            }
         }
-    }
 
+        if (newText != "0"_s || current->shouldShowZero()) {
+            if (!text.isEmpty())
+                text = makeString(newText, m_counter.separator, text);
+            else
+                text = newText;
+        }
+
+        if (m_counter.separator.isNull())
+            return text.isEmpty() ? newText : text;
+
+        if (auto ancestorContainment = ancestorStyleContainmentObject(current->owner())) {
+            if (auto renderer = ancestorContainment) {
+                current = makeCounterNode(*renderer, m_counter.identifier, true);
+                continue;
+            }
+        }
+        return text.isEmpty() ? newText : text;
+    }
     return text;
 }
 


### PR DESCRIPTION
#### 5a4d55dbf634942e0e8d338f6c5f4b625395bba4
<pre>
counters evaluation with style containment
<a href="https://bugs.webkit.org/show_bug.cgi?id=308446">https://bugs.webkit.org/show_bug.cgi?id=308446</a>

Reviewed by NOBODY (OOPS!).

Fixed an issue where counters from outside the style containment were not displayed when contain: style was used.

This behavior should be covered by imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html and imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::CounterNode::CounterNode):
(WebCore::CounterNode::create):
(WebCore::CounterNode::shouldShowZero const):
* Source/WebCore/rendering/CounterNode.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::ancestorStyleContainmentObject):
(WebCore::planCounter):
(WebCore::makeCounterNode):
(WebCore::RenderCounter::originalText const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a4d55dbf634942e0e8d338f6c5f4b625395bba4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114745 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81714 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13903 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159867 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122804 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21358 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17915 "Found 2 new test failures: accessibility/display-contents/aria-grid.html accessibility/mac/text-operation/text-operation-capitalize.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123034 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133310 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77554 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10071 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84770 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->