### PR TITLE
Make Tools/Scripts/update-safer-cpp-expectations favor "macOS" over "Mac"

### DIFF
--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -30,6 +30,17 @@ from webkitpy.safer_cpp.checkers import Checker
 EXPECTATION_LINE_RE = r'(\s*\[\s*(?P<platform>\w+)\s*\]\s*)?(?P<path>.+)'
 
 
+def normalize_platform(platform):
+    if not platform:
+        return None
+    platform = platform.lower()
+    if platform == "mac" or platform == "macos":
+        return "macOS"
+    elif platform == "ios":
+        return "iOS"
+    return None
+
+
 def parser():
     parser = argparse.ArgumentParser(description='Automated tooling for updating safer CPP expectations', epilog='Example: update-safer-cpp-expectations -p WebKit --RefCntblBaseVirtualDtor platform/Scrollbar.h --UncountedCallArgsChecker platform/ScrollAnimator.h')
 
@@ -103,9 +114,7 @@ def update_expectations_from_file(unexpected_results, project, add=False, platfo
 
 
 def modify_expectations_for_checker(checker, unexpected_contents, project, add, platform):
-    if platform:
-        platform = platform.lower()
-    if platform != None and platform != 'mac' and platform != 'ios':
+    if normalize_platform(platform) not in [None, 'macOS', 'iOS']:
         print(f'Unknown platform: {platform}')
         return
 
@@ -127,9 +136,9 @@ def modify_expectations_for_checker(checker, unexpected_contents, project, add, 
             expectation_platform = match.group('platform')
             path = match.group('path')
             if path in expectation_map:
-                if expectation_platform.lower() == 'mac' and platform == 'ios':
+                if normalize_platform(platform) == 'macOS' and normalize_platform(platform) == 'iOS':
                     expectation_platform = None
-                elif expectation_platform.lower() == 'ios' and platform == 'mac':
+                elif normalize_platform(platform) == 'macOS' and normalize_platform(platform) == 'iOS':
                     expectation_platform = None
                 else:
                     print(f'Conflicting or duplicate line in {expectation_relpath}: {path}')
@@ -142,16 +151,15 @@ def modify_expectations_for_checker(checker, unexpected_contents, project, add, 
         for path in unexpected_contents:
             if path in expectation_map:
                 expectation_platform = expectation_map[path]['platform']
-                lowercase_platform = expectation_platform.lower() if expectation_platform else None
-                if lowercase_platform == platform:
+                if normalize_platform(expectation_platform) == normalize_platform(platform):
                     print(f'Path is already present in {expectation_relpath}: {path}')
                     continue
-                if lowercase_platform != 'mac' and lowercase_platform != 'ios':
+                if normalize_platform(expectation_platform) not in [None, 'macOS', 'iOS']:
                     print(f'Unexpected platform in {expectation_relpath}: {expectation_platform}')
                     continue
                 expectation_map[path]['platform'] = None
             else:
-                expectation_map[path] = {'platform': platform, 'comments': []}
+                expectation_map[path] = {'platform': normalize_platform(platform), 'comments': []}
             count += 1
         print(f'Added {count} files with issues.\n')
     else:
@@ -160,14 +168,13 @@ def modify_expectations_for_checker(checker, unexpected_contents, project, add, 
                 print(f'Path not found in {expectation_relpath}: {path}')
                 continue
             if platform:
-                expectation_platform = expectation_map[path]['platform']
-                lowercase_platform = expectation_platform.lower() if expectation_platform else None
-                if lowercase_platform and lowercase_platform != platform:
-                    platform_name = 'Mac' if platform == 'mac' else 'iOS'
-                    print(f'Expectation not found in {expectation_relpath}: {path} for {platform_name}')
+                expectation_platform = normalize_platform(expectation_map[path]['platform'])
+                if expectation_platform not in [None, normalize_platform(platform)]:
+                    print(f'Expectation not found in {expectation_relpath}: {path} for {normalized_platform(platform)}')
                     continue # Expectation is for another platform. We're done
                 if expectation_platform == None:
-                    expectation_map[path]['platform'] = 'Mac' if platform == 'ios' else 'iOS'
+                    # None means it currently applies to both. Keep the expectation for the other platform.
+                    expectation_map[path]['platform'] = 'macOS' if normalize_platform(platform) == 'iOS' else 'iOS'
                 else:
                     del expectation_map[path]
             else:


### PR DESCRIPTION
#### a721e02550b951807e9351b6db9d1845ce5e1e29
<pre>
Make Tools/Scripts/update-safer-cpp-expectations favor &quot;macOS&quot; over &quot;Mac&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=308487">https://bugs.webkit.org/show_bug.cgi?id=308487</a>

Reviewed by Brianna Fan.

Normalize platform names to modern &quot;macOS&quot; and &quot;iOS&quot; instead of legacy &quot;Mac&quot; and &quot;iOS&quot;
in update-safer-cpp-expectations. Preserve the existing platform name where possible.

* Tools/Scripts/update-safer-cpp-expectations:
(normalize_platform):
(modify_expectations_for_checker):

Canonical link: <a href="https://commits.webkit.org/308076@main">https://commits.webkit.org/308076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f47942a2f3cf5d2251abcf701a394d3055ccc94d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19074 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155064 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fc9a1d9-1667-4fbf-8fa1-bd141bf4b94e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148273 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18976 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8db301c9-951b-40b7-acef-cc5a6d55c99e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149361 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/93533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3810740e-cb84-4be2-814d-44e9b02fe2e5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2510 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157386 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/120997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22579 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/18512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->