### PR TITLE
REGRESSION(305794@main): Unconditional CheckedPtr crash when loading any Reddit post with VoiceOver active

### DIFF
--- a/LayoutTests/accessibility/shadow-host-style-invalidation-during-text-under-element-crash-expected.txt
+++ b/LayoutTests/accessibility/shadow-host-style-invalidation-during-text-under-element-crash-expected.txt
@@ -1,0 +1,7 @@
+This test ensures we don't crash when a shadow-scoped stylesheet invalidation causes style re-resolution during textUnderElement.
+
+PASS: No crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ Click me

--- a/LayoutTests/accessibility/shadow-host-style-invalidation-during-text-under-element-crash.html
+++ b/LayoutTests/accessibility/shadow-host-style-invalidation-during-text-under-element-crash.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="text" type="text" />
+<button id="button" aria-describedby="tooltip">Click me</button>
+<div id="tooltip" role="tooltip" style="display: none"></div>
+
+<script>
+var output = "This test ensures we don't crash when a shadow-scoped stylesheet invalidation causes style re-resolution during textUnderElement.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var button = document.getElementById("button");
+    // Create a shadow root on the tooltip with slots.
+    var tooltip = document.getElementById("tooltip");
+    var shadow = tooltip.attachShadow({ mode: "open" });
+    shadow.innerHTML = "<style>.inner { color: red; }</style><slot></slot><slot></slot>";
+    // Add a light DOM child text that will be slotted.
+    tooltip.innerHTML = "Tooltip text";
+
+    setTimeout(async function() {
+        touchAccessibilityTree(accessibilityController.rootElement);
+
+        var styleElement = shadow.querySelector("style");
+        // Dirty the style by changing text color (which is an inherited property).
+        styleElement.textContent = `.inner { color: rgb(50, 0, 0); }`;
+        tooltip.innerHTML = "New text";
+        // Update aria-description so the tooltip's accessibility text is queued for recomputation.
+        tooltip.setAttribute("aria-description", "new description");
+        // Change a text field's value so we start the notification timer. We process isolated object updates before
+        // posting notifications, so we will process the updates from the aria-description change. In doing so, we will 
+        // recompute accessibility text property while the element has dirty style.
+        document.getElementById("text").value = "foo";
+        await sleep(0);
+        touchAccessibilityTree(accessibilityController.rootElement);
+
+        output += "PASS: No crash.";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 54845b1b874202434d8e0dc2bf032d4eb3236828
<pre>
REGRESSION(305794@main): Unconditional CheckedPtr crash when loading any Reddit post with VoiceOver active
<a href="https://bugs.webkit.org/show_bug.cgi?id=308467">https://bugs.webkit.org/show_bug.cgi?id=308467</a>
<a href="https://rdar.apple.com/170985963">rdar://170985963</a>

Reviewed by Chris Fleizach.

Narrow the scope of the CheckedPtr&lt;RenderStyle&gt; in AccessibilityNodeObject::textUnderElement
(added in 305794@main)so it does not live across the child iteration loop.

Previously, a CheckedPtr to the element&apos;s RenderStyle was captured at the
top of the function and held until return. During child iteration,
getOrCreate for a sibling slot element can trigger computedStyle() -&gt;
resolveComputedStyle(), which walks the ancestor chain and re-resolves
the parent&apos;s m_computedStyle. This destroys the old RenderStyle that the
CheckedPtr still references, resulting in a crash (EXC_GUARD from
CheckedPtr accessing a scribbled-over object).

This happens specifically for display:none shadow hosts with slot
children, where a shadow-scoped stylesheet update sets
IsComputedStyleInvalidFlag on the host and slots. The flag is never
cleared by the style tree resolver because display:none subtrees without
renderers are not visited during resolveStyle, and
updateLayoutIgnorePendingStylesheets considers style clean despite the
flag persisting on non-rendered elements.

* LayoutTests/accessibility/shadow-host-style-invalidation-during-text-under-element-crash-expected.txt: Added.
* LayoutTests/accessibility/shadow-host-style-invalidation-during-text-under-element-crash.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::textUnderElement const):

Canonical link: <a href="https://commits.webkit.org/308173@main">https://commits.webkit.org/308173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e95970b1041702cf611d347d134a894501e8877f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155010 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99788 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2eecd322-0d87-4cbd-8133-8b747287d47c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112624 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99788 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40df7ba5-805c-4e7a-8ed6-13a2a19ceb45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c8d5352-e9b3-4b91-bda1-ed7ebe7f5326) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14244 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12003 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157331 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120654 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120952 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74641 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8022 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82210 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18187 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->