### PR TITLE
Drop remaining `protected*()` member functions in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -106,7 +106,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
     }
 
     WGPURenderPassTimestampWrites timestampWrites {
-        .querySet = descriptor.timestampWrites ? convertToBackingContext->convertToBacking(*descriptor.timestampWrites->protectedQuerySet()) : nullptr,
+        .querySet = descriptor.timestampWrites ? convertToBackingContext->convertToBacking(*protect(descriptor.timestampWrites->querySet)) : nullptr,
         .beginningOfPassWriteIndex = descriptor.timestampWrites ? descriptor.timestampWrites->beginningOfPassWriteIndex : 0,
         .endOfPassWriteIndex = descriptor.timestampWrites ? descriptor.timestampWrites->endOfPassWriteIndex : 0
     };
@@ -117,7 +117,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
         .colorAttachmentCount = colorAttachments.size(),
         .colorAttachments = colorAttachments.size() ? colorAttachments.span().data() : nullptr,
         .depthStencilAttachment = depthStencilAttachment ? &depthStencilAttachment.value() : nullptr,
-        .occlusionQuerySet = descriptor.occlusionQuerySet ? convertToBackingContext->convertToBacking(*descriptor.protectedOcclusionQuerySet()) : nullptr,
+        .occlusionQuerySet = descriptor.occlusionQuerySet ? convertToBackingContext->convertToBacking(*protect(descriptor.occlusionQuerySet)) : nullptr,
         .timestampWrites = timestampWrites.querySet ? &timestampWrites : nullptr
     };
 
@@ -129,7 +129,7 @@ RefPtr<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optio
     String label = descriptor ? descriptor->label : emptyString();
 
     WGPUComputePassTimestampWrites timestampWrites {
-        .querySet = (descriptor && descriptor->timestampWrites && descriptor->timestampWrites->querySet) ? m_convertToBackingContext->convertToBacking(*descriptor->timestampWrites->protectedQuerySet().get()) : nullptr,
+        .querySet = (descriptor && descriptor->timestampWrites && descriptor->timestampWrites->querySet) ? m_convertToBackingContext->convertToBacking(*protect(descriptor->timestampWrites->querySet)) : nullptr,
         .beginningOfPassWriteIndex = (descriptor && descriptor->timestampWrites) ? descriptor->timestampWrites->beginningOfPassWriteIndex : 0,
         .endOfPassWriteIndex = (descriptor && descriptor->timestampWrites) ? descriptor->timestampWrites->endOfPassWriteIndex : 0
     };
@@ -166,11 +166,11 @@ void CommandEncoderImpl::copyBufferToTexture(
             .bytesPerRow = source.bytesPerRow.value_or(WGPU_COPY_STRIDE_UNDEFINED),
             .rowsPerImage = source.rowsPerImage.value_or(WGPU_COPY_STRIDE_UNDEFINED),
         },
-        .buffer = convertToBackingContext->convertToBacking(source.protectedBuffer().get()),
+        .buffer = convertToBackingContext->convertToBacking(protect(source.buffer).get()),
     };
 
     WGPUImageCopyTexture backingDestination {
-        .texture = convertToBackingContext->convertToBacking(destination.protectedTexture().get()),
+        .texture = convertToBackingContext->convertToBacking(protect(destination.texture).get()),
         .mipLevel = destination.mipLevel,
         .origin = destination.origin ? convertToBackingContext->convertToBacking(*destination.origin) : WGPUOrigin3D { 0, 0, 0 },
         .aspect = convertToBackingContext->convertToBacking(destination.aspect),
@@ -189,7 +189,7 @@ void CommandEncoderImpl::copyTextureToBuffer(
     Ref convertToBackingContext = m_convertToBackingContext;
 
     WGPUImageCopyTexture backingSource {
-        .texture = convertToBackingContext->convertToBacking(source.protectedTexture().get()),
+        .texture = convertToBackingContext->convertToBacking(protect(source.texture).get()),
         .mipLevel = source.mipLevel,
         .origin = source.origin ? convertToBackingContext->convertToBacking(*source.origin) : WGPUOrigin3D { 0, 0, 0 },
         .aspect = convertToBackingContext->convertToBacking(source.aspect),
@@ -201,7 +201,7 @@ void CommandEncoderImpl::copyTextureToBuffer(
             .bytesPerRow = destination.bytesPerRow.value_or(WGPU_COPY_STRIDE_UNDEFINED),
             .rowsPerImage = destination.rowsPerImage.value_or(WGPU_COPY_STRIDE_UNDEFINED),
         },
-        .buffer = convertToBackingContext->convertToBacking(destination.protectedBuffer().get()),
+        .buffer = convertToBackingContext->convertToBacking(protect(destination.buffer).get()),
     };
 
     WGPUExtent3D backingCopySize = convertToBackingContext->convertToBacking(copySize);
@@ -217,14 +217,14 @@ void CommandEncoderImpl::copyTextureToTexture(
     Ref convertToBackingContext = m_convertToBackingContext;
 
     WGPUImageCopyTexture backingSource {
-        .texture = convertToBackingContext->convertToBacking(source.protectedTexture().get()),
+        .texture = convertToBackingContext->convertToBacking(protect(source.texture).get()),
         .mipLevel = source.mipLevel,
         .origin = source.origin ? convertToBackingContext->convertToBacking(*source.origin) : WGPUOrigin3D { 0, 0, 0 },
         .aspect = convertToBackingContext->convertToBacking(source.aspect),
     };
 
     WGPUImageCopyTexture backingDestination {
-        .texture = convertToBackingContext->convertToBacking(destination.protectedTexture().get()),
+        .texture = convertToBackingContext->convertToBacking(protect(destination.texture).get()),
         .mipLevel = destination.mipLevel,
         .origin = destination.origin ? convertToBackingContext->convertToBacking(*destination.origin) : WGPUOrigin3D { 0, 0, 0 },
         .aspect = convertToBackingContext->convertToBacking(destination.aspect),

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -276,7 +276,7 @@ RefPtr<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descrip
 
     WGPUBindGroupDescriptor backingDescriptor {
         .label = label.data(),
-        .layout = convertToBackingContext->convertToBacking(descriptor.protectedLayout().get()),
+        .layout = convertToBackingContext->convertToBacking(protect(descriptor.layout).get()),
         .entryCount = backingEntries.size(),
         .entries = backingEntries.size() ? backingEntries.span().data() : nullptr,
     };
@@ -300,7 +300,7 @@ RefPtr<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor
         const auto& hint = descriptor.hints[i].value;
         hintsEntries.append(WGPUShaderModuleCompilationHint {
             .entryPoint = entryPoints[i].data(),
-            .layout = convertToBackingContext->convertToBacking(hint.protectedPipelineLayout().get())
+            .layout = convertToBackingContext->convertToBacking(protect(hint.pipelineLayout).get())
         });
     }
 
@@ -341,7 +341,7 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
 
     WGPUComputePipelineDescriptor backingDescriptor {
         .label = label.data(),
-        .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*descriptor.protectedLayout().get()) : nullptr,
+        .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*protect(descriptor.layout)) : nullptr,
         .compute = WGPUProgrammableStageDescriptor {
             .module = convertToBackingContext.convertToBacking(protect(descriptor.compute.module).get()),
             .entryPoint = entryPoint ? entryPoint->data() : nullptr,
@@ -506,7 +506,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
 
     WGPURenderPipelineDescriptor backingDescriptor {
         .label = label.data(),
-        .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*descriptor.protectedLayout()) : nullptr,
+        .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*protect(descriptor.layout)) : nullptr,
         .vertex = {
             .module = convertToBackingContext.convertToBacking(protect(descriptor.vertex.module).get()),
             .entryPoint = vertexEntryPoint ? vertexEntryPoint->data() : nullptr,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -108,7 +108,7 @@ bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfigu
         .reportValidationErrors = canvasConfiguration.reportValidationErrors
     };
 
-    m_swapChain = adoptWebGPU(wgpuDeviceCreateSwapChain(convertToBackingContext->convertToBacking(canvasConfiguration.protectedDevice().get()), m_backing.get(), &backingDescriptor));
+    m_swapChain = adoptWebGPU(wgpuDeviceCreateSwapChain(convertToBackingContext->convertToBacking(protect(canvasConfiguration.device).get()), m_backing.get(), &backingDescriptor));
     return true;
 }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -110,7 +110,7 @@ void QueueImpl::writeTexture(
     Ref convertToBackingContext = m_convertToBackingContext;
 
     WGPUImageCopyTexture backingDestination {
-        .texture = convertToBackingContext->convertToBacking(destination.protectedTexture().get()),
+        .texture = convertToBackingContext->convertToBacking(protect(destination.texture).get()),
         .mipLevel = destination.mipLevel,
         .origin = destination.origin ? convertToBackingContext->convertToBacking(*destination.origin) : WGPUOrigin3D { 0, 0, 0 },
         .aspect = convertToBackingContext->convertToBacking(destination.aspect),

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h
@@ -37,8 +37,6 @@ class BindGroupLayout;
 struct BindGroupDescriptor : public ObjectDescriptorBase {
     WeakRef<BindGroupLayout> layout;
     Vector<BindGroupEntry> entries;
-
-    Ref<BindGroupLayout> protectedLayout() const { return layout.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h
@@ -37,8 +37,6 @@ struct BufferBinding {
     WeakRef<Buffer> buffer;
     Size64 offset { 0 };
     std::optional<Size64> size;
-
-    Ref<Buffer> protectedBuffer() const { return buffer.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
@@ -45,8 +45,6 @@ struct CanvasConfiguration {
     CanvasToneMappingMode toneMappingMode { CanvasToneMappingMode::Standard };
     CanvasAlphaMode compositingAlphaMode { CanvasAlphaMode::Opaque };
     bool reportValidationErrors { true };
-
-    Ref<Device> protectedDevice() const { return device.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
@@ -38,8 +38,6 @@ struct ComputePassTimestampWrites {
     WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { kQuerySetIndexUndefined };
     Size32 endOfPassWriteIndex { kQuerySetIndexUndefined };
-
-    RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h
@@ -36,8 +36,6 @@ class Buffer;
 
 struct ImageCopyBuffer : public ImageDataLayout {
     WeakRef<Buffer> buffer;
-
-    Ref<Buffer> protectedBuffer() const { return buffer.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h
@@ -42,8 +42,6 @@ struct ImageCopyTexture {
     IntegerCoordinate mipLevel { 0 };
     std::optional<Origin3D> origin;
     TextureAspect aspect { TextureAspect::All };
-
-    Ref<Texture> protectedTexture() const { return texture.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h
@@ -33,8 +33,6 @@ namespace WebCore::WebGPU {
 
 struct PipelineDescriptorBase : public ObjectDescriptorBase {
     WeakPtr<PipelineLayout> layout;
-
-    RefPtr<PipelineLayout> protectedLayout() const { return layout.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h
@@ -42,8 +42,6 @@ struct RenderPassDescriptor : public ObjectDescriptorBase {
     WeakPtr<QuerySet> occlusionQuerySet;
     std::optional<RenderPassTimestampWrites> timestampWrites;
     std::optional<uint64_t> maxDrawCount;
-
-    RefPtr<QuerySet> protectedOcclusionQuerySet() const { return occlusionQuerySet.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
@@ -39,8 +39,6 @@ struct RenderPassTimestampWrites {
     WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { kQuerySetIndexUndefined };
     Size32 endOfPassWriteIndex { kQuerySetIndexUndefined };
-
-    RefPtr<QuerySet> protectedQuerySet() const { return querySet.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModuleCompilationHint.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModuleCompilationHint.h
@@ -33,8 +33,6 @@ namespace WebCore::WebGPU {
 
 struct ShaderModuleCompilationHint {
     WeakRef<PipelineLayout> pipelineLayout;
-
-    Ref<PipelineLayout> protectedPipelineLayout() const { return pipelineLayout.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -130,7 +130,6 @@ private:
     void didCancelPaymentSession(PaymentSessionError&&) override;
 
     PaymentCoordinator& NODELETE paymentCoordinator() const;
-    Ref<PaymentCoordinator> NODELETE protectedPaymentCoordinator() const;
 
     bool NODELETE canBegin() const;
     bool NODELETE canAbort() const;

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -148,17 +148,7 @@ Document& ApplePayPaymentHandler::document() const
     return downcast<Document>(*scriptExecutionContext());
 }
 
-Ref<Document> ApplePayPaymentHandler::protectedDocument() const
-{
-    return document();
-}
-
 PaymentCoordinator& ApplePayPaymentHandler::paymentCoordinator() const
-{
-    return WebCore::paymentCoordinator(document());
-}
-
-Ref<PaymentCoordinator> ApplePayPaymentHandler::protectedPaymentCoordinator() const
 {
     return WebCore::paymentCoordinator(document());
 }
@@ -340,12 +330,12 @@ ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
 
 void ApplePayPaymentHandler::hide()
 {
-    protectedPaymentCoordinator()->abortPaymentSession();
+    protect(paymentCoordinator())->abortPaymentSession();
 }
 
 void ApplePayPaymentHandler::canMakePayment(Document&, Function<void(bool)>&& completionHandler)
 {
-    completionHandler(protectedPaymentCoordinator()->canMakePayments());
+    completionHandler(protect(paymentCoordinator())->canMakePayments());
 }
 
 ExceptionOr<Vector<ApplePayShippingMethod>> ApplePayPaymentHandler::computeShippingMethods() const
@@ -591,7 +581,7 @@ ExceptionOr<std::optional<std::tuple<PaymentDetailsModifier, ApplePayModifier>>>
     if (!details.modifiers)
         return { std::nullopt };
 
-    auto& lexicalGlobalObject = *protectedDocument()->globalObject();
+    auto& lexicalGlobalObject = *protect(document())->globalObject();
 
     auto& serializedModifierData = m_paymentRequest->serializedModifierData();
     ASSERT(details.modifiers->size() == serializedModifierData.size());
@@ -672,7 +662,7 @@ ExceptionOr<void> ApplePayPaymentHandler::merchantValidationCompleted(JSC::JSVal
         return Exception { ExceptionCode::TypeError };
 
     String errorMessage;
-    auto merchantSession = PaymentMerchantSession::fromJS(*protectedDocument()->globalObject(), asObject(merchantSessionValue), errorMessage);
+    auto merchantSession = PaymentMerchantSession::fromJS(*protect(document())->globalObject(), asObject(merchantSessionValue), errorMessage);
     if (!merchantSession)
         return Exception { ExceptionCode::TypeError, WTF::move(errorMessage) };
 
@@ -730,7 +720,7 @@ ExceptionOr<void> ApplePayPaymentHandler::shippingAddressUpdated(Vector<Ref<Appl
 #endif
     }
 
-    protectedPaymentCoordinator()->completeShippingContactSelection(WTF::move(update));
+    protect(paymentCoordinator())->completeShippingContactSelection(WTF::move(update));
     return { };
 }
 
@@ -780,7 +770,7 @@ ExceptionOr<void> ApplePayPaymentHandler::shippingOptionUpdated()
 #endif
     }
 
-    protectedPaymentCoordinator()->completeShippingMethodSelection(WTF::move(update));
+    protect(paymentCoordinator())->completeShippingMethodSelection(WTF::move(update));
     return { };
 }
 
@@ -830,7 +820,7 @@ ExceptionOr<void> ApplePayPaymentHandler::paymentMethodUpdated(Vector<Ref<AppleP
 #endif
         }
 
-        protectedPaymentCoordinator()->completeCouponCodeChange(WTF::move(update));
+        protect(paymentCoordinator())->completeCouponCodeChange(WTF::move(update));
         return { };
     }
 #endif // ENABLE(APPLE_PAY_COUPON_CODE)
@@ -883,7 +873,7 @@ ExceptionOr<void> ApplePayPaymentHandler::paymentMethodUpdated(Vector<Ref<AppleP
 #endif
     }
 
-    protectedPaymentCoordinator()->completePaymentMethodSelection(WTF::move(update));
+    protect(paymentCoordinator())->completePaymentMethodSelection(WTF::move(update));
     return { };
 }
 
@@ -952,7 +942,7 @@ ExceptionOr<void> ApplePayPaymentHandler::complete(Document& document, std::opti
     }
 
     ASSERT(authorizationResult.isFinalState());
-    protectedPaymentCoordinator()->completePaymentSession(WTF::move(authorizationResult));
+    protect(paymentCoordinator())->completePaymentSession(WTF::move(authorizationResult));
     return { };
 }
 

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
@@ -59,9 +59,7 @@ private:
     explicit ApplePayPaymentHandler(Document&, const PaymentRequest::MethodIdentifier&, PaymentRequest&);
 
     Document& NODELETE document() const;
-    Ref<Document> NODELETE protectedDocument() const;
     PaymentCoordinator& NODELETE paymentCoordinator() const;
-    Ref<PaymentCoordinator> NODELETE protectedPaymentCoordinator() const;
 
     ExceptionOr<Vector<ApplePayShippingMethod>> computeShippingMethods() const;
     ExceptionOr<std::tuple<ApplePayLineItem, Vector<ApplePayLineItem>>> computeTotalAndLineItems() const;

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -88,7 +88,6 @@ private:
     void ensureOnMainThread(Function<void(ScriptExecutionContext&)>&&);
     void ensureOnContextThread(Function<void(CookieStore&)>&&);
 
-    RefPtr<CookieStore> NODELETE protectedCookieStore() const { return m_cookieStore; }
     WeakPtr<CookieStore, WeakPtrImplWithEventTargetData> m_cookieStore;
     Markable<ScriptExecutionContextIdentifier> m_contextIdentifier;
 };
@@ -103,7 +102,7 @@ void CookieStore::MainThreadBridge::ensureOnMainThread(Function<void(ScriptExecu
 {
     ASSERT(m_cookieStore);
 
-    RefPtr context = protectedCookieStore()->scriptExecutionContext();
+    RefPtr context = protect(m_cookieStore)->scriptExecutionContext();
     if (!context)
         return;
     ASSERT(context->isContextThread());

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -304,7 +304,7 @@ void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, cons
         builder.append(value);
         return true;
     });
-    protectedFormDataConsumer()->start();
+    protect(m_formDataConsumer)->start();
 }
 
 void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchBodySource& source, ScriptExecutionContext* context)
@@ -333,14 +333,14 @@ void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchB
 
         return source->enqueue(ArrayBuffer::tryCreate(value));
     });
-    protectedFormDataConsumer()->start();
+    protect(m_formDataConsumer)->start();
 }
 
 void FetchBodyConsumer::extract(ReadableStream& stream, ReadableStreamToSharedBufferSink::Callback&& callback)
 {
     ASSERT(!m_sink);
     m_sink = ReadableStreamToSharedBufferSink::create(WTF::move(callback));
-    protectedSink()->pipeFrom(stream);
+    protect(m_sink)->pipeFrom(stream);
 }
 
 void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& contentType, FetchBodyOwner* owner, ReadableStream* stream)
@@ -364,7 +364,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
                 protectedPromise->reject(WTF::move(error));
             });
         });
-        protectedSink()->pipeFrom(*stream);
+        protect(m_sink)->pipeFrom(*stream);
         return;
     }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -95,9 +95,6 @@ private:
     Ref<Blob> takeAsBlob(ScriptExecutionContext*, const String& contentType);
     void resetConsumePromise();
 
-    RefPtr<ReadableStreamToSharedBufferSink> protectedSink() { return m_sink; }
-    RefPtr<FormDataConsumer> protectedFormDataConsumer() { return m_formDataConsumer; }
-
     Type m_type;
     SharedBufferBuilder m_buffer;
     RefPtr<DeferredPromise> m_consumePromise;

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
@@ -38,7 +38,6 @@ public:
 
 private:
     FileSystemWritableFileStreamSink(FileSystemWritableFileStreamIdentifier, FileSystemFileHandle&);
-    Ref<FileSystemFileHandle> protectedSource() const { return m_source; }
 
     // WritableStreamSink
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -119,11 +119,6 @@ Ref<DOMStringList> IDBDatabase::objectStoreNames() const
     return objectStoreNames;
 }
 
-RefPtr<IDBTransaction> IDBDatabase::protectedVersionChangeTransaction() const
-{
-    return m_versionChangeTransaction;
-}
-
 void IDBDatabase::renameObjectStore(IDBObjectStore& objectStore, const String& newName)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
@@ -132,7 +127,7 @@ void IDBDatabase::renameObjectStore(IDBObjectStore& objectStore, const String& n
 
     m_info.renameObjectStore(objectStore.info().identifier(), newName);
 
-    protectedVersionChangeTransaction()->renameObjectStore(objectStore, newName);
+    protect(m_versionChangeTransaction)->renameObjectStore(objectStore, newName);
 }
 
 void IDBDatabase::renameIndex(IDBIndex& index, const String& newName)
@@ -144,7 +139,7 @@ void IDBDatabase::renameIndex(IDBIndex& index, const String& newName)
 
     m_info.infoForExistingObjectStore(index.objectStore().info().name())->infoForExistingIndex(index.info().identifier())->rename(newName);
 
-    protectedVersionChangeTransaction()->renameIndex(index, newName);
+    protect(m_versionChangeTransaction)->renameIndex(index, newName);
 }
 
 ScriptExecutionContext* IDBDatabase::scriptExecutionContext() const

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -126,8 +126,6 @@ private:
 
     void maybeCloseInServer();
 
-    RefPtr<IDBTransaction> NODELETE protectedVersionChangeTransaction() const;
-
     const Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;
     IDBDatabaseInfo m_info;
     IDBDatabaseConnectionIdentifier m_databaseConnectionIdentifier;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -140,11 +140,6 @@ IDBTransaction& IDBObjectStore::transaction()
     return m_transaction.get();
 }
 
-Ref<IDBTransaction> IDBObjectStore::protectedTransaction()
-{
-    return transaction();
-}
-
 bool IDBObjectStore::autoIncrement() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_transaction->database().originThread()));

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -75,7 +75,6 @@ public:
     const std::optional<IDBKeyPath>& NODELETE keyPath() const;
     Ref<DOMStringList> indexNames() const;
     IDBTransaction& NODELETE transaction();
-    Ref<IDBTransaction> NODELETE protectedTransaction();
     bool NODELETE autoIncrement() const;
 
     struct IndexParameters {

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -123,11 +123,6 @@ IDBClient::IDBConnectionProxy& IDBTransaction::connectionProxy()
     return m_database->connectionProxy();
 }
 
-Ref<IDBClient::IDBConnectionProxy> IDBTransaction::protectedConnectionProxy()
-{
-    return connectionProxy();
-}
-
 Ref<DOMStringList> IDBTransaction::objectStoreNames() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
@@ -293,7 +288,7 @@ void IDBTransaction::abortInProgressOperations(const IDBError& error)
     m_transactionOperationResultMap.clear();
 
     m_currentlyCompletingRequest = nullptr;
-    protectedConnectionProxy()->forgetActiveOperations(inProgressAbortVector);
+    protect(connectionProxy())->forgetActiveOperations(inProgressAbortVector);
 }
 
 void IDBTransaction::abortOnServerAndCancelRequests(IDBClient::TransactionOperation& operation)
@@ -1572,15 +1567,15 @@ void IDBTransaction::generateIndexKeyForRecord(const IDBResourceIdentifier& requ
     RefPtr context = scriptExecutionContext();
     auto* globalObject = context ? context->globalObject() : nullptr;
     if (!globalObject)
-        return protectedConnectionProxy()->didGenerateIndexKeyForRecord(info().identifier(), requestIdentifier, indexInfo, key, IndexKey { }, recordID);
+        return protect(connectionProxy())->didGenerateIndexKeyForRecord(info().identifier(), requestIdentifier, indexInfo, key, IndexKey { }, recordID);
 
     auto jsValue = deserializeIDBValueToJSValue(*globalObject, value);
     if (jsValue.isUndefinedOrNull())
-        return protectedConnectionProxy()->didGenerateIndexKeyForRecord(info().identifier(), requestIdentifier, indexInfo, key, IndexKey { }, recordID);
+        return protect(connectionProxy())->didGenerateIndexKeyForRecord(info().identifier(), requestIdentifier, indexInfo, key, IndexKey { }, recordID);
 
     IndexKey indexKey;
     generateIndexKeyForValue(*globalObject, indexInfo, jsValue, indexKey, keyPath, key);
-    return protectedConnectionProxy()->didGenerateIndexKeyForRecord(info().identifier(), requestIdentifier, indexInfo, key, indexKey, recordID);
+    return protect(connectionProxy())->didGenerateIndexKeyForRecord(info().identifier(), requestIdentifier, indexInfo, key, indexKey, recordID);
 }
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -149,7 +149,6 @@ public:
     bool didDispatchAbortOrCommit() const { return m_didDispatchAbortOrCommit; }
 
     IDBClient::IDBConnectionProxy& NODELETE connectionProxy();
-    Ref<IDBClient::IDBConnectionProxy> NODELETE protectedConnectionProxy();
     void connectionClosedFromServer(const IDBError&);
     void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -62,7 +62,7 @@ IDBConnectionToServer::~IDBConnectionToServer() = default;
 
 IDBConnectionIdentifier IDBConnectionToServer::identifier() const
 {
-    return *protectedDelegate()->identifier();
+    return *protect(m_delegate)->identifier();
 }
 
 void IDBConnectionToServer::callResultFunctionWithErrorLater(ResultFunction function, const IDBResourceIdentifier& requestIdentifier)
@@ -77,7 +77,7 @@ void IDBConnectionToServer::deleteDatabase(const IDBOpenRequestData& request)
     LOG(IndexedDB, "IDBConnectionToServer::deleteDatabase - %s", request.databaseIdentifier().loggingString().utf8().data());
     
     if (m_serverConnectionIsValid)
-        protectedDelegate()->deleteDatabase(request);
+        protect(m_delegate)->deleteDatabase(request);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteDatabase, request.requestIdentifier());
 }
@@ -93,7 +93,7 @@ void IDBConnectionToServer::openDatabase(const IDBOpenRequestData& request)
     LOG(IndexedDB, "IDBConnectionToServer::openDatabase - %s (%s) (%" PRIu64 ")", request.databaseIdentifier().loggingString().utf8().data(), request.requestIdentifier().loggingString().utf8().data(), request.requestedVersion());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->openDatabase(request);
+        protect(m_delegate)->openDatabase(request);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didOpenDatabase, request.requestIdentifier());
 }
@@ -110,7 +110,7 @@ void IDBConnectionToServer::createObjectStore(const IDBRequestData& requestData,
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->createObjectStore(requestData, info);
+        protect(m_delegate)->createObjectStore(requestData, info);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didCreateObjectStore, requestData.requestIdentifier());
 }
@@ -127,7 +127,7 @@ void IDBConnectionToServer::deleteObjectStore(const IDBRequestData& requestData,
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->deleteObjectStore(requestData, objectStoreName);
+        protect(m_delegate)->deleteObjectStore(requestData, objectStoreName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteObjectStore, requestData.requestIdentifier());
 }
@@ -144,7 +144,7 @@ void IDBConnectionToServer::renameObjectStore(const IDBRequestData& requestData,
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->renameObjectStore(requestData, objectStoreIdentifier, newName);
+        protect(m_delegate)->renameObjectStore(requestData, objectStoreIdentifier, newName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didRenameObjectStore, requestData.requestIdentifier());
 }
@@ -161,7 +161,7 @@ void IDBConnectionToServer::clearObjectStore(const IDBRequestData& requestData, 
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->clearObjectStore(requestData, objectStoreIdentifier);
+        protect(m_delegate)->clearObjectStore(requestData, objectStoreIdentifier);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didClearObjectStore, requestData.requestIdentifier());
 }
@@ -178,7 +178,7 @@ void IDBConnectionToServer::createIndex(const IDBRequestData& requestData, const
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->createIndex(requestData, info);
+        protect(m_delegate)->createIndex(requestData, info);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didCreateIndex, requestData.requestIdentifier());
 }
@@ -195,7 +195,7 @@ void IDBConnectionToServer::deleteIndex(const IDBRequestData& requestData, IDBOb
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->deleteIndex(requestData, objectStoreIdentifier, indexName);
+        protect(m_delegate)->deleteIndex(requestData, objectStoreIdentifier, indexName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteIndex, requestData.requestIdentifier());
 }
@@ -212,7 +212,7 @@ void IDBConnectionToServer::renameIndex(const IDBRequestData& requestData, IDBOb
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->renameIndex(requestData, objectStoreIdentifier, indexIdentifier, newName);
+        protect(m_delegate)->renameIndex(requestData, objectStoreIdentifier, indexIdentifier, newName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didRenameIndex, requestData.requestIdentifier());
 }
@@ -229,7 +229,7 @@ void IDBConnectionToServer::putOrAdd(const IDBRequestData& requestData, const ID
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->putOrAdd(requestData, key, value, indexKeys, overwriteMode);
+        protect(m_delegate)->putOrAdd(requestData, key, value, indexKeys, overwriteMode);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didPutOrAdd, requestData.requestIdentifier());
 }
@@ -247,7 +247,7 @@ void IDBConnectionToServer::getRecord(const IDBRequestData& requestData, const I
     ASSERT(!getRecordData.keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->getRecord(requestData, getRecordData);
+        protect(m_delegate)->getRecord(requestData, getRecordData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didGetRecord, requestData.requestIdentifier());
 }
@@ -264,7 +264,7 @@ void IDBConnectionToServer::getAllRecords(const IDBRequestData& requestData, con
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->getAllRecords(requestData, getAllRecordsData);
+        protect(m_delegate)->getAllRecords(requestData, getAllRecordsData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didGetAllRecords, requestData.requestIdentifier());
 }
@@ -282,7 +282,7 @@ void IDBConnectionToServer::getCount(const IDBRequestData& requestData, const ID
     ASSERT(!keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->getCount(requestData, keyRangeData);
+        protect(m_delegate)->getCount(requestData, keyRangeData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didGetCount, requestData.requestIdentifier());
 }
@@ -300,7 +300,7 @@ void IDBConnectionToServer::deleteRecord(const IDBRequestData& requestData, cons
     ASSERT(!keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->deleteRecord(requestData, keyRangeData);
+        protect(m_delegate)->deleteRecord(requestData, keyRangeData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteRecord, requestData.requestIdentifier());
 }
@@ -317,7 +317,7 @@ void IDBConnectionToServer::openCursor(const IDBRequestData& requestData, const 
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->openCursor(requestData, info);
+        protect(m_delegate)->openCursor(requestData, info);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didOpenCursor, requestData.requestIdentifier());
 }
@@ -334,7 +334,7 @@ void IDBConnectionToServer::iterateCursor(const IDBRequestData& requestData, con
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->iterateCursor(requestData, data);
+        protect(m_delegate)->iterateCursor(requestData, data);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didIterateCursor, requestData.requestIdentifier());
 }
@@ -351,7 +351,7 @@ void IDBConnectionToServer::establishTransaction(IDBDatabaseConnectionIdentifier
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->establishTransaction(databaseConnectionIdentifier, info);
+        protect(m_delegate)->establishTransaction(databaseConnectionIdentifier, info);
 }
 
 void IDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
@@ -360,7 +360,7 @@ void IDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& trans
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->commitTransaction(transactionIdentifier, handledRequestResultsCount);
+        protect(m_delegate)->commitTransaction(transactionIdentifier, handledRequestResultsCount);
     else {
         callOnMainThread([this, protectedThis = Ref { *this }, transactionIdentifier] {
             didCommitTransaction(transactionIdentifier, IDBError::serverConnectionLostError());
@@ -382,7 +382,7 @@ void IDBConnectionToServer::didFinishHandlingVersionChangeTransaction(IDBDatabas
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->didFinishHandlingVersionChangeTransaction(databaseConnectionIdentifier, transactionIdentifier);
+        protect(m_delegate)->didFinishHandlingVersionChangeTransaction(databaseConnectionIdentifier, transactionIdentifier);
 }
 
 void IDBConnectionToServer::abortTransaction(const IDBResourceIdentifier& transactionIdentifier)
@@ -391,7 +391,7 @@ void IDBConnectionToServer::abortTransaction(const IDBResourceIdentifier& transa
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->abortTransaction(transactionIdentifier);
+        protect(m_delegate)->abortTransaction(transactionIdentifier);
     else {
         callOnMainThread([this, protectedThis = Ref { *this }, transactionIdentifier] {
             didAbortTransaction(transactionIdentifier, IDBError::serverConnectionLostError());
@@ -421,7 +421,7 @@ void IDBConnectionToServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdent
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
+        protect(m_delegate)->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
 }
 
 void IDBConnectionToServer::generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const std::optional<IDBKeyPath>& keyPath, const IDBKeyData& key, const IDBValue& value, std::optional<int64_t> recordID)
@@ -436,7 +436,7 @@ void IDBConnectionToServer::didGenerateIndexKeyForRecord(const IDBResourceIdenti
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
+        protect(m_delegate)->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
 }
 
 void IDBConnectionToServer::didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
@@ -479,7 +479,7 @@ void IDBConnectionToServer::openDBRequestCancelled(const IDBOpenRequestData& req
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->openDBRequestCancelled(requestData);
+        protect(m_delegate)->openDBRequestCancelled(requestData);
 }
 
 void IDBConnectionToServer::databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
@@ -488,7 +488,7 @@ void IDBConnectionToServer::databaseConnectionPendingClose(IDBDatabaseConnection
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->databaseConnectionPendingClose(databaseConnectionIdentifier);
+        protect(m_delegate)->databaseConnectionPendingClose(databaseConnectionIdentifier);
 }
 
 void IDBConnectionToServer::databaseConnectionClosed(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
@@ -497,7 +497,7 @@ void IDBConnectionToServer::databaseConnectionClosed(IDBDatabaseConnectionIdenti
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->databaseConnectionClosed(databaseConnectionIdentifier);
+        protect(m_delegate)->databaseConnectionClosed(databaseConnectionIdentifier);
 }
 
 void IDBConnectionToServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier)
@@ -506,7 +506,7 @@ void IDBConnectionToServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdent
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        protectedDelegate()->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
+        protect(m_delegate)->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
 }
 
 void IDBConnectionToServer::getAllDatabaseNamesAndVersions(const IDBResourceIdentifier& requestIdentifier, const ClientOrigin& origin)
@@ -515,7 +515,7 @@ void IDBConnectionToServer::getAllDatabaseNamesAndVersions(const IDBResourceIden
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid) {
-        protectedDelegate()->getAllDatabaseNamesAndVersions(requestIdentifier, origin);
+        protect(m_delegate)->getAllDatabaseNamesAndVersions(requestIdentifier, origin);
         return;
     }
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -159,8 +159,6 @@ private:
     typedef void (IDBConnectionToServer::*ResultFunction)(const IDBResultData&);
     void callResultFunctionWithErrorLater(ResultFunction, const IDBResourceIdentifier& requestIdentifier);
 
-    Ref<IDBConnectionToServerDelegate> protectedDelegate() const { return m_delegate; }
-
     WeakRef<IDBConnectionToServerDelegate> m_delegate;
     bool m_serverConnectionIsValid { true };
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1372,7 +1372,7 @@ void UniqueIDBDatabase::connectionClosedFromServer(UniqueIDBDatabaseConnection& 
     ASSERT(!isMainThread());
     LOG(IndexedDB, "UniqueIDBDatabase::connectionClosedFromServer - %s (%" PRIu64 ")", connection.openRequestIdentifier().loggingString().utf8().data(), connection.identifier().toUInt64());
 
-    connection.protectedConnectionToClient()->didCloseFromServer(connection, IDBError::userDeleteError());
+    protect(connection.connectionToClient())->didCloseFromServer(connection, IDBError::userDeleteError());
 
     m_openDatabaseConnections.remove(&connection);
 }

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
@@ -68,11 +68,6 @@ UniqueIDBDatabaseManager* UniqueIDBDatabaseConnection::manager()
     return m_manager.get();
 }
 
-Ref<IDBConnectionToClient> UniqueIDBDatabaseConnection::protectedConnectionToClient()
-{
-    return m_connectionToClient;
-}
-
 bool UniqueIDBDatabaseConnection::hasNonFinishedTransactions() const
 {
     return !m_transactionMap.isEmpty();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -55,7 +55,6 @@ public:
     UniqueIDBDatabase* database() { return m_database.get(); }
     UniqueIDBDatabaseManager* NODELETE manager();
     IDBConnectionToClient& connectionToClient() { return m_connectionToClient; }
-    Ref<IDBConnectionToClient> NODELETE protectedConnectionToClient();
 
     WEBCORE_EXPORT void NODELETE connectionPendingCloseFromClient();
     WEBCORE_EXPORT void connectionClosedFromClient();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -359,9 +359,9 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didPutOrAdd(IDBResultData::putOrAddSuccess(requestData.requestIdentifier(), key));
+            protect(databaseConnection->connectionToClient())->didPutOrAdd(IDBResultData::putOrAddSuccess(requestData.requestIdentifier(), key));
         else
-            databaseConnection->protectedConnectionToClient()->didPutOrAdd(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didPutOrAdd(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -389,9 +389,9 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
         else
-            databaseConnection->protectedConnectionToClient()->didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -419,9 +419,9 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
         else
-            databaseConnection->protectedConnectionToClient()->didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -449,9 +449,9 @@ void UniqueIDBDatabaseTransaction::getCount(const IDBRequestData& requestData, c
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didGetCount(IDBResultData::getCountSuccess(requestData.requestIdentifier(), count));
+            protect(databaseConnection->connectionToClient())->didGetCount(IDBResultData::getCountSuccess(requestData.requestIdentifier(), count));
         else
-            databaseConnection->protectedConnectionToClient()->didGetCount(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didGetCount(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -479,9 +479,9 @@ void UniqueIDBDatabaseTransaction::deleteRecord(const IDBRequestData& requestDat
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didDeleteRecord(IDBResultData::deleteRecordSuccess(requestData.requestIdentifier()));
+            protect(databaseConnection->connectionToClient())->didDeleteRecord(IDBResultData::deleteRecordSuccess(requestData.requestIdentifier()));
         else
-            databaseConnection->protectedConnectionToClient()->didDeleteRecord(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didDeleteRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -509,9 +509,9 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
         else
-            databaseConnection->protectedConnectionToClient()->didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -542,9 +542,9 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            databaseConnection->protectedConnectionToClient()->didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
         else
-            databaseConnection->protectedConnectionToClient()->didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
+            protect(databaseConnection->connectionToClient())->didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -576,7 +576,7 @@ void UniqueIDBDatabaseTransaction::didActivateInBackingStore(const IDBError& err
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::didActivateInBackingStore");
 
     if (RefPtr connection = m_databaseConnection.get())
-        connection->protectedConnectionToClient()->didStartTransaction(m_transactionInfo.identifier(), error);
+        protect(connection->connectionToClient())->didStartTransaction(m_transactionInfo.identifier(), error);
 }
 
 void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData, const IDBIndexInfo& indexInfo)
@@ -621,7 +621,7 @@ bool UniqueIDBDatabaseTransaction::generateIndexKeyForRecord(const IDBIndexInfo&
         return false;
 
     ++m_pendingGenerateIndexKeyRequests;
-    databaseConnection->protectedConnectionToClient()->generateIndexKeyForRecord(m_createIndexRequestIdentifier, indexInfo, keyPath, key, value, recordID);
+    protect(databaseConnection->connectionToClient())->generateIndexKeyForRecord(m_createIndexRequestIdentifier, indexInfo, keyPath, key, value, recordID);
     return true;
 }
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -152,7 +152,7 @@ const AtomString& MediaControlsHost::mediaControlsContainerClassName() const
 
 Vector<Ref<TextTrack>> MediaControlsHost::sortedTrackListForMenu(TextTrackList& trackList)
 {
-    RefPtr page = protectedMediaElement()->document().page();
+    RefPtr page = protect(m_mediaElement)->document().page();
     if (!page)
         return { };
 
@@ -161,7 +161,7 @@ Vector<Ref<TextTrack>> MediaControlsHost::sortedTrackListForMenu(TextTrackList& 
 
 Vector<Ref<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackList& trackList)
 {
-    RefPtr page = protectedMediaElement()->document().page();
+    RefPtr page = protect(m_mediaElement)->document().page();
     if (!page)
         return { };
 
@@ -173,7 +173,7 @@ String MediaControlsHost::displayNameForTrack(const std::optional<TextOrAudioTra
     if (!track)
         return emptyString();
 
-    RefPtr page = protectedMediaElement()->document().page();
+    RefPtr page = protect(m_mediaElement)->document().page();
     if (!page)
         return emptyString();
 
@@ -199,7 +199,7 @@ TextTrack& MediaControlsHost::captionMenuOnItem()
 
 AtomString MediaControlsHost::captionDisplayMode() const
 {
-    RefPtr page = protectedMediaElement()->document().page();
+    RefPtr page = protect(m_mediaElement)->document().page();
     if (!page)
         return emptyAtom();
 
@@ -220,7 +220,7 @@ AtomString MediaControlsHost::captionDisplayMode() const
 
 void MediaControlsHost::setSelectedTextTrack(TextTrack* track)
 {
-    protectedMediaElement()->setSelectedTextTrack(track);
+    protect(m_mediaElement)->setSelectedTextTrack(track);
 }
 
 MediaControlTextTrackContainerElement* MediaControlsHost::ensureTextTrackContainer()
@@ -289,37 +289,37 @@ void MediaControlsHost::updateCaptionDisplaySizes(ForceUpdate force)
 
 bool MediaControlsHost::allowsInlineMediaPlayback() const
 {
-    return !protect(protectedMediaElement()->mediaSession())->requiresFullscreenForVideoPlayback();
+    return !protect(protect(m_mediaElement)->mediaSession())->requiresFullscreenForVideoPlayback();
 }
 
 bool MediaControlsHost::supportsFullscreen() const
 {
-    return protectedMediaElement()->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard);
+    return protect(m_mediaElement)->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard);
 }
 
 bool MediaControlsHost::isVideoLayerInline() const
 {
-    return protectedMediaElement()->isVideoLayerInline();
+    return protect(m_mediaElement)->isVideoLayerInline();
 }
 
 bool MediaControlsHost::isInMediaDocument() const
 {
-    return protectedMediaElement()->document().isMediaDocument();
+    return protect(m_mediaElement)->document().isMediaDocument();
 }
 
 bool MediaControlsHost::userGestureRequired() const
 {
-    return !protect(protectedMediaElement()->mediaSession())->playbackStateChangePermitted(MediaPlaybackState::Playing);
+    return !protect(protect(m_mediaElement)->mediaSession())->playbackStateChangePermitted(MediaPlaybackState::Playing);
 }
 
 bool MediaControlsHost::shouldForceControlsDisplay() const
 {
-    return protectedMediaElement()->shouldForceControlsDisplay();
+    return protect(m_mediaElement)->shouldForceControlsDisplay();
 }
 
 bool MediaControlsHost::supportsSeeking() const
 {
-    return protectedMediaElement()->supportsSeeking();
+    return protect(m_mediaElement)->supportsSeeking();
 }
 
 bool MediaControlsHost::inWindowFullscreen() const
@@ -340,13 +340,13 @@ bool MediaControlsHost::supportsRewind() const
 
 bool MediaControlsHost::needsChromeMediaControlsPseudoElement() const
 {
-    return protect(protectedMediaElement()->document())->quirks().needsChromeMediaControlsPseudoElement();
+    return protect(protect(m_mediaElement)->document())->quirks().needsChromeMediaControlsPseudoElement();
 }
 
 bool MediaControlsHost::isMediaControlsMacInlineSizeSpecsEnabled() const
 {
 #if HAVE(MATERIAL_HOSTING)
-    return protectedMediaElement()->document().settings().mediaControlsMacInlineSizeSpecsEnabled();
+    return protect(m_mediaElement)->document().settings().mediaControlsMacInlineSizeSpecsEnabled();
 #else
     return false;
 #endif
@@ -355,7 +355,7 @@ bool MediaControlsHost::isMediaControlsMacInlineSizeSpecsEnabled() const
 String MediaControlsHost::externalDeviceDisplayName() const
 {
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    RefPtr player = protectedMediaElement()->player();
+    RefPtr player = protect(m_mediaElement)->player();
     if (!player) {
         LOG(Media, "MediaControlsHost::externalDeviceDisplayName - returning \"\" because player is NULL");
         return emptyString();
@@ -374,7 +374,7 @@ auto MediaControlsHost::externalDeviceType() const -> DeviceType
 #if !ENABLE(WIRELESS_PLAYBACK_TARGET)
     return DeviceType::None;
 #else
-    RefPtr player = protectedMediaElement()->player();
+    RefPtr player = protect(m_mediaElement)->player();
     if (!player) {
         LOG(Media, "MediaControlsHost::externalDeviceType - returning \"none\" because player is NULL");
         return DeviceType::None;
@@ -396,12 +396,12 @@ auto MediaControlsHost::externalDeviceType() const -> DeviceType
 
 bool MediaControlsHost::controlsDependOnPageScaleFactor() const
 {
-    return protectedMediaElement()->mediaControlsDependOnPageScaleFactor();
+    return protect(m_mediaElement)->mediaControlsDependOnPageScaleFactor();
 }
 
 void MediaControlsHost::setControlsDependOnPageScaleFactor(bool value)
 {
-    protectedMediaElement()->setMediaControlsDependOnPageScaleFactor(value);
+    protect(m_mediaElement)->setMediaControlsDependOnPageScaleFactor(value);
 }
 
 String MediaControlsHost::generateUUID()
@@ -411,7 +411,7 @@ String MediaControlsHost::generateUUID()
 
 Vector<String, 2> MediaControlsHost::shadowRootStyleSheets() const
 {
-    return RenderTheme::singleton().mediaControlsStyleSheets(protectedMediaElement());
+    return RenderTheme::singleton().mediaControlsStyleSheets(protect(m_mediaElement));
 }
 
 String MediaControlsHost::base64StringForIconNameAndType(const String& iconName, const String& iconType)
@@ -893,12 +893,12 @@ void MediaControlsHost::hideCaptionDisplaySettingsPreview()
 
 auto MediaControlsHost::sourceType() const -> std::optional<SourceType>
 {
-    return protectedMediaElement()->sourceType();
+    return protect(m_mediaElement)->sourceType();
 }
 
 bool MediaControlsHost::needsCaptionVisibilityInFullscreenAndPictureInPictureQuirk() const
 {
-    return protect(protectedMediaElement()->document())->quirks().ensureCaptionVisibilityInFullscreenAndPictureInPicture();
+    return protect(protect(m_mediaElement)->document())->quirks().ensureCaptionVisibilityInFullscreenAndPictureInPicture();
 }
 
 void MediaControlsHost::handleCaptionVisibilityInFullscreenAndPictureInPictureQuirk()
@@ -911,7 +911,7 @@ void MediaControlsHost::handleCaptionVisibilityInFullscreenAndPictureInPictureQu
     if (!textTrackContainer)
         return;
 
-    if (protectedMediaElement()->isInFullscreenOrPictureInPicture())
+    if (protect(m_mediaElement)->isInFullscreenOrPictureInPicture())
         textTrackContainer->setInlineStyleProperty(CSSPropertyVisibility, CSSValueVisible);
     else
         textTrackContainer->setInlineStyleProperty(CSSPropertyVisibility, CSSValueInherit);
@@ -971,7 +971,7 @@ void MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary()
     if (!previouslySelectedTextTrack)
         return;
 
-    RefPtr textTracks = protectedMediaElement()->textTracks();
+    RefPtr textTracks = protect(m_mediaElement)->textTracks();
     for (unsigned i = 0; textTracks && i < textTracks->length(); ++i) {
         RefPtr textTrack = textTracks->item(i);
         ASSERT(textTrack);
@@ -988,7 +988,7 @@ void MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary()
 #if ENABLE(MEDIA_SESSION)
 RefPtr<MediaSession> MediaControlsHost::mediaSession() const
 {
-    RefPtr window = protectedMediaElement()->document().window();
+    RefPtr window = protect(m_mediaElement)->document().window();
     if (!window)
         return { };
 
@@ -1006,18 +1006,13 @@ void MediaControlsHost::ensureMediaSessionObserver()
 
 void MediaControlsHost::metadataChanged(const RefPtr<MediaMetadata>&)
 {
-    RefPtr shadowRoot = protectedMediaElement()->userAgentShadowRoot();
+    RefPtr shadowRoot = protect(m_mediaElement)->userAgentShadowRoot();
     if (!shadowRoot)
         return;
 
     shadowRoot->dispatchEvent(Event::create(eventNames().webkitmediasessionmetadatachangedEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 #endif // ENABLE(MEDIA_SESSION)
-
-Ref<HTMLMediaElement> MediaControlsHost::protectedMediaElement() const
-{
-    return m_mediaElement.get();
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -194,8 +194,6 @@ private:
     std::pair<Vector<MenuItem>, MenuDataMap> mediaControlsContextMenuItems(String&& optionsJSONString);
 #endif
 
-    Ref<HTMLMediaElement> NODELETE protectedMediaElement() const;
-
     WeakRef<HTMLMediaElement> m_mediaElement;
     RefPtr<MediaControlTextTrackContainerElement> m_textTrackContainer;
     RefPtr<TextTrack> m_previouslySelectedTextTrack;

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -60,7 +60,7 @@ public:
     ExceptionOr<void> leave();
     void close();
 
-    String identifier() const { return m_privateCoordinator ? protectedPrivateCoordinator()->identifier() : String(); }
+    String identifier() const { return m_privateCoordinator ? protect(m_privateCoordinator)->identifier() : String(); }
     MediaSessionCoordinatorState state() const { return m_state; }
 
     void seekTo(double, DOMPromiseDeferred<void>&&);
@@ -111,8 +111,6 @@ private:
     static WTFLogChannel& NODELETE logChannel();
     static ASCIILiteral logClassName() { return "MediaSessionCoordinator"_s; }
     bool NODELETE shouldFireEvents() const;
-
-    RefPtr<MediaSessionCoordinatorPrivate> protectedPrivateCoordinator() const { return m_privateCoordinator; }
 
     WeakPtr<MediaSession> m_session;
     RefPtr<MediaSessionCoordinatorPrivate> m_privateCoordinator;

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -81,7 +81,7 @@ void ManagedMediaSource::setStreaming(bool streaming)
         return;
     ALWAYS_LOG(LOGIDENTIFIER, streaming);
     m_streaming = streaming;
-    if (RefPtr msp = protectedPrivate())
+    if (RefPtr msp = mediaSourcePrivate())
         msp->setStreaming(streaming);
     if (streaming) {
         scheduleEvent(eventNames().startstreamingEvent);
@@ -145,7 +145,7 @@ void ManagedMediaSource::streamingTimerFired()
 {
     ALWAYS_LOG(LOGIDENTIFIER, "Disabling streaming due to policy ", *m_highThreshold);
     m_streamingAllowed = false;
-    if (RefPtr msp = protectedPrivate())
+    if (RefPtr msp = mediaSourcePrivate())
         msp->setStreamingAllowed(false);
     notifyElementUpdateMediaState();
 }

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -184,7 +184,7 @@ protected:
 
     virtual void elementDetached() { }
 
-    RefPtr<MediaSourcePrivate> NODELETE protectedPrivate() const;
+    MediaSourcePrivate* mediaSourcePrivate() const { return m_private; }
 
     WeakPtr<HTMLMediaElement> m_mediaElement;
     bool m_detachable { false };

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -211,7 +211,6 @@ private:
     bool hasAudio() const;
 
     void rangeRemoval(const MediaTime&, const MediaTime&);
-    RefPtr<MediaSource> NODELETE protectedSource() const;
 
     friend class Internals;
     using SamplesPromise = NativePromise<Vector<String>, PlatformMediaError>;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -152,7 +152,6 @@ public:
     void applyConstraints(const std::optional<MediaTrackConstraints>&, DOMPromiseDeferred<void>&&);
 
     RealtimeMediaSource& source() const { return m_private->source(); }
-    Ref<RealtimeMediaSource> protectedSource() const { return source(); }
     RealtimeMediaSource& sourceForProcessor() const { return m_private->sourceForProcessor(); }
     MediaStreamTrackPrivate& privateTrack() { return m_private.get(); }
     const MediaStreamTrackPrivate& privateTrack() const { return m_private.get(); }

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h
@@ -54,7 +54,7 @@ public:
 
     ScriptExecutionContextIdentifier trackContextIdentifier() const { return m_contextIdentifier; }
     WeakPtr<MediaStreamTrack, WeakPtrImplWithEventTargetData> track() const { return m_track; }
-    Ref<MediaStreamTrackPrivateSourceObserver> protectedTrackSourceObserver() const { return m_trackSourceObserver; }
+    MediaStreamTrackPrivateSourceObserver& trackSourceObserver() const { return m_trackSourceObserver; }
 
     const MediaStreamTrack::Keeper& trackKeeper() const { return m_trackKeeper.get(); }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -52,7 +52,7 @@ ExceptionOr<Ref<MediaStreamTrackProcessor>> MediaStreamTrackProcessor::create(Sc
         handle = WTF::move(*trackHandle);
         if (handle->isDetached())
             return Exception { ExceptionCode::TypeError, "Track handle is detached"_s };
-        if (!Ref { handle->protectedTrackSourceObserver()->source() }->isVideo())
+        if (!protect(protect(handle->trackSourceObserver())->source())->isVideo())
             return Exception { ExceptionCode::TypeError, "Track is not video"_s };
     } else {
         Ref track = std::get<Ref<MediaStreamTrack>>(init.track);
@@ -72,7 +72,7 @@ ExceptionOr<Ref<MediaStreamTrackProcessor>> MediaStreamTrackProcessor::create(Sc
 MediaStreamTrackProcessor::MediaStreamTrackProcessor(ScriptExecutionContext& context, Ref<MediaStreamTrackHandle>&& trackHandle, unsigned short maxVideoFramesCount)
     : ContextDestructionObserver(&context)
     , m_trackKeeper(trackHandle->trackKeeper())
-    , m_videoFrameObserverWrapper(VideoFrameObserverWrapper::create(context.identifier(), *this, Ref { trackHandle->protectedTrackSourceObserver()->source() }, maxVideoFramesCount))
+    , m_videoFrameObserverWrapper(VideoFrameObserverWrapper::create(context.identifier(), *this, protect(protect(trackHandle->trackSourceObserver())->source()), maxVideoFramesCount))
     , m_trackObserver(TrackObserverWrapper::create(context, *this, WTF::move(trackHandle)))
 {
     m_trackObserver->start();

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -274,7 +274,7 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
 
     ASSERT(m_offerAnswerCallback);
     validateSDP(sdp);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Offer, sdp });
     });
 }
@@ -285,7 +285,7 @@ void PeerConnectionBackend::createOfferFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, exception.message());
 
     ASSERT(m_offerAnswerCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
         callback(WTF::move(exception));
     });
 }
@@ -309,7 +309,7 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
 #endif
 
     ASSERT(m_offerAnswerCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Answer, sdp });
     });
 }
@@ -320,7 +320,7 @@ void PeerConnectionBackend::createAnswerFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, exception.message());
 
     ASSERT(m_offerAnswerCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
         callback(WTF::move(exception));
     });
 }
@@ -384,7 +384,7 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
     if (transceiverStates)
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -424,7 +424,7 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
             }
             for (auto& track : muteTrackList) {
                 track->setShouldFireMuteEventImmediately(true);
-                track->protectedSource()->setMuted(true);
+                protect(track->source())->setMuted(true);
                 track->setShouldFireMuteEventImmediately(false);
                 if (peerConnection.isClosed())
                     return;
@@ -448,7 +448,7 @@ void PeerConnectionBackend::setLocalDescriptionFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Set local description failed:", exception.message());
 
     ASSERT(m_setDescriptionCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -472,7 +472,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
 
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [this, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
         UNUSED_PARAM(this);
 
         if (peerConnection.isClosed())
@@ -527,7 +527,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
             DEBUG_LOG(LOGIDENTIFIER, "Processing ", muteTrackList.size(), " muted tracks");
             for (auto& track : muteTrackList) {
                 track->setShouldFireMuteEventImmediately(true);
-                track->protectedSource()->setMuted(true);
+                protect(track->source())->setMuted(true);
                 track->setShouldFireMuteEventImmediately(false);
                 if (peerConnection.isClosed()) {
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while processing muted tracks");
@@ -563,7 +563,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
                     return;
                 }
 
-                track->protectedSource()->setMuted(false);
+                protect(track->source())->setMuted(false);
             }
         }
 
@@ -577,7 +577,7 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Set remote description failed:", exception.message());
 
     ASSERT(m_setDescriptionCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -587,7 +587,7 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
 
 void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, state](auto& peerConnection) {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, state](auto& peerConnection) {
         if (peerConnection.isClosed())
             return;
 
@@ -597,11 +597,6 @@ void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
         }
         peerConnection.updateIceGatheringState(state);
     });
-}
-
-Ref<RTCPeerConnection> PeerConnectionBackend::protectedPeerConnection() const
-{
-    return m_peerConnection.get();
 }
 
 static String extractIPAddress(StringView sdp)
@@ -646,7 +641,7 @@ void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Funct
         if (!protectedThis)
             return;
 
-        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedThis->protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(callback), result = std::forward<Result>(result)](auto& peerConnection) mutable {
+        ActiveDOMObject::queueTaskKeepingObjectAlive(protect(protectedThis->m_peerConnection).get(), TaskSource::Networking, [callback = WTF::move(callback), result = std::forward<Result>(result)](auto& peerConnection) mutable {
             if (peerConnection.isClosed())
                 return;
 
@@ -688,7 +683,7 @@ void PeerConnectionBackend::validateSDP(const String& sdp) const
 
 void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned short sdpMLineIndex, String&& serverURL, std::optional<DescriptionStates>&& descriptions)
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, protectedThis = Ref { *this }, sdp = WTF::move(sdp), mid = WTF::move(mid), sdpMLineIndex, serverURL = WTF::move(serverURL), descriptions = WTF::move(descriptions)](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(protect(m_peerConnection).get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, protectedThis = Ref { *this }, sdp = WTF::move(sdp), mid = WTF::move(mid), sdpMLineIndex, serverURL = WTF::move(serverURL), descriptions = WTF::move(descriptions)](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -711,7 +706,7 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
 
 void PeerConnectionBackend::newDataChannel(UniqueRef<RTCDataChannelHandler>&& channelHandler, String&& label, RTCDataChannelInit&& channelInit)
 {
-    protectedPeerConnection()->dispatchDataChannelEvent(WTF::move(channelHandler), WTF::move(label), WTF::move(channelInit));
+    protect(m_peerConnection)->dispatchDataChannelEvent(WTF::move(channelHandler), WTF::move(label), WTF::move(channelInit));
 }
 
 void PeerConnectionBackend::doneGatheringCandidates()
@@ -735,7 +730,7 @@ void PeerConnectionBackend::stop()
 
 void PeerConnectionBackend::markAsNeedingNegotiation(uint32_t eventId)
 {
-    protectedPeerConnection()->updateNegotiationNeededFlag(eventId);
+    protect(m_peerConnection)->updateNegotiationNeededFlag(eventId);
 }
 
 ExceptionOr<Ref<RTCRtpSender>> PeerConnectionBackend::addTrack(MediaStreamTrack&, FixedVector<String>&&)
@@ -781,7 +776,7 @@ void PeerConnectionBackend::generateCertificate(Document& document, const Certif
 
 ScriptExecutionContext* PeerConnectionBackend::context() const
 {
-    return protectedPeerConnection()->scriptExecutionContext();
+    return protect(m_peerConnection)->scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -275,7 +275,6 @@ private:
     virtual void doStop() = 0;
 
 protected:
-    Ref<RTCPeerConnection> NODELETE protectedPeerConnection() const;
     WeakRef<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_peerConnection;
 
 private:

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -137,7 +137,7 @@ public:
     RTCPeerConnectionState connectionState() const { return m_connectionState; }
     std::optional<bool> canTrickleIceCandidates() const;
 
-    void restartIce() { protectedBackend()->restartIce(); }
+    void restartIce() { protect(*m_backend)->restartIce(); }
     const RTCConfiguration& getConfiguration() const { return m_configuration; }
     ExceptionOr<void> setConfiguration(RTCConfiguration&&);
     void close();
@@ -181,13 +181,12 @@ public:
 
     void scheduleEvent(Ref<Event>&&);
 
-    void disableICECandidateFiltering() { protectedBackend()->disableICECandidateFiltering(); }
-    void enableICECandidateFiltering() { protectedBackend()->enableICECandidateFiltering(); }
+    void disableICECandidateFiltering() { protect(*m_backend)->disableICECandidateFiltering(); }
+    void enableICECandidateFiltering() { protect(*m_backend)->enableICECandidateFiltering(); }
 
     void clearController() { m_controller = nullptr; }
 
     Document* document();
-    RefPtr<Document> protectedDocument();
 
     void updateDescriptions(PeerConnectionBackend::DescriptionStates&&);
     void updateTransceiversAfterSuccessfulLocalDescription();
@@ -227,7 +226,7 @@ private:
     void unregisterFromController();
 
     friend class Internals;
-    void applyRotationForOutgoingVideoSources() { protectedBackend()->applyRotationForOutgoingVideoSources(); }
+    void applyRotationForOutgoingVideoSources() { protect(*m_backend)->applyRotationForOutgoingVideoSources(); }
 
     // EventTarget implementation.
     void refEventTarget() final { ref(); }
@@ -246,7 +245,7 @@ private:
     bool doClose();
     void doStop();
 
-    void getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise) { protectedBackend()->getStats(sender, WTF::move(promise)); }
+    void getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise) { protect(*m_backend)->getStats(sender, WTF::move(promise)); }
 
     ExceptionOr<Vector<MediaEndpointConfiguration::CertificatePEM>> certificatesFromConfiguration(const RTCConfiguration&);
     void chainOperation(Ref<DeferredPromise>&&, Function<void(Ref<DeferredPromise>&&)>&&);
@@ -260,7 +259,7 @@ private:
 
     void setSignalingState(RTCSignalingState);
 
-    WEBCORE_EXPORT RefPtr<PeerConnectionBackend> NODELETE protectedBackend() const;
+    PeerConnectionBackend* backend() const { return m_backend.get(); }
 
     bool m_isStopped { false };
     RTCSignalingState m_signalingState { RTCSignalingState::Stable };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -185,8 +185,6 @@ private:
     Seconds statsLogInterval(int64_t) const;
 #endif
 
-    RefPtr<LibWebRTCPeerConnectionBackend> NODELETE protectedPeerConnectionBackend() const;
-
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     const Ref<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
     const RefPtr<webrtc::PeerConnectionInterface> m_backend;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -291,7 +291,7 @@ void LibWebRTCPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
 
 Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(std::unique_ptr<LibWebRTCRtpReceiverBackend>&& backend)
 {
-    Ref document = downcast<Document>(*protectedPeerConnection()->scriptExecutionContext());
+    Ref document = downcast<Document>(*protect(m_peerConnection)->scriptExecutionContext());
 
     auto source = backend->createSource(document.get());
 
@@ -381,7 +381,7 @@ static inline LibWebRTCRtpTransceiverBackend& NODELETE backendFromRTPTransceiver
 
 RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&& matchingFunction)
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : protect(m_peerConnection)->currentTransceivers()) {
         if (matchingFunction(backendFromRTPTransceiver(transceiver)))
             return transceiver.ptr();
     }
@@ -411,7 +411,7 @@ void LibWebRTCPeerConnectionBackend::removeTrack(RTCRtpSender& sender)
 
 void LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources()
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : protect(m_peerConnection)->currentTransceivers()) {
         if (!transceiver->sender().isStopped()) {
             if (RefPtr videoSource = protectedBackendFromRTPSender(transceiver->sender())->videoSource())
                 videoSource->applyRotation();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -80,7 +80,6 @@ private:
     friend class LibWebRTCMediaEndpoint;
     friend class LibWebRTCRtpSenderBackend;
     RTCPeerConnection& connection() { return m_peerConnection; }
-    Ref<RTCPeerConnection> protectedConnection() { return m_peerConnection; }
 
     void getStatsSucceeded(const DeferredPromise&, Ref<RTCStatsReport>&&);
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp
@@ -124,13 +124,8 @@ bool LibWebRTCRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTr
         });
     }
 
-    protectedPeerConnectionBackend()->setSenderSourceFromTrack(*this, *track);
+    protect(m_peerConnectionBackend)->setSenderSourceFromTrack(*this, *track);
     return true;
-}
-
-RefPtr<LibWebRTCPeerConnectionBackend> LibWebRTCRtpSenderBackend::protectedPeerConnectionBackend() const
-{
-    return m_peerConnectionBackend.get();
 }
 
 RTCRtpSendParameters LibWebRTCRtpSenderBackend::getParameters() const

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -58,7 +58,6 @@ public:
 
     void setRTCSender(RefPtr<webrtc::RtpSenderInterface>&& rtcSender) { m_rtcSender = WTF::move(rtcSender); }
     webrtc::RtpSenderInterface* rtcSender() { return m_rtcSender.get(); }
-    RefPtr<webrtc::RtpSenderInterface> protectedRTCSender() { return m_rtcSender; }
 
     RealtimeOutgoingVideoSource* videoSource();
     void clearSource() { setSource(nullptr); }
@@ -82,8 +81,6 @@ private:
     void startSource();
     void stopSource();
     bool hasSource() const;
-
-    RefPtr<LibWebRTCPeerConnectionBackend> NODELETE protectedPeerConnectionBackend() const;
 
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     RefPtr<webrtc::RtpSenderInterface> m_rtcSender;

--- a/Source/WebCore/Modules/notifications/NotificationData.h
+++ b/Source/WebCore/Modules/notifications/NotificationData.h
@@ -47,7 +47,6 @@ struct NotificationData {
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT static std::optional<NotificationData> fromDictionary(NSDictionary *dictionaryRepresentation);
     WEBCORE_EXPORT NSDictionary *dictionaryRepresentation() const;
-    WEBCORE_EXPORT RetainPtr<NSDictionary> protectedDictionaryRepresentation() const;
 #endif
 
     bool isPersistent() const { return !serviceWorkerRegistrationURL.isNull(); }

--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -124,9 +124,4 @@ NSDictionary *NotificationData::dictionaryRepresentation() const
     return result.autorelease();
 }
 
-RetainPtr<NSDictionary> NotificationData::protectedDictionaryRepresentation() const
-{
-    return dictionaryRepresentation();
-}
-
 } // namespace WebKit

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -500,11 +500,6 @@ ScriptExecutionContext* PaymentRequest::scriptExecutionContext() const
     return ActiveDOMObject::scriptExecutionContext();
 }
 
-RefPtr<ScriptExecutionContext> PaymentRequest::protectedScriptExecutionContext() const
-{
-    return scriptExecutionContext();
-}
-
 // https://www.w3.org/TR/payment-request/#abort()-method
 void PaymentRequest::abort(AbortPromise&& promise)
 {
@@ -647,7 +642,7 @@ void PaymentRequest::dispatchAndCheckUpdateEvent(Ref<PaymentRequestUpdateEvent>&
     if (event->didCallUpdateWith())
         return;
 
-    protectedScriptExecutionContext()->addConsoleMessage(JSC::MessageSource::PaymentRequest, JSC::MessageLevel::Warning, makeString("updateWith() should be called synchronously when handling \""_s, event->type(), "\"."_s));
+    protect(scriptExecutionContext())->addConsoleMessage(JSC::MessageSource::PaymentRequest, JSC::MessageLevel::Warning, makeString("updateWith() should be called synchronously when handling \""_s, event->type(), "\"."_s));
 }
 
 void PaymentRequest::settleDetailsPromise(UpdateReason reason)
@@ -744,7 +739,7 @@ void PaymentRequest::accept(const String& methodName, PaymentResponse::DetailsFu
     RefPtr response = m_response;
     bool isRetry = m_response;
     if (!isRetry) {
-        response = PaymentResponse::create(protectedScriptExecutionContext().get(), *this);
+        response = PaymentResponse::create(protect(scriptExecutionContext()).get(), *this);
         m_response = response.copyRef();
         response->setRequestId(m_details.id);
     }
@@ -775,7 +770,7 @@ void PaymentRequest::accept(const String& methodName, PaymentResponse::DetailsFu
     RefPtr response = m_response;
     bool isRetry = m_response;
     if (!isRetry) {
-        response = PaymentResponse::create(protectedScriptExecutionContext().get(), *this);
+        response = PaymentResponse::create(protect(scriptExecutionContext()).get(), *this);
         m_response = response.copyRef();
         response->setRequestId(m_details.id);
     }
@@ -836,7 +831,7 @@ void PaymentRequest::cancel()
 
     if (m_isUpdating) {
         m_isCancelPending = true;
-        protectedScriptExecutionContext()->addConsoleMessage(JSC::MessageSource::PaymentRequest, JSC::MessageLevel::Error, "payment request timed out while waiting for Promise given to show() or updateWith() to settle."_s);
+        protect(scriptExecutionContext())->addConsoleMessage(JSC::MessageSource::PaymentRequest, JSC::MessageLevel::Error, "payment request timed out while waiting for Promise given to show() or updateWith() to settle."_s);
         return;
     }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -137,7 +137,6 @@ private:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::PaymentRequest; }
     ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
     bool isPaymentRequest() const final { return true; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp
@@ -55,7 +55,7 @@ void DocumentPictureInPicture::exitPictureInPicture(Document& document, Ref<Defe
         return;
     }
 
-    HTMLVideoElementPictureInPicture::protectedFrom(*element)->exitPictureInPicture(WTF::move(promise));
+    protect(HTMLVideoElementPictureInPicture::from(*element))->exitPictureInPicture(WTF::move(promise));
 }
 
 DocumentPictureInPicture* DocumentPictureInPicture::from(Document& document)

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -85,11 +85,6 @@ HTMLVideoElementPictureInPicture& HTMLVideoElementPictureInPicture::from(HTMLVid
     return *downcast<HTMLVideoElementPictureInPicture>(Supplement<HTMLVideoElement>::from(&videoElement, supplementName()));
 }
 
-Ref<HTMLVideoElementPictureInPicture> HTMLVideoElementPictureInPicture::protectedFrom(HTMLVideoElement& videoElement)
-{
-    return from(videoElement);
-}
-
 void HTMLVideoElementPictureInPicture::providePictureInPictureTo(HTMLVideoElement& videoElement)
 {
     auto newSupplement = makeUniqueWithoutRefCountedCheck<HTMLVideoElementPictureInPicture>(videoElement);

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -51,7 +51,6 @@ class HTMLVideoElementPictureInPicture
 public:
     HTMLVideoElementPictureInPicture(HTMLVideoElement&);
     static HTMLVideoElementPictureInPicture& from(HTMLVideoElement&);
-    static Ref<HTMLVideoElementPictureInPicture> protectedFrom(HTMLVideoElement&);
     static void providePictureInPictureTo(HTMLVideoElement&);
     virtual ~HTMLVideoElementPictureInPicture();
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -184,7 +184,7 @@ void SpeechSynthesis::cancel()
 {
     // Remove all the items from the utterance queue.
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
-    RefPtr current = protectedCurrentSpeechUtterance();
+    RefPtr current = currentSpeechUtterance();
     // Clear m_utteranceQueue before calling cancel to avoid picking up new utterances
     // on completion callback
     auto utteranceQueue = WTF::move(m_utteranceQueue);
@@ -273,42 +273,42 @@ void SpeechSynthesis::didStartSpeaking()
 {
     if (!m_currentSpeechUtterance)
         return;
-    didStartSpeaking(protectedCurrentSpeechUtterance()->platformUtterance());
+    didStartSpeaking(protect(currentSpeechUtterance())->platformUtterance());
 }
 
 void SpeechSynthesis::didFinishSpeaking()
 {
     if (!m_currentSpeechUtterance)
         return;
-    didFinishSpeaking(protectedCurrentSpeechUtterance()->platformUtterance());
+    didFinishSpeaking(protect(currentSpeechUtterance())->platformUtterance());
 }
 
 void SpeechSynthesis::didPauseSpeaking()
 {
     if (!m_currentSpeechUtterance)
         return;
-    didPauseSpeaking(protectedCurrentSpeechUtterance()->platformUtterance());
+    didPauseSpeaking(protect(currentSpeechUtterance())->platformUtterance());
 }
 
 void SpeechSynthesis::didResumeSpeaking()
 {
     if (!m_currentSpeechUtterance)
         return;
-    didResumeSpeaking(protectedCurrentSpeechUtterance()->platformUtterance());
+    didResumeSpeaking(protect(currentSpeechUtterance())->platformUtterance());
 }
 
 void SpeechSynthesis::speakingErrorOccurred()
 {
     if (!m_currentSpeechUtterance)
         return;
-    speakingErrorOccurred(protectedCurrentSpeechUtterance()->platformUtterance());
+    speakingErrorOccurred(protect(currentSpeechUtterance())->platformUtterance());
 }
 
 void SpeechSynthesis::boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)
 {
     if (!m_currentSpeechUtterance)
         return;
-    boundaryEventOccurred(protectedCurrentSpeechUtterance()->platformUtterance(), wordBoundary ? SpeechBoundary::SpeechWordBoundary : SpeechBoundary::SpeechSentenceBoundary, charIndex, charLength);
+    boundaryEventOccurred(protect(currentSpeechUtterance())->platformUtterance(), wordBoundary ? SpeechBoundary::SpeechWordBoundary : SpeechBoundary::SpeechSentenceBoundary, charIndex, charLength);
 }
 
 void SpeechSynthesis::voicesChanged()
@@ -348,7 +348,7 @@ void SpeechSynthesis::speakingErrorOccurred(PlatformSpeechSynthesisUtterance& ut
         handleSpeakingCompleted(downcast<SpeechSynthesisUtterance>(*utterance.client()), true);
 }
 
-RefPtr<SpeechSynthesisUtterance> SpeechSynthesis::protectedCurrentSpeechUtterance()
+SpeechSynthesisUtterance* SpeechSynthesis::currentSpeechUtterance()
 {
     return m_currentSpeechUtterance ? &m_currentSpeechUtterance->utterance() : nullptr;
 }

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -80,7 +80,6 @@ public:
 
 private:
     SpeechSynthesis(ScriptExecutionContext&);
-    RefPtr<SpeechSynthesisUtterance> NODELETE protectedCurrentSpeechUtterance();
 
     // PlatformSpeechSynthesizerClient
     void voicesDidChange() override;
@@ -116,6 +115,8 @@ private:
     PlatformSpeechSynthesizer& ensurePlatformSpeechSynthesizer();
     Ref<PlatformSpeechSynthesizer> ensureProtectedPlatformSpeechSynthesizer();
     
+    SpeechSynthesisUtterance* currentSpeechUtterance();
+
     RefPtr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
     std::optional<Vector<Ref<SpeechSynthesisVoice>>> m_voiceList;
     std::unique_ptr<SpeechSynthesisUtteranceActivity> m_currentSpeechUtterance;

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -92,7 +92,7 @@ static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator, Exce
 
 void StorageManager::persisted(DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(protectedNavigator().get(), ExceptionCode::TypeError);
+    auto connectionInfoOrException = connectionInfo(protect(m_navigator).get(), ExceptionCode::TypeError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -104,7 +104,7 @@ void StorageManager::persisted(DOMPromiseDeferred<IDLBoolean>&& promise)
 
 void StorageManager::persist(DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(protectedNavigator().get(), ExceptionCode::TypeError);
+    auto connectionInfoOrException = connectionInfo(protect(m_navigator).get(), ExceptionCode::TypeError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -116,7 +116,7 @@ void StorageManager::persist(DOMPromiseDeferred<IDLBoolean>&& promise)
 
 void StorageManager::estimate(DOMPromiseDeferred<IDLDictionary<StorageEstimate>>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(protectedNavigator().get(), ExceptionCode::TypeError);
+    auto connectionInfoOrException = connectionInfo(protect(m_navigator).get(), ExceptionCode::TypeError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -128,7 +128,7 @@ void StorageManager::estimate(DOMPromiseDeferred<IDLDictionary<StorageEstimate>>
 
 void StorageManager::fileSystemGetDirectory(DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(protectedNavigator().get(), ExceptionCode::SecurityError);
+    auto connectionInfoOrException = connectionInfo(protect(m_navigator).get(), ExceptionCode::SecurityError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -146,11 +146,6 @@ void StorageManager::fileSystemGetDirectory(DOMPromiseDeferred<IDLInterface<File
 
         promise.resolve(FileSystemDirectoryHandle::create(*context, { }, identifier, Ref { *connection }));
     });
-}
-
-RefPtr<NavigatorBase> StorageManager::protectedNavigator() const
-{
-    return m_navigator.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/storage/StorageManager.h
+++ b/Source/WebCore/Modules/storage/StorageManager.h
@@ -49,8 +49,6 @@ public:
     void fileSystemGetDirectory(DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&&);
 
 private:
-    RefPtr<NavigatorBase> NODELETE protectedNavigator() const;
-
     explicit StorageManager(NavigatorBase&);
     WeakPtr<NavigatorBase> m_navigator;
 };

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -68,7 +68,6 @@ public:
     void respondPendingPullIntosOnClose(JSDOMGlobalObject&);
 
     ReadableStream& NODELETE stream();
-    Ref<ReadableStream> NODELETE protectedStream();
 
     void pullInto(JSDOMGlobalObject&, JSC::ArrayBufferView&, uint64_t, Ref<ReadableStreamReadIntoRequest>&&);
 

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -115,7 +115,6 @@ public:
 
     bool hasByteStreamController() { return !!m_controller; }
     ReadableByteStreamController* controller() { return m_controller.get(); }
-    RefPtr<ReadableByteStreamController> protectedController() { return m_controller.get(); }
 
     void setByobReader(ReadableStreamBYOBReader*);
     ReadableStreamBYOBReader* NODELETE byobReader();

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -337,7 +337,7 @@ static Ref<DOMPromise> pull1Steps(JSDOMGlobalObject& globalObject, StreamTeeStat
 
     state.setReading(true);
 
-    RefPtr byobRequest = branch1.protectedController()->getByobRequest();
+    RefPtr byobRequest = protect(branch1.controller())->getByobRequest();
     if (!byobRequest)
         pullWithDefaultReader(globalObject, state);
     else
@@ -359,7 +359,7 @@ static Ref<DOMPromise> pull2Steps(JSDOMGlobalObject& globalObject, StreamTeeStat
 
     state.setReading(true);
 
-    RefPtr byobRequest = branch2.protectedController()->getByobRequest();
+    RefPtr byobRequest = protect(branch2.controller())->getByobRequest();
     if (!byobRequest)
         pullWithDefaultReader(globalObject, state);
     else
@@ -423,9 +423,9 @@ private:
             chunk2 = resultOrException.releaseReturnValue();
         }
         if (!m_state->canceled1() && branch1)
-            branch1->protectedController()->enqueue(*globalObject, chunk1);
+            protect(branch1->controller())->enqueue(*globalObject, chunk1);
         if (!m_state->canceled2() && branch2)
-            branch2->protectedController()->enqueue(*globalObject, chunk2);
+            protect(branch2->controller())->enqueue(*globalObject, chunk2);
 
         m_state->setReading(false);
         if (m_state->readAgainForBranch1() && branch1)
@@ -449,10 +449,10 @@ private:
         if (!m_state->canceled2() && branch2)
             branch2->controller()->close(*globalObject);
 
-        if (branch1 && branch1->protectedController()->hasPendingPullIntos())
-            branch1->protectedController()->respond(*globalObject, 0);
-        if (branch2 && branch2->protectedController()->hasPendingPullIntos())
-            branch2->protectedController()->respond(*globalObject, 0);
+        if (branch1 && protect(branch1->controller())->hasPendingPullIntos())
+            protect(branch1->controller())->respond(*globalObject, 0);
+        if (branch2 && protect(branch2->controller())->hasPendingPullIntos())
+            protect(branch2->controller())->respond(*globalObject, 0);
 
         if (!m_state->canceled1() || !m_state->canceled2())
             m_state->resolveCancelPromise();
@@ -538,11 +538,11 @@ private:
             }
             Ref clonedChunk = resultOrException.releaseReturnValue();
             if (!byobCanceled && byobBranch)
-                byobBranch->protectedController()->respondWithNewView(*globalObject, chunk);
+                protect(byobBranch->controller())->respondWithNewView(*globalObject, chunk);
             if (otherBranch)
-                otherBranch->protectedController()->enqueue(*globalObject, clonedChunk);
+                protect(otherBranch->controller())->enqueue(*globalObject, clonedChunk);
         } else if (!byobCanceled && byobBranch)
-            byobBranch->protectedController()->respondWithNewView(*globalObject, chunk);
+            protect(byobBranch->controller())->respondWithNewView(*globalObject, chunk);
 
         m_state->setReading(false);
         if (m_state->readAgainForBranch1() && branch1)
@@ -586,9 +586,9 @@ private:
             ASSERT(!chunk->byteLength());
 
             if (!byobCanceled && branch1)
-                branch1->protectedController()->respondWithNewView(*globalObject, chunk);
+                protect(branch1->controller())->respondWithNewView(*globalObject, chunk);
             if (!otherCanceled && branch2 && branch2->controller()->hasPendingPullIntos())
-                branch2->protectedController()->respond(*globalObject, 0);
+                protect(branch2->controller())->respond(*globalObject, 0);
         }
 
         if (!byobCanceled || !otherCanceled)

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h
@@ -54,7 +54,6 @@ public:
     const String& group() const { return m_group; }
     bool synchronizable() const { return m_synchronizable; }
     LAContext * laContext() const { return m_laContext.get(); }
-    RetainPtr<LAContext> protectedLAContext() const { return m_laContext; }
     RefPtr<ArrayBuffer> largeBlob() const { return m_largeBlob; }
     const String& accessGroup() const { return m_accessGroup; }
 

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -71,7 +71,7 @@ void DatagramByteSource::receiveDatagram(std::span<const uint8_t> datagram, bool
     }
 
     RefPtr controller = m_controller;
-    auto* globalObject = controller->protectedStream()->globalObject();
+    auto* globalObject = protect(controller->stream())->globalObject();
     if (!globalObject)
         return;
 
@@ -114,7 +114,7 @@ void DatagramByteSource::closeStreamIfPossible()
         return;
 
     RefPtr controller = m_controller;
-    auto* globalObject = controller->protectedStream()->globalObject();
+    auto* globalObject = protect(controller->stream())->globalObject();
     if (!globalObject)
         return;
 
@@ -143,7 +143,7 @@ void DatagramByteSource::closeStream(JSDOMGlobalObject& globalObject, ReadableBy
 void DatagramByteSource::tryEnqueuing(JSC::ArrayBuffer& buffer, ReadableByteStreamController& controller, Ref<DeferredPromise>&& promise, JSDOMGlobalObject* globalObject)
 {
     if (!globalObject) {
-        globalObject = controller.protectedStream()->globalObject();
+        globalObject = protect(controller.stream())->globalObject();
         if (!globalObject) {
             // FIXME: We should probably error.
             promise->resolve();

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -242,7 +242,7 @@ void WebTransport::receiveIncomingUnidirectionalStream(WebTransportStreamIdentif
         ASSERT(!m_readStreamSources.contains(identifier));
         m_readStreamSources.add(identifier, WTF::move(incomingStream));
     } else
-        protectedSession()->destroyStream(identifier, std::nullopt);
+        protect(m_session)->destroyStream(identifier, std::nullopt);
 }
 
 static ExceptionOr<Ref<WebTransportBidirectionalStream>> createBidirectionalStream(WebTransport& transport, WebTransportSession& session, JSDOMGlobalObject& globalObject, Ref<WebTransportSendStreamSink>&& sink, Ref<WebTransportReceiveStreamSource>&& source)
@@ -293,7 +293,7 @@ void WebTransport::receiveBidirectionalStream(WebTransportStreamIdentifier ident
         ASSERT(!m_sendStreamSinks.contains(identifier));
         m_sendStreamSinks.add(identifier, WTF::move(sink));
     } else
-        protectedSession()->destroyStream(identifier, std::nullopt);
+        protect(m_session)->destroyStream(identifier, std::nullopt);
 }
 
 void WebTransport::streamReceiveBytes(WebTransportStreamIdentifier identifier, std::span<const uint8_t> span, bool withFin, std::optional<Exception>&& exception)
@@ -667,11 +667,6 @@ void WebTransport::receiveStreamClosed(WebTransportStreamIdentifier identifier)
         if (RefPtr stream = source->stream())
             m_receiveStreams.remove(*stream);
     }
-}
-
-RefPtr<WebTransportSession> WebTransport::protectedSession()
-{
-    return m_session;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -126,8 +126,6 @@ private:
     void didFail(std::optional<uint32_t>&&, String&&) final;
     void didDrain() final;
 
-    RefPtr<WebTransportSession> NODELETE protectedSession();
-
     ListHashSet<Ref<WritableStream>> m_sendStreams;
     ListHashSet<Ref<ReadableStream>> m_receiveStreams;
     const Ref<ReadableStream> m_incomingBidirectionalStreams;

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -435,7 +435,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
                 return;
 
             RefPtr controller = m_controller.get();
-            auto* globalObject = controller->protectedStream()->globalObject();
+            auto* globalObject = protect(controller->stream())->globalObject();
             if (!globalObject)
                 return;
 
@@ -470,7 +470,7 @@ ExceptionOr<Ref<ReadableStream>> Blob::stream()
             });
 
             if (!globalObject) {
-                globalObject = controller.protectedStream()->globalObject();
+                globalObject = protect(controller.stream())->globalObject();
                 if (!globalObject)
                     return;
             }

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h
@@ -55,6 +55,8 @@ IGNORE_CLANG_WARNINGS_END
 namespace WTF {
 
 template<typename T> struct RTCDefaultRefDerefTraits {
+    static constexpr bool isDefaultImplementation = false;
+
     static ALWAYS_INLINE T* refIfNotNull(T* buffer)
     {
         if (buffer) [[likely]]

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2001,7 +2001,7 @@ void Internals::setEnableWebRTCEncryption(bool value)
 
 bool Internals::hasPeerConnectionEnabledServiceClass(const RTCPeerConnection& connection)
 {
-    return connection.protectedBackend()->shouldEnableServiceClass();
+    return protect(connection.backend())->shouldEnableServiceClass();
 }
 #endif // ENABLE(WEB_RTC)
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
@@ -41,7 +41,7 @@ std::optional<BindGroupDescriptor> ConvertToBackingContext::convertToBacking(con
     if (!base)
         return std::nullopt;
 
-    auto identifier = convertToBacking(bindGroupDescriptor.protectedLayout().get());
+    auto identifier = convertToBacking(protect(bindGroupDescriptor.layout).get());
 
     Vector<BindGroupEntry> entries;
     entries.reserveInitialCapacity(bindGroupDescriptor.entries.size());

--- a/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<BufferBinding> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::BufferBinding& bufferBinding)
 {
-    auto buffer = convertToBacking(bufferBinding.protectedBuffer().get());
+    auto buffer = convertToBacking(protect(bufferBinding.buffer).get());
 
     return { { buffer, bufferBinding.offset, bufferBinding.size } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
@@ -41,7 +41,7 @@ std::optional<ComputePassTimestampWrites> ConvertToBackingContext::convertToBack
     if (!computePassTimestampWrite.querySet)
         return std::nullopt;
 
-    auto querySet = convertToBacking(*computePassTimestampWrite.protectedQuerySet());
+    auto querySet = convertToBacking(*protect(computePassTimestampWrite.querySet));
 
     return { { querySet, computePassTimestampWrite.beginningOfPassWriteIndex, computePassTimestampWrite.endOfPassWriteIndex } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
@@ -38,7 +38,7 @@ namespace WebKit::WebGPU {
 std::optional<ImageCopyBuffer> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ImageCopyBuffer& imageCopyBuffer)
 {
     auto base = convertToBacking(static_cast<const WebCore::WebGPU::ImageDataLayout&>(imageCopyBuffer));
-    auto buffer = convertToBacking(imageCopyBuffer.protectedBuffer().get());
+    auto buffer = convertToBacking(protect(imageCopyBuffer.buffer).get());
 
     return { { WTF::move(*base), buffer } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<ImageCopyTexture> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ImageCopyTexture& imageCopyTexture)
 {
-    auto texture = convertToBacking(imageCopyTexture.protectedTexture().get());
+    auto texture = convertToBacking(protect(imageCopyTexture.texture).get());
 
     std::optional<Origin3D> origin;
     if (imageCopyTexture.origin) {

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
@@ -43,7 +43,7 @@ std::optional<PipelineDescriptorBase> ConvertToBackingContext::convertToBacking(
 
     std::optional<WebGPUIdentifier> layout;
     if (pipelineDescriptorBase.layout) {
-        layout = convertToBacking(*pipelineDescriptorBase.protectedLayout().get());
+        layout = convertToBacking(*protect(pipelineDescriptorBase.layout));
         if (!layout)
             return std::nullopt;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassDescriptor.cpp
@@ -61,7 +61,7 @@ std::optional<RenderPassDescriptor> ConvertToBackingContext::convertToBacking(co
 
     std::optional<WebGPUIdentifier> occlusionQuerySet;
     if (renderPassDescriptor.occlusionQuerySet) {
-        occlusionQuerySet = convertToBacking(*renderPassDescriptor.protectedOcclusionQuerySet());
+        occlusionQuerySet = convertToBacking(*protect(renderPassDescriptor.occlusionQuerySet));
         if (!occlusionQuerySet)
             return std::nullopt;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
@@ -40,7 +40,7 @@ std::optional<RenderPassTimestampWrites> ConvertToBackingContext::convertToBacki
     if (!renderPassTimestampWrite.querySet)
         return std::nullopt;
 
-    auto querySet = convertToBacking(*renderPassTimestampWrite.protectedQuerySet());
+    auto querySet = convertToBacking(*protect(renderPassTimestampWrite.querySet));
 
     return { { querySet, renderPassTimestampWrite.beginningOfPassWriteIndex, renderPassTimestampWrite.endOfPassWriteIndex } };
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<ShaderModuleCompilationHint> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ShaderModuleCompilationHint& shaderModuleCompilationHint)
 {
-    WebGPUIdentifier pipelineLayout = convertToBacking(shaderModuleCompilationHint.protectedPipelineLayout());
+    WebGPUIdentifier pipelineLayout = convertToBacking(protect(shaderModuleCompilationHint.pipelineLayout));
 
     return { { pipelineLayout } };
 }

--- a/Source/WebKit/UIProcess/API/C/mac/WKNotificationPrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKNotificationPrivateMac.mm
@@ -31,5 +31,5 @@
 
 NSDictionary *WKNotificationCopyDictionaryRepresentation(WKNotificationRef notification)
 {
-    return WebKit::toImpl(notification)->data().protectedDictionaryRepresentation().leakRef();
+    return protect(WebKit::toImpl(notification)->data().dictionaryRepresentation()).leakRef();
 }


### PR DESCRIPTION
#### 48bb3573d268e5ed227ff941cc938c726b1367cc
<pre>
Drop remaining `protected*()` member functions in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=308449">https://bugs.webkit.org/show_bug.cgi?id=308449</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
(WebCore::WebGPU::CommandEncoderImpl::beginComputePass):
(WebCore::WebGPU::CommandEncoderImpl::copyBufferToTexture):
(WebCore::WebGPU::CommandEncoderImpl::copyTextureToBuffer):
(WebCore::WebGPU::CommandEncoderImpl::copyTextureToTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createBindGroup):
(WebCore::WebGPU::DeviceImpl::createShaderModule):
(WebCore::WebGPU::convertToBacking):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::PresentationContextImpl::configure):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::writeTexture):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h:
(WebCore::WebGPU::BindGroupDescriptor::protectedLayout const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h:
(WebCore::WebGPU::BufferBinding::protectedBuffer const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h:
(WebCore::WebGPU::CanvasConfiguration::protectedDevice const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h:
(WebCore::WebGPU::ComputePassTimestampWrites::protectedQuerySet const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h:
(WebCore::WebGPU::ImageCopyBuffer::protectedBuffer const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h:
(WebCore::WebGPU::ImageCopyTexture::protectedTexture const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h:
(WebCore::WebGPU::PipelineDescriptorBase::protectedLayout const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h:
(WebCore::WebGPU::RenderPassDescriptor::protectedOcclusionQuerySet const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h:
(WebCore::WebGPU::RenderPassTimestampWrites::protectedQuerySet const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModuleCompilationHint.h:
(WebCore::WebGPU::ShaderModuleCompilationHint::protectedPipelineLayout const): Deleted.
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePaySession::abort):
(WebCore::ApplePaySession::completeShippingMethodSelection):
(WebCore::ApplePaySession::completeShippingContactSelection):
(WebCore::ApplePaySession::completePaymentMethodSelection):
(WebCore::ApplePaySession::completeCouponCodeChange):
(WebCore::ApplePaySession::completePayment):
(WebCore::ApplePaySession::didSelectShippingMethod):
(WebCore::ApplePaySession::didSelectShippingContact):
(WebCore::ApplePaySession::didSelectPaymentMethod):
(WebCore::ApplePaySession::didChangeCouponCode):
(WebCore::ApplePaySession::stop):
(WebCore::ApplePaySession::suspend):
(WebCore::ApplePaySession::protectedPaymentCoordinator const): Deleted.
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::ApplePayPaymentHandler::hide):
(WebCore::ApplePayPaymentHandler::canMakePayment):
(WebCore::ApplePayPaymentHandler::firstApplicableModifier const):
(WebCore::ApplePayPaymentHandler::merchantValidationCompleted):
(WebCore::ApplePayPaymentHandler::shippingAddressUpdated):
(WebCore::ApplePayPaymentHandler::shippingOptionUpdated):
(WebCore::ApplePayPaymentHandler::paymentMethodUpdated):
(WebCore::ApplePayPaymentHandler::complete):
(WebCore::ApplePayPaymentHandler::protectedDocument const): Deleted.
(WebCore::ApplePayPaymentHandler::protectedPaymentCoordinator const): Deleted.
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):
(WebCore::CookieStore::MainThreadBridge::protectedCookieStore const): Deleted.
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolveWithFormData):
(WebCore::FetchBodyConsumer::consumeFormDataAsStream):
(WebCore::FetchBodyConsumer::extract):
(WebCore::FetchBodyConsumer::resolve):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp:
(WebCore::FileSystemWritableFileStreamSink::~FileSystemWritableFileStreamSink):
(WebCore::FileSystemWritableFileStreamSink::write):
(WebCore::FileSystemWritableFileStreamSink::close):
(WebCore::FileSystemWritableFileStreamSink::abort):
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::renameObjectStore):
(WebCore::IDBDatabase::renameIndex):
(WebCore::IDBDatabase::protectedVersionChangeTransaction const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::protectedTransaction): Deleted.
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::abortInProgressOperations):
(WebCore::IDBTransaction::generateIndexKeyForRecord):
(WebCore::IDBTransaction::protectedConnectionProxy): Deleted.
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::identifier const):
(WebCore::IDBClient::IDBConnectionToServer::deleteDatabase):
(WebCore::IDBClient::IDBConnectionToServer::openDatabase):
(WebCore::IDBClient::IDBConnectionToServer::createObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::deleteObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::renameObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::clearObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::createIndex):
(WebCore::IDBClient::IDBConnectionToServer::deleteIndex):
(WebCore::IDBClient::IDBConnectionToServer::renameIndex):
(WebCore::IDBClient::IDBConnectionToServer::putOrAdd):
(WebCore::IDBClient::IDBConnectionToServer::getRecord):
(WebCore::IDBClient::IDBConnectionToServer::getAllRecords):
(WebCore::IDBClient::IDBConnectionToServer::getCount):
(WebCore::IDBClient::IDBConnectionToServer::deleteRecord):
(WebCore::IDBClient::IDBConnectionToServer::openCursor):
(WebCore::IDBClient::IDBConnectionToServer::iterateCursor):
(WebCore::IDBClient::IDBConnectionToServer::establishTransaction):
(WebCore::IDBClient::IDBConnectionToServer::commitTransaction):
(WebCore::IDBClient::IDBConnectionToServer::didFinishHandlingVersionChangeTransaction):
(WebCore::IDBClient::IDBConnectionToServer::abortTransaction):
(WebCore::IDBClient::IDBConnectionToServer::didFireVersionChangeEvent):
(WebCore::IDBClient::IDBConnectionToServer::didGenerateIndexKeyForRecord):
(WebCore::IDBClient::IDBConnectionToServer::openDBRequestCancelled):
(WebCore::IDBClient::IDBConnectionToServer::databaseConnectionPendingClose):
(WebCore::IDBClient::IDBConnectionToServer::databaseConnectionClosed):
(WebCore::IDBClient::IDBConnectionToServer::abortOpenAndUpgradeNeeded):
(WebCore::IDBClient::IDBConnectionToServer::getAllDatabaseNamesAndVersions):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::connectionClosedFromServer):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::protectedConnectionToClient): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::connectionToClient):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getCount):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::openCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::iterateCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::didActivateInBackingStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::generateIndexKeyForRecord):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::sortedTrackListForMenu):
(WebCore::MediaControlsHost::displayNameForTrack):
(WebCore::MediaControlsHost::captionDisplayMode const):
(WebCore::MediaControlsHost::setSelectedTextTrack):
(WebCore::MediaControlsHost::allowsInlineMediaPlayback const):
(WebCore::MediaControlsHost::supportsFullscreen const):
(WebCore::MediaControlsHost::isVideoLayerInline const):
(WebCore::MediaControlsHost::isInMediaDocument const):
(WebCore::MediaControlsHost::userGestureRequired const):
(WebCore::MediaControlsHost::shouldForceControlsDisplay const):
(WebCore::MediaControlsHost::supportsSeeking const):
(WebCore::MediaControlsHost::needsChromeMediaControlsPseudoElement const):
(WebCore::MediaControlsHost::isMediaControlsMacInlineSizeSpecsEnabled const):
(WebCore::MediaControlsHost::externalDeviceDisplayName const):
(WebCore::MediaControlsHost::externalDeviceType const):
(WebCore::MediaControlsHost::controlsDependOnPageScaleFactor const):
(WebCore::MediaControlsHost::setControlsDependOnPageScaleFactor):
(WebCore::MediaControlsHost::shadowRootStyleSheets const):
(WebCore::MediaControlsHost::sourceType const):
(WebCore::MediaControlsHost::needsCaptionVisibilityInFullscreenAndPictureInPictureQuirk const):
(WebCore::MediaControlsHost::handleCaptionVisibilityInFullscreenAndPictureInPictureQuirk):
(WebCore::MediaControlsHost::restorePreviouslySelectedTextTrackIfNecessary):
(WebCore::MediaControlsHost::mediaSession const):
(WebCore::MediaControlsHost::metadataChanged):
(WebCore::MediaControlsHost::protectedMediaElement const): Deleted.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
(WebCore::MediaSessionCoordinator::identifier const):
(WebCore::MediaSessionCoordinator::protectedPrivateCoordinator const): Deleted.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::setStreaming):
(WebCore::ManagedMediaSource::streamingTimerFired):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setPrivateAndOpen):
(WebCore::MediaSource::buffered const):
(WebCore::MediaSource::setLiveSeekableRange):
(WebCore::MediaSource::clearLiveSeekableRange):
(WebCore::MediaSource::hasBufferedTime):
(WebCore::MediaSource::hasFutureTime):
(WebCore::MediaSource::isBuffered const):
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::setDurationInternal):
(WebCore::MediaSource::streamEndedWithError):
(WebCore::MediaSource::openIfInEndedState):
(WebCore::MediaSource::readyState const):
(WebCore::MediaSource::createSourceBufferPrivate):
(WebCore::MediaSource::updateBufferedIfNeeded):
(WebCore::MediaSource::protectedPrivate const): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
(WebCore::MediaSource::mediaSourcePrivate const):
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::setTimestampOffset):
(WebCore::SourceBuffer::rangeRemoval):
(WebCore::SourceBuffer::changeType):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::setActive):
(WebCore::SourceBuffer::appendError):
(WebCore::SourceBuffer::sourceBufferPrivateDurationChanged):
(WebCore::SourceBuffer::sourceBufferPrivateDidDropSample):
(WebCore::SourceBuffer::updateBuffered):
(WebCore::SourceBuffer::setBufferedDirty):
(WebCore::SourceBuffer::memoryPressure):
(WebCore::SourceBuffer::protectedSource const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
(WebCore::MediaStreamTrack::source const):
(WebCore::MediaStreamTrack::protectedSource const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrackHandle.h:
(WebCore::MediaStreamTrackHandle::trackSourceObserver const):
(WebCore::MediaStreamTrackHandle::protectedTrackSourceObserver const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::create):
(WebCore::MediaStreamTrackProcessor::MediaStreamTrackProcessor):
(WebCore::m_trackObserver): Deleted.
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::createOfferSucceeded):
(WebCore::PeerConnectionBackend::createOfferFailed):
(WebCore::PeerConnectionBackend::createAnswerSucceeded):
(WebCore::PeerConnectionBackend::createAnswerFailed):
(WebCore::PeerConnectionBackend::setLocalDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setLocalDescriptionFailed):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setRemoteDescriptionFailed):
(WebCore::PeerConnectionBackend::iceGatheringStateChanged):
(WebCore::PeerConnectionBackend::addIceCandidate):
(WebCore::PeerConnectionBackend::newICECandidate):
(WebCore::PeerConnectionBackend::newDataChannel):
(WebCore::PeerConnectionBackend::markAsNeedingNegotiation):
(WebCore::PeerConnectionBackend::context const):
(WebCore::PeerConnectionBackend::protectedPeerConnection const): Deleted.
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::addTrack):
(WebCore::RTCPeerConnection::removeTrack):
(WebCore::RTCPeerConnection::addTransceiver):
(WebCore::RTCPeerConnection::addReceiveOnlyTransceiver):
(WebCore::RTCPeerConnection::createOffer):
(WebCore::RTCPeerConnection::createAnswer):
(WebCore::RTCPeerConnection::setLocalDescription):
(WebCore::RTCPeerConnection::setRemoteDescription):
(WebCore::RTCPeerConnection::addIceCandidate):
(WebCore::RTCPeerConnection::canTrickleIceCandidates const):
(WebCore::RTCPeerConnection::certificatesFromConfiguration):
(WebCore::RTCPeerConnection::setConfiguration):
(WebCore::RTCPeerConnection::getStats):
(WebCore::RTCPeerConnection::gatherDecoderImplementationName):
(WebCore::RTCPeerConnection::createDataChannel):
(WebCore::RTCPeerConnection::doClose):
(WebCore::RTCPeerConnection::close):
(WebCore::RTCPeerConnection::suspend):
(WebCore::RTCPeerConnection::resume):
(WebCore::RTCPeerConnection::updateNegotiationNeededFlag):
(WebCore::RTCPeerConnection::updateTransceiversAfterSuccessfulLocalDescription):
(WebCore::RTCPeerConnection::updateTransceiversAfterSuccessfulRemoteDescription):
(WebCore::RTCPeerConnection::startGatheringStatLogs):
(WebCore::RTCPeerConnection::stopGatheringStatLogs):
(WebCore::RTCPeerConnection::protectedBackend const): Deleted.
(WebCore::RTCPeerConnection::protectedDocument): Deleted.
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::dispatchSenderBitrateRequest):
(WebCore::GStreamerPeerConnectionBackend::createReceiver):
(WebCore::GStreamerPeerConnectionBackend::addTrack):
(WebCore::GStreamerPeerConnectionBackend::existingTransceiver):
(WebCore::GStreamerPeerConnectionBackend::applyRotationForOutgoingVideoSources):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::doSetLocalDescription):
(WebCore::LibWebRTCMediaEndpoint::doSetRemoteDescription):
(WebCore::LibWebRTCMediaEndpoint::addTrack):
(WebCore::LibWebRTCMediaEndpoint::createStatsCollector):
(WebCore::LibWebRTCMediaEndpoint::createTransceiverBackends):
(WebCore::LibWebRTCMediaEndpoint::createSourceAndRTCTrack):
(WebCore::LibWebRTCMediaEndpoint::setSenderSourceFromTrack):
(WebCore::LibWebRTCMediaEndpoint::OnDataChannel):
(WebCore::LibWebRTCMediaEndpoint::OnNegotiationNeededEvent):
(WebCore::LibWebRTCMediaEndpoint::OnStandardizedIceConnectionChange):
(WebCore::LibWebRTCMediaEndpoint::OnIceGatheringChange):
(WebCore::LibWebRTCMediaEndpoint::OnIceCandidate):
(WebCore::LibWebRTCMediaEndpoint::createSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::createSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::mediaStreamsFromRTCStreamIds):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::protectedPeerConnectionBackend const): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::LibWebRTCPeerConnectionBackend::createReceiver):
(WebCore::LibWebRTCPeerConnectionBackend::existingTransceiver):
(WebCore::LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp:
(WebCore::LibWebRTCRtpSenderBackend::replaceTrack):
(WebCore::LibWebRTCRtpSenderBackend::protectedPeerConnectionBackend const): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h:
* Source/WebCore/Modules/notifications/NotificationData.h:
* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::NotificationData::protectedDictionaryRepresentation const): Deleted.
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::dispatchAndCheckUpdateEvent):
(WebCore::PaymentRequest::accept):
(WebCore::PaymentRequest::cancel):
(WebCore::PaymentRequest::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.cpp:
(WebCore::DocumentPictureInPicture::exitPictureInPicture):
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
(WebCore::HTMLVideoElementPictureInPicture::protectedFrom): Deleted.
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::didStartSpeaking):
(WebCore::SpeechSynthesis::didFinishSpeaking):
(WebCore::SpeechSynthesis::didPauseSpeaking):
(WebCore::SpeechSynthesis::didResumeSpeaking):
(WebCore::SpeechSynthesis::speakingErrorOccurred):
(WebCore::SpeechSynthesis::boundaryEventOccurred):
(WebCore::SpeechSynthesis::currentSpeechUtterance):
(WebCore::SpeechSynthesis::protectedCurrentSpeechUtterance): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/storage/StorageManager.cpp:
(WebCore::StorageManager::persisted):
(WebCore::StorageManager::persist):
(WebCore::StorageManager::estimate):
(WebCore::StorageManager::fileSystemGetDirectory):
(WebCore::StorageManager::protectedNavigator const): Deleted.
* Source/WebCore/Modules/storage/StorageManager.h:
* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
(WebCore::ReadableByteStreamController::closeForBindings):
(WebCore::ReadableByteStreamController::enqueueForBindings):
(WebCore::ReadableByteStreamController::enqueue):
(WebCore::ReadableByteStreamController::processReadRequestsUsingQueue):
(WebCore::ReadableByteStreamController::shouldCallPull):
(WebCore::ReadableByteStreamController::respond):
(WebCore::ReadableByteStreamController::respondWithNewView):
(WebCore::ReadableByteStreamController::respondInternal):
(WebCore::ReadableByteStreamController::handleQueueDrain):
(WebCore::ReadableByteStreamController::protectedStream): Deleted.
* Source/WebCore/Modules/streams/ReadableByteStreamController.h:
* Source/WebCore/Modules/streams/ReadableStream.h:
(WebCore::ReadableStream::controller):
(WebCore::ReadableStream::protectedController): Deleted.
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
(WebCore::pull1Steps):
(WebCore::pull2Steps):
(WebCore::TeeDefaultReadRequest::runChunkStepsInMicrotask):
(WebCore::TeeBYOBReadRequest::runChunkStepsInMicrotask):
* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h:
(WebCore::AuthenticatorAssertionResponse::laContext const):
(WebCore::AuthenticatorAssertionResponse::protectedLAContext const): Deleted.
* Source/WebCore/Modules/webtransport/DatagramByteSource.cpp:
(WebCore::DatagramByteSource::receiveDatagram):
(WebCore::DatagramByteSource::closeStreamIfPossible):
(WebCore::DatagramByteSource::tryEnqueuing):
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::receiveIncomingUnidirectionalStream):
(WebCore::WebTransport::receiveBidirectionalStream):
(WebCore::WebTransport::protectedSession): Deleted.
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCRefWrappers.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::hasPeerConnectionEnabledServiceClass):
* Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPUShaderModuleCompilationHint.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/UIProcess/API/C/mac/WKNotificationPrivateMac.mm:
(WKNotificationCopyDictionaryRepresentation):

Canonical link: <a href="https://commits.webkit.org/308029@main">https://commits.webkit.org/308029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4408c9400e9c2ff58dd552ec7786e5aa95ae773

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154963 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99747 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da0e88f5-d7da-4ec6-8fb6-8e152ab71a69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112581 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99747 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26789025-138c-4c01-8a47-0f468dcdcd4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14938 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a14d56b7-bceb-49de-bd28-cd61604804fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14205 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2409 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157284 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/455 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120610 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120908 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30969 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7945 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18141 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18199 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->