### PR TITLE
REGRESSION (275274@main): [ Sonoma+ wk2 ] Multiple pdf/ tests are constant failures

### DIFF
--- a/LayoutTests/pdf/pdf-scrolling-tree-dynamic-expected.txt
+++ b/LayoutTests/pdf/pdf-scrolling-tree-dynamic-expected.txt
@@ -32,9 +32,22 @@ After installing PDF:
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (synchronous event dispatch region for event wheel
-    at (8,23) size 300x250)
   (behavior for fixed 1)
+  (children 1
+    (Plugin hosting node
+      (children 1
+        (Plugin scrolling node
+          (scrollable area size 300 250)
+          (contents size 231 238)
+          (scrollable area parameters
+            (horizontal scroll elasticity 0)
+            (vertical scroll elasticity 0)
+            (horizontal scrollbar mode 0)
+            (vertical scrollbar mode 0))
+        )
+      )
+    )
+  )
 )
 
 After removing PDF:

--- a/LayoutTests/pdf/pdf-scrolling-tree-expected.txt
+++ b/LayoutTests/pdf/pdf-scrolling-tree-expected.txt
@@ -11,8 +11,21 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (synchronous event dispatch region for event wheel
-    at (8,8) size 300x250)
   (behavior for fixed 1)
+  (children 1
+    (Plugin hosting node
+      (children 1
+        (Plugin scrolling node
+          (scrollable area size 300 250)
+          (contents size 231 238)
+          (scrollable area parameters
+            (horizontal scroll elasticity 0)
+            (vertical scroll elasticity 0)
+            (horizontal scrollbar mode 0)
+            (vertical scrollbar mode 0))
+        )
+      )
+    )
+  )
 )
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -43,7 +43,7 @@ swipe [ Pass ]
 view-gestures [ Pass ]
 http/tests/swipe [ Pass ]
 http/tests/pdf [ Pass ]
-[ Sonoma+ ] pdf [ Pass ]
+pdf [ Pass ]
 tiled-drawing [ Pass ]
 ipc/mac [ Pass ]
 ipc/restrictedendpoints/mac [ Pass ]
@@ -1806,10 +1806,6 @@ webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallbac
 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.worker.html [ Failure ]
 
 webkit.org/b/268398 [ Sonoma+ ] pdf/pdf-in-iframe-scrolling-tree-after-back.html [ Pass Failure ]
-
-# webkit.org/b/270092  (REGRESSION (275274@main): [ Sonoma+ wk2 ] Multiple compositing/plugins/pdf/pdf are constant failures)
-[ Sonoma+ ] pdf/pdf-scrolling-tree-dynamic.html [ Failure Timeout ]
-[ Sonoma+ ] pdf/pdf-scrolling-tree.html [ Failure ]
 
 webkit.org/b/270235 [ Debug x86_64 ] webgl/pending/conformance/glsl/misc/shader-with-reserved-words-2.html [ Timeout ]
 


### PR DESCRIPTION
#### 506f34d9c48923d0202aaa0eeec978e8f80ada54
<pre>
REGRESSION (275274@main): [ Sonoma+ wk2 ] Multiple pdf/ tests are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=270092">https://bugs.webkit.org/show_bug.cgi?id=270092</a>
<a href="https://rdar.apple.com/123634997">rdar://123634997</a>

Reviewed by Aditya Keerthi and Lily Spiniolas.

These tests required a rebaseline post-UnifiedPDF.

Furthermore, we remove `Sonoma` annotations from the test expectations
given we only ever test Sonoma+ configurations now.

* LayoutTests/pdf/pdf-scrolling-tree-dynamic-expected.txt:
* LayoutTests/pdf/pdf-scrolling-tree-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308103@main">https://commits.webkit.org/308103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/602bfb824e1ad984c60f62f268703b69a13a74fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99850 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a54e6b12-9f2e-4aeb-9a28-a996accb5eca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112692 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80575 "Exiting early after 60 failures. 15457 tests run. 60 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9a2aae0-728d-4a51-aa8b-190017a316d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93550 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/750e39b2-1307-44d0-8f0a-53517cb3999f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12068 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2532 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157409 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10852 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120722 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121014 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74715 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8094 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18529 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18419 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18315 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->