### PR TITLE
[WebDriver BiDi] browsingContext.create should validate userContext parameter

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -86,7 +86,8 @@
                 "TargetOutOfBounds",
                 "UnableToLoadExtension",
                 "UnableToUnloadExtension",
-                "NoSuchExtension"
+                "NoSuchExtension",
+                "NoSuchUserContext"
             ]
         },
         {

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
@@ -114,6 +114,17 @@ void BidiBrowserAgent::willClosePage(const WebPageProxy& page)
     m_userContextsPendingDeletion.remove(it);
 }
 
+bool BidiBrowserAgent::isValidUserContext(const String& userContextID) const
+{
+    if (userContextID.isEmpty())
+        return false;
+
+    if (userContextID == defaultUserContextID())
+        return true;
+
+    return m_userContexts.contains(userContextID);
+}
+
 // MARK: Inspector::BidiBrowserDispatcherHandler methods.
 
 CommandResult<void> BidiBrowserAgent::close()

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h
@@ -55,6 +55,8 @@ public:
     void didCreatePage(WebPageProxy&);
     void willClosePage(const WebPageProxy&);
 
+    bool isValidUserContext(const String& userContextID) const;
+
 private:
     struct BidiUserContextDeletionRecord;
 

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -124,9 +124,14 @@ void BidiBrowsingContextAgent::create(Inspector::Protocol::BidiBrowsingContext::
     RefPtr session = m_session.get();
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
+    if (!optionalUserContext.isNull()) {
+        bool isValid = session->isValidUserContext(optionalUserContext);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!isValid, NoSuchUserContext);
+    }
+
     // FIXME: implement `referenceContext` option.
     // FIXME: implement `background` option.
-    // FIXME: implement `userContext` option.
+    // FIXME: implement `userContext` option (use validated context to create in specific user context).
 
     session->createBrowsingContext(browsingContextPresentationFromCreateType(createType), [callback = WTF::move(callback)](CommandResultOf<BrowsingContext, Inspector::Protocol::Automation::BrowsingContextPresentation>&& result) {
         if (!result) {

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -406,6 +406,13 @@ Expected<PageAndFrameHandle, AutomationCommandError> WebAutomationSession::extra
     return makeUnexpected(AUTOMATION_COMMAND_ERROR_WITH_NAME(FrameNotFound));
 }
 
+#if ENABLE(WEBDRIVER_BIDI)
+bool WebAutomationSession::isValidUserContext(const String& userContextID) const
+{
+    return m_bidiProcessor->browserAgent().isValidUserContext(userContextID);
+}
+#endif
+
 // Platform-independent Commands.
 
 void WebAutomationSession::getNextContext(Vector<Ref<WebPageProxy>>&& pages, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>> contexts, CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&& callback)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -317,6 +317,10 @@ public:
 
     Expected<PageAndFrameHandle, AutomationCommandError> extractBrowsingContextHandles(const String&);
 
+#if ENABLE(WEBDRIVER_BIDI)
+    bool isValidUserContext(const String& userContextID) const;
+#endif
+
 private:
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
     void getNextContext(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -149,6 +149,8 @@ static String toBidiErrorCode(int errorCode, const String& inspectorInternalMsg)
         return "unable to unload extension"_s;
     case Inspector::Protocol::Automation::ErrorMessage::NoSuchExtension:
         return "no such web extension"_s;
+    case Inspector::Protocol::Automation::ErrorMessage::NoSuchUserContext:
+        return "no such user context"_s;
     default:
         return "unknown error"_s;
     }

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2264,17 +2264,8 @@
             "test_params_type_invalid_value[foo]": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
             },
-            "test_params_user_context_invalid_value[]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
-            "test_params_user_context_invalid_value[unknown]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
-            "test_params_user_context_invalid_value_with_ref_context": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
             "test_params_user_context_removed_context": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+                "expected": { "all": { "status": ["SKIP"], "note": "Test passes but fixture teardown fails trying to remove already-removed user context"}}
             }
         }
     },


### PR DESCRIPTION
#### a92e1388d6a1927a32c109491155dc62a627801d
<pre>
[WebDriver BiDi] browsingContext.create should validate userContext parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=306231">https://bugs.webkit.org/show_bug.cgi?id=306231</a>

Reviewed by Devin Rousso and BJ Burg.

Add validation for the userContext parameter in browsingContext.create command.
Returns &quot;no such user context&quot; error for invalid, empty, or removed user contexts.

* Source/WebKit/UIProcess/Automation/Automation.json:
- Add NoSuchUserContext predefined error type.

* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp:
(WebKit::BidiBrowserAgent::isValidUserContext const):
* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h:
- Add isValidUserContext() to validate user context IDs.

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::create):
- Add userContext validation before processing create request.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::isValidUserContext const):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
- Add delegation method for user context validation.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::toBidiErrorCode):
- Map NoSuchUserContext to &quot;no such user context&quot; BiDi error.

* WebDriverTests/TestExpectations.json:
- Remove expectations for 3 now-passing user_context tests.
- Skip test_params_user_context_removed_context due to fixture teardown issue.

Canonical link: <a href="https://commits.webkit.org/309908@main">https://commits.webkit.org/309908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/861206fc1f3f91c1c152fa405aa4be3c480c0930

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105552 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18752 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/16706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8672 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/128398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163304 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125518 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34110 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136196 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81269 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12973 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88578 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->