### PR TITLE
Ignore non-trusted events in <select> and <option>'s default handlers

### DIFF
--- a/LayoutTests/fast/dom/HTMLSelectElement/remove-element-from-within-focus-handler-crash.html
+++ b/LayoutTests/fast/dom/HTMLSelectElement/remove-element-from-within-focus-handler-crash.html
@@ -3,12 +3,15 @@
 </select>
 <h2>Layout test for <a href='https://bugs.webkit.org/show_bug.cgi?id=23858'>bug 23858</a></h2>
 <p>If this page is displayed without crashing then the test has passed.</p>
+<script src="../../../resources/ui-helper.js"></script>
 <script>
-    if (window.testRunner)
+    if (window.testRunner) {
         testRunner.dumpAsText();
-
-    var select = document.getElementById('bomb');
-    var mouseEvent = document.createEvent("MouseEvents");
-    mouseEvent.initMouseEvent("mousedown", true, true, document.defaultView, 1, select.offsetLeft + 1, select.offsetTop + 1, select.offsetLeft + 1, select.offsetTop + 1, false, false, false, false, 0, document);
-    select.dispatchEvent(mouseEvent);
+        testRunner.waitUntilDone();
+        (async () => {
+            var select = document.getElementById('bomb');
+            await UIHelper.activateElement(select);
+            testRunner.notifyDone();
+        })();
+    }
 </script>

--- a/LayoutTests/fast/forms/select-change-size-during-focus.html
+++ b/LayoutTests/fast/forms/select-change-size-during-focus.html
@@ -1,7 +1,8 @@
 <html>
     <head>
+        <script src="../../resources/ui-helper.js"></script>
         <script>
-            function setup() {
+            async function setup() {
                 if (window.testRunner) {
                     window.testRunner.dumpAsText();
                     window.testRunner.waitUntilDone();
@@ -18,9 +19,7 @@
                     }, 0);
                 });
 
-                ev = document.createEvent("MouseEvent");
-                ev.initMouseEvent("mousedown", true, true, window, 0, 0, 0, 20, 20, false, false, false, false, 0, null);
-                s.dispatchEvent(ev);
+                await UIHelper.activateElement(s);
             }
         </script>
     </head>

--- a/LayoutTests/fast/forms/select-list-box-mouse-focus.html
+++ b/LayoutTests/fast/forms/select-list-box-mouse-focus.html
@@ -1,14 +1,15 @@
+<script src="../../resources/ui-helper.js"></script>
 <script>
-function test()
+async function test()
 {
-    if (window.testRunner)
+    if (window.testRunner) {
         testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
     var select = document.getElementById("select");
-    var x = select.clientLeft + 10;
-    var y = select.clientTop + 10;
-    var event = document.createEvent("MouseEvent");
-    event.initMouseEvent("mousedown", true, true, document.defaultView, 1, x, y, x, y, false, false, false, false, 0, document);
-    select.dispatchEvent(event);
+    await UIHelper.activateElement(select);
+    if (window.testRunner)
+        testRunner.notifyDone();
 }
 function reportFocus()
 {

--- a/LayoutTests/fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur-expected.txt
+++ b/LayoutTests/fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur-expected.txt
@@ -2,6 +2,7 @@ This tests re-opening the select element popup after closing it by bluring the f
 To manually test, after the popup which opened as this test is dismissed (click elsewhere to dismiss it if not). Clicking on the select element should then open the popup menu.
 
 
+PASS - popup opened
 PASS - popup closed by blur
 PASS - popup opened after closed by blur
 

--- a/LayoutTests/fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur.html
@@ -10,6 +10,7 @@ Clicking on the select element should then open the popup menu.</p>
   <option>You should see this</option>
 </select>
 <pre id="result"></pre>
+<script src="../../../../resources/ui-helper.js"></script>
 <script>
 
 const select = document.querySelector('select');
@@ -30,32 +31,23 @@ function log(text) {
     document.getElementById('result').textContent += text + '\n';
 }
 
-function clickOnSelectElement() {
-    const event = document.createEvent("MouseEvent");
-    event.initMouseEvent("mousedown", true, true, document.defaultView, 1, select.offsetLeft + 5, select.offsetTop + 5, select.offsetLeft + 5, select.offsetTop + 5, false, false, false, false, 0, document);
-    select.dispatchEvent(event);
-}
-
-function roundTripToUIProcess() {
-    return new Promise((resolve) => {
-        testRunner.runUIScript(`uiController.uiScriptComplete()`, resolve);
-    });
+async function openSelectPopup() {
+    await UIHelper.activateElement(select);
 }
 
 window.onload = async () => {
-    clickOnSelectElement();
-
     if (!window.testRunner)
         return;
 
-    await roundTripToUIProcess();
+    await openSelectPopup();
+    log(internals.isSelectPopupVisible(select) ? 'PASS - popup opened' : 'FAIL - popup failed to open');
+
     document.querySelector('p').focus();
     log(internals.isSelectPopupVisible(select) ? 'FAIL - popup was open after moving the focus' : 'PASS - popup closed by blur');
 
-    clickOnSelectElement();
+    await openSelectPopup();
     log(internals.isSelectPopupVisible(select) ? 'PASS - popup opened after closed by blur' : 'FAIL - popup failed to open for the second time');
 
-    await roundTripToUIProcess();
     document.querySelector('p').focus();
 
     testRunner.notifyDone();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt
@@ -2,6 +2,6 @@
 one
 two
 
-FAIL defaultbutton: Synthetic events should not trigger behaviors of select element. assert_true: Synthetic mouse/pointer events should not close the picker. expected true got false
-FAIL custombutton: Synthetic events should not trigger behaviors of select element. assert_false: Synthetic mouse/pointer events should not open the picker. expected false got true
+PASS defaultbutton: Synthetic events should not trigger behaviors of select element.
+PASS custombutton: Synthetic events should not trigger behaviors of select element.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
@@ -1,12 +1,13 @@
 light dismiss
-custom button button fallback button
+custom button button
+ fallback button
 
-FAIL fallbackbutton: Select with appearance:base-select should open and close when clicking the button. assert_true: Select should be open after clicking the button. expected true got false
-FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_true: Select should be open after clicking the button. expected true got false
-PASS fallbackbutton: Clicking the label should focus the select button without opening the picker.
+PASS fallbackbutton: Select with appearance:base-select should open and close when clicking the button.
+FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed after clicking an option. expected false got true
+FAIL fallbackbutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
 FAIL fallbackbutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
 PASS custombutton: Select with appearance:base-select should open and close when clicking the button.
-FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_true: Select should be open after clicking the button. expected true got false
-PASS custombutton: Clicking the label should focus the select button without opening the picker.
+FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed after clicking an option. expected false got true
+FAIL custombutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
 FAIL custombutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -272,6 +272,9 @@ bool HTMLOptionElement::accessKeyAction(bool)
 
 void HTMLOptionElement::defaultEventHandler(Event& event)
 {
+    if (!event.isTrusted())
+        return HTMLElement::defaultEventHandler(event);
+
     RefPtr select = ownerSelectElement();
     if (!select || !select->document().settings().htmlEnhancedSelectEnabled() || !select->usesBaseAppearancePicker())
         return HTMLElement::defaultEventHandler(event);

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1434,6 +1434,9 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
     ASSERT(renderer());
     ASSERT(usesMenuList());
 
+    if (!event.isTrusted())
+        return;
+
     auto& eventNames = WebCore::eventNames();
 
     bool isBaseSelectPicker = usesBaseAppearancePicker();


### PR DESCRIPTION
#### ffdc7b0034b3dd9edcd4f6902ff3c14e09931514
<pre>
Ignore non-trusted events in &lt;select&gt; and &lt;option&gt;&apos;s default handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=308457">https://bugs.webkit.org/show_bug.cgi?id=308457</a>
<a href="https://rdar.apple.com/171404071">rdar://171404071</a>

Reviewed by Ryosuke Niwa.

The appearance: auto control already ignores these events, but at a
deeper level. For appearance: base we also need to ignore them at the
element-level. For now we only ignore them for menu lists as
historically synthetic events have worked for list boxes and we&apos;re not
sure whether that should change.

This updates several tests to use end user events instead.

Canonical link: <a href="https://commits.webkit.org/309194@main">https://commits.webkit.org/309194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3114961983dd069fdd11cbc8ee77b7cc99c6b5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe0d04c4-c090-4040-9ef6-f9df2bb98390) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115463 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82082 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96206 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05ee290a-3b74-448f-8672-e015e5fc7f29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14605 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6234 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160868 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123497 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78439 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23051 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10812 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85635 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21697 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->