### PR TITLE
[WebKit][Main] [6b74450cea2d0aa4] ASAN_SEGV | WebCore::IDBTransaction::didCommit; WebCore::IDBTransaction::connectionClosedFromServer; WebCore::IDBDatabase::connectionToServerLost

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4370,6 +4370,8 @@ storage/indexeddb/modern/get-keyrange.html [ Failure Pass ]
 storage/indexeddb/modern/idbobjectstore-delete-1-private.html [ Failure Pass ]
 storage/indexeddb/modern/idbobjectstore-delete-1.html [ Failure Pass ]
 
+storage/indexeddb/abort-while-committing-crash.html [ Skip ]
+
 editing/style/unbold-in-bold.html [ Failure ]
 
 fast/html/body-color-legacy-parsing-3.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/storage/indexeddb/abort-while-committing-crash-expected.txt
+++ b/LayoutTests/storage/indexeddb/abort-while-committing-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/storage/indexeddb/abort-while-committing-crash.html
+++ b/LayoutTests/storage/indexeddb/abort-while-committing-crash.html
@@ -1,0 +1,45 @@
+<script>
+ testRunner?.dumpAsText();
+    (async () => {
+        globalThis.testRunner?.waitUntilDone();
+
+        const databaseName = 'db2';
+        const objectStoreName = 'os0';
+        const databases = await indexedDB.databases();
+
+        function transactionHelper(transaction) {
+            let theOs = transaction.objectStore(objectStoreName);
+            let addRequest = theOs.add(undefined, 1);
+            for (let i = 20; i; i--) {
+                addRequest.addEventListener('success', ev => {
+                    let transaction = ev.target.transaction;
+                    transactionHelper(transaction);
+                });
+            }
+            addRequest.addEventListener('success', ev => {
+                let transaction = ev.target.transaction;
+                transactionHelper(transaction);
+                transaction.commit();
+            });
+        }
+
+        indexedDB.open(databaseName, 1).addEventListener('upgradeneeded', ev => {
+           let db = ev.target.result;
+           let txn = ev.target.transaction;
+           if (!txn.objectStoreNames.contains(objectStoreName)) db.createObjectStore(objectStoreName, {});
+        });
+        navigator.mediaSession.playbackState = 'playing';
+        await navigator.locks.request('', () => {})
+        indexedDB.open(databaseName, 1).addEventListener('success', ev => {
+            let db = ev.target.result;
+            let transaction = db.transaction([objectStoreName], 'readwrite');
+            transactionHelper(transaction);
+        });
+        await navigator.locks.request('', () => {});
+
+        globalThis.testRunner?.notifyDone();
+    })();
+</script>
+<div>
+    This test passes if it doesn't crash.
+</div>

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1420,7 +1420,9 @@ void IDBTransaction::operationCompletedOnClient(IDBClient::TransactionOperation&
     m_transactionOperationsInProgressQueue.removeFirst();
 
     if (m_commitResult && operation.identifier() == *m_lastTransactionOperationBeforeCommit) {
-        didCommit(*m_commitResult);
+        // We might end up here during transaction abortion, in which case we shouldn't call didCommit().
+        if (m_state == IndexedDB::TransactionState::Committing)
+            didCommit(*m_commitResult);
         return;
     }
 


### PR DESCRIPTION
#### 3ef9914eedadd24b6e52a3cb2b1b50d1707a0c42
<pre>
[WebKit][Main] [6b74450cea2d0aa4] ASAN_SEGV | WebCore::IDBTransaction::didCommit; WebCore::IDBTransaction::connectionClosedFromServer; WebCore::IDBDatabase::connectionToServerLost
<a href="https://bugs.webkit.org/show_bug.cgi?id=308462">https://bugs.webkit.org/show_bug.cgi?id=308462</a>

Reviewed by Sihui Liu.

When the connection is closed from the server, we might end up with
transactions that are in the process of aborting and whose operations
complete at the same time. This might cause an aborted transaction to
to call operationCompletedOnClient(), in which case we shouldn&apos;t
call didCommit as we are in an aborting state.

This bug manifests itself in two ways:

1. In Debug builds, the assertion in didCommit() will fail,
as the transaction is in Aborting state instead of Committing.

2. In a Release build, and particularly after 305703@main, it&apos;s
possible to hit an assertion in IDBDatabase::willAbortTransaction(),
as it doesn&apos;t find the transaction in neither the active or the
committing transaction list, as the transaction is already in
aborting state.

Accounting for this in operationCompletedInClient() prevents both
issues.

Test reduced by Frédéric Wang &lt;fwang@igalia.com&gt;

Test: storage/indexeddb/abort-while-committing-crash.html

* LayoutTests/platform/win/TestExpectations:
* LayoutTests/storage/indexeddb/abort-while-committing-crash-expected.txt: Added.
* LayoutTests/storage/indexeddb/abort-while-committing-crash.html: Added.
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::operationCompletedOnClient):

Canonical link: <a href="https://commits.webkit.org/308044@main">https://commits.webkit.org/308044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21d9cf6631fecca2dbf9fe75c040b2975cc7e2a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155006 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112621 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14976 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14243 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157327 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/498 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120650 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30978 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74631 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16622 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18454 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->