### PR TITLE
Update LocalDOMWindow::frame() to return a LocalFrame* instead of a Frame*

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -498,7 +498,7 @@ inline void DialogHandler::dialogCreated(DOMWindow& dialog)
     if (!localDOMWindow)
         return;
     VM& vm = m_globalObject.vm();
-    m_frame = localDOMWindow->localFrame();
+    m_frame = localDOMWindow->frame();
     RefPtr frame = m_frame.get();
 
     // FIXME: This looks like a leak between the normal world and an isolated

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -163,10 +163,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
             if (!protect(scriptExecutionContext.contentSecurityPolicy())->allowInlineEventHandlers(sourceURL().string(), sourcePosition().m_line, code(), element.get()))
                 return;
         }
-        // FIXME: Is this check needed for other contexts?
-        RefPtr frame = dynamicDowncast<LocalFrame>(localDOMWindow->frame());
-        if (!frame)
-            return;
+        Ref frame = *localDOMWindow->frame();
         CheckedRef script = frame->script();
         if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript) || script->isPaused())
             return;

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -113,7 +113,7 @@ static bool viewIsCompositing(WindowProxy* view)
     RefPtr window = dynamicDowncast<LocalDOMWindow>(view->window());
     if (!window)
         return false;
-    RefPtr localFrame = window->localFrame();
+    RefPtr localFrame = window->frame();
     return localFrame && localFrame->editor().hasComposition();
 }
 
@@ -234,7 +234,7 @@ int KeyboardEvent::charCode() const
     bool backwardCompatibilityMode = false;
     RefPtr view = this->view();
     RefPtr window = dynamicDowncast<LocalDOMWindow>(view ? view->window() : nullptr);
-    if (RefPtr frame = window ? window->localFrame() : nullptr)
+    if (RefPtr frame = window ? window->frame() : nullptr)
         backwardCompatibilityMode = frame->eventHandler().needsKeyboardEventDisambiguationQuirks();
 
     if (!m_underlyingPlatformEvent || (type() != eventNames().keypressEvent && !backwardCompatibilityMode))

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -141,7 +141,7 @@ LocalFrameView* MouseRelatedEvent::frameViewFromWindowProxy(WindowProxy* windowP
     if (!window)
         return nullptr;
 
-    RefPtr frame = window->localFrame();
+    RefPtr frame = window->frame();
     return frame ? frame->view() : nullptr;
 }
 

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -54,7 +54,7 @@ DOMWindowExtension::~DOMWindowExtension()
 
 LocalFrame* DOMWindowExtension::frame() const
 {
-    return m_window ? m_window->localFrame() : nullptr;
+    return m_window ? m_window->frame() : nullptr;
 }
 
 void DOMWindowExtension::suspendForBackForwardCache()

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -297,7 +297,7 @@ bool LocalDOMWindow::dispatchAllPendingBeforeUnloadEvents()
         if (!set.contains(window.ptr()))
             continue;
 
-        RefPtr frame = window->localFrame();
+        RefPtr frame = window->frame();
         if (!frame)
             continue;
 
@@ -407,7 +407,7 @@ bool LocalDOMWindow::allowPopUp(LocalFrame& firstFrame)
 
 bool LocalDOMWindow::allowPopUp()
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     return frame && allowPopUp(*frame);
 }
 
@@ -565,7 +565,7 @@ void LocalDOMWindow::willDetachDocumentFromFrame()
     windowsInterestedInStorageEvents().remove(*this);
 
     JSDOMWindowBase::fireFrameClearedWatchpointsForWindow(this);
-    InspectorInstrumentation::frameWindowDiscarded(*protect(localFrame()), this);
+    InspectorInstrumentation::frameWindowDiscarded(*protect(frame()), this);
 }
 
 #if ENABLE(GAMEPAD)
@@ -655,7 +655,7 @@ static ExceptionOr<SelectorQuery&> selectorQueryInFrame(LocalFrame* frame, const
 
 ExceptionOr<Ref<NodeList>> LocalDOMWindow::collectMatchingElementsInFlatTree(Node& scope, const String& selectors)
 {
-    auto queryOrException = selectorQueryInFrame(localFrame(), selectors);
+    auto queryOrException = selectorQueryInFrame(frame(), selectors);
     if (queryOrException.hasException())
         return queryOrException.releaseException();
 
@@ -676,7 +676,7 @@ ExceptionOr<Ref<NodeList>> LocalDOMWindow::collectMatchingElementsInFlatTree(Nod
 
 ExceptionOr<RefPtr<Element>> LocalDOMWindow::matchingElementInFlatTree(Node& scope, const String& selectors)
 {
-    auto queryOrException = selectorQueryInFrame(localFrame(), selectors);
+    auto queryOrException = selectorQueryInFrame(frame(), selectors);
     if (queryOrException.hasException())
         return queryOrException.releaseException();
 
@@ -697,7 +697,7 @@ ExceptionOr<RefPtr<Element>> LocalDOMWindow::matchingElementInFlatTree(Node& sco
 #if ENABLE(ORIENTATION_EVENTS)
 IntDegrees LocalDOMWindow::orientation() const
 {
-    auto* frame = localFrame();
+    auto* frame = this->frame();
     if (!frame)
         return 0;
     return frame->orientation();
@@ -842,7 +842,7 @@ bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world, J
     if (jsCast<JSDOMGlobalObject*>(globalObject)->allowsJSHandleCreation())
         return true;
 
-    RefPtr frame = this->localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
 
@@ -868,7 +868,7 @@ WebKitNamespace* LocalDOMWindow::webkitNamespace()
 {
     if (!isCurrentlyDisplayedInFrame())
         return nullptr;
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
     RefPtr userContentProvider = frame->userContentProvider();
@@ -954,7 +954,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
     if (InspectorInstrumentation::consoleAgentEnabled(document.get()))
         stackTrace = createScriptCallStack(JSExecState::currentState());
 
-    auto postMessageIdentifier = InspectorInstrumentation::willPostMessage(*localFrame());
+    auto postMessageIdentifier = InspectorInstrumentation::willPostMessage(*frame());
 
     auto userGestureToForward = UserGestureIndicator::currentUserGesture();
 
@@ -963,7 +963,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
             return;
 
         RefPtr document = this->document();
-        Ref frame = *localFrame();
+        Ref frame = *this->frame();
         if (targetOrigin) {
             // Check target origin now since the target document may have changed since the timer was scheduled.
             if (!targetOrigin->isSameSchemeHostPort(protect(document->securityOrigin()))) {
@@ -1003,7 +1003,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
         InspectorInstrumentation::didDispatchPostMessage(frame, postMessageIdentifier);
     });
 
-    InspectorInstrumentation::didPostMessage(*protect(localFrame()), postMessageIdentifier, lexicalGlobalObject);
+    InspectorInstrumentation::didPostMessage(*protect(frame()), postMessageIdentifier, lexicalGlobalObject);
 }
 
 ExceptionOr<void> LocalDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue messageValue, WindowPostMessageOptions&& options)
@@ -1084,7 +1084,7 @@ void LocalDOMWindow::focus(LocalDOMWindow& incumbentWindow)
 
 void LocalDOMWindow::focus(bool allowFocus)
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1111,7 +1111,7 @@ void LocalDOMWindow::focus(bool allowFocus)
 
 void LocalDOMWindow::blur()
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1139,7 +1139,7 @@ void LocalDOMWindow::closePage()
 
 void LocalDOMWindow::print()
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1165,7 +1165,7 @@ void LocalDOMWindow::print()
 
 void LocalDOMWindow::stop()
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1177,7 +1177,7 @@ void LocalDOMWindow::stop()
 
 void LocalDOMWindow::alert(const String& message)
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1206,7 +1206,7 @@ void LocalDOMWindow::alert(const String& message)
 
 bool LocalDOMWindow::confirmForBindings(const String& message)
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
 
@@ -1235,7 +1235,7 @@ bool LocalDOMWindow::confirmForBindings(const String& message)
 
 String LocalDOMWindow::prompt(const String& message, const String& defaultValue)
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return String();
 
@@ -1282,7 +1282,7 @@ bool LocalDOMWindow::find(const String& string, bool caseSensitive, bool backwar
         options.add(FindOption::CaseInsensitive);
     if (wrap)
         options.add(FindOption::WrapAround);
-    return localFrame()->editor().findString(string, options).has_value();
+    return frame()->editor().findString(string, options).has_value();
 }
 
 bool LocalDOMWindow::offscreenBuffering() const
@@ -1292,7 +1292,7 @@ bool LocalDOMWindow::offscreenBuffering() const
 
 int LocalDOMWindow::outerHeight() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1320,7 +1320,7 @@ int LocalDOMWindow::outerHeight() const
 
 int LocalDOMWindow::outerWidth() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1355,7 +1355,7 @@ int LocalDOMWindow::innerHeight() const
     if (RefPtr ownerElement = frameElement())
         protect(ownerElement->document())->updateLayoutIfDimensionsOutOfDate(*ownerElement, { DimensionsCheck::Height });
 
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
     
@@ -1375,7 +1375,7 @@ int LocalDOMWindow::innerWidth() const
     if (RefPtr ownerElement = frameElement())
         protect(ownerElement->document())->updateLayoutIfDimensionsOutOfDate(*ownerElement, { DimensionsCheck::Width });
 
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1388,7 +1388,7 @@ int LocalDOMWindow::innerWidth() const
 
 int LocalDOMWindow::screenX() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1401,7 +1401,7 @@ int LocalDOMWindow::screenX() const
 
 int LocalDOMWindow::screenY() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1414,7 +1414,7 @@ int LocalDOMWindow::screenY() const
 
 int LocalDOMWindow::scrollX() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1429,7 +1429,7 @@ int LocalDOMWindow::scrollX() const
     protect(frame->document())->updateLayoutIgnorePendingStylesheets();
 
     // Layout may have affected the current frame:
-    RefPtr frameAfterLayout = localFrame();
+    RefPtr frameAfterLayout = this->frame();
     if (!frameAfterLayout)
         return 0;
 
@@ -1442,7 +1442,7 @@ int LocalDOMWindow::scrollX() const
 
 int LocalDOMWindow::scrollY() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1457,7 +1457,7 @@ int LocalDOMWindow::scrollY() const
     protect(frame->document())->updateLayoutIgnorePendingStylesheets();
 
     // Layout may have affected the current frame:
-    RefPtr frameAfterLayout = localFrame();
+    RefPtr frameAfterLayout = this->frame();
     if (!frameAfterLayout)
         return 0;
 
@@ -1473,12 +1473,12 @@ unsigned LocalDOMWindow::length() const
     if (!isCurrentlyDisplayedInFrame())
         return 0;
 
-    return protect(localFrame())->tree().scopedChildCount();
+    return protect(frame())->tree().scopedChildCount();
 }
 
 AtomString LocalDOMWindow::name() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullAtom();
 
@@ -1487,7 +1487,7 @@ AtomString LocalDOMWindow::name() const
 
 void LocalDOMWindow::setName(const AtomString& string)
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1502,7 +1502,7 @@ void LocalDOMWindow::setStatus(const String& string)
 
 void LocalDOMWindow::disownOpener()
 {
-    if (RefPtr frame = localFrame())
+    if (RefPtr frame = this->frame())
         frame->disownOpener(Frame::NotifyUIProcess::Yes);
 }
 
@@ -1674,7 +1674,7 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
     if (!(pseudoElementIsParsable || (pseudoElementIdentifier && !pseudoElementIdentifier->nameArgument.isNull())) && !pseudoElement.isEmpty())
         return nullptr;
 
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     protect(frame->document())->styleScope().flushPendingUpdate();
 
     unsigned rulesToInclude = Style::Resolver::AuthorCSSRules;
@@ -1742,20 +1742,11 @@ double LocalDOMWindow::devicePixelRatio() const
     if (!page)
         return 0.0;
 
-    auto frameScaleRatio = [&] {
-        float frameScale = 1.0f;
-        if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.get())) {
-            frameScale = localFrame->frameScaleFactor();
-            // Page zoom applies to all frames synchronously, so include it in devicePixelRatio
-            // for both main frame and iframes. frameScaleFactor() doesn't include page zoom
-            // since page zoom is applied globally for rendering.
-            float pageZoom = localFrame->pageZoomFactor();
-            frameScale *= pageZoom;
-        }
-        return frameScale;
-    };
-
-    return page->deviceScaleFactor() * frameScaleRatio();
+    // Page zoom applies to all frames synchronously, so include it in devicePixelRatio
+    // for both main frame and iframes. frameScaleFactor() doesn't include page zoom
+    // since page zoom is applied globally for rendering.
+    auto frameScaleRatio = frame->frameScaleFactor() * frame->pageZoomFactor();
+    return page->deviceScaleFactor() * frameScaleRatio;
 }
 
 void LocalDOMWindow::scrollBy(double x, double y) const
@@ -1770,7 +1761,7 @@ void LocalDOMWindow::scrollBy(const ScrollToOptions& options) const
 
     protect(document())->updateLayoutIgnorePendingStylesheets();
 
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1795,7 +1786,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
     if (!isCurrentlyDisplayedInFrame())
         return;
 
-    RefPtr view = localFrame()->view();
+    RefPtr view = frame()->view();
     if (!view)
         return;
 
@@ -1824,7 +1815,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
 
 bool LocalDOMWindow::allowedToChangeWindowGeometry() const
 {
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
     if (!frame->page())
@@ -2273,7 +2264,7 @@ void LocalDOMWindow::incrementScrollEventListenersCount()
 {
     RefPtr document = this->document();
     if (++m_scrollEventListenerCount == 1 && document->isTopDocument()) {
-        if (RefPtr frame = localFrame(); frame && frame->page())
+        if (RefPtr frame = this->frame(); frame && frame->page())
             protect(frame->page())->chrome().client().setNeedsScrollNotifications(*frame, true);
     }
 }
@@ -2282,7 +2273,7 @@ void LocalDOMWindow::decrementScrollEventListenersCount()
 {
     RefPtr document = this->document();
     if (!--m_scrollEventListenerCount && document->isTopDocument()) {
-        if (RefPtr frame = localFrame(); frame && frame->page() && document->backForwardCacheState() == Document::NotInBackForwardCache)
+        if (RefPtr frame = this->frame(); frame && frame->page() && document->backForwardCacheState() == Document::NotInBackForwardCache)
             protect(frame->page())->chrome().client().setNeedsScrollNotifications(*frame, false);
     }
 }
@@ -2381,7 +2372,7 @@ void LocalDOMWindow::dispatchLoadEvent()
     // as a side effect of what event handling code does.
     Ref protectedThis { *this };
     RefPtr document = this->document();
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     RefPtr protectedLoader = frame ? frame->loader().documentLoader() : nullptr;
     bool shouldMarkLoadEventTimes = protectedLoader && !protectedLoader->timing().loadEventStart();
 
@@ -2404,10 +2395,10 @@ void LocalDOMWindow::dispatchLoadEvent()
     }
 
     // Send a separate load event to the element that owns this frame.
-    if (RefPtr frame = localFrame())
+    if (RefPtr frame = this->frame())
         frame->dispatchLoadEventToParent();
 
-    InspectorInstrumentation::loadEventFired(protect(localFrame()).get());
+    InspectorInstrumentation::loadEventFired(protect(this->frame()).get());
 }
 
 void LocalDOMWindow::dispatchEvent(Event& event, EventTarget* target)
@@ -2436,7 +2427,7 @@ void LocalDOMWindow::dispatchEvent(Event& event, EventTarget* target)
     // events dispatched to the window object are guaranteed to flow through this function.
     // But the instrumentation prevents us from calling EventDispatcher::dispatchEvent here.
     if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
-        protectedFrame = localFrame();
+        protectedFrame = this->frame();
         hasListenersForEvent = hasEventListeners(event.type());
         if (hasListenersForEvent)
             InspectorInstrumentation::willDispatchEventOnWindow(protectedFrame.get(), event);
@@ -2500,7 +2491,7 @@ void LocalDOMWindow::finishedLoading()
 {
     if (m_shouldPrintWhenFinishedLoading) {
         m_shouldPrintWhenFinishedLoading = false;
-        if (RefPtr loader = localFrame()->loader().activeDocumentLoader(); !loader || loader->mainDocumentError().isNull())
+        if (RefPtr loader = frame()->loader().activeDocumentLoader(); !loader || loader->mainDocumentError().isNull())
             print();
     }
 }
@@ -2792,7 +2783,7 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
     RefPtr localParent = dynamicDowncast<LocalFrame>(frame->tree().parent());
     // If the loader for activeWindow's frame (browsing context) has no outgoing referrer, set its outgoing referrer
     // to the URL of its parent frame's Document.
-    if (RefPtr activeFrame = activeWindow.localFrame(); activeFrame && activeFrame->loader().outgoingReferrer().isEmpty() && localParent)
+    if (RefPtr activeFrame = activeWindow.frame(); activeFrame && activeFrame->loader().outgoingReferrer().isEmpty() && localParent)
         activeFrame->loader().setOutgoingReferrer(protect(document())->completeURL(localParent->document()->url().strippedForUseAsReferrer().string));
 
     // We want a new history item if we are processing a user gesture.
@@ -2908,7 +2899,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     if (!activeDocument)
         return RefPtr<WindowProxy> { nullptr };
 
-    RefPtr firstFrame = firstWindow.localFrame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame)
         return RefPtr<WindowProxy> { nullptr };
 
@@ -2928,7 +2919,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     }
 #endif
 
-    RefPtr frame = this->localFrame();
+    RefPtr frame = this->frame();
     if (!frame)
         return RefPtr<WindowProxy> { nullptr };
 
@@ -2993,11 +2984,11 @@ void LocalDOMWindow::showModalDialog(const String& urlString, const String& dial
         return;
     if (!activeWindow.frame())
         return;
-    RefPtr firstFrame = firstWindow.localFrame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame)
         return;
 
-    RefPtr frame = localFrame();
+    RefPtr frame = this->frame();
     RefPtr page = frame->page();
     if (!page)
         return;
@@ -3029,12 +3020,7 @@ void LocalDOMWindow::disableSuddenTermination()
         page->chrome().disableSuddenTermination();
 }
 
-Frame* LocalDOMWindow::frame() const
-{
-    return localFrame();
-}
-
-LocalFrame* LocalDOMWindow::localFrame() const
+LocalFrame* LocalDOMWindow::frame() const
 {
     auto* document = this->document();
     return document ? document->frame() : nullptr;
@@ -3074,7 +3060,7 @@ PushManager& LocalDOMWindow::pushManager()
 
 static URL toScope(LocalDOMWindow& window)
 {
-    if (RefPtr frame = window.localFrame()) {
+    if (RefPtr frame = window.frame()) {
         if (RefPtr document = frame->document())
             return URL { document->url().protocolHostAndPort() };
     }

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -31,6 +31,7 @@
 #include <WebCore/DOMHighResTimeStamp.h>
 #include <WebCore/DOMWindow.h>
 #include <WebCore/EventTargetInterfaces.h>
+#include <WebCore/LocalFrame.h>
 #include <WebCore/PerformanceEventTimingCandidate.h>
 #include <WebCore/PushSubscriptionOwner.h>
 #include <WebCore/Supplementable.h>
@@ -53,7 +54,6 @@ template <typename, ShouldStrongDestructorGrabLock> class Strong;
 namespace WebCore {
 
 class CloseWatcherManager;
-class LocalFrame;
 class SecurityOriginData;
 struct ScrollToOptions;
 struct WindowPostMessageOptions;
@@ -110,8 +110,7 @@ public:
     void suspendForBackForwardCache();
     void resumeFromBackForwardCache();
 
-    WEBCORE_EXPORT Frame* NODELETE frame() const final;
-    WEBCORE_EXPORT LocalFrame* NODELETE localFrame() const;
+    WEBCORE_EXPORT LocalFrame* NODELETE frame() const final;
 
     RefPtr<WebCore::MediaQueryList> matchMedia(const String&);
 

--- a/Source/WebCore/page/LocalDOMWindowProperty.cpp
+++ b/Source/WebCore/page/LocalDOMWindowProperty.cpp
@@ -39,7 +39,7 @@ LocalDOMWindowProperty::LocalDOMWindowProperty(LocalDOMWindow* window)
 
 LocalFrame* LocalDOMWindowProperty::frame() const
 {
-    return m_window ? window()->localFrame() : nullptr;
+    return m_window ? window()->frame() : nullptr;
 }
 
 LocalDOMWindow* LocalDOMWindowProperty::window() const

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -253,7 +253,7 @@ ExceptionOr<void> Location::replace(LocalDOMWindow& activeWindow, LocalDOMWindow
         return { };
     ASSERT(frame->window());
 
-    RefPtr firstFrame = firstWindow.localFrame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame || !firstFrame->document())
         return { };
 
@@ -312,7 +312,7 @@ ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDO
     RefPtr frame = this->frame();
     ASSERT(frame);
 
-    RefPtr firstFrame = firstWindow.localFrame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame || !firstFrame->document())
         return { };
 

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -55,8 +55,8 @@ namespace WebCore {
 
 WebKitNamespace::WebKitNamespace(LocalDOMWindow& window, UserContentProvider& userContentProvider)
     : LocalDOMWindowProperty(&window)
-    , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*protect(window.localFrame()), userContentProvider))
-    , m_buffers(WebKitBufferNamespace::create(*protect(window.localFrame()), userContentProvider))
+    , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*protect(window.frame()), userContentProvider))
+    , m_buffers(WebKitBufferNamespace::create(*protect(window.frame()), userContentProvider))
 {
     ASSERT(window.frame());
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9827,7 +9827,7 @@ void WebPage::remotePostMessage(WebCore::FrameIdentifier source, const WebCore::
     if (!targetWindow)
         return;
 
-    RefPtr targetCoreFrame = targetWindow->localFrame();
+    RefPtr targetCoreFrame = targetWindow->frame();
     if (!targetCoreFrame)
         return;
 


### PR DESCRIPTION
#### f0c0ee8bf6ee1cff1f982b02c87d06ae4c30c9f5
<pre>
Update LocalDOMWindow::frame() to return a LocalFrame* instead of a Frame*
<a href="https://bugs.webkit.org/show_bug.cgi?id=308454">https://bugs.webkit.org/show_bug.cgi?id=308454</a>

Reviewed by Anne van Kesteren.

Update LocalDOMWindow::frame() to return a LocalFrame* instead of a Frame*
and drop LocalDOMWindow::localFrame().

* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::DialogHandler::dialogCreated):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::handleEvent):
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::viewIsCompositing):
(WebCore::KeyboardEvent::charCode const):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::frameViewFromWindowProxy):
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::frame const):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchAllPendingBeforeUnloadEvents):
(WebCore::LocalDOMWindow::allowPopUp):
(WebCore::LocalDOMWindow::willDetachDocumentFromFrame):
(WebCore::LocalDOMWindow::collectMatchingElementsInFlatTree):
(WebCore::LocalDOMWindow::matchingElementInFlatTree):
(WebCore::LocalDOMWindow::orientation const):
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
(WebCore::LocalDOMWindow::webkitNamespace):
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::focus):
(WebCore::LocalDOMWindow::blur):
(WebCore::LocalDOMWindow::print):
(WebCore::LocalDOMWindow::stop):
(WebCore::LocalDOMWindow::alert):
(WebCore::LocalDOMWindow::confirmForBindings):
(WebCore::LocalDOMWindow::prompt):
(WebCore::LocalDOMWindow::find const):
(WebCore::LocalDOMWindow::outerHeight const):
(WebCore::LocalDOMWindow::outerWidth const):
(WebCore::LocalDOMWindow::innerHeight const):
(WebCore::LocalDOMWindow::innerWidth const):
(WebCore::LocalDOMWindow::screenX const):
(WebCore::LocalDOMWindow::screenY const):
(WebCore::LocalDOMWindow::scrollX const):
(WebCore::LocalDOMWindow::scrollY const):
(WebCore::LocalDOMWindow::length const):
(WebCore::LocalDOMWindow::name const):
(WebCore::LocalDOMWindow::setName):
(WebCore::LocalDOMWindow::disownOpener):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
(WebCore::LocalDOMWindow::devicePixelRatio const):
(WebCore::LocalDOMWindow::scrollBy const):
(WebCore::LocalDOMWindow::scrollTo const):
(WebCore::LocalDOMWindow::allowedToChangeWindowGeometry const):
(WebCore::LocalDOMWindow::incrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::decrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::dispatchLoadEvent):
(WebCore::LocalDOMWindow::dispatchEvent):
(WebCore::LocalDOMWindow::finishedLoading):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::open):
(WebCore::LocalDOMWindow::showModalDialog):
(WebCore::LocalDOMWindow::frame const):
(WebCore::toScope):
(WebCore::LocalDOMWindow::localFrame const): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalDOMWindowProperty.cpp:
(WebCore::LocalDOMWindowProperty::frame const):
* Source/WebCore/page/Location.cpp:
(WebCore::Location::replace):
(WebCore::Location::setLocation):
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::WebKitNamespace):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::remotePostMessage):

Canonical link: <a href="https://commits.webkit.org/308036@main">https://commits.webkit.org/308036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/128381204bbf05e8296b9417f0790ecf648f8b93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154976 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2f27f55-3448-463d-ab50-430813f4f582) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f8ca078-61e7-4e5f-a1ee-bfe713ede174) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14946 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93461 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11969 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2422 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157297 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/468 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120621 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30973 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130919 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74588 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7963 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18424 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82176 "Found 2 new failures in page/LocalDOMWindowProperty.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->