### PR TITLE
Removed deprecated API usage (cache_simulate_memory_warning_event) https://bugs.webkit.org/show_bug.cgi?id=308439

### DIFF
--- a/Source/JavaScriptCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/JavaScriptCore/Configurations/AllowedSPI-legacy.toml
@@ -23,7 +23,6 @@ symbols = [
     "_dyld_get_dlopen_image_header",
     "_dyld_get_image_uuid",
     "_dyld_get_shared_cache_uuid",
-    "cache_simulate_memory_warning_event",
     "dyld_image_header_containing_address",
     "dyld_shared_cache_file_path",
     "xpc_connection_copy_entitlement_value",

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -36,17 +36,11 @@
 
 #define ENABLE_FMW_FOOTPRINT_COMPARISON 0
 
-extern "C" void cache_simulate_memory_warning_event(uint64_t);
-
 namespace WTF {
 
 void MemoryPressureHandler::platformReleaseMemory(Critical critical)
 {
-    if (critical == Critical::Yes && (!isUnderMemoryPressure() || m_isSimulatingMemoryPressure)) {
-        // libcache listens to OS memory notifications, but for process suspension
-        // or memory pressure simulation, we need to prod it manually:
-        cache_simulate_memory_warning_event(DISPATCH_MEMORYPRESSURE_CRITICAL);
-    }
+    UNUSED_PARAM(critical);
 }
 
 static OSObjectPtr<dispatch_source_t>& NODELETE memoryPressureEventSource()


### PR DESCRIPTION
#### 35d7ede6b4caefc956ce60d583ebfcd26f7c5886
<pre>
Removed deprecated API usage (cache_simulate_memory_warning_event) <a href="https://bugs.webkit.org/show_bug.cgi?id=308439">https://bugs.webkit.org/show_bug.cgi?id=308439</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d7ede6b4caefc956ce60d583ebfcd26f7c5886

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154973 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99754 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112590 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99754 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14212 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11967 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2419 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138277 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157294 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7098 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120617 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120915 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130901 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74586 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7955 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177605 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82173 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45563 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->