### PR TITLE
[GTK][WPE] Gardening flaky/timeout tests

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1615,7 +1615,7 @@ webkit.org/b/307144 media/video-restricted-invisible-autoplay-not-allowed.html [
 webkit.org/b/254520 media/video-ended-event-negative-playback.html [ Failure Timeout Pass ]
 webkit.org/b/254519 media/media-continues-playing-after-replace-source.html [ Failure Pass ]
 webkit.org/b/254521 imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html [ Pass Failure ]
-webkit.org/b/254521 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-framesize.html [ Pass Failure ]
+webkit.org/b/254521 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-framesize.html [ Pass Failure Timeout ]
 webkit.org/b/254522 media/video-volume.html [ Pass Failure ]
 webkit.org/b/254525 http/tests/media/video-throttled-load-metadata.html [ Pass Failure ]
 media/video-seek-to-current-time.html [ Pass Failure ]
@@ -3419,7 +3419,7 @@ imported/w3c/web-platform-tests/encrypted-media/clearkey-check-encryption-scheme
 imported/w3c/web-platform-tests/encrypted-media/clearkey-check-initdata-type.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-events.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-events-session-closed-event.https.html [ Pass ]
-imported/w3c/web-platform-tests/encrypted-media/clearkey-invalid-license.https.html [ Pass ]
+imported/w3c/web-platform-tests/encrypted-media/clearkey-invalid-license.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html [ Pass ]
@@ -5271,6 +5271,11 @@ webkit.org/b/308146 media/video-size.html [ Pass Failure Timeout ]
 webkit.org/b/308262 fast/css/view-transitions-hide-under-page-background-color.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/308265 media/media-source/media-source-reopen.html [ Pass Failure ]
+
+webkit.org/b/307586 imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html [ Failure Pass ]
+
+webkit.org/b/308480 http/wpt/service-workers/navigation-preload-without-worker-connection.https.html [ Failure Pass ]
+webkit.org/b/308481 fast/speechsynthesis/speech-synthesis-speak-empty-string.html [ Failure Pass ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/wpe-legacy-api/TestExpectations
+++ b/LayoutTests/platform/wpe-legacy-api/TestExpectations
@@ -82,7 +82,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mis
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-wildcard.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html [ Failure ]
-webkit.org/b/307586 imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html [ Failure ]
 
 # Path with marker failures
 svg/W3C-SVG-1.1/painting-marker-03-f.svg [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1314,3 +1314,5 @@ webkit.org/b/308140 fast/dom/webtiming.html [ Pass Failure ]
 webkit.org/b/308145 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-writing-modes.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/308148 imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/chrome-bug-439886903-crash.html [ Pass Timeout ]
+
+webkit.org/b/308479 imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-text-to-the-canvas/canvas.2d.disconnected-font-size-math.html [ ImageOnlyFailure Pass ]


### PR DESCRIPTION
#### 7f268a526a00f26c5fa592bc4b423b949b1aa922
<pre>
[GTK][WPE] Gardening flaky/timeout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=310216">https://bugs.webkit.org/show_bug.cgi?id=310216</a>

Unreviewed gardening.

Updated test expectations after checking the last results in the bots.

* LayoutTests/platform/glib/TestExpectations:
</pre>