### PR TITLE
Re-enable safety warnings as errors

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -103,20 +103,17 @@ WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS) $(WK_SANITIZER_WARNING
 
 CLANG_CXX_STANDARD_LIBRARY_HARDENING = extensive;
 
-// Enable strict memory safety in Swift, and treat any such warnings as errors.
+// Enable strict memory safety in Swift.
 // Enable for sufficiently recent Xcode only.
 WK_SWIFT_MEMORY_SAFETY_FLAGS = $(WK_SWIFT_MEMORY_SAFETY_FLAGS_$(WK_XCODE_BEFORE_17));
 WK_SWIFT_MEMORY_SAFETY_FLAGS_ = -strict-memory-safety -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence -enable-experimental-feature ImportNonPublicCxxMembers;
-// rdar://164903024: Work around strict safety bug by only promoting warnings
-// to errors in certain SDK versions. Merge this -Werror argument into the
-// above build setting once fixed.
+
+// Treat memory safety warnings as errors.
+WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS = -Werror StrictMemorySafety;
 // Keep it turned off on VisionOS until rdar://164555610 and rdar://164559261 are fixed.
-WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=macosx26.0*] = -Werror StrictMemorySafety $(inherited);
-WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=macosx26.1*] = -Werror StrictMemorySafety $(inherited);
-WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=macosx26.2*] = -Werror StrictMemorySafety $(inherited);
-WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=iphone*26.0*] = -Werror StrictMemorySafety $(inherited);
-WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=iphone*26.1*] = -Werror StrictMemorySafety $(inherited);
-WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=iphone*26.2*] = -Werror StrictMemorySafety $(inherited);
+WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS[sdk=xr*] = ;
+// rdar://164903024: Work around false positives in some SDK versions.
+WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS[sdk=*26.3*] = ;
 
 // rdar://168992837 requires us to tell swiftc to tell clang how to set version macros
 // when interpreting C++ headers as clang modules, so that we get identical feature
@@ -124,6 +121,6 @@ WK_SWIFT_MEMORY_SAFETY_FLAGS_[sdk=iphone*26.2*] = -Werror StrictMemorySafety $(i
 WK_SWIFT_CLANG_DEPLOYMENT_TARGET = $(WK_SWIFT_CLANG_DEPLOYMENT_TARGET_$(WK_PLATFORM_NAME);
 WK_SWIFT_CLANG_DEPLOYMENT_TARGET_macosx = -clang-target $(CURRENT_ARCH)-apple-macos$(MACOSX_DEPLOYMENT_TARGET);
 
-OTHER_SWIFT_FLAGS = $(inherited) $(WK_SWIFT_MEMORY_SAFETY_FLAGS) $(WK_SWIFT_CLANG_DEPLOYMENT_TARGET) $(WK_SANITIZER_OTHER_SWIFT_FLAGS);
+OTHER_SWIFT_FLAGS = $(inherited) $(WK_SWIFT_MEMORY_SAFETY_FLAGS) $(WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS) $(WK_SWIFT_CLANG_DEPLOYMENT_TARGET) $(WK_SANITIZER_OTHER_SWIFT_FLAGS);
 
 OTHER_LIBTOOLFLAGS = -no_warning_for_no_symbols;

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -856,8 +856,9 @@ extension WKBridgeLiteral {
 
 internal func toData<T>(_ input: [T]) -> Data {
     #if compiler(>=6.2)
+    // FIXME: (rdar://164559261) understand/document/remove unsafety
     unsafe input.withUnsafeBytes { bufferPointer in
-        Data(bufferPointer)
+        unsafe Data(bufferPointer)
     }
     #else
     input.withUnsafeBytes { bufferPointer in

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -76,6 +76,17 @@ extension _Proto_LowLevelMeshResource_v1 {
     nonisolated func replaceVertexData(_ vertexData: [Data]) {
         for (vertexBufferIndex, vertexData) in vertexData.enumerated() {
             let bufferSizeInByte = vertexData.bytes.byteCount
+            #if compiler(>=6.2)
+            // FIXME: (rdar://164559261) understand/document/remove unsafety
+            self.replaceVertices(at: vertexBufferIndex) { vertexBytes in
+                unsafe vertexBytes.withUnsafeMutableBytes { ptr in
+                    // FIXME(rdar://164559261): understand/document/remove unsafety
+                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                    // swift-format-ignore: NeverForceUnwrap
+                    unsafe vertexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: bufferSizeInByte)
+                }
+            }
+            #else
             self.replaceVertices(at: vertexBufferIndex) { vertexBytes in
                 vertexBytes.withUnsafeMutableBytes { ptr in
                     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -83,17 +94,27 @@ extension _Proto_LowLevelMeshResource_v1 {
                     vertexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: bufferSizeInByte)
                 }
             }
+            #endif
         }
     }
 
     nonisolated func replaceIndexData(_ indexData: Data?) {
         if let indexData = indexData {
             self.replaceIndices { indicesBytes in
+                #if compiler(>=6.2)
+                // FIXME: (rdar://164559261) understand/document/remove unsafety
+                unsafe indicesBytes.withUnsafeMutableBytes { ptr in
+                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                    // swift-format-ignore: NeverForceUnwrap
+                    unsafe indexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
+                }
+                #else
                 indicesBytes.withUnsafeMutableBytes { ptr in
                     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                     // swift-format-ignore: NeverForceUnwrap
                     indexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
                 }
+                #endif
             }
         }
     }

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1216,6 +1216,16 @@ extension WKBridgeReceiver {
 
 extension WKBridgeSkinningData {
     fileprivate func makeDeformerDescription(device: MTLDevice) -> _Proto_LowLevelDeformerDescription_v1 {
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let jointTransformsBuffer = unsafe device.makeBuffer(
+            bytes: self.jointTransforms,
+            length: self.jointTransforms.count * MemoryLayout<simd_float4x4>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointTransformsBuffer = device.makeBuffer(
@@ -1223,6 +1233,7 @@ extension WKBridgeSkinningData {
             length: self.jointTransforms.count * MemoryLayout<simd_float4x4>.size,
             options: .storageModeShared
         )!
+        #endif
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -1233,6 +1244,16 @@ extension WKBridgeSkinningData {
             elementType: .float4x4
         )!
 
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let inverseBindPosesBuffer = unsafe device.makeBuffer(
+            bytes: self.inverseBindPoses,
+            length: self.inverseBindPoses.count * MemoryLayout<simd_float4x4>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let inverseBindPosesBuffer = device.makeBuffer(
@@ -1240,6 +1261,7 @@ extension WKBridgeSkinningData {
             length: self.inverseBindPoses.count * MemoryLayout<simd_float4x4>.size,
             options: .storageModeShared
         )!
+        #endif
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -1250,6 +1272,16 @@ extension WKBridgeSkinningData {
             elementType: .float4x4
         )!
 
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let jointIndicesBuffer = unsafe device.makeBuffer(
+            bytes: self.influenceJointIndices,
+            length: self.influenceJointIndices.count * MemoryLayout<UInt32>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointIndicesBuffer = device.makeBuffer(
@@ -1257,6 +1289,7 @@ extension WKBridgeSkinningData {
             length: self.influenceJointIndices.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
+        #endif
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointIndicesDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1266,6 +1299,16 @@ extension WKBridgeSkinningData {
             elementType: .uint
         )!
 
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let influenceWeightsBuffer = unsafe device.makeBuffer(
+            bytes: self.influenceWeights,
+            length: self.influenceWeights.count * MemoryLayout<Float>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let influenceWeightsBuffer = device.makeBuffer(
@@ -1273,6 +1316,7 @@ extension WKBridgeSkinningData {
             length: self.influenceWeights.count * MemoryLayout<Float>.size,
             options: .storageModeShared
         )!
+        #endif
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let influenceWeightsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(


### PR DESCRIPTION
#### 08cccadae4bfdc9cdcc3fce3d9185a924254213c
<pre>
Re-enable safety warnings as errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=308458">https://bugs.webkit.org/show_bug.cgi?id=308458</a>
<a href="https://rdar.apple.com/170973137">rdar://170973137</a>

Reviewed by Elliott Williams.

This re-enables treating Swift strict memory safety warnings as errors, which
was temporarily disabled due to some false-positives.

Canonical link: <a href="https://commits.webkit.org/308337@main">https://commits.webkit.org/308337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6e2744adc0552286fea4fe369a20cb09095d058

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155903 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100635 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4739bdd2-9f46-4827-9c26-8d41b587cd8c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3c414ae-39ae-4898-8ab0-d7172a031089) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8515e83b-f68e-4431-915c-39489f00b417) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14862 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12646 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124452 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158234 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11616 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121483 "Found 1 new test failure: swipe/swipe-disables-view-transition.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121686 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31161 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75671 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8728 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83073 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19049 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19107 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->