### PR TITLE
Mark isURLAttribute, attributeContainsURL, and isHTMLContentAttribute as NODELETE

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -227,7 +227,7 @@ private:
 
     // DOM overrides.
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
     // StyledElement

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -573,12 +573,12 @@ public:
 
     virtual bool accessKeyAction(bool /*sendToAnyEvent*/) { return false; }
 
-    virtual bool isURLAttribute(const Attribute&) const { return false; }
-    virtual bool attributeContainsURL(const Attribute& attribute) const { return isURLAttribute(attribute); }
+    virtual bool NODELETE isURLAttribute(const Attribute&) const { return false; }
+    virtual bool NODELETE attributeContainsURL(const Attribute& attribute) const { return isURLAttribute(attribute); }
     String resolveURLStringIfNeeded(const String& urlString, ResolveURLs = ResolveURLs::Yes, const URL& base = URL()) const;
     virtual String completeURLsInAttributeValue(const URL& base, const Attribute&, ResolveURLs = ResolveURLs::Yes) const;
     virtual Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const;
-    virtual bool isHTMLContentAttribute(const Attribute&) const { return false; }
+    virtual bool NODELETE isHTMLContentAttribute(const Attribute&) const { return false; }
 
     WEBCORE_EXPORT URL getURLAttribute(const QualifiedName&) const;
     inline URL getURLAttributeForBindings(const QualifiedName&) const;

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -100,7 +100,7 @@ private:
     bool isKeyboardFocusable(const FocusEventData&) const override;
     void defaultEventHandler(Event&) final;
     void setActive(bool active, Style::InvalidationScope) final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     bool canStartSelection() const final;
     int defaultTabIndex() const final;
     bool draggable() const final;

--- a/Source/WebCore/html/HTMLBaseElement.h
+++ b/Source/WebCore/html/HTMLBaseElement.h
@@ -38,7 +38,7 @@ private:
     HTMLBaseElement(const QualifiedName&, Document&);
 
     AtomString target() const final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLBodyElement.h
+++ b/Source/WebCore/html/HTMLBodyElement.h
@@ -47,7 +47,7 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     
     bool supportsFocus() const final;
 

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -80,7 +80,7 @@ private:
     bool isActivatedSubmit() const final;
     void setActivatedSubmit(bool flag) final;
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 
     bool canStartSelection() const final { return false; }
 

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -41,7 +41,7 @@ private:
 
     bool rendererIsNeeded(const RenderStyle&) final;
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     const AtomString& imageSourceURL() const final;
 
     bool isInteractiveContent() const final { return true; }

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -131,7 +131,7 @@ private:
     void finishParsingChildren() final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 
     void resumeFromDocumentSuspension() final;
 

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -67,8 +67,8 @@ private:
     bool supportsFocus() const final;
     void setFocus(bool, FocusVisibility = FocusVisibility::Invisible) final;
     
-    bool isURLAttribute(const Attribute&) const final;
-    bool isHTMLContentAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
+    bool NODELETE isHTMLContentAttribute(const Attribute&) const final;
 
     AtomString m_frameURL;
     bool m_openingURLAfterInserting { false };

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -201,8 +201,8 @@ private:
 
     bool canStartSelection() const override;
 
-    bool isURLAttribute(const Attribute&) const override;
-    bool attributeContainsURL(const Attribute&) const override;
+    bool NODELETE isURLAttribute(const Attribute&) const override;
+    bool NODELETE attributeContainsURL(const Attribute&) const override;
     String completeURLsInAttributeValue(const URL& base, const Attribute&, ResolveURLs = ResolveURLs::Yes) const override;
     Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const override;
 

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -418,7 +418,7 @@ private:
 
     void reset() final;
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     bool isInRange() const final;
     bool isOutOfRange() const final;
 

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -139,7 +139,7 @@ private:
     
     void setDisabledState(bool);
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 
     HTMLLinkElement(const QualifiedName&, Document&, bool createdByParser);
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -743,7 +743,7 @@ protected:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void finishParsingChildren() override;
-    bool isURLAttribute(const Attribute&) const override;
+    bool NODELETE isURLAttribute(const Attribute&) const override;
     void willAttachRenderers() override;
     void didAttachRenderers() override;
     void willDetachRenderers() override;

--- a/Source/WebCore/html/HTMLModElement.h
+++ b/Source/WebCore/html/HTMLModElement.h
@@ -36,7 +36,7 @@ public:
 private:
     HTMLModElement(const QualifiedName&, Document&);
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -71,7 +71,7 @@ private:
 
     void childrenChanged(const ChildChange&) final;
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     const AtomString& imageSourceURL() const final;
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;

--- a/Source/WebCore/html/HTMLQuoteElement.h
+++ b/Source/WebCore/html/HTMLQuoteElement.h
@@ -37,7 +37,7 @@ public:
 private:
     HTMLQuoteElement(const QualifiedName&, Document&);
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -87,7 +87,7 @@ private:
 
     ExceptionOr<void> setTextContent(ExceptionOr<String>);
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -62,8 +62,8 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
-    bool isURLAttribute(const Attribute&) const final;
-    bool attributeContainsURL(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
+    bool NODELETE attributeContainsURL(const Attribute&) const final;
     Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const override;
     void addCandidateSubresourceURLs(ListHashSet<URL>&) const override;
 

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -69,7 +69,7 @@ private:
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     const MutableStyleProperties* additionalPresentationalHintStyle() const override;
 
-    bool isURLAttribute(const Attribute&) const override;
+    bool NODELETE isURLAttribute(const Attribute&) const override;
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
 };

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -76,7 +76,7 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 
     // Used to obtain either a solid or outset border decl and to deal with the frame and rules attributes.
     const MutableStyleProperties* additionalPresentationalHintStyle() const final;

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -83,7 +83,7 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
 
     // EventTarget.
     void eventListenersDidChange() final;

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -163,7 +163,7 @@ private:
     bool isVideo() const final { return true; }
     bool hasVideo() const final { return player() && protect(player())->hasVideo(); }
     bool supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) const final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     const AtomString& imageSourceURL() const final;
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -82,7 +82,7 @@ private:
     bool canStartSelection() const final;
     bool isKeyboardFocusable(const FocusEventData&) const final;
     bool isMouseFocusable() const final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     bool supportsFocus() const final;
 };
 

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -67,7 +67,7 @@ private:
     bool supportsFocus() const final;
     bool isMouseFocusable() const final;
     bool isKeyboardFocusable(const FocusEventData&) const final;
-    bool isURLAttribute(const Attribute&) const final;
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     bool canStartSelection() const final;
     int defaultTabIndex() const final;
 

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -102,6 +102,11 @@ void SVGScriptElement::finishParsingChildren()
     ScriptElement::finishParsingChildren();
 }
 
+bool SVGScriptElement::isURLAttribute(const Attribute& attribute) const
+{
+    return SVGURIReference::isKnownAttribute(attribute.name()) || SVGElement::isURLAttribute(attribute);
+}
+
 void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     SVGElement::addSubresourceAttributeURLs(urls);

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -52,7 +52,7 @@ private:
     void childrenChanged(const ChildChange&) final;
     void finishParsingChildren() final;
 
-    bool isURLAttribute(const Attribute& attribute) const final { return attribute.name() == AtomString { sourceAttributeValue() }; }
+    bool NODELETE isURLAttribute(const Attribute&) const final;
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const final;

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -49,7 +49,9 @@ SVGURIReference::SVGURIReference(SVGElement* contextElement)
 
 bool SVGURIReference::isKnownAttribute(const QualifiedName& attributeName)
 {
-    return PropertyRegistry::isKnownAttribute(attributeName);
+    auto result = attributeName.matches(SVGNames::hrefAttr) || attributeName.matches(XLinkNames::hrefAttr);
+    ASSERT(result == PropertyRegistry::isKnownAttribute(attributeName));
+    return result;
 }
 
 SVGElement& SVGURIReference::contextElement() const

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -74,7 +74,7 @@ public:
 protected:
     SVGURIReference(SVGElement* contextElement);
 
-    static bool isKnownAttribute(const QualifiedName& attributeName);
+    static bool NODELETE isKnownAttribute(const QualifiedName& attributeName);
 
     virtual bool haveFiredLoadEvent() const { return false; }
     virtual void setHaveFiredLoadEvent(bool) { }


### PR DESCRIPTION
#### 40bd38de47936af79a280fc3846650a6df244dd9
<pre>
Mark isURLAttribute, attributeContainsURL, and isHTMLContentAttribute as NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=308505">https://bugs.webkit.org/show_bug.cgi?id=308505</a>

Reviewed by NOBODY (OOPS!).

Added NODELETE annotations on these functions since they&apos;re all trivial.

Also fix a bug in SVGScriptElement that we were comparing attribute&apos;s name
with attribute&apos;s value, which doesn&apos;t make much sense.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/dom/Element.h:
(WebCore::Element::isURLAttribute const):
(WebCore::Element::attributeContainsURL const):
(WebCore::Element::isHTMLContentAttribute const):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLBaseElement.h:
* Source/WebCore/html/HTMLBodyElement.h:
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLEmbedElement.h:
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLFrameElementBase.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLModElement.h:
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLQuoteElement.h:
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLTableCellElement.h:
* Source/WebCore/html/HTMLTableElement.h:
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/mathml/MathMLElement.h:
* Source/WebCore/svg/SVGAElement.h:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::isURLAttribute const):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::isKnownAttribute):
* Source/WebCore/svg/SVGURIReference.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40bd38de47936af79a280fc3846650a6df244dd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155404 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19318 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/113062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149703 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/93807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2848 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157735 "Failed to checkout and rebase branch from PR 59408") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/121282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22642 "") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/18835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->