### PR TITLE
[Site Isolation] Back navigation might not restore state of cross-site frame

### DIFF
--- a/LayoutTests/fast/frames/frame-element-name-expected.txt
+++ b/LayoutTests/fast/frames/frame-element-name-expected.txt
@@ -15,7 +15,7 @@ PASS escape(window.name) is ""
 
 
 --------
-Frame: '<!--frame2-->'
+Frame: '_blank'
 --------
 PASS escape(window.frameElement.name) is "_blank"
 PASS escape(window.name) is "_blank"

--- a/LayoutTests/http/tests/security/dataURL/xss-DENIED-from-data-url-in-foreign-domain-subframe-expected.txt
+++ b/LayoutTests/http/tests/security/dataURL/xss-DENIED-from-data-url-in-foreign-domain-subframe-expected.txt
@@ -7,7 +7,7 @@ Pass: Cross frame access from a data: URL on a different domain was denied.
 
 
 --------
-Frame: '<!--frame1-->'
+Frame: 'aFrame'
 --------
 Inner iframe on a foreign domain.
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -568,7 +568,7 @@ unsigned FrameTree::depth() const
 
 AtomString FrameTree::uniqueName() const
 {
-    if (!parent())
+    if (m_thisFrame->isMainFrame() || !m_specifiedName.isEmpty())
         return m_specifiedName;
 
     auto frameIndex { 0u };

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -641,7 +641,6 @@ void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, R
         return;
 
     if (RefPtr webPageProxy = m_page.get()) {
-
         auto navigatedFrameID = navigatedFrameState->frameID;
         Ref item = WebBackForwardListItem::create(completeFrameStateForNavigation(WTF::move(navigatedFrameState)), webPageProxy->identifier(), navigatedFrameID, protect(webPageProxy->browsingContextGroup()).ptr());
         item->setResourceDirectoryURL(webPageProxy->currentResourceDirectoryURL());

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3643,6 +3643,8 @@ private:
     void beginSiteHasStorageCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
     void beginEnhancedSecurityLinkCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
 
+    Ref<BrowsingContextGroup> browsingContextGroupForNavigation(WebFrameProxy&, API::Navigation&, WebsiteDataStore&, ProcessSwapRequestedByClient);
+
     const UniqueRef<Internals> m_internals;
     Identifier m_identifier;
     WebCore::PageIdentifier m_webPageID;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -1045,3 +1045,93 @@ TEST(WKBackForwardList, NoPageCacheGoBackAfterNavigatingSameSiteIframe)
 {
     runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache::No);
 }
+
+static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache shouldEnablePageCache)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<iframe id='iframe' src='/frame'></iframe>"_s } },
+        { "/frame"_s, { "hi"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().pageCacheEnabled = shouldEnablePageCache == ShouldEnablePageCache::Yes;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    [configuration setProcessPool:processPool.get()];
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    static bool didCommitLoadForAllFrames = false;
+    static unsigned expectedCommittedFrameSize = 2;
+    static Vector<RetainPtr<WKFrameInfo>> committedFrames;
+    navigationDelegate.get().didCommitLoadWithRequestInFrame = makeBlockPtr([&](WKWebView *, NSURLRequest *, WKFrameInfo *frameInfo) {
+        committedFrames.append(frameInfo);
+        if (committedFrames.size() == expectedCommittedFrameSize)
+            didCommitLoadForAllFrames = true;
+    }).get();
+
+    // After initial loading, page has a main frame and a same-site iframe.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
+    EXPECT_TRUE([committedFrames[0] isMainFrame]);
+    EXPECT_WK_STREQ([committedFrames[0] request].URL.absoluteString, "https://example.com/main");
+    EXPECT_FALSE([committedFrames[1] isMainFrame]);
+    EXPECT_WK_STREQ([committedFrames[1] request].URL.absoluteString, "https://example.com/frame");
+    committedFrames.clear();
+    didCommitLoadForAllFrames = false;
+
+    // Navigate iframe cross-site.
+    expectedCommittedFrameSize = 1;
+    [webView evaluateJavaScript:@"document.getElementById('iframe').src = 'https://frame.com/frame'" completionHandler:nil];
+    TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
+    EXPECT_FALSE([committedFrames[0] isMainFrame]);
+    EXPECT_WK_STREQ([committedFrames[0] request].URL.absoluteString, "https://frame.com/frame");
+    committedFrames.clear();
+    didCommitLoadForAllFrames = false;
+
+    // Navigate main frame same-site.
+    expectedCommittedFrameSize = 1;
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/frame"]]];
+    TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
+    EXPECT_TRUE([committedFrames[0] isMainFrame]);
+    EXPECT_WK_STREQ([committedFrames[0] request].URL.absoluteString, "https://example.com/frame");
+    committedFrames.clear();
+    didCommitLoadForAllFrames = false;
+
+    EXPECT_EQ(YES, [webView canGoBack]);
+    EXPECT_EQ([webView backForwardList].backList.count, 2U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    // Navigate main frame back.
+    // For page cache case, iframe is not reloaded, so there is only one commit.
+    expectedCommittedFrameSize = shouldEnablePageCache == ShouldEnablePageCache::Yes ? 1 : 2;
+    [webView goBack];
+
+    TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
+    EXPECT_WK_STREQ([webView URL].absoluteString, @"https://example.com/main");
+    EXPECT_TRUE([committedFrames[0] isMainFrame]);
+    EXPECT_WK_STREQ([committedFrames[0] request].URL.absoluteString, "https://example.com/main");
+    if (expectedCommittedFrameSize == 1) {
+        EXPECT_FALSE([[webView firstChildFrame] isMainFrame]);
+        EXPECT_WK_STREQ([[webView firstChildFrame] request].URL.absoluteString, "https://frame.com/frame");
+    } else {
+        EXPECT_FALSE([committedFrames[1] isMainFrame]);
+        EXPECT_WK_STREQ([committedFrames[1] request].URL.absoluteString, "https://frame.com/frame");
+    }
+}
+
+TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe2)
+{
+    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    if (isSiteIsolationEnabled(webView.get()))
+        return;
+
+    runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache::Yes);
+}
+
+TEST(WKBackForwardList, NoPageCacheGoBackAfterNavigatingSameSiteIframe2)
+{
+    runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache::No);
+}


### PR DESCRIPTION
#### 1732420d99b5d73dedbe3f4c35c65b039855a673
<pre>
[Site Isolation] Back navigation might not restore state of cross-site frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=308450">https://bugs.webkit.org/show_bug.cgi?id=308450</a>
<a href="https://rdar.apple.com/170956531">rdar://170956531</a>

Reviewed by Charlie Wolfe.

With current implementation, sometimes back-forward navigation does not restore cross-site frames on a page correctly.
This cause is subframe process creates back-forward list item with incorrect target (frame unique name), so that when
the navigating web process tries to find child history item with target (see FrameLoader::loadURLIntoChildFrame =&gt;
HistoryItem::childItemWithTarget), it will not find correct history item for frame to use.

Here is key flow of the issue:
1. When an iframe navigates cross-site, UI process starts the load in a different web process.
2. The web process creates a remote frame and a provisional local frame for the iframe, and starts load in local frame.
3. When the load is committed in provsional local frame, the web process asks UI process to create a new backforward
list item, with the target (frame&apos;s unique name) inside (see DocumentLoader::commitLoad =&gt; commitIfReady =&gt;
FrameLoader::transitionToCommitted =&gt; HistoryController::updateBackForwardListClippedAtTarget).
4. Also at load commit time, the web process will also replace the remote frame with the local frame in tree (see
DocumentLoader::commitLoad =&gt; commitData =&gt; FrameLoader::dispatchDidCommitLoad =&gt; WebFrame::commitProvisionalFrame()).

Normally, the target at step 3 should be a string based on frame&apos;s position in tree. However, it is actually null
because FrameTree::uniqueName returns m_specifiedName (default to null) when frame is not added to tree yet. In this
case, frame is only added to tree after step 4. But, FrameTree::uniqueName is read and used in step 3. To fix this, make
sure FrameTree::uniqueName only returns null when frame is a top frame, or frame has a non-null specified name. In other
cases, we still traverse the frame tree to generate correct unique name -- this fix works in this case as the remote
frame is already in tree.

With this fix, the API test SiteIsolation.RestoreSessionFromAnotherWebView starts to time out. Before the fix, when
doing back-forward navigation, FrameLoader::loadURLIntoChildFrame will not be able to find child frame state with target
(HistoryItem::childItemWithTarget) since target is wrong, so it just treats the iframe load as a normal navigation
initiated by web page, and browser context group will stay the same (see browsingContextGroup setting logic in
WebPageProxy::receivedNavigationActionPolicyDecision). After the fix, the iframe load will be treated as navigation
requested from client (as it&apos;s part of back-forward navigation from session restore), so a new browsing context group
will be created for the navigation. As this is a new browsing context group, BrowsingContextGroup::m_pages is empty. So,
RemotePageProxy will not be created, WebPage will not be created in navigating process, and thus navigation will not
succeed. Browsing context group should never be changed for non-main frame navigation -- all frames in the same page
should belong to the same BCG. So this patch fixes the issue by ensuring that.

(Credits to Basuke who found the test case.)
API Tests: WKBackForwardList.PageCacheGoBackAfterNavigatingSameSiteIframe2
           WKBackForwardList.NoPageCacheGoBackAfterNavigatingSameSiteIframe2

* LayoutTests/fast/frames/frame-element-name-expected.txt:
* LayoutTests/http/tests/security/dataURL/xss-DENIED-from-data-url-in-foreign-domain-subframe-expected.txt: Rebaseline
test expectation, as the fix is a progression.

* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::uniqueName const):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardAddItemShared):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::browsingContextGroupForNavigation): This is a new helper function to pick browsing context group.
Most of it is just the same as current implementation, with a fix to reuse same BCG for iframe navigation.
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(runGoBackAfterNavigatingSameSiteIframe2):
(TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe2)):
(TEST(WKBackForwardList, NoPageCacheGoBackAfterNavigatingSameSiteIframe2)):

Canonical link: <a href="https://commits.webkit.org/308220@main">https://commits.webkit.org/308220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4214ba42111ed607ee3a4aa416479e661efd9def

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100038 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80685 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/566733d7-2588-4bbe-bc13-8df4a3d32f4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93740 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f2fd6f8-f049-478d-a481-790f904743f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157643 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120998 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31085 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74939 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16837 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8292 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82493 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18476 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->