### PR TITLE
Introduce LocalFrameViewDestructionObserver.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2147,6 +2147,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/LocalFrame.h
     page/LocalFrameInlines.h
     page/LocalFrameView.h
+    page/LocalFrameViewDestructionObserver.h
     page/LocalFrameViewInlines.h
     page/LocalFrameViewLayoutContext.h
     page/LoginStatus.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2164,6 +2164,7 @@ page/LocalDOMWindow.cpp
 page/LocalDOMWindowProperty.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
+page/LocalFrameViewDestructionObserver.cpp
 page/LocalFrameViewLayoutContext.cpp
 page/Location.cpp
 page/LoginStatus.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4297,6 +4297,7 @@
 		A58C59D11E382EAE0047859C /* JSPerformanceMark.h in Headers */ = {isa = PBXBuildFile; fileRef = A58C59CD1E382EA90047859C /* JSPerformanceMark.h */; };
 		A58C59D31E382EB20047859C /* JSPerformanceMeasure.h in Headers */ = {isa = PBXBuildFile; fileRef = A58C59CF1E382EA90047859C /* JSPerformanceMeasure.h */; };
 		A593CF8B1840535200BFCE27 /* InspectorWebAgentBase.h in Headers */ = {isa = PBXBuildFile; fileRef = A593CF8A1840535200BFCE27 /* InspectorWebAgentBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A5961C282F479022002579D5 /* LocalFrameViewDestructionObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A5961C242F479013002579D5 /* LocalFrameViewDestructionObserver.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A59C230A21F29206004EC939 /* InspectorCPUProfilerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A59C230821F29206004EC939 /* InspectorCPUProfilerAgent.h */; };
 		A5A7AA43132F0ECC00D3A3C2 /* AutocapitalizeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A7AA42132F0ECC00D3A3C2 /* AutocapitalizeTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5A9933D1E37FB19005B5E4D /* PerformanceObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A993361E37FAFD005B5E4D /* PerformanceObserver.h */; };
@@ -17060,6 +17061,8 @@
 		A58C59CE1E382EA90047859C /* JSPerformanceMeasure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSPerformanceMeasure.cpp; sourceTree = "<group>"; };
 		A58C59CF1E382EA90047859C /* JSPerformanceMeasure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSPerformanceMeasure.h; sourceTree = "<group>"; };
 		A593CF8A1840535200BFCE27 /* InspectorWebAgentBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorWebAgentBase.h; sourceTree = "<group>"; };
+		A5961C242F479013002579D5 /* LocalFrameViewDestructionObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalFrameViewDestructionObserver.h; sourceTree = "<group>"; };
+		A5961C252F479013002579D5 /* LocalFrameViewDestructionObserver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalFrameViewDestructionObserver.cpp; sourceTree = "<group>"; };
 		A59C230621F29205004EC939 /* InspectorCPUProfilerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorCPUProfilerAgent.cpp; sourceTree = "<group>"; };
 		A59C230821F29206004EC939 /* InspectorCPUProfilerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorCPUProfilerAgent.h; sourceTree = "<group>"; };
 		A5A7AA42132F0ECC00D3A3C2 /* AutocapitalizeTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutocapitalizeTypes.h; sourceTree = "<group>"; };
@@ -30283,6 +30286,8 @@
 				9B46C04F2DC4AAC7002E22C4 /* LocalFrameInlines.h */,
 				65CBFEF70974F607001DAC25 /* LocalFrameView.cpp */,
 				65CBFEF80974F607001DAC25 /* LocalFrameView.h */,
+				A5961C252F479013002579D5 /* LocalFrameViewDestructionObserver.cpp */,
+				A5961C242F479013002579D5 /* LocalFrameViewDestructionObserver.h */,
 				9B46C0542DC4B821002E22C4 /* LocalFrameViewInlines.h */,
 				113D0B4F1F9FDD2B00F611BB /* LocalFrameViewLayoutContext.cpp */,
 				113D0B501F9FDD2B00F611BB /* LocalFrameViewLayoutContext.h */,
@@ -45874,6 +45879,7 @@
 				9B46C0502DC4AB14002E22C4 /* LocalFrameInlines.h in Headers */,
 				656D373E0ADBA5DE00A4554D /* LocalFrameLoaderClient.h in Headers */,
 				65CBFEFA0974F607001DAC25 /* LocalFrameView.h in Headers */,
+				A5961C282F479022002579D5 /* LocalFrameViewDestructionObserver.h in Headers */,
 				113D0B521F9FDD2B00F611BB /* LocalFrameViewLayoutContext.h in Headers */,
 				E35B907F23F60A50000011FF /* LocalizedDeviceModel.h in Headers */,
 				935207BE09BD410A00F2038D /* LocalizedStrings.h in Headers */,

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -81,6 +81,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
+#include "LocalFrameViewDestructionObserver.h"
 #include "Logging.h"
 #include "MemoryCache.h"
 #include "NodeInlines.h"
@@ -246,6 +247,9 @@ Ref<LocalFrameView> LocalFrameView::create(LocalFrame& frame, const IntSize& ini
 
 LocalFrameView::~LocalFrameView()
 {
+    while (WeakPtr destructionObserver = m_destructionObservers.takeAny())
+        destructionObserver->frameViewIsBeingDestroyed();
+
     removeFromAXObjectCache();
     resetScrollbars();
 
@@ -259,6 +263,16 @@ LocalFrameView::~LocalFrameView()
     ASSERT(!m_scrollCorner);
 
     ASSERT(m_frame->view() != this || !m_frame->contentRenderer());
+}
+
+void LocalFrameView::addDestructionObserver(LocalFrameViewDestructionObserver& observer)
+{
+    m_destructionObservers.add(observer);
+}
+
+void LocalFrameView::removeDestructionObserver(LocalFrameViewDestructionObserver& observer)
+{
+    m_destructionObservers.remove(observer);
 }
 
 void LocalFrameView::reset()

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -61,6 +61,7 @@ class FloatSize;
 class Frame;
 class GraphicsContext;
 class HTMLFrameOwnerElement;
+class LocalFrameViewDestructionObserver;
 class Page;
 class RegionContext;
 class RenderBox;
@@ -104,6 +105,9 @@ public:
     static Ref<LocalFrameView> create(LocalFrame&, const IntSize& initialSize);
 
     virtual ~LocalFrameView();
+
+    void addDestructionObserver(LocalFrameViewDestructionObserver&);
+    void removeDestructionObserver(LocalFrameViewDestructionObserver&);
 
     WEBCORE_EXPORT void setFrameRect(const IntRect&) final;
     Type viewType() const final { return Type::Local; }
@@ -1075,6 +1079,8 @@ private:
     std::unique_ptr<ScrollableAreaSet> m_anchoringScrollableAreas;
     std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
     mutable std::optional<bool> m_hasAnchorPositionedViewportConstrainedObjects;
+
+    SingleThreadWeakHashSet<LocalFrameViewDestructionObserver> m_destructionObservers;
 
     OptionSet<LayoutMilestone> m_milestonesPendingPaint;
 

--- a/Source/WebCore/page/LocalFrameViewDestructionObserver.cpp
+++ b/Source/WebCore/page/LocalFrameViewDestructionObserver.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalFrameViewDestructionObserver.h"
+
+#include "LocalFrameView.h"
+
+namespace WebCore {
+
+LocalFrameViewDestructionObserver::LocalFrameViewDestructionObserver(LocalFrameView& frameView)
+{
+    observeFrameView(frameView);
+}
+
+LocalFrameViewDestructionObserver::~LocalFrameViewDestructionObserver()
+{
+    unobserveFrameView();
+}
+
+void LocalFrameViewDestructionObserver::observeFrameView(LocalFrameView& frameView)
+{
+    if (m_frameView)
+        unobserveFrameView();
+    m_frameView = &frameView;
+    m_frameView->addDestructionObserver(*this);
+}
+
+void LocalFrameViewDestructionObserver::unobserveFrameView()
+{
+    ASSERT(m_frameView);
+    if (m_frameView)
+        m_frameView->removeDestructionObserver(*this);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/LocalFrameViewDestructionObserver.h
+++ b/Source/WebCore/page/LocalFrameViewDestructionObserver.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CheckedPtr.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class LocalFrameView;
+
+class LocalFrameViewDestructionObserver : public CanMakeSingleThreadWeakPtr<LocalFrameViewDestructionObserver>, public CanMakeCheckedPtr<LocalFrameViewDestructionObserver> {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LocalFrameViewDestructionObserver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocalFrameViewDestructionObserver);
+public:
+    LocalFrameViewDestructionObserver(LocalFrameView&);
+
+    virtual ~LocalFrameViewDestructionObserver();
+    virtual void frameViewIsBeingDestroyed() = 0;
+
+    LocalFrameView* localFrameView() { return m_frameView.get(); }
+    LocalFrameView* localFrameView() const { return m_frameView.get(); }
+
+    void observeFrameView(LocalFrameView&);
+    void unobserveFrameView();
+
+private:
+    CheckedPtr<LocalFrameView> m_frameView;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -29,6 +29,7 @@
 #include "DebugPageOverlays.h"
 #include "Document.h"
 #include "DocumentEnums.h"
+#include "FrameInlines.h"
 #include "InspectorInstrumentation.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutContext.h"

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -43,6 +43,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "LocalFrameViewDestructionObserver.h"
 #include "Logging.h"
 #include "NodeInlines.h"
 #include "NodeTraversal.h"
@@ -81,9 +82,19 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderView);
 
+RenderView::FrameViewDestructionObserver::FrameViewDestructionObserver(LocalFrameView& frameView)
+    : LocalFrameViewDestructionObserver(frameView)
+{
+}
+
+void RenderView::FrameViewDestructionObserver::frameViewIsBeingDestroyed()
+{
+    WTFReportBacktraceWithPrefix("RenderView::LocalFrameViewDestructionObserver::frameViewIsBeingDestroyed()");
+}
+
 RenderView::RenderView(Document& document, RenderStyle&& style)
     : RenderBlockFlow(Type::View, document, WTF::move(style))
-    , m_frameView(*document.view())
+    , m_frameViewDestructionObserver(makeUniqueRef<FrameViewDestructionObserver>(*document.view()))
     , m_initialContainingBlock(makeUniqueRef<Layout::InitialContainingBlock>(RenderStyle::clone(this->style())))
     , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, m_initialContainingBlock, Layout::LayoutState::Type::Primary, LayoutIntegration::layoutWithFormattingContextForBox, LayoutIntegration::formattingContextRootLogicalWidthForType, LayoutIntegration::formattingContextRootLogicalHeightForType, LayoutIntegration::layoutWithFormattingContextForBlockInInline))
     , m_selection(*this)

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/LocalFrameViewDestructionObserver.h>
 #include <WebCore/Region.h>
 #include <WebCore/RenderBlockFlow.h>
 #include <WebCore/RenderSelection.h>
@@ -74,7 +75,7 @@ public:
 
     float zoomFactor() const;
 
-    LocalFrameView& frameView() const { return m_frameView.get(); }
+    LocalFrameView& frameView() const { return m_frameViewDestructionObserver->frameView(); }
 
     Layout::InitialContainingBlock& initialContainingBlock() { return m_initialContainingBlock.get(); }
     const Layout::InitialContainingBlock& initialContainingBlock() const { return m_initialContainingBlock.get(); }
@@ -200,6 +201,15 @@ public:
         bool m_wasAccumulatingRepaintRegion { false };
     };
 
+    class FrameViewDestructionObserver final : public LocalFrameViewDestructionObserver {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FrameViewDestructionObserver);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameViewDestructionObserver);
+    public:
+        FrameViewDestructionObserver(LocalFrameView&);
+        void frameViewIsBeingDestroyed() final;
+        LocalFrameView& frameView() const { return *localFrameView(); }
+    };
+
     void registerBoxWithScrollSnapPositions(const RenderBox&);
     void unregisterBoxWithScrollSnapPositions(const RenderBox&);
     const SingleThreadWeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
@@ -250,7 +260,7 @@ private:
 
     void updateInitialContainingBlockSize();
 
-    const CheckedRef<LocalFrameView> m_frameView;
+    const UniqueRef<FrameViewDestructionObserver> m_frameViewDestructionObserver;
 
     // Include this RenderView.
     uint64_t m_rendererCount { 1 };


### PR DESCRIPTION
#### 6bbd56c5ecd76938fe9cb0d2b52c0b7afa72e416
<pre>
Introduce LocalFrameViewDestructionObserver.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308484">https://bugs.webkit.org/show_bug.cgi?id=308484</a>
<a href="https://rdar.apple.com/171008275">rdar://171008275</a>

Reviewed by NOBODY (OOPS!).

This patch introduces LocalFrameViewDestructionObserver, which is a
simple helper class that is used to be notified when a particular
LocalFrameView is being destroyed. This class and API follow a very
similar pattern to FrameDestructionObserver, which is also used in a few
different places throughout the codebase. We apply this new class by
starting to use it inside of RenderView to observe the LocalFrameView
that is associated with it.

Use of this new class is fairly straightforward since it has a very
small API.

(WebCore::LocalFrameView::~LocalFrameView):
We want to make sure that we notify any observers that are currently
observing the LocalFrameView that it is being destroyed so that they can
respond properly.

* Source/WebCore/page/LocalFrameViewDestructionObserver.cpp: Added.
(WebCore::LocalFrameViewDestructionObserver::LocalFrameViewDestructionObserver):
In order to begin observing a LocalFrameView, clients will create an observer by
passing in the associated LocalFrameView to the constructor. This new
observer will notify the LocalFrameView of its creation so that it can
begin keeping track of it. We do this by storing them in a SingleThreadWeakHashSet
since the LocalFrameView is not responsible for any of its observers and
should not care if any of them disappear.

(WebCore::LocalFrameViewDestructionObserver::~LocalFrameViewDestructionObserver):
When the client decides it no longer needs the observer, we will
unobserve the associated LocalFrameView so that it can perform its
bookkeeping properly. Destroying the observer is one way to accomplish
this but there is also an unobserve API that could be used.

(WebCore::LocalFrameViewDestructionObserver::frameViewIsBeingDestroyed):
This pure virtual function is the primary way that observers will get
notified that their associated LocalFrameView is being destroyed. They
will need to implement this since the context will likely play a large
part in how they want to respond to this event. The LocalFrameView will
go through any of the observers that are still alive and call this
method inside of its destructor.

(WebCore::LocalFrameViewDestructionObserver::observeFrameView):
(WebCore::LocalFrameViewDestructionObserver::unobserveFrameView):
Clients can arbitrarily observe and unobserve LocalFrameViews through the
dedicated public methods which inform the LocalFrameView properly.

* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::FrameViewDestructionObserver::FrameViewDestructionObserver):
In RenderView we create a new nested class: FrameViewDestructionObserver
which inherits from LocalFrameViewDestructionObserver since RenderView
itself cannot inherit directly from it. That would result in two
different ways it would inherit from CanMakeSingleThreadWeakPtr.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bbd56c5ecd76938fe9cb0d2b52c0b7afa72e416

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99878 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80598 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a50ff1b4-a30b-4cd6-9443-4263a68bb568) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93588 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cace7b35-b16e-4bbe-8267-cd3ce5e8c608) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14336 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2576 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157455 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/611 "Found 33 new failures in rendering/RenderSearchField.cpp, rendering/svg/SVGPaintServerHandlingInlines.h, rendering/BackgroundPainter.cpp, page/LocalFrameViewDestructionObserver.cpp, inspector/agents/page/PageTimelineAgent.cpp, rendering/RenderLayerModelObject.cpp, rendering/RenderReplaced.cpp, rendering/RenderMultiColumnFlow.cpp, rendering/RenderBlockFlow.cpp, rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp ...") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120804 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74750 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16706 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8130 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18568 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82318 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18297 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->