### PR TITLE
Use C++20 std::ranges::find more in the codebase

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -649,7 +649,7 @@ String intlStringOption(JSGlobalObject* globalObject, JSObject* options, Propert
         String stringValue = value.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, String());
 
-        if (values.size() && std::find(values.begin(), values.end(), stringValue) == values.end()) {
+        if (values.size() && std::ranges::find(values, stringValue) == values.end()) {
             throwException(globalObject, scope, createRangeError(globalObject, notFound));
             return { };
         }

--- a/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
@@ -188,7 +188,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncDateUntil, (JSGlobalObject
     }
 
     auto disallowedUnits = { TemporalUnit::Hour, TemporalUnit::Minute, TemporalUnit::Second, TemporalUnit::Millisecond, TemporalUnit::Microsecond, TemporalUnit::Nanosecond };
-    if (disallowedUnits.size() && std::find(disallowedUnits.begin(), disallowedUnits.end(), largestUnit) != disallowedUnits.end())
+    if (disallowedUnits.size() && std::ranges::find(disallowedUnits, largestUnit) != disallowedUnits.end())
         return throwVMRangeError(globalObject, scope, "largestUnit is a disallowed unit"_s);
 
     auto result = TemporalCalendar::calendarDateUntil(date1->plainDate(), date2->plainDate(), largestUnit);

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -370,7 +370,7 @@ std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOp
     if (std::holds_alternative<std::optional<TemporalUnit>>(largestUnitMaybeAuto)) {
         auto largestUnitOptional = std::get<std::optional<TemporalUnit>>(largestUnitMaybeAuto);
         if (largestUnitOptional) {
-            if (disallowedUnitsList.size() && std::find(disallowedUnitsList.begin(), disallowedUnitsList.end(), largestUnitOptional.value()) != disallowedUnitsList.end()) [[unlikely]] {
+            if (disallowedUnitsList.size() && std::ranges::find(disallowedUnitsList, largestUnitOptional.value()) != disallowedUnitsList.end()) [[unlikely]] {
                 throwRangeError(globalObject, scope, "largestUnit is a disallowed unit"_s);
                 return { };
             }
@@ -382,7 +382,7 @@ std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOp
 
     auto smallestUnit = smallestUnitOptional.value_or(fallbackSmallestUnit);
 
-    if (disallowedUnitsList.size() && std::find(disallowedUnitsList.begin(), disallowedUnitsList.end(), smallestUnit) != disallowedUnitsList.end()) [[unlikely]] {
+    if (disallowedUnitsList.size() && std::ranges::find(disallowedUnitsList, smallestUnit) != disallowedUnitsList.end()) [[unlikely]] {
         throwRangeError(globalObject, scope, "smallestUnit is a disallowed unit"_s);
         return { };
     }
@@ -455,7 +455,7 @@ PrecisionData secondsStringPrecision(JSGlobalObject* globalObject, JSObject* opt
     auto smallestUnit = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
 
     auto disallowedUnits = { TemporalUnit::Year, TemporalUnit::Month, TemporalUnit::Week, TemporalUnit::Day, TemporalUnit::Hour };
-    if (disallowedUnits.size() && std::find(disallowedUnits.begin(), disallowedUnits.end(), smallestUnit) != disallowedUnits.end()) {
+    if (disallowedUnits.size() && std::ranges::find(disallowedUnits, smallestUnit) != disallowedUnits.end()) {
         throwRangeError(globalObject, scope, "smallestUnit is a disallowed unit"_s);
         return { };
     }

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -40,7 +40,7 @@ static constexpr auto dummyURLCharacters { "https://w/"_s };
 static bool isValidIPv6HostCodePoint(auto codepoint)
 {
     static constexpr std::array validSpecialCodepoints { '[', ']', ':' };
-    return isASCIIHexDigit(codepoint) || std::find(validSpecialCodepoints.begin(), validSpecialCodepoints.end(), codepoint) != validSpecialCodepoints.end();
+    return isASCIIHexDigit(codepoint) || std::ranges::find(validSpecialCodepoints, codepoint) != validSpecialCodepoints.end();
 }
 
 // https://urlpattern.spec.whatwg.org/#is-an-absolute-pathname

--- a/Tools/TestRunnerShared/WPTFunctions.cpp
+++ b/Tools/TestRunnerShared/WPTFunctions.cpp
@@ -61,8 +61,8 @@ bool isWebPlatformTestURL(const URL& url)
     if (!url.isValid())
         return false;
 
-    auto contains = [] (const auto& collection, const auto& value) {
-        return std::find(collection.cbegin(), collection.cend(), value) != collection.cend();
+    auto contains = [](const auto& collection, const auto& value) {
+        return std::ranges::find(collection, value) != collection.cend();
     };
 
     // Sourced from imported/w3c/resources/config.json


### PR DESCRIPTION
#### 96794d970480311c994071a82f22df045aba2b68
<pre>
Use C++20 std::ranges::find more in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=308448">https://bugs.webkit.org/show_bug.cgi?id=308448</a>
<a href="https://rdar.apple.com/170950687">rdar://170950687</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlStringOption):
* Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::extractDifferenceOptions):
(JSC::secondsStringPrecision):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::isValidIPv6HostCodePoint):
* Tools/TestRunnerShared/WPTFunctions.cpp:
(WTR::isWebPlatformTestURL):

Canonical link: <a href="https://commits.webkit.org/308040@main">https://commits.webkit.org/308040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdae8119cc386d2c2e206e2e312adeb769de5f5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112570 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80520 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14195 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2398 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138256 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157273 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7120 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/444 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120601 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30977 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74555 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7917 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82152 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45557 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18130 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->