### PR TITLE
Web Inspector: adopt smart pointers for InspectorBackendClient and InspectorFrontendClient

### DIFF
--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -27,7 +27,9 @@
 #pragma once
 
 #include <optional>
+#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace Inspector {
 class FrontendChannel;
@@ -47,7 +49,7 @@ enum class InspectorBackendClientDeveloperPreference : uint8_t {
     NeedsSiteSpecificQuirks,
 };
 
-class InspectorBackendClient {
+class InspectorBackendClient : public AbstractCanMakeCheckedPtr, public CanMakeWeakPtr<InspectorBackendClient> {
 public:
     virtual ~InspectorBackendClient() = default;
 

--- a/Source/WebCore/inspector/InspectorFrontendClient.h
+++ b/Source/WebCore/inspector/InspectorFrontendClient.h
@@ -38,6 +38,7 @@
 #include <WebCore/InspectorDebuggableType.h>
 #include <WebCore/InspectorFrontendAPIDispatcher.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -48,15 +49,6 @@ using ExtensionID = String;
 using ExtensionTabID = String;
 }
 #endif
-
-namespace WebCore {
-class InspectorFrontendClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::InspectorFrontendClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -76,7 +68,7 @@ struct InspectorFrontendClientSaveData {
     bool base64Encoded;
 };
 
-class InspectorFrontendClient : public CanMakeWeakPtr<InspectorFrontendClient> {
+class InspectorFrontendClient : public AbstractRefCountedAndCanMakeWeakPtr<InspectorFrontendClient> {
 public:
     enum class DockSide {
         Undocked = 0,

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -35,6 +35,7 @@
 #include <WebCore/InspectorFrontendClient.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -49,7 +50,7 @@ class LocalFrame;
 class Page;
 class PageInspectorController;
 
-class InspectorFrontendClientLocal : public InspectorFrontendClient {
+class InspectorFrontendClientLocal : public RefCounted<InspectorFrontendClientLocal>, public InspectorFrontendClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(InspectorFrontendClientLocal, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(InspectorFrontendClientLocal);
 public:
@@ -67,6 +68,10 @@ public:
 
     WEBCORE_EXPORT InspectorFrontendClientLocal(PageInspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings>, DispatchBackendTarget = DispatchBackendTarget::Page);
     WEBCORE_EXPORT ~InspectorFrontendClientLocal() override;
+
+    // InspectorFrontendClient.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     WEBCORE_EXPORT void resetState() override;
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -396,7 +396,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     context.fillPath(shapePath);
 }
 
-InspectorOverlay::InspectorOverlay(PageInspectorController& controller, InspectorBackendClient* client)
+InspectorOverlay::InspectorOverlay(PageInspectorController& controller, InspectorBackendClient& client)
     : m_controller(controller)
     , m_client(client)
     , m_paintRectUpdateTimer(*this, &InspectorOverlay::updatePaintRectsTimerFired)

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -143,7 +143,7 @@ struct InspectorOverlayHighlight {
 class InspectorOverlay : public CanMakeWeakPtr<InspectorOverlay> {
     WTF_MAKE_TZONE_ALLOCATED(InspectorOverlay);
 public:
-    InspectorOverlay(PageInspectorController&, InspectorBackendClient*);
+    InspectorOverlay(PageInspectorController&, InspectorBackendClient&);
     ~InspectorOverlay();
 
     void ref() const;
@@ -254,7 +254,7 @@ private:
     Page& page() const;
 
     const WeakRef<PageInspectorController> m_controller;
-    InspectorBackendClient* m_client;
+    const WeakRef<InspectorBackendClient> m_client;
 
     RefPtr<Node> m_highlightNode;
     RefPtr<NodeList> m_highlightNodeList;

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -90,7 +90,7 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PageInspectorController);
 
-PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<InspectorBackendClient>&& inspectorBackendClient)
+PageInspectorController::PageInspectorController(Page& page, UniqueRef<InspectorBackendClient>&& inspectorBackendClient)
     : m_page(page)
     , m_instrumentingAgents(InstrumentingAgents::create(*this))
     , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
@@ -100,7 +100,6 @@ PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<Ins
     , m_executionStopwatch(Stopwatch::create())
     , m_inspectorBackendClient(WTF::move(inspectorBackendClient))
 {
-    ASSERT_ARG(inspectorBackendClient, m_inspectorBackendClient);
 
     auto pageContext = pageAgentContext();
 
@@ -112,7 +111,6 @@ PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<Ins
 PageInspectorController::~PageInspectorController()
 {
     m_instrumentingAgents->reset();
-    ASSERT(!m_inspectorBackendClient);
 }
 
 void PageInspectorController::ref() const
@@ -198,16 +196,20 @@ void PageInspectorController::inspectedPageDestroyed()
 
     // Disconnect the client.
     m_inspectorBackendClient->inspectedPageDestroyed();
-    m_inspectorBackendClient = nullptr;
 
     m_agents.discardValues();
 
     m_debugger = nullptr;
 }
 
-void PageInspectorController::setInspectorFrontendClient(InspectorFrontendClient* inspectorFrontendClient)
+void PageInspectorController::setInspectorFrontendClient(InspectorFrontendClient& client)
 {
-    m_inspectorFrontendClient = inspectorFrontendClient;
+    m_inspectorFrontendClient = client;
+}
+
+InspectorFrontendClient* PageInspectorController::inspectorFrontendClient() const
+{
+    return m_inspectorFrontendClient.get();
 }
 
 bool PageInspectorController::hasLocalFrontend() const
@@ -241,7 +243,6 @@ void PageInspectorController::didClearWindowObjectInWorld(LocalFrame& frame, DOM
 
 void PageInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel, bool isAutomaticInspection, bool immediatelyPause)
 {
-    ASSERT(m_inspectorBackendClient);
     Ref page = m_page.get();
 
     // If a frontend has connected enable the developer extras and keep them enabled.

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -70,7 +70,7 @@ class PageInspectorController final : public Inspector::InspectorEnvironment, pu
     WTF_MAKE_TZONE_ALLOCATED(PageInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageInspectorController);
 public:
-    PageInspectorController(Page&, std::unique_ptr<InspectorBackendClient>&&);
+    PageInspectorController(Page&, UniqueRef<InspectorBackendClient>&&);
     ~PageInspectorController() override;
 
     // AbstractCanMakeCheckedPtr overrides
@@ -90,7 +90,7 @@ public:
 
     WEBCORE_EXPORT void show();
 
-    WEBCORE_EXPORT void setInspectorFrontendClient(InspectorFrontendClient*);
+    WEBCORE_EXPORT void setInspectorFrontendClient(InspectorFrontendClient&);
     unsigned inspectionLevel() const;
     void didClearWindowObjectInWorld(LocalFrame&, DOMWrapperWorld&);
 
@@ -123,8 +123,8 @@ public:
     WEBCORE_EXPORT unsigned flexOverlayCount() const;
     WEBCORE_EXPORT unsigned paintRectCount() const;
 
-    InspectorBackendClient* inspectorBackendClient() const { return m_inspectorBackendClient.get(); }
-    InspectorFrontendClient* inspectorFrontendClient() const { return m_inspectorFrontendClient; }
+    InspectorBackendClient& inspectorBackendClient() const { return m_inspectorBackendClient.get(); }
+    InspectorFrontendClient* inspectorFrontendClient() const;
 
     InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
     Inspector::BackendDispatcher& backendDispatcher() const { return m_backendDispatcher.get(); }
@@ -160,8 +160,8 @@ private:
     std::unique_ptr<PageDebugger> m_debugger;
     Inspector::AgentRegistry m_agents;
 
-    std::unique_ptr<InspectorBackendClient> m_inspectorBackendClient;
-    InspectorFrontendClient* m_inspectorFrontendClient { nullptr };
+    const UniqueRef<InspectorBackendClient> m_inspectorBackendClient;
+    WeakPtr<InspectorFrontendClient> m_inspectorFrontendClient;
 
     // Lazy, but also on-demand agents.
     CheckedPtr<Inspector::InspectorAgent> m_inspectorAgent;

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -179,11 +179,7 @@ void WorkerInspectorController::updateServiceWorkerPageFrontendCount()
 
     // When a service worker is loaded in a Page, we need to report its inspector frontend count
     // up to the page's inspectorController so the client knows about it.
-    auto inspectorBackendClient = serviceWorkerPage->inspectorController().inspectorBackendClient();
-    if (!inspectorBackendClient)
-        return;
-
-    inspectorBackendClient->frontendCountChanged(m_frontendRouter->frontendCount());
+    serviceWorkerPage->inspectorController().inspectorBackendClient().frontendCountChanged(m_frontendRouter->frontendCount());
 }
 
 void WorkerInspectorController::dispatchMessageFromFrontend(const String& message)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1372,8 +1372,7 @@ void InspectorDOMAgent::setSearchingForNode(Inspector::Protocol::ErrorString& er
 
     protectedOverlay()->didSetSearchingForNode(m_searchingForNode);
 
-    if (InspectorBackendClient* client = m_inspectedPage->inspectorController().inspectorBackendClient())
-        client->elementSelectionChanged(m_searchingForNode);
+    m_inspectedPage->inspectorController().inspectorBackendClient().elementSelectionChanged(m_searchingForNode);
 }
 
 std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highlightConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, RefPtr<JSON::Object>&& highlightInspectorObject)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -104,7 +104,7 @@ Ref<InspectorOverlay> InspectorPageAgent::protectedOverlay() const
     return m_overlay.get();
 }
 
-InspectorPageAgent::InspectorPageAgent(PageAgentContext& context, InspectorBackendClient* client, InspectorOverlay& overlay)
+InspectorPageAgent::InspectorPageAgent(PageAgentContext& context, InspectorBackendClient& client, InspectorOverlay& overlay)
     : InspectorAgentBase("Page"_s, context)
     , m_frontendDispatcher(makeUniqueRef<Inspector::PageFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::PageBackendDispatcher::create(context.backendDispatcher, this))

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -66,7 +66,7 @@ class InspectorPageAgent final : public InspectorAgentBase, public Inspector::Pa
     WTF_MAKE_TZONE_ALLOCATED(InspectorPageAgent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorPageAgent);
 public:
-    InspectorPageAgent(PageAgentContext&, InspectorBackendClient*, InspectorOverlay&);
+    InspectorPageAgent(PageAgentContext&, InspectorBackendClient&, InspectorOverlay&);
     ~InspectorPageAgent();
 
     // InspectorAgentBase
@@ -142,7 +142,7 @@ private:
     const Ref<Inspector::PageBackendDispatcher> m_backendDispatcher;
 
     WeakRef<Page> m_inspectedPage;
-    InspectorBackendClient* m_client { nullptr };
+    WeakRef<InspectorBackendClient> m_client;
     WeakRef<InspectorOverlay> m_overlay;
 
     WeakHashMap<Frame, String> m_frameToIdentifier;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -44,11 +44,11 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PageNetworkAgent);
 
-PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorBackendClient* client)
+PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorBackendClient& client)
     : InspectorNetworkAgent(context, { context.inspectedPage->settings().inspectorMaximumResourcesContentSize(), context.inspectedPage->settings().inspectorSupportsShowingCertificate() })
     , m_inspectedPage(context.inspectedPage)
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
-    , m_client(client)
+    , m_backendClient(client)
 #endif
 {
 #if !ENABLE(INSPECTOR_NETWORK_THROTTLING)
@@ -111,7 +111,7 @@ void PageNetworkAgent::setResourceCachingDisabledInternal(bool disabled)
 
 bool PageNetworkAgent::setEmulatedConditionsInternal(std::optional<int>&& bytesPerSecondLimit)
 {
-    return m_client && m_client->setEmulatedConditions(WTF::move(bytesPerSecondLimit));
+    return m_backendClient->setEmulatedConditions(WTF::move(bytesPerSecondLimit));
 }
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
@@ -37,7 +37,7 @@ class PageNetworkAgent final : public InspectorNetworkAgent {
     WTF_MAKE_NONCOPYABLE(PageNetworkAgent);
     WTF_MAKE_TZONE_ALLOCATED(PageNetworkAgent);
 public:
-    PageNetworkAgent(PageAgentContext&, InspectorBackendClient*);
+    PageNetworkAgent(PageAgentContext&, InspectorBackendClient&);
     ~PageNetworkAgent();
 
 private:
@@ -54,7 +54,7 @@ private:
 
     WeakRef<Page> m_inspectedPage;
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
-    InspectorBackendClient* m_client { nullptr };
+    WeakRef<InspectorBackendClient> m_backendClient;
 #endif
 };
 

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -155,8 +155,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
 
     InspectorTimelineAgent::internalStart(WTF::move(maxCallStackDepth));
 
-    if (auto* client = m_inspectedPage->inspectorController().inspectorBackendClient())
-        client->timelineRecordingChanged(true);
+    m_inspectedPage->inspectorController().inspectorBackendClient().timelineRecordingChanged(true);
 }
 
 void PageTimelineAgent::internalStop()
@@ -175,8 +174,7 @@ void PageTimelineAgent::internalStop()
 
     InspectorTimelineAgent::internalStop();
 
-    if (auto* client = m_inspectedPage->inspectorController().inspectorBackendClient())
-        client->timelineRecordingChanged(false);
+    m_inspectedPage->inspectorController().inspectorBackendClient().timelineRecordingChanged(false);
 }
 
 Inspector::Protocol::ErrorStringOr<void> PageTimelineAgent::setAutoCaptureEnabled(bool enabled)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -441,8 +441,17 @@ private:
 #endif
 };
 
-class EmptyInspectorBackendClient final : public InspectorBackendClient {
+class EmptyInspectorBackendClient final : public InspectorBackendClient, public CanMakeCheckedPtr<EmptyInspectorBackendClient> {
     WTF_MAKE_TZONE_ALLOCATED(EmptyInspectorBackendClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyInspectorBackendClient);
+public:
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+
     void NODELETE inspectedPageDestroyed() final { }
     Inspector::FrontendChannel* NODELETE openLocalFrontend(PageInspectorController*) final { return nullptr; }
     void NODELETE bringFrontendToFront() final { }
@@ -1248,6 +1257,7 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         identifier,
         sessionID,
         makeUniqueRef<EmptyEditorClient>(),
+        makeUniqueRef<EmptyInspectorBackendClient>(),
         adoptRef(*new EmptySocketProvider),
         WebRTCProvider::create(),
         CacheStorageProvider::create(),
@@ -1287,8 +1297,6 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
 #if ENABLE(DRAG_SUPPORT)
     pageConfiguration.dragClient = makeUnique<EmptyDragClient>();
 #endif
-
-    pageConfiguration.inspectorBackendClient = makeUnique<EmptyInspectorBackendClient>();
 
     pageConfiguration.diagnosticLoggingClient = makeUnique<EmptyDiagnosticLoggingClient>();
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4841,11 +4841,8 @@ void LocalFrameView::scheduleResizeEventIfNeeded()
     LOG_WITH_STREAM(Events, stream << "LocalFrameView " << this << " scheduleResizeEventIfNeeded scheduling resize event for document" << document << ", size " << currentSize);
     document->setNeedsDOMWindowResizeEvent();
 
-    bool isMainFrame = m_frame->isMainFrame();
-    if (InspectorInstrumentation::hasFrontends() && isMainFrame) {
-        if (InspectorBackendClient* inspectorBackendClient = page ? page->inspectorController().inspectorBackendClient() : nullptr)
-            inspectorBackendClient->didResizeMainFrame(m_frame.ptr());
-    }
+    if (InspectorInstrumentation::hasFrontends() && m_frame->isMainFrame())
+        page->inspectorController().inspectorBackendClient().didResizeMainFrame(m_frame.ptr());
 }
 
 void LocalFrameView::willStartLiveResize()

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -78,6 +78,7 @@ PageConfiguration::PageConfiguration(
     std::optional<PageIdentifier> identifier,
     PAL::SessionID sessionID,
     UniqueRef<EditorClient>&& editorClient,
+    UniqueRef<InspectorBackendClient>&& inspectorBackendClient,
     Ref<SocketProvider>&& socketProvider,
     UniqueRef<WebRTCProvider>&& webRTCProvider,
     Ref<CacheStorageProvider>&& cacheStorageProvider,
@@ -115,6 +116,7 @@ PageConfiguration::PageConfiguration(
 #endif
     , editorClient(WTF::move(editorClient))
     , socketProvider(WTF::move(socketProvider))
+    , inspectorBackendClient(WTF::move(inspectorBackendClient))
 #if ENABLE(APPLE_PAY)
     , paymentCoordinatorClient(WTF::move(paymentCoordinatorClient))
 #endif

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -122,6 +122,7 @@ public:
         std::optional<PageIdentifier>,
         PAL::SessionID,
         UniqueRef<EditorClient>&&,
+        UniqueRef<InspectorBackendClient>&&,
         Ref<SocketProvider>&&,
         UniqueRef<WebRTCProvider>&&,
         Ref<CacheStorageProvider>&&,
@@ -164,7 +165,7 @@ public:
     UniqueRef<EditorClient> editorClient;
     Ref<SocketProvider> socketProvider;
     std::unique_ptr<DragClient> dragClient;
-    std::unique_ptr<InspectorBackendClient> inspectorBackendClient;
+    UniqueRef<InspectorBackendClient> inspectorBackendClient;
 #if ENABLE(APPLE_PAY)
     Ref<PaymentCoordinatorClient> paymentCoordinatorClient;
 #endif

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -498,7 +498,7 @@ InspectorStubFrontend::InspectorStubFrontend(Page& inspectedPage, LocalFrame& ma
 {
     ASSERT_ARG(frontendWindow, frontendWindow);
 
-    frontendPage()->inspectorController().setInspectorFrontendClient(this);
+    frontendPage()->inspectorController().setInspectorFrontendClient(*this);
     inspectedPage.protectedInspectorController()->connectFrontend(*this);
     protect(mainFrame.inspectorController())->connectFrontend(*this);
 }
@@ -513,7 +513,6 @@ void InspectorStubFrontend::closeWindow()
     if (!m_frontendWindow)
         return;
 
-    frontendPage()->inspectorController().setInspectorFrontendClient(nullptr);
     if (RefPtr controller = m_mainFrameInspectorController.get())
         controller->disconnectFrontend(*this);
     if (RefPtr page = inspectedPage())
@@ -3372,7 +3371,7 @@ RefPtr<WindowProxy> Internals::openDummyInspectorFrontend(const String& url)
 #endif
 
     auto frontendWindowProxy = window->open(*window, *window, url, emptyAtom(), emptyString()).releaseReturnValue();
-    m_inspectorFrontend = makeUnique<InspectorStubFrontend>(*inspectedPage, *localMainFrame, downcast<LocalDOMWindow>(frontendWindowProxy->window()));
+    m_inspectorFrontend = adoptRef(*new InspectorStubFrontend(*inspectedPage, *localMainFrame, downcast<LocalDOMWindow>(frontendWindowProxy->window())));
     return frontendWindowProxy;
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1761,7 +1761,7 @@ private:
     RefPtr<ArtworkImageLoader> m_artworkLoader;
     std::unique_ptr<ArtworkImagePromise> m_artworkImagePromise;
 #endif
-    std::unique_ptr<InspectorStubFrontend> m_inspectorFrontend;
+    RefPtr<InspectorStubFrontend> m_inspectorFrontend;
     RefPtr<CacheStorageConnection> m_cacheStorageConnection;
 
     HashMap<unsigned, std::unique_ptr<WebCore::SleepDisabler>> m_sleepDisablers;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -451,12 +451,12 @@ void WKBundlePageListenForLayoutMilestones(WKBundlePageRef pageRef, WKLayoutMile
 
 void WKBundlePageCloseInspectorForTest(WKBundlePageRef page)
 {
-    protect(WebKit::toProtectedImpl(page)->inspector())->close();
+    protect(WebKit::toProtectedImpl(page)->inspectorBackend())->close();
 }
 
 void WKBundlePageEvaluateScriptInInspectorForTest(WKBundlePageRef page, WKStringRef script)
 {
-    protect(WebKit::toProtectedImpl(page)->inspector())->evaluateScriptForTest(WebKit::toWTFString(script));
+    protect(WebKit::toProtectedImpl(page)->inspectorBackend())->evaluateScriptForTest(WebKit::toWTFString(script));
 }
 
 void WKBundlePageForceRepaint(WKBundlePageRef page)

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -72,7 +72,7 @@ void RemoteWebInspectorUI::initialize(DebuggableInfoData&& debuggableInfo, const
     m_debuggableInfo = WTF::move(debuggableInfo);
     m_backendCommandsURL = backendCommandsURL;
 
-    protect(protect(m_page)->corePage())->inspectorController().setInspectorFrontendClient(this);
+    protect(protect(m_page)->corePage())->inspectorController().setInspectorFrontendClient(*this);
 
     m_frontendAPIDispatcher->reset();
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockingUnavailable"_s, { JSON::Value::create(true) });
@@ -173,8 +173,6 @@ void RemoteWebInspectorUI::bringToFront()
 
 void RemoteWebInspectorUI::closeWindow()
 {
-    protect(protect(m_page)->corePage())->inspectorController().setInspectorFrontendClient(nullptr);
-
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = nullptr;
 #endif

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -67,8 +67,8 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorBackendClient);
 
-WebInspectorBackendClient::WebInspectorBackendClient(WebPage* page)
-    : m_page(page)
+WebInspectorBackendClient::WebInspectorBackendClient(WebPage& page)
+    : m_inspectedPage(page)
 {
 }
 
@@ -80,67 +80,48 @@ WebInspectorBackendClient::~WebInspectorBackendClient()
     m_paintRectLayers.clear();
 
     if (RefPtr paintRectOverlay = m_paintRectOverlay) {
-        RefPtr page = m_page.get();
-        if (page && page->corePage())
-            page->corePage()->pageOverlayController().uninstallPageOverlay(*paintRectOverlay, PageOverlay::FadeMode::Fade);
+        if (RefPtr corePage = m_inspectedPage->corePage())
+            corePage->pageOverlayController().uninstallPageOverlay(*paintRectOverlay, PageOverlay::FadeMode::Fade);
     }
 }
 
 void WebInspectorBackendClient::inspectedPageDestroyed()
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector(WebPage::LazyCreationPolicy::UseExistingOnly))
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend(WebPage::LazyCreationPolicy::UseExistingOnly))
         inspector->close();
 }
 
 void WebInspectorBackendClient::frontendCountChanged(unsigned count)
 {
-    if (RefPtr page = m_page.get())
-        page->inspectorFrontendCountChanged(count);
+    m_inspectedPage->inspectorFrontendCountChanged(count);
 }
 
 Inspector::FrontendChannel* WebInspectorBackendClient::openLocalFrontend(PageInspectorController* controller)
 {
-    if (RefPtr page = m_page.get())
-        protect(page->inspector())->openLocalInspectorFrontend();
+    protect(m_inspectedPage->inspectorBackend())->openLocalInspectorFrontend();
     return nullptr;
 }
 
 void WebInspectorBackendClient::bringFrontendToFront()
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector())
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend())
         inspector->bringToFront();
 }
 
 void WebInspectorBackendClient::didResizeMainFrame(LocalFrame*)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector())
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend())
         inspector->updateDockingAvailability();
 }
 
 void WebInspectorBackendClient::highlight()
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (!page->corePage()->settings().acceleratedCompositingEnabled()) {
+    if (!m_inspectedPage->corePage()->settings().acceleratedCompositingEnabled()) {
 #if PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(PLAYSTATION)
         // FIXME: It can be optimized by marking only highlighted rect dirty.
         // setNeedsDisplay always makes whole rect dirty, and could lead to poor performance.
         // https://bugs.webkit.org/show_bug.cgi?id=195933
-        page->drawingArea()->setNeedsDisplay();
+        m_inspectedPage->drawingArea()->setNeedsDisplay();
 #endif
         return;
     }
@@ -152,60 +133,52 @@ void WebInspectorBackendClient::highlight()
     } else {
         Ref newHighlightOverlay = PageOverlay::create(*this);
         m_highlightOverlay = newHighlightOverlay.ptr();
-        page->corePage()->pageOverlayController().installPageOverlay(newHighlightOverlay.copyRef(), PageOverlay::FadeMode::Fade);
+        m_inspectedPage->corePage()->pageOverlayController().installPageOverlay(newHighlightOverlay.copyRef(), PageOverlay::FadeMode::Fade);
         newHighlightOverlay->setNeedsDisplay();
     }
 #else
     InspectorOverlay::Highlight highlight;
-    page->corePage()->inspectorController().getHighlight(highlight, InspectorOverlay::CoordinateSystem::Document);
-    page->showInspectorHighlight(highlight);
+    m_inspectedPage->corePage()->inspectorController().getHighlight(highlight, InspectorOverlay::CoordinateSystem::Document);
+    m_inspectedPage->showInspectorHighlight(highlight);
 #endif
 }
 
 void WebInspectorBackendClient::hideHighlight()
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
 #if PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(PLAYSTATION)
-    if (!page->corePage()->settings().acceleratedCompositingEnabled()) {
+    if (!m_inspectedPage->corePage()->settings().acceleratedCompositingEnabled()) {
         // FIXME: It can be optimized by marking only highlighted rect dirty.
         // setNeedsDisplay always makes whole rect dirty, and could lead to poor performance.
         // https://bugs.webkit.org/show_bug.cgi?id=195933
-        page->drawingArea()->setNeedsDisplay();
+        m_inspectedPage->drawingArea()->setNeedsDisplay();
         return;
     }
 #endif
 
 #if !PLATFORM(IOS_FAMILY)
     if (RefPtr highlightOverlay = m_highlightOverlay.get())
-        page->corePage()->pageOverlayController().uninstallPageOverlay(*highlightOverlay, PageOverlay::FadeMode::Fade);
+        m_inspectedPage->corePage()->pageOverlayController().uninstallPageOverlay(*highlightOverlay, PageOverlay::FadeMode::Fade);
 #else
-    page->hideInspectorHighlight();
+    m_inspectedPage->hideInspectorHighlight();
 #endif
 }
 
 void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (!page->corePage()->settings().acceleratedCompositingEnabled())
+    if (!m_inspectedPage->corePage()->settings().acceleratedCompositingEnabled())
         return;
 
     RefPtr paintRectOverlay = m_paintRectOverlay;
     if (!paintRectOverlay) {
         m_paintRectOverlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
         paintRectOverlay = m_paintRectOverlay.copyRef();
-        page->corePage()->pageOverlayController().installPageOverlay(*paintRectOverlay, PageOverlay::FadeMode::DoNotFade);
+        m_inspectedPage->corePage()->pageOverlayController().installPageOverlay(*paintRectOverlay, PageOverlay::FadeMode::DoNotFade);
     }
 
     if (!m_paintIndicatorLayerClient)
         m_paintIndicatorLayerClient = makeUnique<RepaintIndicatorLayerClient>(*this);
 
-    Ref paintLayer = GraphicsLayer::create(protect(page->drawingArea())->graphicsLayerFactory(), *m_paintIndicatorLayerClient);
+    Ref paintLayer = GraphicsLayer::create(protect(m_inspectedPage->drawingArea())->graphicsLayerFactory(), *m_paintIndicatorLayerClient);
 
     paintLayer->setName(MAKE_STATIC_STRING_IMPL("paint rect"));
     paintLayer->setAnchorPoint(FloatPoint3D());
@@ -240,56 +213,38 @@ void WebInspectorBackendClient::animationEndedForLayer(const GraphicsLayer* laye
 #if PLATFORM(IOS_FAMILY)
 void WebInspectorBackendClient::showInspectorIndication()
 {
-    if (RefPtr page = m_page.get())
-        page->showInspectorIndication();
+    m_inspectedPage->showInspectorIndication();
 }
 
 void WebInspectorBackendClient::hideInspectorIndication()
 {
-    if (RefPtr page = m_page.get())
-        page->hideInspectorIndication();
+    m_inspectedPage->hideInspectorIndication();
 }
 
 void WebInspectorBackendClient::didSetSearchingForNode(bool enabled)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
     if (enabled)
-        page->enableInspectorNodeSearch();
+        m_inspectedPage->enableInspectorNodeSearch();
     else
-        page->disableInspectorNodeSearch();
+        m_inspectedPage->disableInspectorNodeSearch();
 }
 #endif
 
 void WebInspectorBackendClient::elementSelectionChanged(bool active)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector())
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend())
         inspector->elementSelectionChanged(active);
 }
 
 void WebInspectorBackendClient::timelineRecordingChanged(bool active)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector())
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend())
         inspector->timelineRecordingChanged(active);
 }
 
 void WebInspectorBackendClient::setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector())
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend())
         inspector->setDeveloperPreferenceOverride(developerPreference, overrideValue);
 }
 
@@ -297,9 +252,8 @@ void WebInspectorBackendClient::setDeveloperPreferenceOverride(WebCore::Inspecto
 
 bool WebInspectorBackendClient::setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit)
 {
-    RefPtr page = m_page.get();
-    if (page && page->inspector()) {
-        page->inspector()->setEmulatedConditions(WTF::move(bytesPerSecondLimit));
+    if (RefPtr inspector = m_inspectedPage->inspectorBackend()) {
+        inspector->setEmulatedConditions(WTF::move(bytesPerSecondLimit));
         return true;
     }
 
@@ -324,8 +278,7 @@ void WebInspectorBackendClient::didMoveToPage(PageOverlay&, Page*)
 
 void WebInspectorBackendClient::drawRect(PageOverlay&, WebCore::GraphicsContext& context, const WebCore::IntRect& /*dirtyRect*/)
 {
-    if (RefPtr page = m_page.get())
-        page->corePage()->inspectorController().drawHighlight(context);
+    m_inspectedPage->corePage()->inspectorController().drawHighlight(context);
 }
 
 bool WebInspectorBackendClient::mouseEvent(PageOverlay&, const PlatformMouseEvent&)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/InspectorBackendClient.h>
 #include <WebCore/PageOverlay.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -42,12 +43,20 @@ namespace WebKit {
 class WebPage;
 class RepaintIndicatorLayerClient;
 
-class WebInspectorBackendClient : public WebCore::InspectorBackendClient, private WebCore::PageOverlayClient {
+class WebInspectorBackendClient : public WebCore::InspectorBackendClient, private WebCore::PageOverlayClient, public CanMakeCheckedPtr<WebInspectorBackendClient> {
     WTF_MAKE_TZONE_ALLOCATED(WebInspectorBackendClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebInspectorBackendClient);
 friend class RepaintIndicatorLayerClient;
 public:
-    WebInspectorBackendClient(WebPage*);
+    WebInspectorBackendClient(WebPage&);
     virtual ~WebInspectorBackendClient();
+
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
 private:
     // WebCore::InspectorBackendClient
@@ -88,7 +97,7 @@ private:
 
     void animationEndedForLayer(const WebCore::GraphicsLayer*);
 
-    WeakPtr<WebPage> m_page;
+    WeakRef<WebPage> m_inspectedPage;
     WeakPtr<WebCore::PageOverlay> m_highlightOverlay;
 
     RefPtr<WebCore::PageOverlay> m_paintRectOverlay;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -76,7 +76,7 @@ void WebInspectorUI::establishConnection(WebPageProxyIdentifier inspectedPageIde
 
     m_frontendAPIDispatcher->reset();
     m_frontendController = m_page->corePage()->inspectorController();
-    Ref { *m_frontendController }->setInspectorFrontendClient(this);
+    Ref { *m_frontendController }->setInspectorFrontendClient(*this);
 
     updateConnection();
 
@@ -150,9 +150,6 @@ void WebInspectorUI::closeWindow()
 
     if (RefPtr backendConnection = std::exchange(m_backendConnection, nullptr))
         backendConnection->invalidate();
-
-    if (RefPtr frontendController = std::exchange(m_frontendController, nullptr).get())
-        frontendController->setInspectorFrontendClient(nullptr);
 
     if (RefPtr frontendHost = m_frontendHost)
         frontendHost->disconnectClient();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -789,6 +789,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         pageID,
         WebProcess::singleton().sessionID(),
         makeUniqueRef<WebEditorClient>(*this),
+        makeUniqueRef<WebInspectorBackendClient>(*this),
         WebSocketProvider::create(parameters.webPageProxyIdentifier),
         createLibWebRTCProvider(*this),
         WebProcess::singleton().cacheStorageProvider(),
@@ -822,7 +823,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if ENABLE(DRAG_SUPPORT)
     pageConfiguration.dragClient = makeUnique<WebDragClient>(this);
 #endif
-    pageConfiguration.inspectorBackendClient = makeUnique<WebInspectorBackendClient>(this);
 #if USE(AUTOCORRECTION_PANEL)
     pageConfiguration.alternativeTextClient = makeUnique<WebAlternativeTextClient>(this);
 #endif
@@ -2024,7 +2024,7 @@ void WebPage::close()
     if (WebProcess::singleton().injectedBundle())
         WebProcess::singleton().injectedBundle()->willDestroyPage(Ref { *this });
 
-    if (RefPtr inspector = std::exchange(m_inspector, nullptr))
+    if (RefPtr inspector = std::exchange(m_inspectorBackend, nullptr))
         inspector->disconnectFromPage();
 
     m_page->inspectorController().disconnectAllFrontends();
@@ -5249,13 +5249,13 @@ unsigned WebPage::remoteImagesCountForTesting() const
     return 0;
 }
 
-WebInspectorBackend* WebPage::inspector(LazyCreationPolicy behavior)
+WebInspectorBackend* WebPage::inspectorBackend(LazyCreationPolicy behavior)
 {
     if (m_isClosed)
         return nullptr;
-    if (!m_inspector && behavior == LazyCreationPolicy::CreateIfNeeded)
-        m_inspector = WebInspectorBackend::create(*this);
-    return m_inspector.get();
+    if (!m_inspectorBackend && behavior == LazyCreationPolicy::CreateIfNeeded)
+        m_inspectorBackend = WebInspectorBackend::create(*this);
+    return m_inspectorBackend.get();
 }
 
 WebInspectorUI* WebPage::inspectorUI()
@@ -6362,7 +6362,7 @@ bool WebPage::windowAndWebPageAreFocused() const
 bool WebPage::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (decoder.messageReceiverName() == Messages::WebInspectorBackend::messageReceiverName()) {
-        if (RefPtr inspector = this->inspector())
+        if (RefPtr inspector = this->inspectorBackend())
             inspector->didReceiveMessage(connection, decoder);
         return true;
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -698,7 +698,7 @@ public:
 
     enum class LazyCreationPolicy { UseExistingOnly, CreateIfNeeded };
 
-    WebInspectorBackend* inspector(LazyCreationPolicy = LazyCreationPolicy::CreateIfNeeded);
+    WebInspectorBackend* inspectorBackend(LazyCreationPolicy = LazyCreationPolicy::CreateIfNeeded);
     WebInspectorUI* inspectorUI();
     RemoteWebInspectorUI* remoteInspectorUI();
     bool isInspectorPage() { return !!m_inspectorUI || !!m_remoteInspectorUI; }
@@ -2875,7 +2875,7 @@ private:
 
     const UniqueRef<WebFoundTextRangeController> m_foundTextRangeController;
 
-    RefPtr<WebInspectorBackend> m_inspector;
+    RefPtr<WebInspectorBackend> m_inspectorBackend;
     RefPtr<WebInspectorUI> m_inspectorUI;
     RefPtr<RemoteWebInspectorUI> m_remoteInspectorUI;
     std::unique_ptr<PageInspectorTarget> m_inspectorTarget;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -32,6 +32,7 @@
 #import <WebCore/InspectorBackendClient.h>
 #import <WebCore/InspectorDebuggableType.h>
 #import <WebCore/InspectorFrontendClientLocal.h>
+#import <wtf/CheckedRef.h>
 #import <wtf/Forward.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
@@ -56,11 +57,19 @@ class PageInspectorController;
 
 class WebInspectorFrontendClient;
 
-class WebInspectorClient final : public WebCore::InspectorBackendClient, public Inspector::FrontendChannel {
+class WebInspectorClient final : public WebCore::InspectorBackendClient, public Inspector::FrontendChannel, public CanMakeCheckedPtr<WebInspectorClient> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WebInspectorClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebInspectorClient);
 public:
     explicit WebInspectorClient(WebView *inspectedWebView);
     virtual ~WebInspectorClient();
+
+    // AbstractCanMakeCheckedPtr overrides
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     void inspectedPageDestroyed() override;
 
@@ -105,7 +114,7 @@ private:
     WeakObjCPtr<WebView> m_inspectedWebView;
     RetainPtr<WebNodeHighlighter> m_highlighter;
     WeakPtr<WebCore::Page> m_frontendPage;
-    std::unique_ptr<WebInspectorFrontendClient> m_frontendClient;
+    RefPtr<WebInspectorFrontendClient> m_frontendClient;
 };
 
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -116,12 +116,12 @@ FrontendChannel* WebInspectorClient::openLocalFrontend(PageInspectorController* 
     m_frontendPage = core([windowController.get() frontendWebView]);
 
     RefPtr webPageInspectorController = [m_inspectedWebView.get() inspectorController];
-    m_frontendClient = makeUnique<WebInspectorFrontendClient>(m_inspectedWebView.get().get(), *webPageInspectorController, windowController.get(), inspectedPageController, m_frontendPage.get(), createFrontendSettings());
+    m_frontendClient = adoptRef(*new WebInspectorFrontendClient(m_inspectedWebView.get().get(), *webPageInspectorController, windowController.get(), inspectedPageController, m_frontendPage.get(), createFrontendSettings()));
 
     RetainPtr<WebInspectorFrontend> webInspectorFrontend = adoptNS([[WebInspectorFrontend alloc] initWithFrontendClient:m_frontendClient.get()]);
     [[m_inspectedWebView.get() inspector] setFrontend:webInspectorFrontend.get()];
 
-    m_frontendPage->inspectorController().setInspectorFrontendClient(m_frontendClient.get());
+    m_frontendPage->inspectorController().setInspectorFrontendClient(*m_frontendClient);
 
     webPageInspectorController->connectFrontend(*this);
     return nullptr;
@@ -747,8 +747,6 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
 {
     RetainPtr<WebInspectorWindowController> protect(self);
 
-    if (Page* frontendPage = _frontendClient->frontendPage())
-        frontendPage->inspectorController().setInspectorFrontendClient(nullptr);
     RefPtr { [_inspectedWebView.get() inspectorController] }->disconnectFrontend(*_inspectorClient);
 
     [[_inspectedWebView.get() inspector] releaseFrontend];

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1480,6 +1480,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         WebCore::PageIdentifier::generate(),
         [[self preferences] privateBrowsingEnabled] ? PAL::SessionID::legacyPrivateSessionID() : PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(self),
+        makeUniqueRef<WebInspectorClient>(self),
         LegacySocketProvider::create(),
         WebCore::WebRTCProvider::create(),
         WebCore::CacheStorageProvider::create(),
@@ -1522,7 +1523,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 #if !PLATFORM(IOS_FAMILY)
     pageConfiguration.validationMessageClient = makeUnique<WebValidationMessageClient>(self);
 #endif
-    pageConfiguration.inspectorBackendClient = makeUnique<WebInspectorClient>(self);
+    pageConfiguration.inspectorBackendClient = makeUniqueRef<WebInspectorClient>(self);
 
 #if ENABLE(DRAG_SUPPORT)
     pageConfiguration.dragClient = makeUnique<WebDragClient>(self);
@@ -1745,6 +1746,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         WebCore::PageIdentifier::generate(),
         [[self preferences] privateBrowsingEnabled] ? PAL::SessionID::legacyPrivateSessionID() : PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(self),
+        makeUniqueRef<WebInspectorClient>(self),
         LegacySocketProvider::create(),
         WebCore::WebRTCProvider::create(),
         WebCore::CacheStorageProvider::create(),
@@ -1781,7 +1783,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     pageConfiguration.dragClient = makeUnique<WebDragClient>(self);
 #endif
 
-    pageConfiguration.inspectorBackendClient = makeUnique<WebInspectorClient>(self);
+    pageConfiguration.inspectorBackendClient = makeUniqueRef<WebInspectorClient>(self);
     pageConfiguration.databaseProvider = WebDatabaseProvider::singleton();
     pageConfiguration.storageNamespaceProvider = _private->group->storageNamespaceProvider();
     pageConfiguration.visitedLinkStore = _private->group->visitedLinkStore();


### PR DESCRIPTION
#### 835f94a07757d0645c66753d0b81bc59ef99dafb
<pre>
Web Inspector: adopt smart pointers for InspectorBackendClient and InspectorFrontendClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=307460">https://bugs.webkit.org/show_bug.cgi?id=307460</a>
<a href="https://rdar.apple.com/170082310">rdar://170082310</a>

Reviewed by NOBODY (OOPS!).

Adopt modern smart pointer patterns for InspectorBackendClient and
InspectorFrontendClient to clarify the lifetime and ownership of these classes.

InspectorBackendClient is held by a UniqueRef instead of unique_ptr, allowing use of WeakRef
and WeakPtr instead of raw pointer. Agents and other page-scoped objects can freely create WeakRefs
for backend client as long as they don&apos;t outlast the associated Page. If the lifetime is less
clear, then use WeakPtr instead.

Unlike the backend client, the InspectorFrontendClient is only set when a local frontend is attached,
and the backend controller does not affect its reference count. This is incompatible with WeakRefs.
When the frontend client goes away because the frontend closes, its WeakPtr will become nullopt.

Renamed WebPage::inspector() to WebPage::inspectorBackend() and m_inspector to m_inspectorBackend for
clarity, since this returns the WebInspectorBackend (not the UI or controller).

No new tests, no change in behavior.

* Source/WebCore/inspector/InspectorBackendClient.h:
* Source/WebCore/inspector/InspectorFrontendClient.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/PageInspectorController.cpp:
* Source/WebCore/inspector/PageInspectorController.h:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.h:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/PageConfiguration.cpp:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/testing/Internals.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/835f94a07757d0645c66753d0b81bc59ef99dafb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154958 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99742 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e11c198-c2fa-4659-a31c-dc9213827c6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112576 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99742 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/def7b227-d790-4d52-93f2-9f3932580d55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d31a2721-875e-46ff-bb5a-e6fee7af597a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14198 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11954 "1 api test failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2404 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157279 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/450 "Found 32 new failures in WebProcess/Inspector/WebInspectorBackendClient.cpp, inspector/PageDebugger.cpp, inspector/PageInspectorController.cpp, mac/WebInspector/WebInspectorFrontend.mm, inspector/InspectorFrontendHost.h and found 2 fixed files: inspector/agents/InspectorPageAgent.h, inspector/PageInspectorController.h") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120605 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120903 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74564 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7935 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18405 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82158 "Found 52 new failures in cf/WebCoreSupport/WebInspectorClientCF.cpp, mac/WebCoreSupport/WebInspectorClient.mm, WebProcess/Inspector/WebInspectorBackendClient.cpp, inspector/PageDebugger.cpp, inspector/PageInspectorController.cpp, WebProcess/Inspector/WebInspectorUIExtensionController.cpp, mac/WebInspector/WebInspectorFrontend.mm, inspector/InspectorFrontendHost.h and found 2 fixed files: inspector/agents/InspectorPageAgent.h, inspector/PageInspectorController.h") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->