### PR TITLE
[Grid] Baseline alignment eligibility does not change throughout track sizing

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1236,7 +1236,7 @@ bool GridTrackSizingAlgorithm::canParticipateInBaselineAlignment(const RenderBox
 
 bool GridTrackSizingAlgorithm::participateInBaselineAlignment(const RenderBox& gridItem, Style::GridTrackSizingDirection alignmentContextType) const
 {
-    return alignmentContextType == Style::GridTrackSizingDirection::Rows ? m_baselineAlignmentItemsForRows.get(&gridItem) : m_baselineAlignmentItemsForColumns.get(&gridItem);
+    return alignmentContextType == Style::GridTrackSizingDirection::Rows ? m_baselineAlignmentItemsForRows.contains(gridItem) : m_baselineAlignmentItemsForColumns.contains(gridItem);
 }
 
 void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& gridItem, Style::GridTrackSizingDirection alignmentContextType)
@@ -1281,9 +1281,9 @@ void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, S
         alignmentContextType = alignmentContextType == Style::GridTrackSizingDirection::Rows ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
 
     if (alignmentContextType == Style::GridTrackSizingDirection::Rows)
-        m_baselineAlignmentItemsForRows.add(item, true);
+        m_baselineAlignmentItemsForRows.add(item);
     else
-        m_baselineAlignmentItemsForColumns.add(item, true);
+        m_baselineAlignmentItemsForColumns.add(item);
 
     const auto* gridItemParent = dynamicDowncast<RenderGrid>(item.parent());
     if (gridItemParent) {
@@ -2085,17 +2085,11 @@ void GridTrackSizingAlgorithm::computeBaselineAlignmentContext()
     m_baselineAlignment.clear(alignmentContextType);
     m_baselineAlignment.setWritingMode(m_renderGrid->style().writingMode());
     BaselineItemsCache& baselineItemsCache = alignmentContextType == Style::GridTrackSizingDirection::Rows ? m_baselineAlignmentItemsForRows : m_baselineAlignmentItemsForColumns;
-    BaselineItemsCache tmpBaselineItemsCache = baselineItemsCache;
-    for (auto& gridItem : tmpBaselineItemsCache.keys()) {
-        // FIXME (jfernandez): We may have to get rid of the baseline participation
-        // flag (hence just using a HashSet) depending on the CSS WG resolution on
-        // https://github.com/w3c/csswg-drafts/issues/3046
-        if (canParticipateInBaselineAlignment(gridItem, alignmentContextType)) {
-            updateBaselineAlignmentContext(gridItem, alignmentContextType);
-            baselineItemsCache.set(gridItem, true);
-        } else
-            baselineItemsCache.set(gridItem, false);
-    }
+    baselineItemsCache.removeIf([&](const RenderBox& gridItem) {
+        return !canParticipateInBaselineAlignment(gridItem, alignmentContextType);
+    });
+    for (auto& gridItem : baselineItemsCache)
+        updateBaselineAlignmentContext(gridItem, alignmentContextType);
 }
 
 static void removeSubgridMarginBorderPaddingFromTracks(Vector<UniqueRef<GridTrack>>& tracks, LayoutUnit mbp, bool forwards)

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -335,7 +335,7 @@ private:
     SizingState m_sizingState;
 
     GridBaselineAlignment m_baselineAlignment;
-    using BaselineItemsCache = HashMap<SingleThreadWeakRef<const RenderBox>, bool>;
+    using BaselineItemsCache = HashSet<SingleThreadWeakRef<const RenderBox>>;
 
     // Rows/columns here indicate the alignment context.
     BaselineItemsCache m_baselineAlignmentItemsForRows;


### PR DESCRIPTION
#### 615ae2c8b8b7a050a254567c0e8785ee77185432
<pre>
[Grid] Baseline alignment eligibility does not change throughout track sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=308499">https://bugs.webkit.org/show_bug.cgi?id=308499</a>
<a href="https://rdar.apple.com/171020701">rdar://171020701</a>

Reviewed by NOBODY (OOPS!).

BaselineItemsCache was typed as a HashMap&lt;RederBox, bool&gt; due to an open
question posed to the working group: <a href="https://github.com/w3c/csswg-drafts/issues/3046">https://github.com/w3c/csswg-drafts/issues/3046</a>

The working group has responded to this issue and it is now closed. The
conclusion was that the basline alignment eligibility does not change
depending on what step of the track sizing algorithm you are in and is
determined by the alignment properties along with some considerations
related to cyclic dependencies. The cyclic dependencies also do not
change based upon the step of the track sizing algorithm.

As a result, we can change the type of this structure from being a
HashMap to just straight up being a HashSet of the items.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/615ae2c8b8b7a050a254567c0e8785ee77185432

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99869 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f725c5e-a04e-428e-9d0e-76077a2f72a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112718 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80589 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93571 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c42f26dc-34b4-4a73-86cb-e4ee69520a57) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14455 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12088 "Found 1 new API test failure: TestWebKitAPI.HistoryDelegate.NonpersistentDataStoreDoesNotSendHistoryEvents (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2561 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157440 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120752 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74737 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8115 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18553 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82305 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18282 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->