### PR TITLE
mail.yahoo.com: [macOS] Losing formatting while copying article from another website in email body

### DIFF
--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,6 +90,16 @@ SOFT_LINK(WebKitLegacy, _WebCreateFragment, void, (WebCore::Document& document, 
 #endif
 
 namespace WebCore {
+
+#if PLATFORM(MAC)
+// rdar://157657531
+static void applyYahooMailPasteQuirk(String& markup)
+{
+    markup = makeStringByReplacingAll(markup, "<head><meta charset=\"UTF-8\"></head>"_s, ""_s);
+    markup = makeStringByReplacingAll(markup, "<head></head>"_s, ""_s);
+    markup = makeString("<div>"_s, markup, String::fromUTF8("<p>\xC2\xA0</p></div>"));
+}
+#endif
 
 #if PLATFORM(MACCATALYST)
 
@@ -598,7 +608,7 @@ bool WebContentReader::readWebArchive(SharedBuffer& buffer)
     });
     if (!result)
         return false;
-    
+
     Ref frameDocument = *frame->document();
     if (!DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
         m_fragment = createFragmentFromMarkup(frameDocument, result->markup, result->mainResource->url().string(), { });
@@ -615,6 +625,13 @@ bool WebContentReader::readWebArchive(SharedBuffer& buffer)
     String sanitizedMarkup = sanitizeMarkupWithArchive(frame, frameDocument, *result, msoListQuirksForMarkup(), [&] (const String& type) {
         return frame->loader().client().canShowMIMETypeAsHTML(type);
     });
+
+#if PLATFORM(MAC)
+    // rdar://157657531
+    if (frame->document()->quirks().needsYahooMailPasteFormattingQuirk())
+        applyYahooMailPasteQuirk(sanitizedMarkup);
+#endif
+
     m_fragment = createFragmentFromMarkup(frameDocument, sanitizedMarkup, aboutBlankURL().string(), { });
 
     return m_fragment;
@@ -632,14 +649,13 @@ bool WebContentMarkupReader::readWebArchive(SharedBuffer& buffer)
     if (!result)
         return false;
 
-    if (!shouldSanitize()) {
+    if (!shouldSanitize())
         m_markup = result->markup;
-        return true;
+    else {
+        m_markup = sanitizeMarkupWithArchive(frame, *protect(frame->document()), *result, msoListQuirksForMarkup(), [&] (const String& type) {
+            return frame->loader().client().canShowMIMETypeAsHTML(type);
+        });
     }
-
-    m_markup = sanitizeMarkupWithArchive(frame, *protect(frame->document()), *result, msoListQuirksForMarkup(), [&] (const String& type) {
-        return frame->loader().client().canShowMIMETypeAsHTML(type);
-    });
 
     return true;
 }
@@ -689,6 +705,7 @@ bool WebContentMarkupReader::readHTML(const String& string)
         return false;
 
     String rawHTML = stripMicrosoftPrefix(string);
+
     if (shouldSanitize()) {
         m_markup = sanitizeMarkup(rawHTML, frame().document(), msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
             removeSubresourceURLAttributes(fragment, [](auto& url) {

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -632,6 +632,18 @@ bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsPrimeVideoUserSelectNoneQuirk);
+#else
+    return false;
+#endif
+}
+
+// mail.yahoo.com rdar://157657531
+bool Quirks::needsYahooMailPasteFormattingQuirk() const
+{
+#if PLATFORM(MAC)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsYahooMailPasteFormattingQuirk);
 #else
     return false;
 #endif
@@ -2724,6 +2736,18 @@ static void handleClaudeQuirks(QuirksData& quirksData, const URL& /* quirksURL *
 }
 #endif
 
+#if PLATFORM(MAC)
+// mail.yahoo.com rdar://157657531
+static void handleYahooQuirks(QuirksData& quirksData, const URL& quirksURL, const String& /* quirksDomainString */, const URL& /* documentURL */)
+{
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "mail.yahoo.com"_s && !topDocumentHost.endsWith(".mail.yahoo.com"_s))
+        return;
+
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsYahooMailPasteFormattingQuirk);
+}
+#endif
+
 #if ENABLE(TEXT_AUTOSIZING)
 static void handleYCombinatorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& /* quirksDomainString */, const URL& /* documentURL */)
 {
@@ -3584,6 +3608,9 @@ void Quirks::determineRelevantQuirks()
         { "wpdevelopment"_s, &handleWPDevelopmentQuirks },
 #endif
         { "x"_s, &handleTwitterXQuirks },
+#if PLATFORM(MAC)
+        { "yahoo"_s, &handleYahooQuirks },
+#endif
 #if ENABLE(TEXT_AUTOSIZING)
         { "ycombinator"_s, &handleYCombinatorQuirks },
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,6 +135,8 @@ public:
     bool needsGeforcenowWarningDisplayNoneQuirk() const;
 
     bool needsPrimeVideoUserSelectNoneQuirk() const;
+
+    bool needsYahooMailPasteFormattingQuirk() const;
 
     bool needsFacebookRemoveNotSupportedQuirk() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,6 +117,9 @@ struct QuirksData {
         NeedsVP9FullRangeFlagQuirk,
         NeedsVideoShouldMaintainAspectRatioQuirk,
         NeedsWebKitMediaTextTrackDisplayQuirk,
+#if PLATFORM(MAC)
+        NeedsYahooMailPasteFormattingQuirk,
+#endif
 #if ENABLE(TWO_PHASE_CLICKS)
         NeedsYouTubeMouseOutQuirk,
 #endif


### PR DESCRIPTION
#### e72e5f5c2e24a570d9467e6d30b0f6871e024a6c
<pre>
mail.yahoo.com: [macOS] Losing formatting while copying article from another website in email body
<a href="https://bugs.webkit.org/show_bug.cgi?id=308164">https://bugs.webkit.org/show_bug.cgi?id=308164</a>
<a href="https://rdar.apple.com/157657531">rdar://157657531</a>

Reviewed by NOBODY (OOPS!).

Yahoo Mail&apos;s post-paste JavaScript corrupts the last &lt;p&gt; element which
removes its styles. This solution works by adding a sacrificial
paragraph that gets corrupted instead of the user&apos;s pasted content.

* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::applyYahooMailPasteQuirk):
(WebCore::WebContentReader::readWebArchive):
(WebCore::WebContentMarkupReader::readWebArchive):
(WebCore::WebContentMarkupReader::readHTML):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsYahooMailPasteFormattingQuirk const):
(WebCore::handleYahooQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72e5f5c2e24a570d9467e6d30b0f6871e024a6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154950 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99739 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112568 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99739 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14196 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11951 "1 api test failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157271 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/442 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120596 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120895 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130778 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74550 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7919 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82150 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->