### PR TITLE
REGRESSION(307595@main): [macOS iOS] TestWebKitAPI.WebpagePreferences.ContentRuleListEnablement is a constant failure

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2667,7 +2667,7 @@ bool WebProcess::requiresScriptTrackingPrivacyProtections(const URL& url, const 
 
 bool WebProcess::shouldAllowScriptAccess(const URL& url, const SecurityOrigin& topOrigin, ScriptTrackingPrivacyCategory category) const
 {
-    return m_scriptTrackingPrivacyFilter && m_scriptTrackingPrivacyFilter->shouldAllowAccess(url, topOrigin, category);
+    return !m_scriptTrackingPrivacyFilter || m_scriptTrackingPrivacyFilter->shouldAllowAccess(url, topOrigin, category);
 }
 
 bool WebProcess::requiresConsistentPrivacyQuirkForDomain(const URL& url) const

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1790,8 +1790,7 @@ TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDarkForContentThatDoesN
     EXPECT_WK_STREQ(backgroundColorWithoutPreference, backgroundColorWithPreference);
 }
 
-// FIXME when webkit.org/b/308064 is resolved.
-TEST(WebpagePreferences, DISABLED_ContentRuleListEnablement)
+TEST(WebpagePreferences, ContentRuleListEnablement)
 {
     [TestProtocol registerWithScheme:@"https"];
 


### PR DESCRIPTION
#### 3ca309c6472c4afb63f82033a69f218460ec5835
<pre>
REGRESSION(307595@main): [macOS iOS] TestWebKitAPI.WebpagePreferences.ContentRuleListEnablement is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=308064">https://bugs.webkit.org/show_bug.cgi?id=308064</a>
<a href="https://rdar.apple.com/170566192">rdar://170566192</a>

Reviewed by Matthew Finkel.

I fixed this test for internal builds in 307786@main, but it&apos;s still failing in open-source builds
because m_scriptTrackingPrivacyFilter is always null in those builds. When it&apos;s null, we should
always allow script access.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::shouldAllowScriptAccess const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
((WebpagePreferences, ContentRuleListEnablement)):
((WebpagePreferences, DISABLED_ContentRuleListEnablement)): Deleted.

Canonical link: <a href="https://commits.webkit.org/308081@main">https://commits.webkit.org/308081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59ab270b3960a24ca0078cac94a4d64b50932565

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99816 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73080fce-4169-4cc7-8b33-4a94ab5e110d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112648 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80555 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/998b515a-247d-44d9-b42c-d9d66442125e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93517 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd363499-70b6-4db4-80c6-5ddcb55fb7fb) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/145701 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14272 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157363 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/534 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120683 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120978 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74677 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8066 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18218 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18383 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->