### PR TITLE
[XML Parser] Perform microtask checkpoint before preparing script element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Microtask before prepare-the-script-element steps
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02.xhtml
@@ -1,0 +1,42 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<link rel="help" href="https://html.spec.whatwg.org/#parsing-xhtml-documents"/>
+<link rel="help" href="https://html.spec.whatwg.org/#perform-a-microtask-checkpoint"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+<![CDATA[
+
+let classicScriptRan = false;
+let moduleScriptRan = false;
+let asyncScriptRan = false;
+let deferSCriptRan = false;
+
+new MutationObserver((mutations, observer) => {
+  mutations.forEach(({ addedNodes }) => {
+    addedNodes.forEach(node => {
+      if (node.nodeType == 1 && node.tagName == "script") {
+        node.setAttribute("type", "text/plain");
+      }
+    });
+  });
+}).observe(document.body, { childList: true, subtree: true });
+
+let test = async_test("Microtask before prepare-the-script-element steps");
+window.onload = test.step_func_done(function(e) {
+  assert_false(classicScriptRan, "Classic script should not run");
+  assert_false(moduleScriptRan, "Module script should not run");
+  assert_false(asyncScriptRan, "Async script should not run");
+  assert_false(deferSCriptRan, "Defer script should not run");
+});
+
+]]>
+</script>
+<script>classicScriptRan = true;</script>
+<script type="module">moduleScriptRan = true;</script>
+<script src="resources/async.js" async=""></script>
+<script src="resources/defer.js" defer=""></script>
+</body>
+</html>

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -953,12 +953,14 @@ void XMLDocumentParser::endElementNs()
     ASSERT(!m_pendingScript);
     m_requestingScript = true;
 
+    Ref document = *this->document();
+    protect(document->eventLoop())->performMicrotaskCheckpoint();
     if (scriptElement->prepareScript(m_scriptStartPosition)) {
         if (scriptElement->readyToBeParserExecuted()) {
             if (scriptElement->scriptType() == ScriptType::Classic)
-                scriptElement->executeClassicScript(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document()->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(*scriptElement)));
+                scriptElement->executeClassicScript(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(*scriptElement)));
             else
-                scriptElement->registerImportMap(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document()->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::ImportMap));
+                scriptElement->registerImportMap(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::ImportMap));
         } else if (scriptElement->willBeParserExecuted() && scriptElement->loadableScript()) {
             m_pendingScript = PendingScript::create(*scriptElement, *protect(scriptElement->loadableScript()));
             RefPtr { m_pendingScript }->setClient(*this);


### PR DESCRIPTION
#### 1e8516439d6922c2ad2664702289825935136ef0
<pre>
[XML Parser] Perform microtask checkpoint before preparing script element
<a href="https://bugs.webkit.org/show_bug.cgi?id=308452">https://bugs.webkit.org/show_bug.cgi?id=308452</a>

Reviewed by Ryosuke Niwa and Anne van Kesteren.

The HTML spec requires performing a microtask checkpoint before the
&quot;prepare the script element&quot; step when parsing XHTML documents.
Without this, microtasks queued during element insertion do not run
before script preparation.

Test: imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02.xhtml

* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/microtask_before_prepare_the_script_element-02.xhtml: Added.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::endElementNs): Add microtask checkpoint before prepareScript.

Canonical link: <a href="https://commits.webkit.org/308171@main">https://commits.webkit.org/308171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70367eeac30ea22399f42c1b49bbe8dbb22cce5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112915 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80652 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12180 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157550 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120937 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121140 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31048 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131305 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74837 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8212 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->