### PR TITLE
[macOS] QR code detection context menu tests are flaky failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -324,36 +324,49 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringDefaultC
     EXPECT_NULL(elementInfo.qrCodePayloadString);
 }
 
-// FIXME when rdar://168100136 is resolved.
-#if PLATFORM(MAC) && defined(NDEBUG)
-TEST(ContextMenuTests, DISABLED_ContextMenuElementInfoContainsQRCodePayloadString)
-#else
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadString)
-#endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+
+    __block bool imageLoaded = false;
+    [testMessageHandler addMessage:@"imageLoaded" withHandler:^{
+        imageLoaded = true;
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
-    [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png' onload=\"window.webkit.messageHandlers.testHandler.postMessage('imageLoaded')\"></img>"];
+    Util::run(&imageLoaded);
 
-    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(150, 150)];
-    EXPECT_NULL(elementInfo.qrCodePayloadString);
+    RetainPtr elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(150, 150)];
+    EXPECT_NULL([elementInfo qrCodePayloadString]);
 
     elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
-    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+    EXPECT_WK_STREQ([elementInfo qrCodePayloadString], "https://www.webkit.org");
 }
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringInsideLink)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+
+    __block bool imageLoaded = false;
+    [testMessageHandler addMessage:@"imageLoaded" withHandler:^{
+        imageLoaded = true;
+    }];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
-    [webView synchronouslyLoadHTMLString:@"<a href='https://www.webkit.org'><img src='qr-code.png'></img></a>"];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<a href='https://www.webkit.org'><img src='qr-code.png' onload=\"window.webkit.messageHandlers.testHandler.postMessage('imageLoaded')\"></img></a>"];
+    Util::run(&imageLoaded);
 
-    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
-    EXPECT_NULL(elementInfo.qrCodePayloadString);
+    RetainPtr elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
+    EXPECT_NULL([elementInfo qrCodePayloadString]);
 }
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringCanvas)
@@ -453,31 +466,37 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZ
     EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
 }
 
-// FIXME: Re-enable this test once webkit.org/b/266650 is resolved
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 140000 && !defined(NDEBUG)
-TEST(ContextMenuElementInfoWithQRCodeDetectionCrash, DISABLED_ContextMenuTests)
-#else
 TEST(ContextMenuTests, ContextMenuElementInfoWithQRCodeDetectionCrash)
-#endif
 {
     auto createWebView = [] {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+
+        __block bool imageLoaded = false;
+        [testMessageHandler addMessage:@"imageLoaded" withHandler:^{
+            imageLoaded = true;
+        }];
+
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
         [configuration _setContextMenuQRCodeDetectionEnabled:YES];
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
-        [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
+
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+        [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png' onload=\"window.webkit.messageHandlers.testHandler.postMessage('imageLoaded')\"></img>"];
+        Util::run(&imageLoaded);
+
         return webView;
     };
 
     @autoreleasepool {
-        auto webView = createWebView();
+        RetainPtr webView = createWebView();
         [webView rightClickAtPoint:CGPointMake(300, 300)];
         [webView waitForNextPresentationUpdate];
         [webView removeFromSuperview];
     }
 
-    auto webView = createWebView();
-    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
-    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+    RetainPtr webView = createWebView();
+    RetainPtr elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
+    EXPECT_WK_STREQ([elementInfo qrCodePayloadString], "https://www.webkit.org");
 }
 
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)


### PR DESCRIPTION
#### 91289f9cb5583100d569f723641f90d32d2625cc
<pre>
[macOS] QR code detection context menu tests are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=266650">https://bugs.webkit.org/show_bug.cgi?id=266650</a>
<a href="https://rdar.apple.com/111706229">rdar://111706229</a>

Reviewed by NOBODY (OOPS!).

Wait for images to load prior to invoking the context menu. If the image is
right-clicked before it is loaded, no QR code payload would be found.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadString)):
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringInsideLink)):

This test was already passing because it asserts that no QR code payload is
found. It is also updated to wait for the image to load, to ensure the result
is not a false positive.

(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoWithQRCodeDetectionCrash)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91289f9cb5583100d569f723641f90d32d2625cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99798 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f55b746d-b32d-47b7-a327-7069a7ce999e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112632 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80541 "Exiting early after 60 failures. 15328 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1810461-0648-412f-b3ae-299df28a4ebc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14986 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131496 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93501 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14253 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12010 "1 api test failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2466 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157341 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120660 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120958 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74651 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8033 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18468 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18197 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18362 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->