### PR TITLE
[macOS] media/remote-control-command-is-user-gesture.html is a flaky timeout

### DIFF
--- a/LayoutTests/media/remote-control-command-is-user-gesture-expected.txt
+++ b/LayoutTests/media/remote-control-command-is-user-gesture-expected.txt
@@ -12,6 +12,6 @@ EXPECTED (video.paused == 'true') OK
 * Send a play command, it should succeed.
 RUN(internals.postRemoteControlCommand('play'))
 
-EVENT(timeupdate)
+EVENT(playing)
 END OF TEST
 

--- a/LayoutTests/media/remote-control-command-is-user-gesture.html
+++ b/LayoutTests/media/remote-control-command-is-user-gesture.html
@@ -16,7 +16,7 @@
                 run('internals.setMediaElementRestrictions(video, "RequireUserGestureForVideoRateChange")');
 
                 waitForEvent('loadedmetadata', loadedmetadata, false, true, document)
-                waitForEventAndEnd('timeupdate')
+                waitForEventAndEnd('playing')
 
                 consoleWrite('* set video.src');
                 video.src = findMediaFile('video', 'content/test');

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2507,7 +2507,7 @@ webkit.org/b/308326 [ Debug ] imported/w3c/web-platform-tests/fetch/api/basic/er
 
 webkit.org/b/308334 [ Tahoe Debug ] http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration.html [ Skip ]
 
-webkit.org/b/308494 media/remote-control-command-is-user-gesture.html [ Timeout Pass ]
+webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
 
 webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 16d0b7e33fe253f3a7c777c8bea6f610ddac6879
<pre>
[macOS] media/remote-control-command-is-user-gesture.html is a flaky timeout
<a href="https://rdar.apple.com/171016280">rdar://171016280</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308494">https://bugs.webkit.org/show_bug.cgi?id=308494</a>

Reviewed by Jer Noble.

This patch resolves a flaky timeout with the following layout test.

Per the HTML5 spec, timeupdate events fire periodically in ~250ms intervals during playback, not immediately
when playback starts. Under system load or with --run-singly it appears that timeupdate doesn&apos;t fire within
the expected window.
The solution for this is to change waitForEventAndEnd(&apos;timeupdate&apos;) to waitForEventAndEnd(&apos;playing&apos;) since the
playing event fires immediately when playback begins per spec.

Spec: <a href="https://html.spec.whatwg.org/multipage/media.html">https://html.spec.whatwg.org/multipage/media.html</a>

* LayoutTests/media/remote-control-command-is-user-gesture-expected.txt:
* LayoutTests/media/remote-control-command-is-user-gesture.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308938@main">https://commits.webkit.org/308938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b9a90090c8c82c6991ab565640410f9e79b6969

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102314 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114772 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16080 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13936 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160053 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122828 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33463 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77595 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18359 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10107 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21009 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->