### PR TITLE
Fix compiler warning in SequesteredImmortalHeap.h

### DIFF
--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -115,7 +115,8 @@ public:
         {
             Locker lock(m_lock);
             retval = allocateImpl(bytes);
-            newAllocHead = reinterpret_cast<void*>(m_allocHead);
+            if constexpr (verbose)
+                newAllocHead = reinterpret_cast<void*>(m_allocHead);
         }
         dataLogLnIf(verbose,
             "SequesteredImmortalAllocator at ", RawPointer(this),
@@ -132,7 +133,8 @@ public:
         {
             Locker lock(m_lock);
             retval = alignedAllocateImpl(alignment, bytes);
-            newAllocHead = reinterpret_cast<void*>(m_allocHead);
+            if constexpr (verbose)
+                newAllocHead = reinterpret_cast<void*>(m_allocHead);
         }
         dataLogLnIf(verbose,
             "SequesteredImmortalAllocator at ", RawPointer(this),


### PR DESCRIPTION
#### 00500122071e7033b1b93a9806c85b9b3cf2327b
<pre>
Fix compiler warning in SequesteredImmortalHeap.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=308455">https://bugs.webkit.org/show_bug.cgi?id=308455</a>

Reviewed by Darin Adler.

Fix `Value stored to &apos;newAllocHead&apos; is never read [deadcode.DeadStores]`
warnings in SequesteredImmortalHeap.h.

* Source/WTF/wtf/SequesteredImmortalHeap.h:
(WTF::SequesteredImmortalAllocator::allocate):
(WTF::SequesteredImmortalAllocator::alignedAllocate):

Canonical link: <a href="https://commits.webkit.org/308073@main">https://commits.webkit.org/308073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6104c1e5fa17db04319ed04730581d53a2b171bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99753 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7b9a9af-b4ba-4609-bb2c-676ffe908709) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112588 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80527 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a180924-e411-4aea-8b01-53733a9bceb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fe3420a-2566-4256-bee9-190ea96cf764) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11966 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2418 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138276 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157293 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7097 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/464 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120618 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30990 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16592 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7954 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177604 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82172 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45562 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->