### PR TITLE
Reduce use of protected functions in Source/WebCore/platform

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -629,7 +629,6 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    using PlatformMediaSessionClient::protectedLogger;
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     ASCIILiteral logClassName() const final { return "HTMLMediaElement"_s; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -644,7 +644,7 @@ void MediaSessionManagerInterface::processSystemDidWake()
 void MediaSessionManagerInterface::addSession(PlatformMediaSessionInterface& session)
 {
 #if !RELEASE_LOG_DISABLED && (ENABLE(VIDEO) || ENABLE(WEB_AUDIO))
-    m_logger->addLogger(session.protectedLogger());
+    m_logger->addLogger(protect(session.logger()));
     MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(ADDSESSION, session.logIdentifier());
 #endif
 
@@ -668,7 +668,7 @@ void MediaSessionManagerInterface::removeSession(PlatformMediaSessionInterface& 
         maybeDeactivateAudioSession();
 
 #if !RELEASE_LOG_DISABLED && (ENABLE(VIDEO) || ENABLE(WEB_AUDIO))
-    m_logger->removeLogger(session.protectedLogger());
+    m_logger->removeLogger(protect(session.logger()));
 #endif
 
     scheduleUpdateSessionState();

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -109,7 +109,6 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
-    Ref<const Logger> protectedLogger() const { return logger(); }
     virtual uint64_t logIdentifier() const = 0;
 #endif
 
@@ -249,7 +248,6 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
-    Ref<const Logger> protectedLogger() const { return logger(); }
     virtual uint64_t logIdentifier() const = 0;
     virtual ASCIILiteral logClassName() const = 0;
     virtual WTFLogChannel& logChannel() const = 0;

--- a/Source/WebCore/platform/audio/SharedAudioDestination.h
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.h
@@ -61,7 +61,6 @@ private:
 
     void setIsPlaying(bool);
 
-    Ref<SharedAudioDestinationAdapter> protectedOutputAdapter() const;
 
     Lock m_dispatchToRenderThreadLock;
     Function<void(Function<void()>&&)> m_dispatchToRenderThread WTF_GUARDED_BY_LOCK(m_dispatchToRenderThreadLock);

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -79,7 +79,6 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
-    Ref<const Logger> protectedLogger() const { return m_logger; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     void setLogger(Ref<const Logger>&&, uint64_t);
 #endif

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -77,7 +77,6 @@ class WEBCORE_EXPORT MediaSessionHelper
 {
 public:
     static MediaSessionHelper& sharedHelper();
-    static Ref<MediaSessionHelper> protectedSharedHelper();
     static void setSharedHelper(Ref<MediaSessionHelper>&&);
     static void resetSharedHelper();
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -139,10 +139,6 @@ MediaSessionHelper& MediaSessionHelper::sharedHelper()
     return *helper;
 }
 
-Ref<MediaSessionHelper> MediaSessionHelper::protectedSharedHelper()
-{
-    return sharedHelper();
-}
 
 void MediaSessionHelper::resetSharedHelper()
 {

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -68,7 +68,7 @@ private:
     bool enabled() const;
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    Ref<ParentalControlsURLFilter> protectedImpl() const;
+    Ref<ParentalControlsURLFilter> urlFilter() const;
     void updateFilterStateOnMain();
 #elif HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
     void updateFilterState();

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -54,7 +54,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ParentalControlsContentFilter);
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
-Ref<ParentalControlsURLFilter> ParentalControlsContentFilter::protectedImpl() const
+Ref<ParentalControlsURLFilter> ParentalControlsContentFilter::urlFilter() const
 {
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     return ParentalControlsURLFilter::filterWithConfigurationPath(m_webContentRestrictionsConfigurationPath);
@@ -68,7 +68,7 @@ Ref<ParentalControlsURLFilter> ParentalControlsContentFilter::protectedImpl() co
 bool ParentalControlsContentFilter::enabled() const
 {
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    return protectedImpl()->isEnabled();
+    return urlFilter()->isEnabled();
 #elif HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
     return [getWebFilterEvaluatorClassSingleton() isManagedSession];
 #else
@@ -113,7 +113,7 @@ void ParentalControlsContentFilter::responseReceived(const ResourceResponse& res
     ASSERT(!m_evaluatedURL);
     m_evaluatedURL = response.url();
     m_state = State::Filtering;
-    protectedImpl()->isURLAllowed(m_mainDocumentURL, *m_evaluatedURL, *this);
+    urlFilter()->isURLAllowed(m_mainDocumentURL, *m_evaluatedURL, *this);
 #elif HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
     ASSERT(!m_webFilterEvaluator);
     m_webFilterEvaluator = adoptNS([allocWebFilterEvaluatorInstance() initWithResponse:response.protectedNSURLResponse().get()]);

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -153,11 +153,6 @@ public:
         return const_cast<Font*>(this);
     }
 
-    RefPtr<const Font> protectedVariantFont(const FontDescription& description, FontVariant variant) const
-    {
-        return variantFont(description, variant);
-    }
-
     bool variantCapsSupportedForSynthesis(FontVariantCaps) const;
 
     const Font& verticalRightOrientationFont() const;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1600,7 +1600,7 @@ inline static float offsetToMiddleOfGlyph(const Font& fontData, Glyph glyph)
 
 inline static float offsetToMiddleOfGlyphAtIndex(const GlyphBuffer& glyphBuffer, unsigned i)
 {
-    return offsetToMiddleOfGlyph(glyphBuffer.protectedFontAt(i), glyphBuffer.glyphAt(i));
+    return offsetToMiddleOfGlyph(protect(glyphBuffer.fontAt(i)), glyphBuffer.glyphAt(i));
 }
 
 void FontCascade::drawEmphasisMarks(GraphicsContext& context, const GlyphBuffer& glyphBuffer, const AtomString& mark, const FloatPoint& point) const

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -385,7 +385,7 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(char32_t character, const
     if (variant == NormalVariant)
         fallbackGlyphData = systemFallbackFont->glyphDataForCharacter(character);
     else
-        fallbackGlyphData = systemFallbackFont->protectedVariantFont(description, variant)->glyphDataForCharacter(character);
+        fallbackGlyphData = protect(systemFallbackFont->variantFont(description, variant))->glyphDataForCharacter(character);
 
     if (fallbackGlyphData.font && fallbackGlyphData.font->platformData().orientation() == FontOrientation::Vertical && !fallbackGlyphData.font->isTextOrientationFallback()) {
         if (variant == NormalVariant && !FontCascade::isCJKIdeographOrSymbol(character))

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -78,7 +78,6 @@ public:
         return *m_fonts[index];
     }
 
-    Ref<const Font> protectedFontAt(size_t index) const { return fontAt(index); }
 
     GlyphBufferGlyph glyphAt(size_t index) const { return m_glyphs[index]; }
     GlyphBufferAdvance& advanceAt(size_t index) LIFETIME_BOUND { return m_advances[index]; }

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -51,7 +51,6 @@ struct GlyphData {
     }
 
     bool isValid() const { return !!font; }
-    RefPtr<const Font> protectedFont() const { return font.get(); }
 
     Glyph glyph;
     ColorGlyphType colorGlyphType;

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
@@ -60,8 +60,6 @@ public:
 private:
     ImageFrameWorkQueue(BitmapImageSource&);
 
-    Ref<BitmapImageSource> protectedSource() const { return m_source.get().releaseNonNull(); }
-
     static const int BufferSize = 8;
     using RequestQueue = SynchronizedFixedQueue<Request, BufferSize>;
     using DecodeQueue = Deque<Request, BufferSize>;
@@ -71,7 +69,7 @@ private:
 
     Seconds minimumDecodingDurationForTesting() const { return m_minimumDecodingDurationForTesting; }
 
-    ThreadSafeWeakPtr<BitmapImageSource> m_source;
+    ThreadSafeWeakRef<BitmapImageSource> m_source;
 
     RefPtr<RequestQueue> m_requestQueue;
     DecodeQueue m_decodeQueue;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -424,10 +424,6 @@ MediaPlayerPrivateInterface* MediaPlayer::playerPrivate()
     return m_private.get();
 }
 
-RefPtr<MediaPlayerPrivateInterface> MediaPlayer::protectedPlayerPrivate()
-{
-    return m_private.get();
-}
 
 const MediaPlayerFactory* MediaPlayer::mediaEngine(MediaPlayerEnums::MediaEngineIdentifier identifier)
 {
@@ -745,18 +741,18 @@ void MediaPlayer::queueTaskOnEventLoop(Function<void()>&& task)
 
 bool MediaPlayer::hasAvailableVideoFrame() const
 {
-    return protectedPrivate()->hasAvailableVideoFrame();
+    return protect(m_private)->hasAvailableVideoFrame();
 }
 
 void MediaPlayer::prepareForRendering()
 {
     m_shouldPrepareToRender = true;
-    protectedPrivate()->prepareForRendering();
+    protect(m_private)->prepareForRendering();
 }
 
 void MediaPlayer::cancelLoad()
 {
-    protectedPrivate()->cancelLoad();
+    protect(m_private)->cancelLoad();
 }    
 
 void MediaPlayer::prepareToPlay()
@@ -764,44 +760,44 @@ void MediaPlayer::prepareToPlay()
     Ref<MediaPlayer> protectedThis(*this);
 
     m_shouldPrepareToPlay = true;
-    protectedPrivate()->prepareToPlay();
+    protect(m_private)->prepareToPlay();
 }
 
 void MediaPlayer::play()
 {
-    protectedPrivate()->play();
+    protect(m_private)->play();
 }
 
 void MediaPlayer::pause()
 {
-    protectedPrivate()->pause();
+    protect(m_private)->pause();
 }
 
 void MediaPlayer::setBufferingPolicy(BufferingPolicy policy)
 {
-    protectedPrivate()->setBufferingPolicy(policy);
+    protect(m_private)->setBufferingPolicy(policy);
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 RefPtr<LegacyCDMSession> MediaPlayer::createSession(const String& keySystem, LegacyCDMSessionClient& client)
 {
-    return protectedPrivate()->createSession(keySystem, client);
+    return protect(m_private)->createSession(keySystem, client);
 }
 
 void MediaPlayer::setCDM(LegacyCDM* cdm)
 {
-    protectedPrivate()->setCDM(cdm);
+    protect(m_private)->setCDM(cdm);
 }
 
 void MediaPlayer::setCDMSession(LegacyCDMSession* session)
 {
-    protectedPrivate()->setCDMSession(session);
+    protect(m_private)->setCDMSession(session);
 }
 
 void MediaPlayer::keyAdded()
 {
-    protectedPrivate()->keyAdded();
+    protect(m_private)->keyAdded();
 }
 
 #endif
@@ -810,17 +806,17 @@ void MediaPlayer::keyAdded()
 
 void MediaPlayer::cdmInstanceAttached(CDMInstance& instance)
 {
-    protectedPrivate()->cdmInstanceAttached(instance);
+    protect(m_private)->cdmInstanceAttached(instance);
 }
 
 void MediaPlayer::cdmInstanceDetached(CDMInstance& instance)
 {
-    protectedPrivate()->cdmInstanceDetached(instance);
+    protect(m_private)->cdmInstanceDetached(instance);
 }
 
 void MediaPlayer::attemptToDecryptWithInstance(CDMInstance& instance)
 {
-    protectedPrivate()->attemptToDecryptWithInstance(instance);
+    protect(m_private)->attemptToDecryptWithInstance(instance);
 }
 
 #endif
@@ -829,48 +825,48 @@ void MediaPlayer::attemptToDecryptWithInstance(CDMInstance& instance)
 void MediaPlayer::setShouldContinueAfterKeyNeeded(bool should)
 {
     m_shouldContinueAfterKeyNeeded = should;
-    protectedPrivate()->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
+    protect(m_private)->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
 }
 #endif
 
 MediaTime MediaPlayer::duration() const
 {
-    return protectedPrivate()->duration();
+    return protect(m_private)->duration();
 }
 
 MediaTime MediaPlayer::startTime() const
 {
-    return protectedPrivate()->startTime();
+    return protect(m_private)->startTime();
 }
 
 MediaTime MediaPlayer::initialTime() const
 {
-    return protectedPrivate()->initialTime();
+    return protect(m_private)->initialTime();
 }
 
 MediaTime MediaPlayer::currentTime() const
 {
-    return protectedPrivate()->currentTime();
+    return protect(m_private)->currentTime();
 }
 
 bool MediaPlayer::timeIsProgressing() const
 {
-    return protectedPrivate()->timeIsProgressing();
+    return protect(m_private)->timeIsProgressing();
 }
 
 bool MediaPlayer::setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&& callback)
 {
-    return protectedPrivate()->setCurrentTimeDidChangeCallback(WTF::move(callback));
+    return protect(m_private)->setCurrentTimeDidChangeCallback(WTF::move(callback));
 }
 
 MediaTime MediaPlayer::getStartDate() const
 {
-    return protectedPrivate()->getStartDate();
+    return protect(m_private)->getStartDate();
 }
 
 void MediaPlayer::willSeekToTarget(const MediaTime& time)
 {
-    protectedPrivate()->willSeekToTarget(time);
+    protect(m_private)->willSeekToTarget(time);
 }
 
 void MediaPlayer::seekToTarget(const SeekTarget& target)
@@ -887,7 +883,7 @@ void MediaPlayer::seekToTime(const MediaTime& time)
 
 void MediaPlayer::seekWhenPossible(const MediaTime& time)
 {
-    if (protectedPrivate()->readyState() < MediaPlayer::ReadyState::HaveMetadata)
+    if (protect(m_private)->readyState() < MediaPlayer::ReadyState::HaveMetadata)
         m_pendingSeekRequest = time;
     else
         seekToTime(time);
@@ -900,89 +896,89 @@ void MediaPlayer::seeked(const MediaTime& time)
 
 bool MediaPlayer::paused() const
 {
-    return protectedPrivate()->paused();
+    return protect(m_private)->paused();
 }
 
 bool MediaPlayer::seeking() const
 {
-    return protectedPrivate()->seeking();
+    return protect(m_private)->seeking();
 }
 
 bool MediaPlayer::supportsFullscreen() const
 {
-    return protectedPrivate()->supportsFullscreen();
+    return protect(m_private)->supportsFullscreen();
 }
 
 bool MediaPlayer::canSaveMediaData() const
 {
-    return protectedPrivate()->canSaveMediaData();
+    return protect(m_private)->canSaveMediaData();
 }
 
 bool MediaPlayer::supportsScanning() const
 {
-    return protectedPrivate()->supportsScanning();
+    return protect(m_private)->supportsScanning();
 }
 
 bool MediaPlayer::supportsProgressMonitoring() const
 {
-    return protectedPrivate()->supportsProgressMonitoring();
+    return protect(m_private)->supportsProgressMonitoring();
 }
 
 bool MediaPlayer::requiresImmediateCompositing() const
 {
-    return protectedPrivate()->requiresImmediateCompositing();
+    return protect(m_private)->requiresImmediateCompositing();
 }
 
 FloatSize MediaPlayer::naturalSize()
 {
-    return protectedPrivate()->naturalSize();
+    return protect(m_private)->naturalSize();
 }
 
 bool MediaPlayer::hasVideo() const
 {
-    return protectedPrivate()->hasVideo();
+    return protect(m_private)->hasVideo();
 }
 
 bool MediaPlayer::hasAudio() const
 {
-    return protectedPrivate()->hasAudio();
+    return protect(m_private)->hasAudio();
 }
 
 PlatformLayer* MediaPlayer::platformLayer() const
 {
-    return protectedPrivate()->platformLayer();
+    return protect(m_private)->platformLayer();
 }
     
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
 RetainPtr<PlatformLayer> MediaPlayer::createVideoFullscreenLayer()
 {
-    return protectedPrivate()->createVideoFullscreenLayer();
+    return protect(m_private)->createVideoFullscreenLayer();
 }
 
 void MediaPlayer::setVideoFullscreenLayer(PlatformLayer* layer, Function<void()>&& completionHandler)
 {
-    protectedPrivate()->setVideoFullscreenLayer(layer, WTF::move(completionHandler));
+    protect(m_private)->setVideoFullscreenLayer(layer, WTF::move(completionHandler));
 }
 
 void MediaPlayer::updateVideoFullscreenInlineImage()
 {
-    protectedPrivate()->updateVideoFullscreenInlineImage();
+    protect(m_private)->updateVideoFullscreenInlineImage();
 }
 
 void MediaPlayer::setVideoFullscreenFrame(const FloatRect& frame)
 {
-    protectedPrivate()->setVideoFullscreenFrame(frame);
+    protect(m_private)->setVideoFullscreenFrame(frame);
 }
 
 void MediaPlayer::setVideoFullscreenGravity(MediaPlayer::VideoGravity gravity)
 {
-    protectedPrivate()->setVideoFullscreenGravity(gravity);
+    protect(m_private)->setVideoFullscreenGravity(gravity);
 }
 
 void MediaPlayer::setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode mode)
 {
-    protectedPrivate()->setVideoFullscreenMode(mode);
+    protect(m_private)->setVideoFullscreenMode(mode);
 }
 
 MediaPlayer::VideoFullscreenMode MediaPlayer::fullscreenMode() const
@@ -992,7 +988,7 @@ MediaPlayer::VideoFullscreenMode MediaPlayer::fullscreenMode() const
 
 void MediaPlayer::videoFullscreenStandbyChanged()
 {
-    protectedPrivate()->videoFullscreenStandbyChanged();
+    protect(m_private)->videoFullscreenStandbyChanged();
 }
 
 bool MediaPlayer::isVideoFullscreenStandby() const
@@ -1018,7 +1014,7 @@ void MediaPlayer::setSceneIdentifier(const String& identifier)
     if (m_sceneIdentifier == identifier)
         return;
     m_sceneIdentifier = identifier;
-    protectedPrivate()->sceneIdentifierDidChange();
+    protect(m_private)->sceneIdentifierDidChange();
 }
 #endif
 
@@ -1029,41 +1025,41 @@ void MediaPlayer::videoLayerSizeDidChange(const FloatSize& size)
 
 void MediaPlayer::setVideoLayerSizeFenced(const FloatSize& size, WTF::MachSendRightAnnotated&& fence)
 {
-    protectedPrivate()->setVideoLayerSizeFenced(size, WTF::move(fence));
+    protect(m_private)->setVideoLayerSizeFenced(size, WTF::move(fence));
 }
 
 #if PLATFORM(IOS_FAMILY)
 
 NSArray* MediaPlayer::timedMetadata() const
 {
-    return protectedPrivate()->timedMetadata();
+    return protect(m_private)->timedMetadata();
 }
 
 String MediaPlayer::accessLog() const
 {
-    return protectedPrivate()->accessLog();
+    return protect(m_private)->accessLog();
 }
 
 String MediaPlayer::errorLog() const
 {
-    return protectedPrivate()->errorLog();
+    return protect(m_private)->errorLog();
 }
 
 #endif
 
 MediaPlayer::NetworkState MediaPlayer::networkState()
 {
-    return protectedPrivate()->networkState();
+    return protect(m_private)->networkState();
 }
 
 MediaPlayer::ReadyState MediaPlayer::readyState() const
 {
-    return protectedPrivate()->readyState();
+    return protect(m_private)->readyState();
 }
 
 void MediaPlayer::setVolumeLocked(bool volumeLocked)
 {
-    protectedPrivate()->setVolumeLocked(volumeLocked);
+    protect(m_private)->setVolumeLocked(volumeLocked);
 }
 
 double MediaPlayer::volume() const
@@ -1074,7 +1070,7 @@ double MediaPlayer::volume() const
 void MediaPlayer::setVolume(double volume)
 {
     m_volume = volume;
-    protectedPrivate()->setVolumeDouble(volume);
+    protect(m_private)->setVolumeDouble(volume);
 }
 
 bool MediaPlayer::muted() const
@@ -1086,32 +1082,32 @@ void MediaPlayer::setMuted(bool muted)
 {
     m_muted = muted;
 
-    protectedPrivate()->setMuted(muted);
+    protect(m_private)->setMuted(muted);
 }
 
 bool MediaPlayer::hasClosedCaptions() const
 {
-    return protectedPrivate()->hasClosedCaptions();
+    return protect(m_private)->hasClosedCaptions();
 }
 
 void MediaPlayer::setClosedCaptionsVisible(bool closedCaptionsVisible)
 {
-    protectedPrivate()->setClosedCaptionsVisible(closedCaptionsVisible);
+    protect(m_private)->setClosedCaptionsVisible(closedCaptionsVisible);
 }
 
 double MediaPlayer::rate() const
 {
-    return protectedPrivate()->rate();
+    return protect(m_private)->rate();
 }
 
 void MediaPlayer::setRate(double rate)
 {
-    protectedPrivate()->setRateDouble(rate);
+    protect(m_private)->setRateDouble(rate);
 }
 
 double MediaPlayer::effectiveRate() const
 {
-    return protectedPrivate()->effectiveRate();
+    return protect(m_private)->effectiveRate();
 }
 
 double MediaPlayer::requestedRate() const
@@ -1127,7 +1123,7 @@ bool MediaPlayer::preservesPitch() const
 void MediaPlayer::setPreservesPitch(bool preservesPitch)
 {
     m_preservesPitch = preservesPitch;
-    protectedPrivate()->setPreservesPitch(preservesPitch);
+    protect(m_private)->setPreservesPitch(preservesPitch);
 }
 
 void MediaPlayer::setPitchCorrectionAlgorithm(PitchCorrectionAlgorithm pitchCorrectionAlgorithm)
@@ -1136,37 +1132,33 @@ void MediaPlayer::setPitchCorrectionAlgorithm(PitchCorrectionAlgorithm pitchCorr
         return;
 
     m_pitchCorrectionAlgorithm = pitchCorrectionAlgorithm;
-    protectedPrivate()->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
+    protect(m_private)->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
 }
 
-RefPtr<MediaPlayerPrivateInterface> MediaPlayer::protectedPrivate() const
-{
-    return m_private;
-}
 
 const PlatformTimeRanges& MediaPlayer::buffered() const
 {
-    return protectedPrivate()->buffered();
+    return protect(m_private)->buffered();
 }
 
 const PlatformTimeRanges& MediaPlayer::seekable() const
 {
-    return protectedPrivate()->seekable();
+    return protect(m_private)->seekable();
 }
 
 MediaTime MediaPlayer::maxTimeSeekable() const
 {
-    return protectedPrivate()->maxTimeSeekable();
+    return protect(m_private)->maxTimeSeekable();
 }
 
 MediaTime MediaPlayer::minTimeSeekable() const
 {
-    return protectedPrivate()->minTimeSeekable();
+    return protect(m_private)->minTimeSeekable();
 }
 
 double MediaPlayer::seekableTimeRangesLastModifiedTime()
 {
-    return protectedPrivate()->seekableTimeRangesLastModifiedTime();
+    return protect(m_private)->seekableTimeRangesLastModifiedTime();
 }
 
 void MediaPlayer::bufferedTimeRangesChanged()
@@ -1181,12 +1173,12 @@ void MediaPlayer::seekableTimeRangesChanged()
 
 double MediaPlayer::liveUpdateInterval()
 {
-    return protectedPrivate()->liveUpdateInterval();
+    return protect(m_private)->liveUpdateInterval();
 }
 
 void MediaPlayer::didLoadingProgress(DidLoadingProgressCompletionHandler&& callback) const
 {
-    protectedPrivate()->didLoadingProgressAsync(WTF::move(callback));
+    protect(m_private)->didLoadingProgressAsync(WTF::move(callback));
 }
 
 void MediaPlayer::setPresentationSize(const IntSize& size)
@@ -1195,13 +1187,13 @@ void MediaPlayer::setPresentationSize(const IntSize& size)
         return;
 
     m_presentationSize = size;
-    protectedPrivate()->setPresentationSize(size);
+    protect(m_private)->setPresentationSize(size);
 }
 
 void MediaPlayer::setPageIsVisible(bool visible)
 {
     m_pageIsVisible = visible;
-    protectedPrivate()->setPageIsVisible(visible);
+    protect(m_private)->setPageIsVisible(visible);
 }
 
 void MediaPlayer::setVisibleForCanvas(bool visible)
@@ -1210,7 +1202,7 @@ void MediaPlayer::setVisibleForCanvas(bool visible)
         return;
 
     m_visibleForCanvas = visible;
-    protectedPrivate()->setVisibleForCanvas(visible);
+    protect(m_private)->setVisibleForCanvas(visible);
 }
 
 void MediaPlayer::setVisibleInViewport(bool visible)
@@ -1219,13 +1211,13 @@ void MediaPlayer::setVisibleInViewport(bool visible)
         return;
 
     m_visibleInViewport = visible;
-    protectedPrivate()->setVisibleInViewport(visible);
+    protect(m_private)->setVisibleInViewport(visible);
 }
 
 void MediaPlayer::setResourceOwner(const ProcessIdentity& processIdentity)
 {
     m_processIdentity = processIdentity;
-    protectedPrivate()->setResourceOwner(processIdentity);
+    protect(m_private)->setResourceOwner(processIdentity);
 }
 
 MediaPlayer::Preload MediaPlayer::preload() const
@@ -1236,47 +1228,47 @@ MediaPlayer::Preload MediaPlayer::preload() const
 void MediaPlayer::setPreload(MediaPlayer::Preload preload)
 {
     m_preload = preload;
-    protectedPrivate()->setPreload(preload);
+    protect(m_private)->setPreload(preload);
 }
 
 void MediaPlayer::paint(GraphicsContext& context, const FloatRect& destination)
 {
-    protectedPrivate()->paint(context, destination);
+    protect(m_private)->paint(context, destination);
 }
 
 void MediaPlayer::paintCurrentFrameInContext(GraphicsContext& context, const FloatRect& destination)
 {
-    protectedPrivate()->paintCurrentFrameInContext(context, destination);
+    protect(m_private)->paintCurrentFrameInContext(context, destination);
 }
 
 RefPtr<VideoFrame> MediaPlayer::videoFrameForCurrentTime()
 {
-    return protectedPrivate()->videoFrameForCurrentTime();
+    return protect(m_private)->videoFrameForCurrentTime();
 }
 
 RefPtr<NativeImage> MediaPlayer::nativeImageForCurrentTime()
 {
-    return protectedPrivate()->nativeImageForCurrentTime();
+    return protect(m_private)->nativeImageForCurrentTime();
 }
 
 RefPtr<ShareableBitmap> MediaPlayer::bitmapImageForCurrentTimeSync()
 {
-    return protectedPrivate()->bitmapImageForCurrentTimeSync();
+    return protect(m_private)->bitmapImageForCurrentTimeSync();
 }
 
 Ref<MediaPlayer::BitmapImagePromise> MediaPlayer::bitmapImageForCurrentTime()
 {
-    return protectedPrivate()->bitmapImageForCurrentTime();
+    return protect(m_private)->bitmapImageForCurrentTime();
 }
 
 DestinationColorSpace MediaPlayer::colorSpace()
 {
-    return protectedPrivate()->colorSpace();
+    return protect(m_private)->colorSpace();
 }
 
 bool MediaPlayer::shouldGetNativeImageForCanvasDrawing() const
 {
-    return protectedPrivate()->shouldGetNativeImageForCanvasDrawing();
+    return protect(m_private)->shouldGetNativeImageForCanvasDrawing();
 }
 
 MediaPlayer::SupportsType MediaPlayer::supportsType(const MediaEngineSupportParameters& parameters)
@@ -1317,34 +1309,34 @@ bool MediaPlayer::isAvailable()
 
 bool MediaPlayer::supportsPictureInPicture() const
 {
-    return protectedPrivate()->supportsPictureInPicture();
+    return protect(m_private)->supportsPictureInPicture();
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 bool MediaPlayer::isCurrentPlaybackTargetWireless() const
 {
-    return protectedPrivate()->isCurrentPlaybackTargetWireless();
+    return protect(m_private)->isCurrentPlaybackTargetWireless();
 }
 
 String MediaPlayer::wirelessPlaybackTargetName() const
 {
-    return protectedPrivate()->wirelessPlaybackTargetName();
+    return protect(m_private)->wirelessPlaybackTargetName();
 }
 
 MediaPlayer::WirelessPlaybackTargetType MediaPlayer::wirelessPlaybackTargetType() const
 {
-    return protectedPrivate()->wirelessPlaybackTargetType();
+    return protect(m_private)->wirelessPlaybackTargetType();
 }
 
 bool MediaPlayer::wirelessVideoPlaybackDisabled() const
 {
-    return protectedPrivate()->wirelessVideoPlaybackDisabled();
+    return protect(m_private)->wirelessVideoPlaybackDisabled();
 }
 
 void MediaPlayer::setWirelessVideoPlaybackDisabled(bool disabled)
 {
-    protectedPrivate()->setWirelessVideoPlaybackDisabled(disabled);
+    protect(m_private)->setWirelessVideoPlaybackDisabled(disabled);
 }
 
 void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
@@ -1354,64 +1346,64 @@ void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackT
 
 OptionSet<MediaPlaybackTargetType> MediaPlayer::supportedPlaybackTargetTypes() const
 {
-    return protectedPrivate()->supportedPlaybackTargetTypes();
+    return protect(m_private)->supportedPlaybackTargetTypes();
 }
 
 void MediaPlayer::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& device)
 {
-    protectedPrivate()->setWirelessPlaybackTarget(WTF::move(device));
+    protect(m_private)->setWirelessPlaybackTarget(WTF::move(device));
 }
 
 void MediaPlayer::setShouldPlayToPlaybackTarget(bool shouldPlay)
 {
-    protectedPrivate()->setShouldPlayToPlaybackTarget(shouldPlay);
+    protect(m_private)->setShouldPlayToPlaybackTarget(shouldPlay);
 }
 
 #endif
 
 double MediaPlayer::maxFastForwardRate() const
 {
-    return protectedPrivate()->maxFastForwardRate();
+    return protect(m_private)->maxFastForwardRate();
 }
 
 double MediaPlayer::minFastReverseRate() const
 {
-    return protectedPrivate()->minFastReverseRate();
+    return protect(m_private)->minFastReverseRate();
 }
 
 void MediaPlayer::acceleratedRenderingStateChanged()
 {
-    protectedPrivate()->acceleratedRenderingStateChanged();
+    protect(m_private)->acceleratedRenderingStateChanged();
 }
 
 bool MediaPlayer::supportsAcceleratedRendering() const
 {
-    return protectedPrivate()->supportsAcceleratedRendering();
+    return protect(m_private)->supportsAcceleratedRendering();
 }
 
 void MediaPlayer::setShouldMaintainAspectRatio(bool maintainAspectRatio)
 {
-    protectedPrivate()->setShouldMaintainAspectRatio(maintainAspectRatio);
+    protect(m_private)->setShouldMaintainAspectRatio(maintainAspectRatio);
 }
 
 void MediaPlayer::requestHostingContext(LayerHostingContextCallback&& callback)
 {
-    return protectedPrivate()->requestHostingContext(WTF::move(callback));
+    return protect(m_private)->requestHostingContext(WTF::move(callback));
 }
 
 HostingContext MediaPlayer::hostingContext() const
 {
-    return protectedPrivate()->hostingContext();
+    return protect(m_private)->hostingContext();
 }
 
 bool MediaPlayer::didPassCORSAccessCheck() const
 {
-    return protectedPrivate()->didPassCORSAccessCheck();
+    return protect(m_private)->didPassCORSAccessCheck();
 }
 
 bool MediaPlayer::isCrossOrigin(const SecurityOrigin& origin) const
 {
-    if (auto crossOrigin = protectedPrivate()->isCrossOrigin(origin))
+    if (auto crossOrigin = protect(m_private)->isCrossOrigin(origin))
         return *crossOrigin;
 
     if (m_url.protocolIsData())
@@ -1422,37 +1414,37 @@ bool MediaPlayer::isCrossOrigin(const SecurityOrigin& origin) const
 
 MediaPlayer::MovieLoadType MediaPlayer::movieLoadType() const
 {
-    return protectedPrivate()->movieLoadType();
+    return protect(m_private)->movieLoadType();
 }
 
 MediaTime MediaPlayer::mediaTimeForTimeValue(const MediaTime& timeValue) const
 {
-    return protectedPrivate()->mediaTimeForTimeValue(timeValue);
+    return protect(m_private)->mediaTimeForTimeValue(timeValue);
 }
 
 unsigned MediaPlayer::decodedFrameCount() const
 {
-    return protectedPrivate()->decodedFrameCount();
+    return protect(m_private)->decodedFrameCount();
 }
 
 unsigned MediaPlayer::droppedFrameCount() const
 {
-    return protectedPrivate()->droppedFrameCount();
+    return protect(m_private)->droppedFrameCount();
 }
 
 unsigned MediaPlayer::audioDecodedByteCount() const
 {
-    return protectedPrivate()->audioDecodedByteCount();
+    return protect(m_private)->audioDecodedByteCount();
 }
 
 unsigned MediaPlayer::videoDecodedByteCount() const
 {
-    return protectedPrivate()->videoDecodedByteCount();
+    return protect(m_private)->videoDecodedByteCount();
 }
 
 void MediaPlayer::reloadTimerFired()
 {
-    protectedPrivate()->cancelLoad();
+    protect(m_private)->cancelLoad();
     loadWithNextMediaEngine(CheckedPtr { m_currentMediaEngine.get() });
 }
 
@@ -1527,7 +1519,7 @@ void MediaPlayer::networkStateChanged()
 void MediaPlayer::readyStateChanged()
 {
     protect(client())->mediaPlayerReadyStateChanged();
-    if (m_pendingSeekRequest && protectedPrivate()->readyState() == MediaPlayer::ReadyState::HaveMetadata)
+    if (m_pendingSeekRequest && protect(m_private)->readyState() == MediaPlayer::ReadyState::HaveMetadata)
         seekToTime(*std::exchange(m_pendingSeekRequest, std::nullopt));
 }
 
@@ -1535,7 +1527,7 @@ void MediaPlayer::volumeChanged(double newVolume)
 {
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(newVolume);
-    m_volume = protectedPrivate()->volume();
+    m_volume = protect(m_private)->volume();
 #else
     m_volume = newVolume;
 #endif
@@ -1595,7 +1587,7 @@ void MediaPlayer::characteristicChanged()
 
 AudioSourceProvider* MediaPlayer::audioSourceProvider()
 {
-    return protectedPrivate()->audioSourceProvider();
+    return protect(m_private)->audioSourceProvider();
 }
 
 #endif
@@ -1635,7 +1627,7 @@ bool MediaPlayer::waitingForKey() const
 {
     if (!m_private)
         return false;
-    return protectedPrivate()->waitingForKey();
+    return protect(m_private)->waitingForKey();
 }
 #endif
 
@@ -1660,7 +1652,7 @@ long MediaPlayer::platformErrorCode() const
     if (!m_private)
         return 0;
 
-    return protectedPrivate()->platformErrorCode();
+    return protect(m_private)->platformErrorCode();
 }
 
 CachedResourceLoader* MediaPlayer::cachedResourceLoader() const
@@ -1708,17 +1700,17 @@ void MediaPlayer::removeVideoTrack(VideoTrackPrivate& track)
 
 void MediaPlayer::setTextTrackRepresentation(TextTrackRepresentation* representation)
 {
-    protectedPrivate()->setTextTrackRepresentation(representation);
+    protect(m_private)->setTextTrackRepresentation(representation);
 }
 
 void MediaPlayer::syncTextTrackBounds()
 {
-    protectedPrivate()->syncTextTrackBounds();
+    protect(m_private)->syncTextTrackBounds();
 }
 
 void MediaPlayer::tracksChanged()
 {
-    protectedPrivate()->tracksChanged();
+    protect(m_private)->tracksChanged();
 }
 
 void MediaPlayer::notifyTrackModeChanged()
@@ -1751,7 +1743,7 @@ void MediaPlayer::simulateAudioInterruption()
     if (!m_private)
         return;
 
-    protectedPrivate()->simulateAudioInterruption();
+    protect(m_private)->simulateAudioInterruption();
 }
 
 bool MediaPlayer::isGStreamerHolePunchingEnabled()
@@ -1782,12 +1774,12 @@ unsigned long long MediaPlayer::fileSize() const
     if (!m_private)
         return 0;
     
-    return protectedPrivate()->fileSize();
+    return protect(m_private)->fileSize();
 }
 
 bool MediaPlayer::ended() const
 {
-    return protectedPrivate()->ended();
+    return protect(m_private)->ended();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayer::videoPlaybackQualityMetrics()
@@ -1898,36 +1890,36 @@ const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaCaptionFormatTypes
 
 void MediaPlayer::applicationWillResignActive()
 {
-    protectedPrivate()->applicationWillResignActive();
+    protect(m_private)->applicationWillResignActive();
 }
 
 void MediaPlayer::applicationDidBecomeActive()
 {
-    protectedPrivate()->applicationDidBecomeActive();
+    protect(m_private)->applicationDidBecomeActive();
 }
 
 #if USE(AVFOUNDATION)
 
 AVPlayer* MediaPlayer::objCAVFoundationAVPlayer() const
 {
-    return protectedPrivate()->objCAVFoundationAVPlayer();
+    return protect(m_private)->objCAVFoundationAVPlayer();
 }
 
 #endif
 
 bool MediaPlayer::performTaskAtTime(Function<void(const MediaTime&)>&& task, const MediaTime& time)
 {
-    return protectedPrivate()->performTaskAtTime(WTF::move(task), time);
+    return protect(m_private)->performTaskAtTime(WTF::move(task), time);
 }
 
 bool MediaPlayer::shouldIgnoreIntrinsicSize()
 {
-    return protectedPrivate()->shouldIgnoreIntrinsicSize();
+    return protect(m_private)->shouldIgnoreIntrinsicSize();
 }
 
 void MediaPlayer::isLoopingChanged()
 {
-    protectedPrivate()->isLoopingChanged();
+    protect(m_private)->isLoopingChanged();
 }
 
 void MediaPlayer::remoteEngineFailedToLoad()
@@ -1943,7 +1935,7 @@ SecurityOriginData MediaPlayer::documentSecurityOrigin() const
 void MediaPlayer::setPreferredDynamicRangeMode(DynamicRangeMode mode)
 {
     m_preferredDynamicRangeMode = mode;
-    protectedPrivate()->setPreferredDynamicRangeMode(mode);
+    protect(m_private)->setPreferredDynamicRangeMode(mode);
 }
 
 void MediaPlayer::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
@@ -1951,49 +1943,49 @@ void MediaPlayer::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platfor
     if (m_platformDynamicRangeLimit == platformDynamicRangeLimit)
         return;
     m_platformDynamicRangeLimit = platformDynamicRangeLimit;
-    protectedPrivate()->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
+    protect(m_private)->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
 }
 
 void MediaPlayer::audioOutputDeviceChanged()
 {
-    protectedPrivate()->audioOutputDeviceChanged();
+    protect(m_private)->audioOutputDeviceChanged();
 }
 
 std::optional<MediaPlayerIdentifier> MediaPlayer::identifier() const
 {
-    return protectedPrivate()->identifier();
+    return protect(m_private)->identifier();
 }
 
 std::optional<VideoFrameMetadata> MediaPlayer::videoFrameMetadata()
 {
-    return protectedPrivate()->videoFrameMetadata();
+    return protect(m_private)->videoFrameMetadata();
 }
 
 void MediaPlayer::startVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = true;
-    protectedPrivate()->startVideoFrameMetadataGathering();
+    protect(m_private)->startVideoFrameMetadataGathering();
 }
 
 void MediaPlayer::stopVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = false;
-    protectedPrivate()->stopVideoFrameMetadataGathering();
+    protect(m_private)->stopVideoFrameMetadataGathering();
 }
 
 void MediaPlayer::renderVideoWillBeDestroyed()
 {
-    protectedPrivate()->renderVideoWillBeDestroyed();
+    protect(m_private)->renderVideoWillBeDestroyed();
 }
 
 void MediaPlayer::setShouldDisableHDR(bool shouldDisable)
 {
-    protectedPrivate()->setShouldDisableHDR(shouldDisable);
+    protect(m_private)->setShouldDisableHDR(shouldDisable);
 }
 
 void MediaPlayer::playerContentBoxRectChanged(const LayoutRect& rect)
 {
-    protectedPrivate()->playerContentBoxRectChanged(rect);
+    protect(m_private)->playerContentBoxRectChanged(rect);
 }
 
 #if PLATFORM(COCOA)
@@ -2010,12 +2002,12 @@ String MediaPlayer::elementId() const
 
 bool MediaPlayer::supportsPlayAtHostTime() const
 {
-    return protectedPrivate()->supportsPlayAtHostTime();
+    return protect(m_private)->supportsPlayAtHostTime();
 }
 
 bool MediaPlayer::supportsPauseAtHostTime() const
 {
-    return protectedPrivate()->supportsPauseAtHostTime();
+    return protect(m_private)->supportsPauseAtHostTime();
 }
 
 bool MediaPlayer::playAtHostTime(const MonotonicTime& hostTime)
@@ -2023,7 +2015,7 @@ bool MediaPlayer::playAtHostTime(const MonotonicTime& hostTime)
     // It is invalid to call playAtHostTime() if the underlying
     // media player does not support it.
     ASSERT(supportsPlayAtHostTime());
-    return protectedPrivate()->playAtHostTime(hostTime);
+    return protect(m_private)->playAtHostTime(hostTime);
 }
 
 bool MediaPlayer::pauseAtHostTime(const MonotonicTime& hostTime)
@@ -2031,12 +2023,12 @@ bool MediaPlayer::pauseAtHostTime(const MonotonicTime& hostTime)
     // It is invalid to call pauseAtHostTime() if the underlying
     // media player does not support it.
     ASSERT(supportsPauseAtHostTime());
-    return protectedPrivate()->pauseAtHostTime(hostTime);
+    return protect(m_private)->pauseAtHostTime(hostTime);
 }
 
 void MediaPlayer::setShouldCheckHardwareSupport(bool value)
 {
-    protectedPrivate()->setShouldCheckHardwareSupport(value);
+    protect(m_private)->setShouldCheckHardwareSupport(value);
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -2050,7 +2042,7 @@ void MediaPlayer::setDefaultSpatialTrackingLabel(const String& defaultSpatialTra
     if (m_defaultSpatialTrackingLabel == defaultSpatialTrackingLabel)
         return;
     m_defaultSpatialTrackingLabel = defaultSpatialTrackingLabel;
-    protectedPrivate()->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
+    protect(m_private)->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
 }
 
 String MediaPlayer::spatialTrackingLabel() const
@@ -2063,7 +2055,7 @@ void MediaPlayer::setSpatialTrackingLabel(const String& spatialTrackingLabel)
     if (m_spatialTrackingLabel == spatialTrackingLabel)
         return;
     m_spatialTrackingLabel = spatialTrackingLabel;
-    protectedPrivate()->setSpatialTrackingLabel(spatialTrackingLabel);
+    protect(m_private)->setSpatialTrackingLabel(spatialTrackingLabel);
 }
 #endif
 
@@ -2073,7 +2065,7 @@ void MediaPlayer::setPrefersSpatialAudioExperience(bool value)
     if (m_prefersSpatialAudioExperience == value)
         return;
     m_prefersSpatialAudioExperience = value;
-    protectedPrivate()->prefersSpatialAudioExperienceChanged();
+    protect(m_private)->prefersSpatialAudioExperienceChanged();
 }
 #endif
 
@@ -2084,7 +2076,7 @@ auto MediaPlayer::soundStageSize() const -> SoundStageSize
 
 void MediaPlayer::soundStageSizeDidChange()
 {
-    protectedPrivate()->soundStageSizeDidChange();
+    protect(m_private)->soundStageSizeDidChange();
 }
 
 void MediaPlayer::setInFullscreenOrPictureInPicture(bool isInFullscreenOrPictureInPicture)
@@ -2093,7 +2085,7 @@ void MediaPlayer::setInFullscreenOrPictureInPicture(bool isInFullscreenOrPicture
         return;
 
     m_isInFullscreenOrPictureInPicture = isInFullscreenOrPictureInPicture;
-    protectedPrivate()->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
+    protect(m_private)->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
 }
 
 bool MediaPlayer::isInFullscreenOrPictureInPicture() const
@@ -2104,7 +2096,7 @@ bool MediaPlayer::isInFullscreenOrPictureInPicture() const
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 bool MediaPlayer::supportsLinearMediaPlayer() const
 {
-    return protectedPrivate()->supportsLinearMediaPlayer();
+    return protect(m_private)->supportsLinearMediaPlayer();
 }
 #endif
 
@@ -2118,7 +2110,7 @@ const Logger& MediaPlayer::mediaPlayerLogger()
 void MediaPlayer::setMessageClientForTesting(WeakPtr<MessageClientForTesting> internalMessageClient)
 {
     m_internalMessageClient = WTF::move(internalMessageClient);
-    protectedPrivate()->setMessageClientForTesting(m_internalMessageClient);
+    protect(m_private)->setMessageClientForTesting(m_internalMessageClient);
 }
 
 MessageClientForTesting* MediaPlayer::messageClientForTesting() const

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -749,7 +749,6 @@ public:
 
     const MediaPlayerPrivateInterface* NODELETE playerPrivate() const;
     MediaPlayerPrivateInterface* NODELETE playerPrivate();
-    RefPtr<MediaPlayerPrivateInterface> protectedPlayerPrivate();
 
     DynamicRangeMode preferredDynamicRangeMode() const { return m_preferredDynamicRangeMode; }
     void setPreferredDynamicRangeMode(DynamicRangeMode);
@@ -824,7 +823,6 @@ private:
 
     MediaPlayerClient& client() const { return *m_client; }
 
-    RefPtr<MediaPlayerPrivateInterface> protectedPrivate() const;
 
     CheckedPtr<const MediaPlayerFactory> nextBestMediaEngine(const MediaPlayerFactory*);
     void loadWithNextMediaEngine(const MediaPlayerFactory*);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -243,10 +243,9 @@ private:
     void iterateTrackBuffers(NOESCAPE const Function<void(const TrackBuffer&)>&) const;
 
     using OperationPromise = NativePromise<void, PlatformMediaError, WTF::PromiseOption::Default | WTF::PromiseOption::NonExclusive>;
-    Ref<OperationPromise> protectedCurrentSourceBufferOperation() const;
-    Ref<MediaPromise> protectedCurrentAppendProcessing() const;
 
     void ensureWeakOnDispatcher(Function<void(SourceBufferPrivate&)>&&);
+    MediaPromise& currentAppendProcessing() const;
 
     bool m_hasAudio WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get()) { false };
     bool m_hasVideo WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get()) { false };

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -74,8 +74,6 @@ public:
             RefPtr<MediaDescription> description;
             RefPtr<AudioTrackPrivate> track;
 
-            RefPtr<MediaDescription> protectedDescription() const { return description; }
-            RefPtr<AudioTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<AudioTrackInformation> audioTracks;
 
@@ -83,8 +81,6 @@ public:
             RefPtr<MediaDescription> description;
             RefPtr<VideoTrackPrivate> track;
 
-            RefPtr<MediaDescription> protectedDescription() const { return description; }
-            RefPtr<VideoTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<VideoTrackInformation> videoTracks;
 
@@ -92,8 +88,6 @@ public:
             RefPtr<MediaDescription> description;
             RefPtr<InbandTextTrackPrivate> track;
 
-            RefPtr<MediaDescription> protectedDescription() const { return description; }
-            RefPtr<InbandTextTrackPrivate> protectedTrack() const { return track; }
         };
         Vector<TextTrackInformation> textTracks;
     };

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -396,11 +396,11 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
     auto shouldProcessTextSpacingTrim = !fontDescription.textSpacingTrim().isSpaceAll();
     if (shouldProcessTextSpacingTrim) {
         TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
-        halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*glyphData.protectedFont(), fontDescription.textSpacingTrim(), charactersData);
+        halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*protect(glyphData.font), fontDescription.textSpacingTrim(), charactersData);
         glyphData.font = halfWidthFont ? halfWidthFont.get() : glyphData.font;
     }
 
-    advanceInternalState.updateFont(glyphData.font ? glyphData.protectedFont().get() : primaryFont.ptr());
+    advanceInternalState.updateFont(glyphData.font ? protect(glyphData.font).get() : primaryFont.ptr());
     auto capitalizedCharacter = capitalized(character);
     if (shouldSynthesizeSmallCaps(smallCapsState.dontSynthesizeSmallCaps, advanceInternalState.font.get(), character, capitalizedCharacter, smallCapsState.fontVariantCaps, smallCapsState.engageAllSmallCapsProcessing))
         smallCapsState.setSmallCapsData(advanceInternalState.font.get(), fontDescription);
@@ -432,11 +432,11 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
 
         if (shouldProcessTextSpacingTrim) {
             TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
-            halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*glyphData.protectedFont(), fontDescription.textSpacingTrim(), charactersData);
+            halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*protect(glyphData.font), fontDescription.textSpacingTrim(), charactersData);
             glyphData.font = halfWidthFont ? halfWidthFont.get() : glyphData.font;
         }
 
-        advanceInternalState.updateFont(glyphData.font ? glyphData.protectedFont().get() : primaryFont.ptr());
+        advanceInternalState.updateFont(glyphData.font ? protect(glyphData.font).get() : primaryFont.ptr());
         smallCapsState.shouldSynthesizeCharacter = shouldSynthesizeSmallCaps(smallCapsState.dontSynthesizeSmallCaps, advanceInternalState.font.get(), character, capitalizedCharacter, smallCapsState.fontVariantCaps, smallCapsState.engageAllSmallCapsProcessing);
         updateCharacterAndSmallCapsIfNeeded(smallCapsState, capitalizedCharacter, characterToWrite);
 
@@ -646,7 +646,7 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
         if (!textAutospace.isNoAutospace()) {
             characterClass = TextSpacing::characterClass(m_run.get()[i]);
             if (textAutospace.shouldApplySpacing(characterClass, previousCharacterClass)) {
-                textAutospaceSpacing = TextAutospace::textAutospaceSize(glyphBuffer.protectedFontAt(glyphIndexRange->leadingGlyphIndex));
+                textAutospaceSpacing = TextAutospace::textAutospaceSize(protect(glyphBuffer.fontAt(glyphIndexRange->leadingGlyphIndex)));
                 glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange->leadingGlyphIndex, textAutospaceSpacing);
                 m_runWidthSoFar += textAutospaceSpacing;
             }
@@ -801,7 +801,7 @@ void WidthIterator::applyCSSVisibilityRules(GlyphBuffer& glyphBuffer, unsigned g
             // Let's assume that .notdef is visible.
             GlyphBufferGlyph visibleGlyph = 0;
             clobberGlyph(i, visibleGlyph);
-            clobberAdvance(i, glyphBuffer.protectedFontAt(i)->widthForGlyph(visibleGlyph));
+            clobberAdvance(i, protect(glyphBuffer.fontAt(i))->widthForGlyph(visibleGlyph));
             continue;
         }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -226,7 +226,6 @@ private:
     void cancelSeekingPromiseIfNeeded();
     void cancelPerformTaskAtTimeObserverIfNeeded();
 
-    RefPtr<VideoMediaSampleRenderer> protectedVideoRenderer() const;
     bool canUseDecompressionSession() const;
     bool isUsingDecompressionSession() const;
     bool willUseDecompressionSessionIfNeeded() const;
@@ -242,7 +241,6 @@ private:
 
     // Logger
     const Logger& logger() const final { return m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const final { return "AudioVideoRendererAVFObjC"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -277,7 +277,7 @@ bool AudioVideoRendererAVFObjC::isReadyForMoreSamples(TrackIdentifier trackId)
 
     switch (*type) {
     case TrackType::Video:
-        return m_readyToRequestVideoData && isEnabledVideoTrackId(trackId) && protectedVideoRenderer()->isReadyForMoreMediaData();
+        return m_readyToRequestVideoData && isEnabledVideoTrackId(trackId) && protect(m_videoRenderer)->isReadyForMoreMediaData();
     case TrackType::Audio:
         if (!m_readyToRequestAudioData)
             return false;
@@ -1370,10 +1370,6 @@ void AudioVideoRendererAVFObjC::configureLayerOrVideoRenderer(WebSampleBufferVid
         m_sampleBufferDisplayLayerState = SampleBufferLayerState::AddedToSynchronizer;
 }
 
-RefPtr<VideoMediaSampleRenderer> AudioVideoRendererAVFObjC::protectedVideoRenderer() const
-{
-    return m_videoRenderer;
-}
 
 void AudioVideoRendererAVFObjC::sizeWillChangeAtTime(const MediaTime& time, const FloatSize& size)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -152,7 +152,6 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateAVFoundation"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -393,11 +393,6 @@ private:
     bool supportsLinearMediaPlayer() const final { return true; }
 #endif
 
-    RefPtr<SharedBuffer> protectedKeyID() const { return m_keyID; }
-
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    RefPtr<CDMInstanceFairPlayStreamingAVFObjC> protectedCDMInstance() const;
-#endif
 
     void forEachResourceLoader(Function<void(WebCoreAVFResourceLoader&)>&&) const;
     void addResourceLoader(AVAssetResourceLoadingRequest *, Ref<WebCoreAVFResourceLoader>&&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -247,7 +247,6 @@ private:
 
     Ref<AudioVideoRenderer> audioVideoRenderer() const;
 
-    RefPtr<MediaSourcePrivateAVFObjC> protectedMediaSourcePrivate() const;
 
     // NOTE: Because the only way for MSE to recieve data is through an ArrayBuffer provided by
     // javascript running in the page, the video will, by necessity, always be CORS correct and

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -661,19 +661,15 @@ const PlatformTimeRanges& MediaPlayerPrivateMediaSourceAVFObjC::buffered() const
     return PlatformTimeRanges::emptyRanges();
 }
 
-RefPtr<MediaSourcePrivateAVFObjC> MediaPlayerPrivateMediaSourceAVFObjC::protectedMediaSourcePrivate() const
-{
-    return m_mediaSourcePrivate;
-}
 
 void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
 {
     assertIsMainThread();
     m_renderer->cancelTimeReachedAction();
 
-    auto ranges = protectedMediaSourcePrivate()->buffered();
+    auto ranges = protect(m_mediaSourcePrivate)->buffered();
     auto currentTime = this->currentTime();
-    if (!protectedMediaSourcePrivate()->hasFutureTime(currentTime) && shouldBePlaying()) {
+    if (!protect(m_mediaSourcePrivate)->hasFutureTime(currentTime) && shouldBePlaying()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Not having data to play at currentTime: ", currentTime, " stalling");
         stall();
     }
@@ -699,7 +695,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
-            if (protectedThis->protectedMediaSourcePrivate()->hasFutureTime(stallTime) && protectedThis->shouldBePlaying()) {
+            if (protect(protectedThis->m_mediaSourcePrivate)->hasFutureTime(stallTime) && protectedThis->shouldBePlaying()) {
                 ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Data now available at ", stallTime, " resuming");
                 protectedThis->m_renderer->play(); // New data was added, resume. Can't happen in practice, action would have been cancelled once buffered changed.
                 return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -249,7 +249,6 @@ private:
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) final;
     void requestHostingContext(LayerHostingContextCallback&&) final;
 
-    RefPtr<MediaStreamPrivate> protectedMediaStreamPrivate() const;
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MediaStreamPrivate> m_mediaStreamPrivate;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -499,10 +499,6 @@ void MediaPlayerPrivateMediaStreamAVFObjC::load(const URL&, const LoadOptions&, 
 }
 #endif
 
-RefPtr<MediaStreamPrivate> MediaPlayerPrivateMediaStreamAVFObjC::protectedMediaStreamPrivate() const
-{
-    return m_mediaStreamPrivate;
-}
 
 void MediaPlayerPrivateMediaStreamAVFObjC::load(MediaStreamPrivate& stream)
 {
@@ -572,7 +568,7 @@ MediaPlayerPrivateMediaStreamAVFObjC::DisplayMode MediaPlayerPrivateMediaStreamA
         return WaitingForFirstImage;
 
     if (playing() && !m_ended) {
-        if (!protectedMediaStreamPrivate()->isProducingData())
+        if (!protect(m_mediaStreamPrivate)->isProducingData())
             return PausedImage;
         return LivePreview;
     }
@@ -812,7 +808,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged()
 {
     SizeChanged sizeChanged = SizeChanged::No;
 
-    IntSize intrinsicSize = protectedMediaStreamPrivate()->intrinsicSize();
+    IntSize intrinsicSize = protect(m_mediaStreamPrivate)->intrinsicSize();
     if (intrinsicSize.isEmpty() || m_intrinsicSize.isEmpty()) {
         if (intrinsicSize.height() != m_intrinsicSize.height() || intrinsicSize.width() != m_intrinsicSize.width()) {
             m_intrinsicSize = intrinsicSize;
@@ -991,7 +987,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::checkSelectedVideoTrack()
 
 void MediaPlayerPrivateMediaStreamAVFObjC::updateTracks()
 {
-    auto currentTracks = protectedMediaStreamPrivate()->tracks();
+    auto currentTracks = protect(m_mediaStreamPrivate)->tracks();
 
     auto player = m_player.get();
     if (!player)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -175,9 +175,9 @@ private:
 
     void maybeUpdateNeedsVideoLayer();
 
-    RefPtr<AudioVideoRenderer> protectedRenderer() const;
     void ensureWeakOnDispatcher(Function<void(SourceBufferPrivateAVFObjC&)>&&);
     void callOnMainThreadWithPlayer(Function<void(MediaPlayerPrivateMediaSourceAVFObjC&)>&&);
+    AudioVideoRenderer& renderer() const;
 
     StdUnorderedMap<TrackID, RefPtr<VideoTrackPrivate>> m_videoTracks WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     StdUnorderedMap<TrackID, RefPtr<AudioTrackPrivate>> m_audioTracks WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h
@@ -82,7 +82,6 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const { return "WebCoreAVFResourceLoader"_s; }
     WTFLogChannel& logChannel() const;
 #endif

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -512,7 +512,7 @@ std::optional<PlatformLayerIdentifier> GraphicsLayerCA::primaryLayerID() const
 
 std::optional<PlatformLayerIdentifier> GraphicsLayerCA::layerIDIgnoringStructuralLayer() const
 {
-    return protectedLayer()->layerID();
+    return protect(m_layer)->layerID();
 }
 
 PlatformLayer* GraphicsLayerCA::platformLayer() const
@@ -777,7 +777,7 @@ void GraphicsLayerCA::setTonemappingEnabled(bool tonemappingEnabled)
 
 void GraphicsLayerCA::setNeedsDisplayIfEDRHeadroomExceeds(float headroom)
 {
-    if (protectedLayer()->setNeedsDisplayIfEDRHeadroomExceeds(headroom)) {
+    if (protect(m_layer)->setNeedsDisplayIfEDRHeadroomExceeds(headroom)) {
         if (!!m_uncommittedChanges)
             client().notifyFlushRequired(this);
     }
@@ -991,7 +991,7 @@ void GraphicsLayerCA::setBlendMode(BlendMode blendMode)
 
 bool GraphicsLayerCA::backingStoreAttached() const
 {
-    return protectedLayer()->backingStoreAttached();
+    return protect(m_layer)->backingStoreAttached();
 }
 
 bool GraphicsLayerCA::backingStoreAttachedForTesting() const
@@ -1685,7 +1685,7 @@ bool GraphicsLayerCA::visibleRectChangeRequiresFlush(const FloatRect& clipRect) 
 
 TiledBacking* GraphicsLayerCA::tiledBacking() const
 {
-    return protectedLayer()->tiledBacking();
+    return protect(m_layer)->tiledBacking();
 }
 
 TransformationMatrix GraphicsLayerCA::layerTransform(const FloatPoint& position, const TransformationMatrix* customTransform) const
@@ -2383,23 +2383,23 @@ void GraphicsLayerCA::updateNames()
     auto name = debugName();
     switch (structuralLayerPurpose()) {
     case StructuralLayerForPreserves3D:
-        protectedStructuralLayer()->setName(makeString("preserve-3d: "_s, name));
+        protect(m_structuralLayer)->setName(makeString("preserve-3d: "_s, name));
         break;
     case StructuralLayerForReplicaFlattening:
-        protectedStructuralLayer()->setName(makeString("replica flattening: "_s, name));
+        protect(m_structuralLayer)->setName(makeString("replica flattening: "_s, name));
         break;
     case StructuralLayerForBackdrop:
-        protectedStructuralLayer()->setName(makeString("backdrop hosting: "_s, name));
+        protect(m_structuralLayer)->setName(makeString("backdrop hosting: "_s, name));
         break;
 #if HAVE(MATERIAL_HOSTING)
     case StructuralLayerForMaterial:
-        protectedStructuralLayer()->setName(makeString("material hosting: "_s, name));
+        protect(m_structuralLayer)->setName(makeString("material hosting: "_s, name));
         break;
 #endif
     case NoStructuralLayer:
         break;
     }
-    protectedLayer()->setName(name);
+    protect(m_layer)->setName(name);
 }
 
 void GraphicsLayerCA::updateSublayerList(bool maxLayerDepthReached)
@@ -2589,7 +2589,7 @@ void GraphicsLayerCA::updateChildrenTransform()
 
 void GraphicsLayerCA::updateMasksToBounds()
 {
-    protectedLayer()->setMasksToBounds(m_masksToBounds);
+    protect(m_layer)->setMasksToBounds(m_masksToBounds);
 
     if (m_layerClones) {
         for (auto& layer : m_layerClones->primaryLayerClones.values())
@@ -2624,7 +2624,7 @@ void GraphicsLayerCA::updateContentsVisibility()
 
 void GraphicsLayerCA::updateUserInteractionEnabled()
 {
-    protectedLayer()->setUserInteractionEnabled(m_userInteractionEnabled);
+    protect(m_layer)->setUserInteractionEnabled(m_userInteractionEnabled);
 }
 
 void GraphicsLayerCA::updateContentsOpaque(float pageScaleFactor)
@@ -2636,7 +2636,7 @@ void GraphicsLayerCA::updateContentsOpaque(float pageScaleFactor)
             contentsOpaque = false;
     }
     
-    protectedLayer()->setOpaque(contentsOpaque);
+    protect(m_layer)->setOpaque(contentsOpaque);
 
     if (m_layerClones) {
         for (auto& layer : m_layerClones->primaryLayerClones.values())
@@ -2655,7 +2655,7 @@ void GraphicsLayerCA::updateBackfaceVisibility()
         }
     }
 
-    protectedLayer()->setDoubleSided(m_backfaceVisibility);
+    protect(m_layer)->setDoubleSided(m_backfaceVisibility);
 
     if (m_layerClones) {
         for (auto& layer : m_layerClones->primaryLayerClones.values())
@@ -2795,7 +2795,7 @@ void GraphicsLayerCA::updateBackdropFiltersRect()
 
 void GraphicsLayerCA::updateBackdropRoot()
 {
-    protectedLayer()->setIsBackdropRoot(isBackdropRoot());
+    protect(m_layer)->setIsBackdropRoot(isBackdropRoot());
 }
 
 void GraphicsLayerCA::updateBlendMode()
@@ -2819,7 +2819,7 @@ void GraphicsLayerCA::updateVideoGravity()
 
 void GraphicsLayerCA::updateShape()
 {
-    protectedLayer()->setShapePath(m_shapeLayerPath);
+    protect(m_layer)->setShapePath(m_shapeLayerPath);
 
     if (LayerMap* layerCloneMap = primaryLayerClones()) {
         for (auto& layer : layerCloneMap->values())
@@ -2829,7 +2829,7 @@ void GraphicsLayerCA::updateShape()
 
 void GraphicsLayerCA::updateWindRule()
 {
-    protectedLayer()->setShapeWindRule(m_shapeLayerWindRule);
+    protect(m_layer)->setShapeWindRule(m_shapeLayerWindRule);
 }
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
@@ -2858,9 +2858,9 @@ void GraphicsLayerCA::updateAppleVisualEffectData()
         backdropLayer->setAppleVisualEffectData(m_appleVisualEffectData);
 
     if (appleVisualEffectAppliesFilter(m_appleVisualEffectData.effect))
-        protectedLayer()->setAppleVisualEffectData(m_appleVisualEffectData);
+        protect(m_layer)->setAppleVisualEffectData(m_appleVisualEffectData);
     else
-        protectedLayer()->setAppleVisualEffectData({ });
+        protect(m_layer)->setAppleVisualEffectData({ });
 
 #if HAVE(MATERIAL_HOSTING)
     if (RefPtr structuralLayer = m_structuralLayer; structuralLayer && appleVisualEffectIsHostedMaterial(m_appleVisualEffectData.effect))
@@ -3066,7 +3066,7 @@ void GraphicsLayerCA::updateCoverage(const CommitState& commitState)
 
 void GraphicsLayerCA::updateAcceleratesDrawing()
 {
-    protectedLayer()->setAcceleratesDrawing(m_acceleratesDrawing);
+    protect(m_layer)->setAcceleratesDrawing(m_acceleratesDrawing);
 }
 
 static void setLayerDebugBorder(PlatformCALayer& layer, Color borderColor, float borderWidth)
@@ -3128,7 +3128,7 @@ void GraphicsLayerCA::updateTiles()
 
 void GraphicsLayerCA::updateBackgroundColor()
 {
-    protectedLayer()->setBackgroundColor(m_backgroundColor);
+    protect(m_layer)->setBackgroundColor(m_backgroundColor);
 }
 
 void GraphicsLayerCA::updateContentsImage()
@@ -3357,7 +3357,7 @@ void GraphicsLayerCA::updateMaskLayer()
         structuralLayer->setMaskLayer(WTF::move(maskCALayer));
         layerCloneMap = m_layerClones ? &m_layerClones->structuralLayerClones : nullptr;
     } else {
-        protectedLayer()->setMaskLayer(WTF::move(maskCALayer));
+        protect(m_layer)->setMaskLayer(WTF::move(maskCALayer));
         layerCloneMap = m_layerClones ? &m_layerClones->primaryLayerClones : nullptr;
     }
 
@@ -3382,19 +3382,19 @@ void GraphicsLayerCA::updateReplicatedLayers()
     if (RefPtr structuralLayer = m_structuralLayer)
         structuralLayer->insertSublayer(*replicaRoot, 0);
     else
-        protectedLayer()->insertSublayer(*replicaRoot, 0);
+        protect(m_layer)->insertSublayer(*replicaRoot, 0);
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
 void GraphicsLayerCA::updateDrawsHDRContent()
 {
     auto contentsFormat = PlatformCALayer::contentsFormatForLayer(this);
-    protectedLayer()->setContentsFormat(contentsFormat);
+    protect(m_layer)->setContentsFormat(contentsFormat);
 }
 
 void GraphicsLayerCA::updateTonemappingEnabled()
 {
-    protectedLayer()->setTonemappingEnabled(m_tonemappingEnabled);
+    protect(m_layer)->setTonemappingEnabled(m_tonemappingEnabled);
 }
 #endif
 
@@ -4438,7 +4438,7 @@ void GraphicsLayerCA::updateContentsScale(float pageScaleFactor)
 
 void GraphicsLayerCA::updateCustomAppearance()
 {
-    protectedLayer()->updateCustomAppearance(m_customAppearance);
+    protect(m_layer)->updateCustomAppearance(m_customAppearance);
 }
 
 void GraphicsLayerCA::setShowDebugBorder(bool showBorder)
@@ -4514,9 +4514,9 @@ String GraphicsLayerCA::replayDisplayListAsText(OptionSet<DisplayList::AsTextFla
 void GraphicsLayerCA::setDebugBackgroundColor(const Color& color)
 {    
     if (color.isValid())
-        protectedLayer()->setBackgroundColor(color);
+        protect(m_layer)->setBackgroundColor(color);
     else
-        protectedLayer()->setBackgroundColor(Color::transparentBlack);
+        protect(m_layer)->setBackgroundColor(Color::transparentBlack);
 }
 
 Color GraphicsLayerCA::pageTiledBackingBorderColor() const
@@ -4571,7 +4571,7 @@ ASCIILiteral GraphicsLayerCA::purposeNameForInnerLayer(PlatformCALayer& layer) c
         return "contents shape mask layer"_s;
     if (&layer == m_backdropLayer.get()) {
 #if HAVE(CORE_MATERIAL)
-        if (protectedBackdropLayer()->appleVisualEffectData().effect != AppleVisualEffect::None)
+        if (protect(m_backdropLayer)->appleVisualEffectData().effect != AppleVisualEffect::None)
             return "backdrop layer (material)"_s;
 #endif
         return "backdrop layer"_s;
@@ -4826,7 +4826,7 @@ String GraphicsLayerCA::platformLayerTreeAsText(OptionSet<PlatformLayerTreeAsTex
 
 void GraphicsLayerCA::setDebugBorder(const Color& color, float borderWidth)
 {
-    setLayerDebugBorder(*protectedLayer(), color, borderWidth);
+    setLayerDebugBorder(*protect(m_layer), color, borderWidth);
 }
 
 void GraphicsLayerCA::setCustomAppearance(CustomAppearance customAppearance)
@@ -5321,7 +5321,7 @@ Vector<GraphicsLayer::AcceleratedAnimationForTesting> GraphicsLayerCA::accelerat
     for (auto& animation : m_animations) {
         if (animation.m_pendingRemoval)
             continue;
-        if (auto caAnimation = protectedAnimatedLayer(animation.m_property)->animationForKey(animation.animationIdentifier())) {
+        if (auto caAnimation = protect(animatedLayer(animation.m_property))->animationForKey(animation.animationIdentifier())) {
             animations.append({
                 .property = animatedPropertyIDAsString(animation.m_property),
                 .speed = caAnimation->speed(),

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -329,14 +329,10 @@ private:
 
     virtual void setLayerContentsToImageBuffer(PlatformCALayer&, ImageBuffer*) { }
 
-    RefPtr<PlatformCALayer> protectedLayer() const { return m_layer; }
-    RefPtr<PlatformCALayer> protectedBackdropLayer() const { return m_backdropLayer; }
-    RefPtr<PlatformCALayer> protectedStructuralLayer() const { return m_structuralLayer; }
     PlatformCALayer* primaryLayer() const { return m_structuralLayer.get() ? m_structuralLayer.get() : m_layer.get(); }
     PlatformCALayer* hostLayerForSublayers() const;
     PlatformCALayer* layerForSuperlayer() const;
     PlatformCALayer* animatedLayer(AnimatedProperty) const;
-    RefPtr<PlatformCALayer> protectedAnimatedLayer(AnimatedProperty property) const { return animatedLayer(property); }
 
     WEBCORE_EXPORT void setTileCoverage(TileCoverage) override;
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerCocoa.mm
@@ -34,7 +34,7 @@ namespace WebCore {
 
 void MediaPlayer::setVideoTarget(const PlatformVideoTarget& target)
 {
-    protectedPrivate()->setVideoTarget(target);
+    protect(m_private)->setVideoTarget(target);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -291,7 +291,6 @@ private:
     std::optional<MediaPlayerIdentifier> identifier() const final { return m_playerIdentifier; }
 
     const Logger& logger() const final { return m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const final { return "MediaPlayerPrivateWebM"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1344,7 +1344,7 @@ void MediaPlayerPrivateWebM::addTrackBuffer(TrackID trackId, RefPtr<MediaDescrip
     setHasVideo(m_hasVideo || description->isVideo());
 
     auto trackBuffer = TrackBuffer::create(WTF::move(description), discontinuityTolerance);
-    trackBuffer->setLogger(protectedLogger(), logIdentifier());
+    trackBuffer->setLogger(protect(logger()), logIdentifier());
     m_trackBufferMap.try_emplace(trackId, WTF::move(trackBuffer));
     m_requestReadyForMoreSamplesSetMap[trackId] = false;
 }

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -194,7 +194,6 @@ private:
 #if !RELEASE_LOG_DISABLED
     // Logger
     const Logger& logger() const final { return m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const final { return "VideoMediaSampleRenderer"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -162,7 +162,7 @@ void AudioMediaStreamTrackRendererUnit::Unit::close()
 void AudioMediaStreamTrackRendererUnit::Unit::addSource(Ref<AudioSampleDataSource>&& source)
 {
 #if !RELEASE_LOG_DISABLED
-    source->protectedLogger()->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::addSource ", source->logIdentifier());
+    protect(source->logger())->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::addSource ", source->logIdentifier());
 #endif
     assertIsMainThread();
 
@@ -183,7 +183,7 @@ void AudioMediaStreamTrackRendererUnit::Unit::addSource(Ref<AudioSampleDataSourc
 bool AudioMediaStreamTrackRendererUnit::Unit::removeSource(AudioSampleDataSource& source)
 {
 #if !RELEASE_LOG_DISABLED
-    source.protectedLogger()->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::removeSource ", source.logIdentifier());
+    protect(source.logger())->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::removeSource ", source.logIdentifier());
 #endif
     assertIsMainThread();
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -212,15 +212,6 @@ CoreAudioCaptureSource::CoreAudioCaptureSource(const CaptureDevice& device, uint
     initializeVolume(unit->volume());
 }
 
-Ref<CoreAudioCaptureUnit> CoreAudioCaptureSource::protectedUnit()
-{
-    return m_unit;
-}
-
-Ref<const CoreAudioCaptureUnit> CoreAudioCaptureSource::protectedUnit() const
-{
-    return m_unit;
-}
 
 void CoreAudioCaptureSource::initializeToStartProducingData()
 {
@@ -256,21 +247,21 @@ void CoreAudioCaptureSource::initializeToStartProducingData()
 
 CoreAudioCaptureSource::~CoreAudioCaptureSource()
 {
-    protectedUnit()->removeClient(*this);
+    protect(m_unit)->removeClient(*this);
 }
 
 void CoreAudioCaptureSource::startProducingData()
 {
     m_canResumeAfterInterruption = true;
     initializeToStartProducingData();
-    protectedUnit()->startProducingData();
+    protect(m_unit)->startProducingData();
     m_currentSettings = { };
 }
 
 void CoreAudioCaptureSource::stopProducingData()
 {
     ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
-    protectedUnit()->stopProducingData();
+    protect(m_unit)->stopProducingData();
 }
 
 void CoreAudioCaptureSource::endProducingData()
@@ -351,35 +342,35 @@ void CoreAudioCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSett
         changeAudioUnit();
         return;
 #else
-        protectedUnit()->setEnableEchoCancellation(echoCancellation());
+        protect(m_unit)->setEnableEchoCancellation(echoCancellation());
         shouldReconfigure = true;
 #endif
     }
     if (settings.contains(RealtimeMediaSourceSettings::Flag::SampleRate)) {
-        protectedUnit()->setSampleRate(sampleRate());
+        protect(m_unit)->setSampleRate(sampleRate());
         shouldReconfigure = true;
     }
     if (shouldReconfigure)
-        protectedUnit()->reconfigure();
+        protect(m_unit)->reconfigure();
 
     m_currentSettings = std::nullopt;
 }
 
 bool CoreAudioCaptureSource::interrupted() const
 {
-    return protectedUnit()->isSuspended() || RealtimeMediaSource::interrupted();
+    return protect(m_unit)->isSuspended() || RealtimeMediaSource::interrupted();
 }
 
 void CoreAudioCaptureSource::delaySamples(Seconds seconds)
 {
-    protectedUnit()->delaySamples(seconds);
+    protect(m_unit)->delaySamples(seconds);
 }
 
 #if PLATFORM(IOS_FAMILY)
 void CoreAudioCaptureSource::setIsInBackground(bool value)
 {
     if (isProducingData())
-        protectedUnit()->setIsInBackground(value);
+        protect(m_unit)->setIsInBackground(value);
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -113,8 +113,6 @@ private:
     ASCIILiteral logClassName() const override { return "CoreAudioCaptureSource"_s; }
 #endif
 
-    Ref<CoreAudioCaptureUnit> protectedUnit();
-    Ref<const CoreAudioCaptureUnit> protectedUnit() const;
 
     uint32_t m_captureDeviceID { 0 };
     Ref<CoreAudioCaptureUnit> m_unit;

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -157,8 +157,6 @@ private:
 #endif
     void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
 
-    Ref<MockRealtimeVideoSource> protectedSource() const { return m_source; }
-
     void readyTimerFired();
 
     Ref<MockRealtimeVideoSource> m_source;
@@ -183,7 +181,7 @@ bool MockDisplayCapturer::start()
     ASSERT(!m_isRunning);
 
     m_isRunning = true;
-    protectedSource()->start();
+    protect(m_source)->start();
     return true;
 }
 
@@ -192,7 +190,7 @@ void MockDisplayCapturer::stop()
     ASSERT(!m_whenReadyCallback);
 
     m_isRunning = false;
-    protectedSource()->stop();
+    protect(m_source)->stop();
 }
 
 void MockDisplayCapturer::whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback)
@@ -219,7 +217,7 @@ void MockDisplayCapturer::commitConfiguration(const RealtimeMediaSourceSettings&
 
 DisplayCaptureSourceCocoa::DisplayFrameType MockDisplayCapturer::generateFrame()
 {
-    if (RefPtr imageBuffer = protectedSource()->imageBuffer())
+    if (RefPtr imageBuffer = protect(m_source)->imageBuffer())
         return imageBuffer->copyNativeImage();
     return { };
 }

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -250,21 +250,17 @@ MediaTime MockMediaPlayerMediaSource::duration() const
     return mediaSourcePrivate ? mediaSourcePrivate->duration() : MediaTime::zeroTime();
 }
 
-RefPtr<MockMediaSourcePrivate> MockMediaPlayerMediaSource::protectedMediaSourcePrivate()
-{
-    return m_mediaSourcePrivate;
-}
 
 void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
 {
     m_lastSeekTarget = target;
-    protectedMediaSourcePrivate()->waitForTarget(target)->whenSettled(RunLoop::currentSingleton(), [weakThis = WeakPtr { this }](auto&& result) {
+    protect(m_mediaSourcePrivate)->waitForTarget(target)->whenSettled(RunLoop::currentSingleton(), [weakThis = WeakPtr { this }](auto&& result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !result)
             return;
 
         const auto seekTime = *result;
-        protectedThis->protectedMediaSourcePrivate()->seekToTime(seekTime);
+        protect(protectedThis->m_mediaSourcePrivate)->seekToTime(seekTime);
         protectedThis->m_lastSeekTarget.reset();
         protectedThis->m_currentTime = seekTime;
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -101,7 +101,6 @@ private:
     MediaTime duration() const override;
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() override;
     DestinationColorSpace colorSpace() override;
-    RefPtr<MockMediaSourcePrivate> protectedMediaSourcePrivate();
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MockMediaSourcePrivate> m_mediaSourcePrivate;

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -86,7 +86,7 @@ static void registerBlobResourceHandleConstructor()
 Ref<ResourceHandle> BlobRegistryImpl::createResourceHandle(const ResourceRequest& request, ResourceHandleClient* client)
 {
     // This seems like it is only used from WebKitLegacy, so it does not support blob registry partitioning
-    Ref handle = BlobResourceHandle::createAsync(protectedBlobDataFromURL(request.url()).get(), request, client);
+    Ref handle = BlobResourceHandle::createAsync(protect(blobDataFromURL(request.url())), request, client);
     handle->start();
     return handle;
 }
@@ -303,11 +303,6 @@ BlobData* BlobRegistryImpl::blobDataFromURL(const URL& url, const std::optional<
         return nullptr;
     }
     return m_blobs.get(urlKey);
-}
-
-RefPtr<BlobData> BlobRegistryImpl::protectedBlobDataFromURL(const URL& url, const std::optional<SecurityOriginData>& topOrigin) const
-{
-    return blobDataFromURL(url, topOrigin);
 }
 
 String BlobRegistryImpl::blobType(const URL& url)

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -56,7 +56,6 @@ public:
     virtual ~BlobRegistryImpl();
 
     BlobData* blobDataFromURL(const URL&, const std::optional<SecurityOriginData>& topOrigin = std::nullopt) const;
-    RefPtr<BlobData> protectedBlobDataFromURL(const URL&, const std::optional<SecurityOriginData>& topOrigin = std::nullopt) const;
 
     Ref<ResourceHandle> createResourceHandle(const ResourceRequest&, ResourceHandleClient*);
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -662,7 +662,7 @@ void GPUConnectionToWebProcess::providePresentingApplicationPID(WebCore::PageIde
 
     ProcessID processID = presentingApplicationPID(pageIdentifier);
     ASSERT(processID);
-    MediaSessionHelper::protectedSharedHelper()->providePresentingApplicationPID(processID);
+    protect(MediaSessionHelper::sharedHelper())->providePresentingApplicationPID(processID);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -226,7 +226,7 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const MediaPlayer::LoadO
     player->load(url, options, *protect(m_mediaSourceProxy));
 
     if (reattached)
-        protect(m_mediaSourceProxy)->setMediaPlayers(*this, player->protectedPlayerPrivate().get());
+        protect(m_mediaSourceProxy)->setMediaPlayers(*this, protect(player->playerPrivate()));
     getConfiguration(configuration);
     completionHandler(WTF::move(configuration));
 }
@@ -865,7 +865,7 @@ void RemoteMediaPlayerProxy::setWirelessPlaybackTarget(MediaPlaybackTargetContex
 MediaPlaybackTargetType RemoteMediaPlayerProxy::playbackTargetType() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (RefPtr playbackTarget = MediaSessionHelper::protectedSharedHelper()->playbackTarget())
+    if (RefPtr playbackTarget = protect(MediaSessionHelper::sharedHelper())->playbackTarget())
         return playbackTarget->type();
 #endif
     return MediaPlaybackTargetType::None;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -380,7 +380,7 @@ std::optional<InitializationSegmentInfo> RemoteSourceBufferProxy::createInitiali
         RefPtr track = audioTrackInfo.track;
         auto id = track->id();
         remoteMediaPlayerProxy->addRemoteAudioTrackProxy(*track);
-        m_mediaDescriptions.try_emplace(id, *audioTrackInfo.protectedDescription());
+        m_mediaDescriptions.try_emplace(id, *protect(audioTrackInfo.description));
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*audioTrackInfo.description), id };
     });
 
@@ -388,7 +388,7 @@ std::optional<InitializationSegmentInfo> RemoteSourceBufferProxy::createInitiali
         RefPtr track = videoTrackInfo.track;
         auto id = track->id();
         remoteMediaPlayerProxy->addRemoteVideoTrackProxy(*track);
-        m_mediaDescriptions.try_emplace(id, *videoTrackInfo.protectedDescription());
+        m_mediaDescriptions.try_emplace(id, *protect(videoTrackInfo.description));
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*videoTrackInfo.description), id };
     });
 
@@ -396,7 +396,7 @@ std::optional<InitializationSegmentInfo> RemoteSourceBufferProxy::createInitiali
         RefPtr track = textTrackInfo.track;
         auto id = track->id();
         remoteMediaPlayerProxy->addRemoteTextTrackProxy(*track);
-        m_mediaDescriptions.try_emplace(id, *textTrackInfo.protectedDescription());
+        m_mediaDescriptions.try_emplace(id, *protect(textTrackInfo.description));
         return InitializationSegmentInfo::TrackInformation { MediaDescriptionInfo(*textTrackInfo.description), id };
     });
 

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -42,13 +42,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaSessionHelperProxy);
 RemoteMediaSessionHelperProxy::RemoteMediaSessionHelperProxy(GPUConnectionToWebProcess& gpuConnection)
     : m_gpuConnection(gpuConnection)
 {
-    MediaSessionHelper::protectedSharedHelper()->addClient(*this);
+    protect(MediaSessionHelper::sharedHelper())->addClient(*this);
 }
 
 RemoteMediaSessionHelperProxy::~RemoteMediaSessionHelperProxy()
 {
     stopMonitoringWirelessRoutes();
-    MediaSessionHelper::protectedSharedHelper()->removeClient(*this);
+    protect(MediaSessionHelper::sharedHelper())->removeClient(*this);
 }
 
 void RemoteMediaSessionHelperProxy::ref() const
@@ -75,7 +75,7 @@ void RemoteMediaSessionHelperProxy::startMonitoringWirelessRoutes()
         return;
 
     m_isMonitoringWirelessRoutes = true;
-    MediaSessionHelper::protectedSharedHelper()->startMonitoringWirelessRoutes();
+    protect(MediaSessionHelper::sharedHelper())->startMonitoringWirelessRoutes();
 }
 
 void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
@@ -84,7 +84,7 @@ void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
         return;
 
     m_isMonitoringWirelessRoutes = false;
-    MediaSessionHelper::protectedSharedHelper()->stopMonitoringWirelessRoutes();
+    protect(MediaSessionHelper::sharedHelper())->stopMonitoringWirelessRoutes();
 }
 
 void RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
     std::optional<MediaPlayerIdentifier> playerId;
     Ref gpuProcessConnection = this->gpuProcessConnection();
     if (auto player = cdm.mediaPlayer())
-        playerId = protect(gpuProcessConnection->mediaPlayerManager())->findRemotePlayerId(player->protectedPlayerPrivate().get());
+        playerId = protect(gpuProcessConnection->mediaPlayerManager())->findRemotePlayerId(protect(player->playerPrivate()));
 
     auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm.keySystem(), WTF::move(playerId)), { });
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);


### PR DESCRIPTION
#### 4eb9aede17b4bedaa324d404c3f030f21b33ff39
<pre>
Reduce use of protected functions in Source/WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=308459">https://bugs.webkit.org/show_bug.cgi?id=308459</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::addSession):
(WebCore::MediaSessionManagerInterface::removeSession):
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
(WebCore::SharedAudioDestination::start):
(WebCore::SharedAudioDestination::stop):
(WebCore::SharedAudioDestination::outputLatency const):
(WebCore::SharedAudioDestination::setSceneIdentifier):
(WebCore::SharedAudioDestination::protectedOutputAdapter const): Deleted.
* Source/WebCore/platform/audio/SharedAudioDestination.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
(WebCore::AudioSampleDataSource::protectedLogger const): Deleted.
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::protectedSharedHelper): Deleted.
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::urlFilter const):
(WebCore::ParentalControlsContentFilter::enabled const):
(WebCore::ParentalControlsContentFilter::responseReceived):
(WebCore::ParentalControlsContentFilter::protectedImpl const): Deleted.
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::protectedVariantFont const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::offsetToMiddleOfGlyphAtIndex):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::glyphDataForSystemFallback):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::protectedFontAt const): Deleted.
* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphData::isValid const):
(WebCore::GlyphData::protectedFont const): Deleted.
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp:
(WebCore::ImageFrameWorkQueue::start):
(WebCore::ImageFrameWorkQueue::stop):
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.h:
(WebCore::ImageFrameWorkQueue::protectedSource const): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::hasAvailableVideoFrame const):
(WebCore::MediaPlayer::prepareForRendering):
(WebCore::MediaPlayer::cancelLoad):
(WebCore::MediaPlayer::prepareToPlay):
(WebCore::MediaPlayer::play):
(WebCore::MediaPlayer::pause):
(WebCore::MediaPlayer::setBufferingPolicy):
(WebCore::MediaPlayer::createSession):
(WebCore::MediaPlayer::setCDM):
(WebCore::MediaPlayer::setCDMSession):
(WebCore::MediaPlayer::keyAdded):
(WebCore::MediaPlayer::cdmInstanceAttached):
(WebCore::MediaPlayer::cdmInstanceDetached):
(WebCore::MediaPlayer::attemptToDecryptWithInstance):
(WebCore::MediaPlayer::setShouldContinueAfterKeyNeeded):
(WebCore::MediaPlayer::duration const):
(WebCore::MediaPlayer::startTime const):
(WebCore::MediaPlayer::initialTime const):
(WebCore::MediaPlayer::currentTime const):
(WebCore::MediaPlayer::timeIsProgressing const):
(WebCore::MediaPlayer::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayer::getStartDate const):
(WebCore::MediaPlayer::willSeekToTarget):
(WebCore::MediaPlayer::seekWhenPossible):
(WebCore::MediaPlayer::paused const):
(WebCore::MediaPlayer::seeking const):
(WebCore::MediaPlayer::supportsFullscreen const):
(WebCore::MediaPlayer::canSaveMediaData const):
(WebCore::MediaPlayer::supportsScanning const):
(WebCore::MediaPlayer::supportsProgressMonitoring const):
(WebCore::MediaPlayer::requiresImmediateCompositing const):
(WebCore::MediaPlayer::naturalSize):
(WebCore::MediaPlayer::hasVideo const):
(WebCore::MediaPlayer::hasAudio const):
(WebCore::MediaPlayer::platformLayer const):
(WebCore::MediaPlayer::createVideoFullscreenLayer):
(WebCore::MediaPlayer::setVideoFullscreenLayer):
(WebCore::MediaPlayer::updateVideoFullscreenInlineImage):
(WebCore::MediaPlayer::setVideoFullscreenFrame):
(WebCore::MediaPlayer::setVideoFullscreenGravity):
(WebCore::MediaPlayer::setVideoFullscreenMode):
(WebCore::MediaPlayer::videoFullscreenStandbyChanged):
(WebCore::MediaPlayer::setSceneIdentifier):
(WebCore::MediaPlayer::setVideoLayerSizeFenced):
(WebCore::MediaPlayer::timedMetadata const):
(WebCore::MediaPlayer::accessLog const):
(WebCore::MediaPlayer::errorLog const):
(WebCore::MediaPlayer::networkState):
(WebCore::MediaPlayer::readyState const):
(WebCore::MediaPlayer::setVolumeLocked):
(WebCore::MediaPlayer::setVolume):
(WebCore::MediaPlayer::setMuted):
(WebCore::MediaPlayer::hasClosedCaptions const):
(WebCore::MediaPlayer::setClosedCaptionsVisible):
(WebCore::MediaPlayer::rate const):
(WebCore::MediaPlayer::setRate):
(WebCore::MediaPlayer::effectiveRate const):
(WebCore::MediaPlayer::setPreservesPitch):
(WebCore::MediaPlayer::setPitchCorrectionAlgorithm):
(WebCore::MediaPlayer::buffered const):
(WebCore::MediaPlayer::seekable const):
(WebCore::MediaPlayer::maxTimeSeekable const):
(WebCore::MediaPlayer::minTimeSeekable const):
(WebCore::MediaPlayer::seekableTimeRangesLastModifiedTime):
(WebCore::MediaPlayer::liveUpdateInterval):
(WebCore::MediaPlayer::didLoadingProgress const):
(WebCore::MediaPlayer::setPresentationSize):
(WebCore::MediaPlayer::setPageIsVisible):
(WebCore::MediaPlayer::setVisibleForCanvas):
(WebCore::MediaPlayer::setVisibleInViewport):
(WebCore::MediaPlayer::setResourceOwner):
(WebCore::MediaPlayer::setPreload):
(WebCore::MediaPlayer::paint):
(WebCore::MediaPlayer::paintCurrentFrameInContext):
(WebCore::MediaPlayer::videoFrameForCurrentTime):
(WebCore::MediaPlayer::nativeImageForCurrentTime):
(WebCore::MediaPlayer::bitmapImageForCurrentTimeSync):
(WebCore::MediaPlayer::bitmapImageForCurrentTime):
(WebCore::MediaPlayer::colorSpace):
(WebCore::MediaPlayer::shouldGetNativeImageForCanvasDrawing const):
(WebCore::MediaPlayer::supportsPictureInPicture const):
(WebCore::MediaPlayer::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayer::wirelessPlaybackTargetName const):
(WebCore::MediaPlayer::wirelessPlaybackTargetType const):
(WebCore::MediaPlayer::wirelessVideoPlaybackDisabled const):
(WebCore::MediaPlayer::setWirelessVideoPlaybackDisabled):
(WebCore::MediaPlayer::supportedPlaybackTargetTypes const):
(WebCore::MediaPlayer::setWirelessPlaybackTarget):
(WebCore::MediaPlayer::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayer::maxFastForwardRate const):
(WebCore::MediaPlayer::minFastReverseRate const):
(WebCore::MediaPlayer::acceleratedRenderingStateChanged):
(WebCore::MediaPlayer::supportsAcceleratedRendering const):
(WebCore::MediaPlayer::setShouldMaintainAspectRatio):
(WebCore::MediaPlayer::requestHostingContext):
(WebCore::MediaPlayer::hostingContext const):
(WebCore::MediaPlayer::didPassCORSAccessCheck const):
(WebCore::MediaPlayer::isCrossOrigin const):
(WebCore::MediaPlayer::movieLoadType const):
(WebCore::MediaPlayer::mediaTimeForTimeValue const):
(WebCore::MediaPlayer::decodedFrameCount const):
(WebCore::MediaPlayer::droppedFrameCount const):
(WebCore::MediaPlayer::audioDecodedByteCount const):
(WebCore::MediaPlayer::videoDecodedByteCount const):
(WebCore::MediaPlayer::reloadTimerFired):
(WebCore::MediaPlayer::readyStateChanged):
(WebCore::MediaPlayer::volumeChanged):
(WebCore::MediaPlayer::audioSourceProvider):
(WebCore::MediaPlayer::waitingForKey const):
(WebCore::MediaPlayer::platformErrorCode const):
(WebCore::MediaPlayer::setTextTrackRepresentation):
(WebCore::MediaPlayer::syncTextTrackBounds):
(WebCore::MediaPlayer::tracksChanged):
(WebCore::MediaPlayer::simulateAudioInterruption):
(WebCore::MediaPlayer::fileSize const):
(WebCore::MediaPlayer::ended const):
(WebCore::MediaPlayer::applicationWillResignActive):
(WebCore::MediaPlayer::applicationDidBecomeActive):
(WebCore::MediaPlayer::objCAVFoundationAVPlayer const):
(WebCore::MediaPlayer::performTaskAtTime):
(WebCore::MediaPlayer::shouldIgnoreIntrinsicSize):
(WebCore::MediaPlayer::isLoopingChanged):
(WebCore::MediaPlayer::setPreferredDynamicRangeMode):
(WebCore::MediaPlayer::setPlatformDynamicRangeLimit):
(WebCore::MediaPlayer::audioOutputDeviceChanged):
(WebCore::MediaPlayer::identifier const):
(WebCore::MediaPlayer::videoFrameMetadata):
(WebCore::MediaPlayer::startVideoFrameMetadataGathering):
(WebCore::MediaPlayer::stopVideoFrameMetadataGathering):
(WebCore::MediaPlayer::renderVideoWillBeDestroyed):
(WebCore::MediaPlayer::setShouldDisableHDR):
(WebCore::MediaPlayer::playerContentBoxRectChanged):
(WebCore::MediaPlayer::supportsPlayAtHostTime const):
(WebCore::MediaPlayer::supportsPauseAtHostTime const):
(WebCore::MediaPlayer::playAtHostTime):
(WebCore::MediaPlayer::pauseAtHostTime):
(WebCore::MediaPlayer::setShouldCheckHardwareSupport):
(WebCore::MediaPlayer::setDefaultSpatialTrackingLabel):
(WebCore::MediaPlayer::setSpatialTrackingLabel):
(WebCore::MediaPlayer::setPrefersSpatialAudioExperience):
(WebCore::MediaPlayer::soundStageSizeDidChange):
(WebCore::MediaPlayer::setInFullscreenOrPictureInPicture):
(WebCore::MediaPlayer::supportsLinearMediaPlayer const):
(WebCore::MediaPlayer::setMessageClientForTesting):
(WebCore::MediaPlayer::protectedPlayerPrivate): Deleted.
(WebCore::MediaPlayer::protectedPrivate const): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removeCodedFrames):
(WebCore::SourceBufferPrivate::asyncEvictCodedFrames):
(WebCore::SourceBufferPrivate::currentAppendProcessing const):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
(WebCore::SourceBufferPrivate::resetParserState):
(WebCore::SourceBufferPrivate::memoryPressure):
(WebCore::SourceBufferPrivate::protectedCurrentAppendProcessing const): Deleted.
(WebCore::SourceBufferPrivate::protectedCurrentSourceBufferOperation const): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation::protectedDescription const): Deleted.
(WebCore::SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation::protectedTrack const): Deleted.
(WebCore::SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation::protectedDescription const): Deleted.
(WebCore::SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation::protectedTrack const): Deleted.
(WebCore::SourceBufferPrivateClient::InitializationSegment::TextTrackInformation::protectedDescription const): Deleted.
(WebCore::SourceBufferPrivateClient::InitializationSegment::TextTrackInformation::protectedTrack const): Deleted.
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advanceInternal):
(WebCore::WidthIterator::applyExtraSpacingAfterShaping):
(WebCore::WidthIterator::applyCSSVisibilityRules):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
(WebCore::AudioVideoRendererAVFObjC::protectedLogger const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::isReadyForMoreSamples):
(WebCore::AudioVideoRendererAVFObjC::protectedVideoRenderer const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::protectedLogger const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::MediaPlayerPrivateAVFoundationObjC):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::MediaPlayerPrivateAVFoundationObjC::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateAVFoundationObjC::attemptToDecryptWithInstance):
(WebCore::MediaPlayerPrivateAVFoundationObjC::protectedCDMInstance const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::protectedMediaSourcePrivate const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::currentDisplayMode const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateTracks):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::protectedMediaStreamPrivate const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::destroyRendererTracks):
(WebCore::SourceBufferPrivateAVFObjC::videoTrackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::audioTrackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::flush):
(WebCore::SourceBufferPrivateAVFObjC::removeTrackID):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::setMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivateAVFObjC::renderer const):
(WebCore::SourceBufferPrivateAVFObjC::protectedRenderer const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h:
(WebCore::WebCoreAVFResourceLoader::logger const):
(WebCore::WebCoreAVFResourceLoader::protectedLogger const): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::layerIDIgnoringStructuralLayer const):
(WebCore::GraphicsLayerCA::setNeedsDisplayIfEDRHeadroomExceeds):
(WebCore::GraphicsLayerCA::backingStoreAttached const):
(WebCore::GraphicsLayerCA::tiledBacking const):
(WebCore::GraphicsLayerCA::updateNames):
(WebCore::GraphicsLayerCA::updateMasksToBounds):
(WebCore::GraphicsLayerCA::updateUserInteractionEnabled):
(WebCore::GraphicsLayerCA::updateContentsOpaque):
(WebCore::GraphicsLayerCA::updateBackfaceVisibility):
(WebCore::GraphicsLayerCA::updateBackdropRoot):
(WebCore::GraphicsLayerCA::updateShape):
(WebCore::GraphicsLayerCA::updateWindRule):
(WebCore::GraphicsLayerCA::updateAppleVisualEffectData):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
(WebCore::GraphicsLayerCA::protectedLayer const): Deleted.
(WebCore::GraphicsLayerCA::protectedBackdropLayer const): Deleted.
(WebCore::GraphicsLayerCA::protectedStructuralLayer const): Deleted.
(WebCore::GraphicsLayerCA::protectedAnimatedLayer const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerCocoa.mm:
(WebCore::MediaPlayer::setVideoTarget):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
(WebCore::MediaPlayerPrivateWebM::protectedLogger const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::addTrackBuffer):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::addSource):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::removeSource):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::~CoreAudioCaptureSource):
(WebCore::CoreAudioCaptureSource::startProducingData):
(WebCore::CoreAudioCaptureSource::stopProducingData):
(WebCore::CoreAudioCaptureSource::settingsDidChange):
(WebCore::CoreAudioCaptureSource::interrupted const):
(WebCore::CoreAudioCaptureSource::delaySamples):
(WebCore::CoreAudioCaptureSource::setIsInBackground):
(WebCore::CoreAudioCaptureSource::protectedUnit): Deleted.
(WebCore::CoreAudioCaptureSource::protectedUnit const): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockDisplayCapturer::start):
(WebCore::MockDisplayCapturer::stop):
(WebCore::MockDisplayCapturer::generateFrame):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
(WebCore::MockMediaPlayerMediaSource::protectedMediaSourcePrivate): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::createResourceHandle):
(WebCore::BlobRegistryImpl::protectedBlobDataFromURL const): Deleted.
* Source/WebCore/platform/network/BlobRegistryImpl.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::providePresentingApplicationPID const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::loadMediaSource):
(WebKit::RemoteMediaPlayerProxy::playbackTargetType const):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::createInitializationSegmentInfo):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::RemoteMediaSessionHelperProxy):
(WebKit::RemoteMediaSessionHelperProxy::~RemoteMediaSessionHelperProxy):
(WebKit::RemoteMediaSessionHelperProxy::startMonitoringWirelessRoutes):
(WebKit::RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::createCDM):

Canonical link: <a href="https://commits.webkit.org/308098@main">https://commits.webkit.org/308098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8c3259517a75c29454aea27a586937493b86f1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99828 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112664 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80563 "Exiting early after 60 failures. 15470 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49daafdc-f055-481d-87b9-d4161d382a0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c64b07a-427e-4368-83db-14d80a91ac6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12049 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2502 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157378 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120702 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31005 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74692 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8077 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18504 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18233 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18397 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->