### PR TITLE
Drop remaining `checked*()` member functions in the codebase

### DIFF
--- a/Source/JavaScriptCore/API/APIUtils.h
+++ b/Source/JavaScriptCore/API/APIUtils.h
@@ -46,7 +46,7 @@ inline ExceptionStatus handleExceptionIfNeeded(JSC::TopExceptionScope& scope, JS
             *returnedExceptionRef = toRef(globalObject, exception->value());
         scope.clearException();
 #if ENABLE(REMOTE_INSPECTOR)
-        globalObject->checkedInspectorController()->reportAPIException(globalObject, exception);
+        protect(globalObject->inspectorController())->reportAPIException(globalObject, exception);
 #endif
         return ExceptionStatus::DidThrow;
     }
@@ -60,7 +60,7 @@ inline void setException(JSContextRef ctx, JSValueRef* returnedExceptionRef, JSC
         *returnedExceptionRef = toRef(globalObject, exception);
 #if ENABLE(REMOTE_INSPECTOR)
     JSC::VM& vm = getVM(globalObject);
-    globalObject->checkedInspectorController()->reportAPIException(globalObject, JSC::Exception::create(vm, exception));
+    protect(globalObject->inspectorController())->reportAPIException(globalObject, JSC::Exception::create(vm, exception));
 #endif
 }
 

--- a/Source/JavaScriptCore/API/JSBase.cpp
+++ b/Source/JavaScriptCore/API/JSBase.cpp
@@ -61,7 +61,7 @@ JSValueRef JSEvaluateScriptInternal(const JSLockHolder&, JSContextRef ctx, JSObj
         // Debugger path is currently ignored by inspector.
         // NOTE: If we don't have a debugger, this SourceCode will be forever lost to the inspector.
         // We could stash it in the inspector in case an inspector is ever opened.
-        globalObject->checkedInspectorController()->reportAPIException(globalObject, evaluationException);
+        protect(globalObject->inspectorController())->reportAPIException(globalObject, evaluationException);
 #endif
         return nullptr;
     }
@@ -114,7 +114,7 @@ bool JSCheckScriptSyntax(JSContextRef ctx, JSStringRef script, JSStringRef sourc
             *exception = toRef(globalObject, syntaxException);
 #if ENABLE(REMOTE_INSPECTOR)
         Exception* exception = Exception::create(vm, syntaxException);
-        globalObject->checkedInspectorController()->reportAPIException(globalObject, exception);
+        protect(globalObject->inspectorController())->reportAPIException(globalObject, exception);
 #endif
         return false;
     }

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -882,7 +882,7 @@ static void reportExceptionToInspector(JSGlobalContextRef context, JSC::JSValue 
     JSC::JSGlobalObject* globalObject = toJS(context);
     JSC::VM& vm = globalObject->vm();
     JSC::Exception* exception = JSC::Exception::create(vm, exceptionValue);
-    globalObject->checkedInspectorController()->reportAPIException(globalObject, exception);
+    protect(globalObject->inspectorController())->reportAPIException(globalObject, exception);
 }
 #endif
 

--- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
@@ -59,7 +59,7 @@ InjectedScript::~InjectedScript() = default;
 
 void InjectedScript::execute(Protocol::ErrorString& errorString, const String& functionString, ExecuteOptions&& options, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "execute"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "execute"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(functionString);
     function.appendArgument(options.objectGroup);
     function.appendArgument(options.includeCommandLineAPI);
@@ -72,7 +72,7 @@ void InjectedScript::execute(Protocol::ErrorString& errorString, const String& f
 
 void InjectedScript::evaluate(Protocol::ErrorString& errorString, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluate"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluate"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(expression);
     function.appendArgument(objectGroup);
     function.appendArgument(includeCommandLineAPI);
@@ -84,7 +84,7 @@ void InjectedScript::evaluate(Protocol::ErrorString& errorString, const String& 
 
 void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByValue, bool generatePreview, bool saveResult, AsyncCallCallback&& callback)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "awaitPromise"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "awaitPromise"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(promiseObjectId);
     function.appendArgument(returnByValue);
     function.appendArgument(generatePreview);
@@ -94,7 +94,7 @@ void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByVa
 
 void InjectedScript::callFunctionOn(const String& objectId, const String& expression, const String& arguments, bool returnByValue, bool generatePreview, bool awaitPromise, AsyncCallCallback&& callback)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "callFunctionOn"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "callFunctionOn"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(expression);
     function.appendArgument(arguments);
@@ -106,7 +106,7 @@ void InjectedScript::callFunctionOn(const String& objectId, const String& expres
 
 void InjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC::JSValue callFrames, const String& callFrameId, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluateOnCallFrame"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluateOnCallFrame"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(callFrames);
     function.appendArgument(callFrameId);
     function.appendArgument(expression);
@@ -120,7 +120,7 @@ void InjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC
 
 void InjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, const String& functionId, RefPtr<Protocol::Debugger::FunctionDetails>& result)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getFunctionDetails"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getFunctionDetails"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(functionId);
 
     RefPtr<JSON::Value> resultValue = makeCall(function);
@@ -136,7 +136,7 @@ void InjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, cons
 
 void InjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JSValue value, RefPtr<Protocol::Debugger::FunctionDetails>& result)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "functionDetails"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "functionDetails"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(value);
 
     RefPtr<JSON::Value> resultValue = makeCall(function);
@@ -152,7 +152,7 @@ void InjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JS
 
 void InjectedScript::getPreview(Protocol::ErrorString& errorString, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getPreview"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getPreview"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
 
     RefPtr<JSON::Value> resultValue = makeCall(function);
@@ -171,7 +171,7 @@ void InjectedScript::getProperties(Protocol::ErrorString& errorString, const Str
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
 
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getProperties"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getProperties"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(ownProperties);
     function.appendArgument(fetchStart);
@@ -192,7 +192,7 @@ void InjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
 
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getDisplayableProperties"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getDisplayableProperties"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(fetchStart);
     function.appendArgument(fetchCount);
@@ -209,7 +209,7 @@ void InjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString
 
 void InjectedScript::getInternalProperties(Protocol::ErrorString& errorString, const String& objectId, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>& properties)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getInternalProperties"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getInternalProperties"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(generatePreview);
 
@@ -229,7 +229,7 @@ void InjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, co
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
 
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getCollectionEntries"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getCollectionEntries"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
     function.appendArgument(objectGroup);
     function.appendArgument(fetchStart);
@@ -246,7 +246,7 @@ void InjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, co
 
 void InjectedScript::saveResult(Protocol::ErrorString& errorString, const String& callArgumentJSON, std::optional<int>& savedResultIndex)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "saveResult"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "saveResult"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(callArgumentJSON);
 
     RefPtr<JSON::Value> result = makeCall(function);
@@ -261,7 +261,7 @@ void InjectedScript::saveResult(Protocol::ErrorString& errorString, const String
 Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InjectedScript::wrapCallFrames(JSC::JSValue callFrames) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "wrapCallFrames"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "wrapCallFrames"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(callFrames);
 
     auto callResult = callFunctionWithEvalEnabled(function);
@@ -279,7 +279,7 @@ Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InjectedScript::wrapCallFrames
 RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue value, const String& groupName, bool generatePreview) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapObject"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapObject"_s, protect(inspectorEnvironment())->functionCallHandler());
     wrapFunction.appendArgument(value);
     wrapFunction.appendArgument(groupName);
     wrapFunction.appendArgument(hasAccessToInspectedScriptState());
@@ -303,7 +303,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue 
 RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const String& json, const String& groupName, bool generatePreview) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapJSONString"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapJSONString"_s, protect(inspectorEnvironment())->functionCallHandler());
     wrapFunction.appendArgument(json);
     wrapFunction.appendArgument(groupName);
     wrapFunction.appendArgument(generatePreview);
@@ -329,7 +329,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const Str
 RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue table, JSC::JSValue columns) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapTable"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapTable"_s, protect(inspectorEnvironment())->functionCallHandler());
     wrapFunction.appendArgument(hasAccessToInspectedScriptState());
     wrapFunction.appendArgument(table);
     if (!columns)
@@ -355,7 +355,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue t
 RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSValue value) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "previewValue"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "previewValue"_s, protect(inspectorEnvironment())->functionCallHandler());
     wrapFunction.appendArgument(value);
 
     auto callResult = callFunctionWithEvalEnabled(wrapFunction);
@@ -376,7 +376,7 @@ RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSVal
 void InjectedScript::setEventValue(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setEventValue"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setEventValue"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(value);
     makeCall(function);
 }
@@ -384,14 +384,14 @@ void InjectedScript::setEventValue(JSC::JSValue value)
 void InjectedScript::clearEventValue()
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearEventValue"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearEventValue"_s, protect(inspectorEnvironment())->functionCallHandler());
     makeCall(function);
 }
 
 void InjectedScript::setExceptionValue(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setExceptionValue"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setExceptionValue"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(value);
     makeCall(function);
 }
@@ -399,14 +399,14 @@ void InjectedScript::setExceptionValue(JSC::JSValue value)
 void InjectedScript::clearExceptionValue()
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearExceptionValue"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearExceptionValue"_s, protect(inspectorEnvironment())->functionCallHandler());
     makeCall(function);
 }
 
 JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "findObjectById"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "findObjectById"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
 
     auto callResult = callFunctionWithEvalEnabled(function);
@@ -419,14 +419,14 @@ JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
 void InjectedScript::inspectObject(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "inspectObject"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "inspectObject"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(value);
     makeCall(function);
 }
 
 void InjectedScript::releaseObject(const String& objectId)
 {
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "releaseObject"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "releaseObject"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(objectId);
     makeCall(function);
 }
@@ -434,7 +434,7 @@ void InjectedScript::releaseObject(const String& objectId)
 void InjectedScript::releaseObjectGroup(const String& objectGroup)
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall releaseFunction(globalObject(), injectedScriptObject(), "releaseObjectGroup"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall releaseFunction(globalObject(), injectedScriptObject(), "releaseObjectGroup"_s, protect(inspectorEnvironment())->functionCallHandler());
     releaseFunction.appendArgument(objectGroup);
 
     auto callResult = callFunctionWithEvalEnabled(releaseFunction);
@@ -444,7 +444,7 @@ void InjectedScript::releaseObjectGroup(const String& objectGroup)
 JSC::JSObject* InjectedScript::createCommandLineAPIObject(JSC::JSValue callFrame) const
 {
     ASSERT(!hasNoValue());
-    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "createCommandLineAPIObject"_s, checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(globalObject(), injectedScriptObject(), "createCommandLineAPIObject"_s, protect(inspectorEnvironment())->functionCallHandler());
     function.appendArgument(callFrame);
 
     auto callResult = callFunctionWithEvalEnabled(function);

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.h
@@ -67,7 +67,6 @@ protected:
     InjectedScriptBase(const String& name, JSC::JSGlobalObject*, JSC::JSObject*, InspectorEnvironment*);
 
     InspectorEnvironment& inspectorEnvironment() const { return *m_environment; }
-    CheckedRef<InspectorEnvironment> checkedInspectorEnvironment() const { return inspectorEnvironment(); }
 
     bool hasAccessToInspectedScriptState() const;
 

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -173,7 +173,7 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
             return it1->value;
     }
 
-    if (!checkedInspectorEnvironment()->canAccessInspectedScriptState(globalObject))
+    if (!protect(inspectorEnvironment())->canAccessInspectedScriptState(globalObject))
         return InjectedScript();
 
     int id = injectedScriptIdFor(globalObject);

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -62,7 +62,6 @@ public:
 
     InjectedScriptHost& injectedScriptHost();
     InspectorEnvironment& inspectorEnvironment() const { return *m_environment; }
-    CheckedRef<InspectorEnvironment> checkedInspectorEnvironment() const { return inspectorEnvironment(); }
 
     JS_EXPORT_PRIVATE InjectedScript injectedScriptFor(JSC::JSGlobalObject*);
     JS_EXPORT_PRIVATE InjectedScript injectedScriptForId(int);

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -59,7 +59,7 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
 
     // FIXME: Make the InjectedScript a module itself.
     JSC::JSLockHolder locker(injectedScript.globalObject());
-    ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "hasInjectedModule"_s, injectedScriptManager->checkedInspectorEnvironment()->functionCallHandler());
+    ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "hasInjectedModule"_s, protect(injectedScriptManager->inspectorEnvironment())->functionCallHandler());
     function.appendArgument(name());
     auto hasInjectedModuleResult = injectedScript.callFunctionWithEvalEnabled(function);
     ASSERT(hasInjectedModuleResult);
@@ -78,7 +78,7 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!hasInjectedModuleResult.value().isBoolean() || !hasInjectedModuleResult.value().asBoolean()) {
-        ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "injectModule"_s, injectedScriptManager->checkedInspectorEnvironment()->functionCallHandler());
+        ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "injectModule"_s, protect(injectedScriptManager->inspectorEnvironment())->functionCallHandler());
         function.appendArgument(name());
         function.appendArgument(JSC::JSValue(injectModuleFunction(injectedScript.globalObject())));
         function.appendArgument(host(injectedScriptManager, injectedScript.globalObject()));

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
@@ -84,7 +84,7 @@ Protocol::ErrorStringOr<void> InspectorAgent::disable()
 
 Protocol::ErrorStringOr<void> InspectorAgent::initialized()
 {
-    checkedEnvironment()->frontendInitialized();
+    protect(m_environment)->frontendInitialized();
 
     return { };
 }

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
@@ -65,8 +65,6 @@ public:
     void evaluateForTestInFrontend(const String& script);
 
 private:
-    CheckedRef<InspectorEnvironment> checkedEnvironment() { return m_environment.get(); }
-
     WeakRef<InspectorEnvironment> m_environment;
     const UniqueRef<InspectorFrontendDispatcher> m_frontendDispatcher;
     const Ref<InspectorBackendDispatcher> m_backendDispatcher;

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -1780,7 +1780,7 @@ void InspectorDebuggerAgent::didPause(JSC::JSGlobalObject* globalObject, JSC::De
         m_continueToLocationDebuggerBreakpoint = nullptr;
     }
 
-    auto& stopwatch = injectedScriptManager().checkedInspectorEnvironment()->executionStopwatch();
+    auto& stopwatch = protect(injectedScriptManager().inspectorEnvironment())->executionStopwatch();
     if (stopwatch.isActive()) {
         stopwatch.stop();
         m_didPauseStopwatch = true;
@@ -1818,7 +1818,7 @@ void InspectorDebuggerAgent::breakpointActionProbe(JSC::JSGlobalObject* globalOb
         .setProbeId(actionID)
         .setBatchId(batchId)
         .setSampleId(sampleId)
-        .setTimestamp(injectedScriptManager().checkedInspectorEnvironment()->executionStopwatch().elapsedTime().seconds())
+        .setTimestamp(protect(injectedScriptManager().inspectorEnvironment())->executionStopwatch().elapsedTime().seconds())
         .setPayload(payload.releaseNonNull())
         .release();
     m_frontendDispatcher->didSampleProbe(WTF::move(result));
@@ -1828,7 +1828,7 @@ void InspectorDebuggerAgent::didContinue()
 {
     if (m_didPauseStopwatch) {
         m_didPauseStopwatch = false;
-        injectedScriptManager().checkedInspectorEnvironment()->executionStopwatch().start();
+        protect(injectedScriptManager().inspectorEnvironment())->executionStopwatch().start();
     }
 
     m_pausedGlobalObject = nullptr;

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -69,7 +69,7 @@ Protocol::ErrorStringOr<void> InspectorHeapAgent::enable()
 
     m_enabled = true;
 
-    checkedEnvironment()->vm().heap.addObserver(this);
+    protect(m_environment)->vm().heap.addObserver(this);
 
     return { };
 }
@@ -82,7 +82,7 @@ Protocol::ErrorStringOr<void> InspectorHeapAgent::disable()
     m_enabled = false;
     m_tracking = false;
 
-    checkedEnvironment()->vm().heap.removeObserver(this);
+    protect(m_environment)->vm().heap.removeObserver(this);
 
     clearHeapSnapshots();
 
@@ -91,7 +91,7 @@ Protocol::ErrorStringOr<void> InspectorHeapAgent::disable()
 
 Protocol::ErrorStringOr<void> InspectorHeapAgent::gc()
 {
-    VM& vm = checkedEnvironment()->vm();
+    VM& vm = protect(m_environment)->vm();
     JSLockHolder lock(vm);
     sanitizeStackForVM(vm);
     vm.heap.collectNow(Sync, CollectionScope::Full);
@@ -101,7 +101,7 @@ Protocol::ErrorStringOr<void> InspectorHeapAgent::gc()
 
 Protocol::ErrorStringOr<std::tuple<double, Protocol::Heap::HeapSnapshotData>> InspectorHeapAgent::snapshot()
 {
-    VM& vm = checkedEnvironment()->vm();
+    VM& vm = protect(m_environment)->vm();
     JSLockHolder lock(vm);
 
     HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler());
@@ -109,7 +109,7 @@ Protocol::ErrorStringOr<std::tuple<double, Protocol::Heap::HeapSnapshotData>> In
 
     snapshotBuilder.buildSnapshot();
 
-    auto timestamp = checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+    auto timestamp = protect(m_environment)->executionStopwatch().elapsedTime().seconds();
     auto snapshotData = snapshotBuilder.json();
     return { { timestamp, snapshotData } };
 }
@@ -150,7 +150,7 @@ Protocol::ErrorStringOr<void> InspectorHeapAgent::stopTracking()
 
 std::optional<HeapSnapshotNode> InspectorHeapAgent::nodeForHeapObjectIdentifier(Protocol::ErrorString& errorString, unsigned heapObjectIdentifier)
 {
-    HeapProfiler* heapProfiler = checkedEnvironment()->vm().heapProfiler();
+    HeapProfiler* heapProfiler = protect(m_environment)->vm().heapProfiler();
     if (!heapProfiler) {
         errorString = "No heap snapshot"_s;
         return std::nullopt;
@@ -176,7 +176,7 @@ Protocol::ErrorStringOr<std::tuple<String, RefPtr<Protocol::Debugger::FunctionDe
     Protocol::ErrorString errorString;
 
     // Prevent the cell from getting collected as we look it up.
-    VM& vm = checkedEnvironment()->vm();
+    VM& vm = protect(m_environment)->vm();
     JSLockHolder lock(vm);
     DeferGC deferGC(vm);
 
@@ -226,7 +226,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorHeapAgent
     Protocol::ErrorString errorString;
 
     // Prevent the cell from getting collected as we look it up.
-    VM& vm = checkedEnvironment()->vm();
+    VM& vm = protect(m_environment)->vm();
     JSLockHolder lock(vm);
     DeferGC deferGC(vm);
 
@@ -272,7 +272,7 @@ void InspectorHeapAgent::willGarbageCollect()
     if (!m_enabled)
         return;
 
-    m_gcStartTime = checkedEnvironment()->executionStopwatch().elapsedTime();
+    m_gcStartTime = protect(m_environment)->executionStopwatch().elapsedTime();
 }
 
 void InspectorHeapAgent::didGarbageCollect(CollectionScope scope)
@@ -289,7 +289,7 @@ void InspectorHeapAgent::didGarbageCollect(CollectionScope scope)
 
     // FIXME: Include number of bytes freed by collection.
 
-    Seconds endTime = checkedEnvironment()->executionStopwatch().elapsedTime();
+    Seconds endTime = protect(m_environment)->executionStopwatch().elapsedTime();
     dispatchGarbageCollectedEvent(protocolTypeForHeapOperation(scope), m_gcStartTime, endTime);
 
     m_gcStartTime = Seconds::nan();
@@ -299,7 +299,7 @@ bool InspectorHeapAgent::heapSnapshotBuilderIgnoreNode(const HeapSnapshotBuilder
 {
     if (const Structure* structure = cell->structure()) {
         if (JSGlobalObject* globalObject = structure->globalObject()) {
-            if (!checkedEnvironment()->canAccessInspectedScriptState(globalObject))
+            if (!protect(m_environment)->canAccessInspectedScriptState(globalObject))
                 return true;
         }
     }
@@ -308,7 +308,7 @@ bool InspectorHeapAgent::heapSnapshotBuilderIgnoreNode(const HeapSnapshotBuilder
 
 void InspectorHeapAgent::clearHeapSnapshots()
 {
-    VM& vm = checkedEnvironment()->vm();
+    VM& vm = protect(m_environment)->vm();
     JSLockHolder lock(vm);
 
     if (HeapProfiler* heapProfiler = vm.heapProfiler()) {

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -78,8 +78,6 @@ protected:
 
     virtual void dispatchGarbageCollectedEvent(Protocol::Heap::GarbageCollection::Type, Seconds startTime, Seconds endTime);
 
-    CheckedRef<InspectorEnvironment> checkedEnvironment() { return m_environment.get(); }
-
 private:
     std::optional<JSC::HeapSnapshotNode> nodeForHeapObjectIdentifier(Protocol::ErrorString&, unsigned heapObjectIdentifier);
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
@@ -60,7 +60,7 @@ void InspectorScriptProfilerAgent::willDestroyFrontendAndBackend(DisconnectReaso
     if (m_tracking) {
         m_tracking = false;
         m_activeEvaluateScript = false;
-        checkedEnvironment()->debugger()->setProfilingClient(nullptr);
+        protect(m_environment)->debugger()->setProfilingClient(nullptr);
 
         // Stop sampling without processing the samples.
         stopSamplingWhenDisconnecting();
@@ -74,11 +74,11 @@ Protocol::ErrorStringOr<void> InspectorScriptProfilerAgent::startTracking(std::o
 
     m_tracking = true;
 
-    auto& stopwatch = checkedEnvironment()->executionStopwatch();
+    auto& stopwatch = protect(m_environment)->executionStopwatch();
 
 #if ENABLE(SAMPLING_PROFILER)
     if (includeSamples && *includeSamples) {
-        VM& vm = checkedEnvironment()->debugger()->vm();
+        VM& vm = protect(m_environment)->debugger()->vm();
         SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(stopwatch);
 
         Locker locker { samplingProfiler.getLock() };
@@ -91,7 +91,7 @@ Protocol::ErrorStringOr<void> InspectorScriptProfilerAgent::startTracking(std::o
     UNUSED_PARAM(includeSamples);
 #endif // ENABLE(SAMPLING_PROFILER)
 
-    checkedEnvironment()->debugger()->setProfilingClient(this);
+    protect(m_environment)->debugger()->setProfilingClient(this);
 
     m_frontendDispatcher->trackingStart(stopwatch.elapsedTime().seconds());
 
@@ -106,7 +106,7 @@ Protocol::ErrorStringOr<void> InspectorScriptProfilerAgent::stopTracking()
     m_tracking = false;
     m_activeEvaluateScript = false;
 
-    checkedEnvironment()->debugger()->setProfilingClient(nullptr);
+    protect(m_environment)->debugger()->setProfilingClient(nullptr);
 
     trackingComplete();
 
@@ -124,20 +124,20 @@ Seconds InspectorScriptProfilerAgent::willEvaluateScript()
 
 #if ENABLE(SAMPLING_PROFILER)
     if (m_enabledSamplingProfiler) {
-        SamplingProfiler* samplingProfiler = checkedEnvironment()->debugger()->vm().samplingProfiler();
+        SamplingProfiler* samplingProfiler = protect(m_environment)->debugger()->vm().samplingProfiler();
         RELEASE_ASSERT(samplingProfiler);
         samplingProfiler->noticeCurrentThreadAsJSCExecutionThread();
     }
 #endif
 
-    return checkedEnvironment()->executionStopwatch().elapsedTime();
+    return protect(m_environment)->executionStopwatch().elapsedTime();
 }
 
 void InspectorScriptProfilerAgent::didEvaluateScript(Seconds startTime, ProfilingReason reason)
 {
     m_activeEvaluateScript = false;
 
-    Seconds endTime = checkedEnvironment()->executionStopwatch().elapsedTime();
+    Seconds endTime = protect(m_environment)->executionStopwatch().elapsedTime();
 
     addEvent(startTime, endTime, reason);
 }
@@ -210,11 +210,11 @@ static Ref<Protocol::ScriptProfiler::Samples> buildSamples(VM& vm, Vector<Sampli
 
 void InspectorScriptProfilerAgent::trackingComplete()
 {
-    auto stopwatchTimestamp = checkedEnvironment()->executionStopwatch().elapsedTime().seconds();
+    auto stopwatchTimestamp = protect(m_environment)->executionStopwatch().elapsedTime().seconds();
 
 #if ENABLE(SAMPLING_PROFILER)
     if (m_enabledSamplingProfiler) {
-        VM& vm = checkedEnvironment()->debugger()->vm();
+        VM& vm = protect(m_environment)->debugger()->vm();
         JSLockHolder lock(vm);
         DeferGC deferGC(vm); // This is required because we will have raw pointers into the heap after we releaseStackTraces().
         SamplingProfiler* samplingProfiler = vm.samplingProfiler();
@@ -243,7 +243,7 @@ void InspectorScriptProfilerAgent::stopSamplingWhenDisconnecting()
     if (!m_enabledSamplingProfiler)
         return;
 
-    VM& vm = checkedEnvironment()->debugger()->vm();
+    VM& vm = protect(m_environment)->debugger()->vm();
     JSLockHolder lock(vm);
     SamplingProfiler* samplingProfiler = vm.samplingProfiler();
     RELEASE_ASSERT(samplingProfiler);

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
@@ -62,7 +62,6 @@ private:
     void addEvent(Seconds startTime, Seconds endTime, JSC::ProfilingReason);
     void trackingComplete();
     void stopSamplingWhenDisconnecting();
-    CheckedRef<InspectorEnvironment> checkedEnvironment() { return m_environment.get(); }
 
     const UniqueRef<ScriptProfilerFrontendDispatcher> m_frontendDispatcher;
     const Ref<ScriptProfilerBackendDispatcher> m_backendDispatcher;

--- a/Source/JavaScriptCore/parser/ParserArena.cpp
+++ b/Source/JavaScriptCore/parser/ParserArena.cpp
@@ -121,7 +121,7 @@ const Identifier* IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Ide
 const Identifier& IdentifierArena::makePrivateIdentifier(VM& vm, ASCIILiteral prefix, unsigned identifier)
 {
     auto symbolName = makeString(prefix, identifier);
-    auto symbol = vm.checkedPrivateSymbolRegistry()->symbolForKey(symbolName);
+    auto symbol = protect(vm.privateSymbolRegistry())->symbolForKey(symbolName);
     m_identifiers.append(Identifier::fromUid(symbol));
     return m_identifiers.last();
 }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -756,9 +756,9 @@ public:
             if (m_isRegistered) {
                 String str(buffer);
                 if (m_isPrivate)
-                    symbol = static_cast<SymbolImpl*>(&vm.checkedPrivateSymbolRegistry()->symbolForKey(str).leakRef());
+                    symbol = static_cast<SymbolImpl*>(&protect(vm.privateSymbolRegistry())->symbolForKey(str).leakRef());
                 else
-                    symbol = static_cast<SymbolImpl*>(&vm.checkedSymbolRegistry()->symbolForKey(str).leakRef());
+                    symbol = static_cast<SymbolImpl*>(&protect(vm.symbolRegistry())->symbolForKey(str).leakRef());
             } else if (m_isWellKnownSymbol)
                 symbol = vm.propertyNames->builtinNames().lookUpWellKnownSymbol(buffer);
             else

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -930,7 +930,7 @@ JSGlobalObject::~JSGlobalObject()
 {
     clearWeakTickets();
 #if ENABLE(REMOTE_INSPECTOR)
-    checkedInspectorController()->globalObjectDestroyed();
+    protect(inspectorController())->globalObjectDestroyed();
     m_inspectorDebuggable->globalObjectDestroyed();
 #endif
 
@@ -1052,7 +1052,7 @@ void JSGlobalObject::init(VM& vm)
     m_inspectorController = makeUnique<Inspector::JSGlobalObjectInspectorController>(*this);
     m_inspectorDebuggable = JSGlobalObjectDebuggable::create(*this);
     m_inspectorDebuggable->init();
-    m_consoleClient = checkedInspectorController()->consoleClient().get();
+    m_consoleClient = protect(inspectorController())->consoleClient().get();
 #endif
 
     m_functionPrototype.set(vm, this, FunctionPrototype::create(vm, FunctionPrototype::createStructure(vm, this, jsNull()))); // The real prototype will be set once ObjectPrototype is created.
@@ -3789,11 +3789,6 @@ Ref<JSGlobalObjectDebuggable> JSGlobalObject::protectedInspectorDebuggable()
 Inspector::JSGlobalObjectInspectorController& JSGlobalObject::inspectorController() const
 {
     return *m_inspectorController.get();
-}
-
-CheckedRef<Inspector::JSGlobalObjectInspectorController> JSGlobalObject::checkedInspectorController() const
-{
-    return *m_inspectorController;
 }
 #endif
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1029,7 +1029,6 @@ public:
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.
     Inspector::JSGlobalObjectInspectorController& inspectorController() const;
-    CheckedRef<Inspector::JSGlobalObjectInspectorController> checkedInspectorController() const;
     JSGlobalObjectDebuggable& inspectorDebuggable() { return *m_inspectorDebuggable; }
     Ref<JSGlobalObjectDebuggable> protectedInspectorDebuggable();
 #endif

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
@@ -66,7 +66,7 @@ void JSGlobalObjectDebuggable::connect(FrontendChannel& frontendChannel, bool au
         return;
 
     JSLockHolder locker(&m_globalObject->vm());
-    m_globalObject->checkedInspectorController()->connectFrontend(frontendChannel, automaticInspection, immediatelyPause);
+    protect(m_globalObject->inspectorController())->connectFrontend(frontendChannel, automaticInspection, immediatelyPause);
 }
 
 void JSGlobalObjectDebuggable::disconnect(FrontendChannel& frontendChannel)
@@ -76,7 +76,7 @@ void JSGlobalObjectDebuggable::disconnect(FrontendChannel& frontendChannel)
 
     JSLockHolder locker(&m_globalObject->vm());
 
-    m_globalObject->checkedInspectorController()->disconnectFrontend(frontendChannel);
+    protect(m_globalObject->inspectorController())->disconnectFrontend(frontendChannel);
 }
 
 void JSGlobalObjectDebuggable::dispatchMessageFromRemote(String&& message)
@@ -86,7 +86,7 @@ void JSGlobalObjectDebuggable::dispatchMessageFromRemote(String&& message)
 
     JSLockHolder locker(&m_globalObject->vm());
 
-    m_globalObject->checkedInspectorController()->dispatchMessageFromFrontend(WTF::move(message));
+    protect(m_globalObject->inspectorController())->dispatchMessageFromFrontend(WTF::move(message));
 }
 
 void JSGlobalObjectDebuggable::pauseWaitingForAutomaticInspection()

--- a/Source/JavaScriptCore/runtime/SymbolConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolConstructor.cpp
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(symbolConstructorFor, (JSGlobalObject* globalObject, Ca
     auto string = stringKey->value(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    return JSValue::encode(Symbol::create(vm, vm.checkedSymbolRegistry()->symbolForKey(string)));
+    return JSValue::encode(Symbol::create(vm, protect(vm.symbolRegistry())->symbolForKey(string)));
 }
 
 const ASCIILiteral SymbolKeyForTypeError { "Symbol.keyFor requires that the first argument be a symbol"_s };

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -633,9 +633,7 @@ public:
 
     AtomStringTable* atomStringTable() const { return m_atomStringTable; }
     SymbolRegistry& symbolRegistry() { return m_symbolRegistry.get(); }
-    CheckedRef<SymbolRegistry> checkedSymbolRegistry() { return m_symbolRegistry.get(); }
     SymbolRegistry& privateSymbolRegistry() { return m_privateSymbolRegistry.get(); }
-    CheckedRef<SymbolRegistry> checkedPrivateSymbolRegistry() { return m_privateSymbolRegistry.get(); }
 
     WriteBarrier<JSBigInt> heapBigIntConstantOne;
 

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
@@ -84,9 +84,7 @@ protected:
 private:
 
     WebCore::MediaPlaybackTargetPicker& targetPicker();
-    CheckedRef<WebCore::MediaPlaybackTargetPicker> checkedTargetPicker();
     WebCore::MediaPlaybackTargetPickerMock& mockPicker();
-    CheckedRef<WebCore::MediaPlaybackTargetPickerMock> checkedMockPicker();
 
     // MediaPlaybackTargetPicker::Client
     void setPlaybackTarget(Ref<WebCore::MediaPlaybackTarget>&&) final;

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.mm
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.mm
@@ -177,13 +177,13 @@ void WebMediaSessionManager::setMockMediaPlaybackTargetPickerEnabled(bool enable
 void WebMediaSessionManager::setMockMediaPlaybackTargetPickerState(const String& name, MediaPlaybackTargetMockState state)
 {
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__);
-    checkedMockPicker()->setState(name, state);
+    protect(mockPicker())->setState(name, state);
 }
 
 void WebMediaSessionManager::mockMediaPlaybackTargetPickerDismissPopup()
 {
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__);
-    checkedMockPicker()->dismissPopup();
+    protect(mockPicker())->dismissPopup();
 }
 
 MediaPlaybackTargetPickerMock& WebMediaSessionManager::mockPicker()
@@ -194,22 +194,12 @@ MediaPlaybackTargetPickerMock& WebMediaSessionManager::mockPicker()
     return *m_pickerOverride.get();
 }
 
-CheckedRef<WebCore::MediaPlaybackTargetPickerMock> WebMediaSessionManager::checkedMockPicker()
-{
-    return mockPicker();
-}
-
 WebCore::MediaPlaybackTargetPicker& WebMediaSessionManager::targetPicker()
 {
     if (m_mockPickerEnabled)
         return mockPicker();
 
     return platformPicker();
-}
-
-CheckedRef<WebCore::MediaPlaybackTargetPicker> WebMediaSessionManager::checkedTargetPicker()
-{
-    return targetPicker();
 }
 
 WebMediaSessionManager::WebMediaSessionManager()
@@ -279,7 +269,7 @@ void WebMediaSessionManager::showPlaybackTargetPicker(WebMediaSessionManagerClie
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, m_clientState[index].get());
 
     bool hasActiveRoute = flagsAreSet(m_clientState[index]->flags, MediaProducerMediaState::IsPlayingToExternalDevice);
-    checkedTargetPicker()->showPlaybackTargetPicker(client.platformView().get(), FloatRect(rect), hasActiveRoute, useDarkAppearance);
+    protect(targetPicker())->showPlaybackTargetPicker(client.platformView().get(), FloatRect(rect), hasActiveRoute, useDarkAppearance);
 }
 
 void WebMediaSessionManager::clientStateDidChange(WebMediaSessionManagerClient& client, PlaybackTargetClientContextIdentifier contextId, MediaProducerMediaStateFlags newFlags)
@@ -467,10 +457,10 @@ void WebMediaSessionManager::configurePlaybackTargetMonitoring()
 
     if (monitoringRequired || (hasAvailabilityListener && haveClientWithMedia)) {
         ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, "starting monitoring");
-        checkedTargetPicker()->startingMonitoringPlaybackTargets();
+        protect(targetPicker())->startingMonitoringPlaybackTargets();
     } else {
         ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, "stopping monitoring");
-        checkedTargetPicker()->stopMonitoringPlaybackTargets();
+        protect(targetPicker())->stopMonitoringPlaybackTargets();
     }
 }
 
@@ -552,7 +542,7 @@ void WebMediaSessionManager::watchdogTimerFired()
         return;
 
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__);
-    checkedTargetPicker()->invalidatePlaybackTargets();
+    protect(targetPicker())->invalidatePlaybackTargets();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -247,7 +247,7 @@ void Geolocation::resetAllGeolocationPermission()
     if (m_allowGeolocation == AllowGeolocation::InProgress) {
         RefPtr page = this->page();
         if (page)
-            GeolocationController::checkedFrom(page.get())->cancelPermissionRequest(*this);
+            protect(GeolocationController::from(page))->cancelPermissionRequest(*this);
 
         // This return is not technically correct as GeolocationController::cancelPermissionRequest() should have cleared the active request.
         // Neither iOS nor macOS supports cancelPermissionRequest() (https://bugs.webkit.org/show_bug.cgi?id=89524), so we workaround that and let ongoing requests complete. :(
@@ -282,7 +282,7 @@ void Geolocation::stop()
 {
     RefPtr page = this->page();
     if (page && m_allowGeolocation == AllowGeolocation::InProgress)
-        GeolocationController::checkedFrom(page.get())->cancelPermissionRequest(*this);
+        protect(GeolocationController::from(page))->cancelPermissionRequest(*this);
     // The frame may be moving to a new page and we want to get the permissions from the new page's client.
     resetIsAllowed();
     cancelAllRequests();
@@ -298,7 +298,7 @@ GeolocationPosition* Geolocation::lastPosition()
     if (!page)
         return nullptr;
 
-    m_lastPosition = createGeolocationPosition(GeolocationController::checkedFrom(page.get())->lastPosition());
+    m_lastPosition = createGeolocationPosition(protect(GeolocationController::from(page))->lastPosition());
 
     return m_lastPosition.get();
 }
@@ -651,7 +651,7 @@ void Geolocation::requestPermission()
     m_hasBeenRequested = true;
 
     // Ask the embedder: it maintains the geolocation challenge policy itself.
-    GeolocationController::checkedFrom(page.get())->requestPermission(*this);
+    protect(GeolocationController::from(page))->requestPermission(*this);
 }
 
 void Geolocation::revokeAuthorizationTokenIfNecessary()
@@ -663,7 +663,7 @@ void Geolocation::revokeAuthorizationTokenIfNecessary()
     if (!page)
         return;
 
-    GeolocationController::checkedFrom(page.get())->revokeAuthorizationToken(std::exchange(m_authorizationToken, String()));
+    protect(GeolocationController::from(page))->revokeAuthorizationToken(std::exchange(m_authorizationToken, String()));
 }
 
 void Geolocation::resetIsAllowed()
@@ -728,7 +728,7 @@ bool Geolocation::startUpdating(GeoNotifier& notifier)
     if (!page)
         return false;
 
-    GeolocationController::checkedFrom(page.get())->addObserver(*this, notifier.options().enableHighAccuracy);
+    protect(GeolocationController::from(page))->addObserver(*this, notifier.options().enableHighAccuracy);
     return true;
 }
 

--- a/Source/WebCore/Modules/geolocation/GeolocationController.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.h
@@ -65,7 +65,6 @@ public:
 
     WEBCORE_EXPORT static ASCIILiteral supplementName();
     static GeolocationController* from(Page* page) { return downcast<GeolocationController>(Supplement<Page>::from(page, supplementName())); }
-    static CheckedPtr<GeolocationController> checkedFrom(Page* page) { return from(page); }
 
     void revokeAuthorizationToken(const String&);
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -83,7 +83,7 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
         auto isMainAxisParallelWithInlineAxis = FlexFormattingUtils::isMainAxisParallelWithInlineAxis(root());
         auto isReversedInCrossAxis = FlexFormattingUtils::areFlexLinesReversedInCrossAxis(root());
 
-        for (CheckedPtr flexItem = checkedRoot()->firstInFlowChild(); flexItem; flexItem = flexItem->nextInFlowSibling()) {
+        for (CheckedPtr flexItem = protect(root())->firstInFlowChild(); flexItem; flexItem = flexItem->nextInFlowSibling()) {
             auto& flexItemGeometry = m_globalLayoutState->geometryForBox(*flexItem);
             CheckedRef style = flexItem->style();
             auto mainAxis = LogicalFlexItem::MainAxisGeometry { };
@@ -224,7 +224,7 @@ void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexIt
         // Let's use content size when available size is inf.
         auto& lastFlexItem = logicalFlexItemList.last();
         auto& lastRect = logicalRects.last();
-        return lastRect.right() + lastRect.marginRight() + (lastFlexItem.isContentBoxBased() ? geometryForFlexItem(lastFlexItem.checkedLayoutBox()).horizontalBorderAndPadding() : 0_lu);
+        return lastRect.right() + lastRect.marginRight() + (lastFlexItem.isContentBoxBased() ? geometryForFlexItem(protect(lastFlexItem.layoutBox())).horizontalBorderAndPadding() : 0_lu);
     }();
     auto flexContainerCrossAxisSize = [&] {
         if (auto crossAxisSize = constraints.crossAxis().availableSize)
@@ -238,7 +238,7 @@ void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexIt
 
     for (size_t index = 0; index < logicalFlexItemList.size(); ++index) {
         auto& logicalFlexItem = logicalFlexItemList[index];
-        auto& flexItemGeometry = geometryForFlexItem(logicalFlexItem.checkedLayoutBox());
+        auto& flexItemGeometry = geometryForFlexItem(protect(logicalFlexItem.layoutBox()));
         auto logicalRect = [&] {
             // Note that flex rects are inner size based.
             if (flexBoxStyle->flexWrap() != FlexWrap::Reverse)
@@ -291,7 +291,7 @@ void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexIt
 void FlexFormattingContext::positionOutOfFlowChildren()
 {
     // FIXME: Implement out-of-flow positioning.
-    for (CheckedPtr outOfFlowChild = checkedRoot()->firstOutOfFlowChild(); outOfFlowChild; outOfFlowChild = outOfFlowChild->nextOutOfFlowSibling())
+    for (CheckedPtr outOfFlowChild = protect(root())->firstOutOfFlowChild(); outOfFlowChild; outOfFlowChild = outOfFlowChild->nextOutOfFlowSibling())
         m_globalLayoutState->ensureGeometryForBox(*outOfFlowChild).setTopLeft({ });
 }
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
@@ -46,7 +46,6 @@ public:
     IntrinsicWidthConstraints computedIntrinsicWidthConstraints();
 
     const ElementBox& root() const { return m_flexBox; }
-    CheckedRef<const ElementBox> checkedRoot() const { return m_flexBox; }
     const FlexFormattingUtils& formattingUtils() const { return m_flexFormattingUtils; }
 
     const BoxGeometry& geometryForFlexItem(const Box&) const;

--- a/Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h
+++ b/Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h
@@ -85,7 +85,6 @@ public:
     bool isContentBoxBased() const { return style().boxSizing() == BoxSizing::ContentBox; }
 
     const ElementBox& layoutBox() const { return *m_layoutBox; }
-    CheckedRef<const ElementBox> checkedLayoutBox() const { return *m_layoutBox; }
     const RenderStyle& style() const { return layoutBox().style(); }
     WritingMode writingMode() const { return style().writingMode(); }
 

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -158,7 +158,7 @@ void WebGeolocationManager::didChangePosition(const WebCore::RegistrableDomain& 
     if (auto it = m_pageSets.find(registrableDomain); it != m_pageSets.end()) {
         for (auto& page : copyToVector(it->value.pageSet)) {
             if (RefPtr corePage = page->corePage())
-                GeolocationController::checkedFrom(corePage.get())->positionChanged(position);
+                protect(GeolocationController::from(corePage))->positionChanged(position);
         }
     }
 #else
@@ -176,7 +176,7 @@ void WebGeolocationManager::didFailToDeterminePosition(const WebCore::Registrabl
 
         for (auto& page : copyToVector(it->value.pageSet)) {
             if (RefPtr corePage = page->corePage())
-                GeolocationController::checkedFrom(corePage.get())->errorOccurred(error.get());
+                protect(GeolocationController::from(corePage))->errorOccurred(error.get());
         }
     }
 #else


### PR DESCRIPTION
#### 0ad46ea5074f62e1a82a62f764dfbb384495012d
<pre>
Drop remaining `checked*()` member functions in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=308447">https://bugs.webkit.org/show_bug.cgi?id=308447</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

* Source/JavaScriptCore/API/APIUtils.h:
(handleExceptionIfNeeded):
(setException):
* Source/JavaScriptCore/API/JSBase.cpp:
(JSEvaluateScriptInternal):
(JSCheckScriptSyntax):
* Source/JavaScriptCore/API/JSValue.mm:
(reportExceptionToInspector):
* Source/JavaScriptCore/inspector/InjectedScript.cpp:
(Inspector::InjectedScript::execute):
(Inspector::InjectedScript::evaluate):
(Inspector::InjectedScript::awaitPromise):
(Inspector::InjectedScript::callFunctionOn):
(Inspector::InjectedScript::evaluateOnCallFrame):
(Inspector::InjectedScript::getFunctionDetails):
(Inspector::InjectedScript::functionDetails):
(Inspector::InjectedScript::getPreview):
(Inspector::InjectedScript::getProperties):
(Inspector::InjectedScript::getDisplayableProperties):
(Inspector::InjectedScript::getInternalProperties):
(Inspector::InjectedScript::getCollectionEntries):
(Inspector::InjectedScript::saveResult):
(Inspector::InjectedScript::wrapCallFrames const):
(Inspector::InjectedScript::wrapObject const):
(Inspector::InjectedScript::wrapJSONString const):
(Inspector::InjectedScript::wrapTable const):
(Inspector::InjectedScript::previewValue const):
(Inspector::InjectedScript::setEventValue):
(Inspector::InjectedScript::clearEventValue):
(Inspector::InjectedScript::setExceptionValue):
(Inspector::InjectedScript::clearExceptionValue):
(Inspector::InjectedScript::findObjectById const):
(Inspector::InjectedScript::inspectObject):
(Inspector::InjectedScript::releaseObject):
(Inspector::InjectedScript::releaseObjectGroup):
(Inspector::InjectedScript::createCommandLineAPIObject const):
* Source/JavaScriptCore/inspector/InjectedScriptBase.h:
(Inspector::InjectedScriptBase::inspectorEnvironment const):
(Inspector::InjectedScriptBase::checkedInspectorEnvironment const): Deleted.
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::injectedScriptFor):
* Source/JavaScriptCore/inspector/InjectedScriptManager.h:
(Inspector::InjectedScriptManager::inspectorEnvironment const):
(Inspector::InjectedScriptManager::checkedInspectorEnvironment const): Deleted.
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::ensureInjected):
* Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp:
(Inspector::InspectorAgent::initialized):
* Source/JavaScriptCore/inspector/agents/InspectorAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::didPause):
(Inspector::InspectorDebuggerAgent::breakpointActionProbe):
(Inspector::InspectorDebuggerAgent::didContinue):
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
(Inspector::InspectorHeapAgent::enable):
(Inspector::InspectorHeapAgent::disable):
(Inspector::InspectorHeapAgent::gc):
(Inspector::InspectorHeapAgent::snapshot):
(Inspector::InspectorHeapAgent::nodeForHeapObjectIdentifier):
(Inspector::InspectorHeapAgent::getPreview):
(Inspector::InspectorHeapAgent::getRemoteObject):
(Inspector::InspectorHeapAgent::willGarbageCollect):
(Inspector::InspectorHeapAgent::didGarbageCollect):
(Inspector::InspectorHeapAgent::heapSnapshotBuilderIgnoreNode):
(Inspector::InspectorHeapAgent::clearHeapSnapshots):
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp:
(Inspector::InspectorScriptProfilerAgent::willDestroyFrontendAndBackend):
(Inspector::InspectorScriptProfilerAgent::startTracking):
(Inspector::InspectorScriptProfilerAgent::stopTracking):
(Inspector::InspectorScriptProfilerAgent::willEvaluateScript):
(Inspector::InspectorScriptProfilerAgent::didEvaluateScript):
(Inspector::InspectorScriptProfilerAgent::trackingComplete):
(Inspector::InspectorScriptProfilerAgent::stopSamplingWhenDisconnecting):
* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h:
* Source/JavaScriptCore/parser/ParserArena.cpp:
(JSC::IdentifierArena::makePrivateIdentifier):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedUniquedStringImplBase::decode const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::~JSGlobalObject):
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::inspectorController const):
(JSC::JSGlobalObject::checkedInspectorController const): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
(JSC::JSGlobalObjectDebuggable::connect):
(JSC::JSGlobalObjectDebuggable::disconnect):
(JSC::JSGlobalObjectDebuggable::dispatchMessageFromRemote):
* Source/JavaScriptCore/runtime/SymbolConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::symbolRegistry):
(JSC::VM::privateSymbolRegistry):
(JSC::VM::checkedSymbolRegistry): Deleted.
(JSC::VM::checkedPrivateSymbolRegistry): Deleted.
* Source/WebCore/Modules/airplay/WebMediaSessionManager.h:
* Source/WebCore/Modules/airplay/WebMediaSessionManager.mm:
(WebCore::WebMediaSessionManager::setMockMediaPlaybackTargetPickerState):
(WebCore::WebMediaSessionManager::mockMediaPlaybackTargetPickerDismissPopup):
(WebCore::WebMediaSessionManager::showPlaybackTargetPicker):
(WebCore::WebMediaSessionManager::configurePlaybackTargetMonitoring):
(WebCore::WebMediaSessionManager::watchdogTimerFired):
(WebCore::WebMediaSessionManager::checkedMockPicker): Deleted.
(WebCore::WebMediaSessionManager::checkedTargetPicker): Deleted.
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::resetAllGeolocationPermission):
(WebCore::Geolocation::stop):
(WebCore::Geolocation::lastPosition):
(WebCore::Geolocation::requestPermission):
(WebCore::Geolocation::revokeAuthorizationTokenIfNecessary):
(WebCore::Geolocation::startUpdating):
* Source/WebCore/Modules/geolocation/GeolocationController.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::Layout::FlexFormattingContext::convertFlexItemsToLogicalSpace):
(WebCore::Layout::FlexFormattingContext::setFlexItemsGeometry):
(WebCore::Layout::FlexFormattingContext::positionOutOfFlowChildren):
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h:
(WebCore::Layout::FlexFormattingContext::root const):
(WebCore::Layout::FlexFormattingContext::checkedRoot const): Deleted.
* Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h:
(WebCore::Layout::LogicalFlexItem::layoutBox const):
(WebCore::Layout::LogicalFlexItem::checkedLayoutBox const): Deleted.
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::didChangePosition):
(WebKit::WebGeolocationManager::didFailToDeterminePosition):

Canonical link: <a href="https://commits.webkit.org/308031@main">https://commits.webkit.org/308031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3ec02eeeed1b9eaef70e023401f4108483d44aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99748 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d11dafa3-c205-45e9-a32a-b7386f20369a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112584 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80524 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85ab6764-d074-4da2-89ea-c9c989af7f8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14940 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7781c7c-cc6e-4e39-92c5-251264a6a33c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14207 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2411 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138269 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157286 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7090 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/457 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120613 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30968 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74575 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16585 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7951 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177597 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82165 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45558 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18143 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18309 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->