### PR TITLE
[iOS] Fix touch freeze during rapid swiping with active touch event listeners

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -78,7 +78,7 @@ struct TouchEventData {
 
     WebCore::FrameIdentifier frameID;
     WebTouchEvent event;
-    CompletionHandler<void(bool, std::optional<RemoteWebTouchEvent>)> completionHandler;
+    Vector<CompletionHandler<void(bool, std::optional<RemoteWebTouchEvent>)>> completionHandlers;
 };
 #endif
 


### PR DESCRIPTION
#### a1a65ba028ebc3aeeab4aca74f01a87e93902d4a
<pre>
[iOS] Fix touch freeze during rapid swiping with active touch event listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=306598">https://bugs.webkit.org/show_bug.cgi?id=306598</a>
<a href="https://rdar.apple.com/169279665">rdar://169279665</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

A race condition between UIProcess main thread and WebContentProcess IPC
thread causes touch input to freeze on iOS. When a preventable TouchMove is
queued on the IPC thread but not yet dispatched, and a TouchStart reply flips
_touchEventsCanPreventNativeGestures to NO, the next TouchMove routes as
unpreventable. EventDispatcher coalesces the two TouchMoves, destroying the
preventable CompletionHandler that would have transitioned
m_touchMovePreventionState out of Waiting. The state gets permanently stuck,
blocking all deferring gesture recognizers until the
GestureRecognizerConsistencyEnforcer safety timeout fires.

Fix this by changing TouchEventData to hold a Vector&lt;CompletionHandler&gt;
instead of a single CompletionHandler. When coalescing, the incoming handler
is appended to the existing vector rather than replacing it. At dispatch
time, all coalesced-away handlers are invoked with the JS result before the
final handler, ensuring no state transitions are lost.

* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::TouchEventData::TouchEventData):
(WebKit::EventDispatcher::touchEvent):
(WebKit::EventDispatcher::dispatchTouchEvents):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::dispatchAsynchronousTouchEvents):
(WebKit::WebPage::cancelAsynchronousTouchEvents):

Canonical link: <a href="https://commits.webkit.org/308237@main">https://commits.webkit.org/308237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add51c4124d875be9ae24720f29f0fdd4d8a4c9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100183 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1c653fd-aa23-4947-adcc-9abff29ced8e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113108 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80746 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1f4e7c6-50fe-4377-9f60-2de8b3aa2cf7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93853 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12369 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2906 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124186 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157794 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/939 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121118 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121330 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31096 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75106 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8407 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18622 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18681 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->