### PR TITLE
[GFC][Cleanup] Tidy up PlacedGridItem construction a bit

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -226,28 +226,10 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
     placedGridItems.reserveInitialCapacity(gridAreas.size());
     CheckedRef formattingContextStyle = root().style();
     for (auto [ unplacedGridItem, gridAreaLines ] : gridAreas) {
-
-        CheckedRef gridItemStyle = unplacedGridItem.m_layoutBox->style();
-
-        ComputedSizes inlineAxisSizes {
-            gridItemStyle->width(),
-            gridItemStyle->minWidth(),
-            gridItemStyle->maxWidth(),
-            gridItemStyle->marginLeft(),
-            gridItemStyle->marginRight()
-        };
-
-        ComputedSizes blockAxisSizes {
-            gridItemStyle->height(),
-            gridItemStyle->minHeight(),
-            gridItemStyle->maxHeight(),
-            gridItemStyle->marginTop(),
-            gridItemStyle->marginBottom()
-        };
-
-        auto& boxGeometry = geometryForGridItem(unplacedGridItem.m_layoutBox);
-        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes, boxGeometry.horizontalBorderAndPadding(), boxGeometry.verticalBorderAndPadding(),
-            gridItemStyle->justifySelf().resolve(formattingContextStyle.ptr()), gridItemStyle->alignSelf().resolve(formattingContextStyle.ptr()), gridItemStyle->writingMode(), gridItemStyle->usedZoomForLength());
+        CheckedRef gridItem = unplacedGridItem.m_layoutBox;
+        CheckedRef gridContainerStyle = this->gridContainerStyle();
+        auto& boxGeometry = geometryForGridItem(gridItem);
+        placedGridItems.constructAndAppend(gridItem, gridAreaLines, boxGeometry, gridContainerStyle);
     }
     return placedGridItems;
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -156,6 +156,8 @@ private:
     BoxGeometry& geometryForGridItem(const ElementBox&);
     void setGridItemGeometries(const GridItemRects&);
 
+    const RenderStyle& gridContainerStyle() const { return m_gridBox->style(); }
+
     const CheckedRef<const ElementBox> m_gridBox;
     const CheckedRef<LayoutState> m_globalLayoutState;
     const IntegrationUtils m_integrationUtils;

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -32,20 +32,22 @@
 namespace WebCore {
 namespace Layout {
 
-PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines,
-    const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes, const LayoutUnit& usedInlineBorderAndPadding,
-    const LayoutUnit& usedBlockBorderAndPadding, const StyleSelfAlignmentData& inlineAxisAlignment, const StyleSelfAlignmentData& blockAxisAlignment,
-    const WritingMode& writingMode, const Style::ZoomFactor& usedZoom)
-        : m_layoutBox(unplacedGridItem.m_layoutBox)
-        , m_inlineAxisSizes(inlineAxisSizes)
-        , m_blockAxisSizes(blockAxisSizes)
-        , m_usedInlineBorderAndPadding(usedInlineBorderAndPadding)
-        , m_usedBlockBorderAndPadding(usedBlockBorderAndPadding)
-        , m_inlineAxisAlignment(inlineAxisAlignment)
-        , m_blockAxisAlignment(blockAxisAlignment)
-        , m_writingMode(writingMode)
-        , m_usedZoom(usedZoom)
-        , m_gridAreaLines(gridAreaLines)
+PlacedGridItem::PlacedGridItem(const ElementBox& gridItem, const GridAreaLines& gridAreaLines, const BoxGeometry& gridItemGeometry, const RenderStyle& gridContainerStyle)
+    : PlacedGridItem(gridItem, gridAreaLines, gridItemGeometry, gridContainerStyle, gridItem.style())
+{
+}
+
+PlacedGridItem::PlacedGridItem(const ElementBox& gridItem, const GridAreaLines& gridAreaLines, const BoxGeometry& gridItemGeometry, const RenderStyle& gridContainerStyle, const RenderStyle& gridItemStyle)
+    : m_layoutBox(gridItem)
+    , m_inlineAxisSizes({ gridItemStyle.width(), gridItemStyle.minWidth(), gridItemStyle.maxWidth(), gridItemStyle.marginLeft(), gridItemStyle.marginRight() })
+    , m_blockAxisSizes({ gridItemStyle.height(), gridItemStyle.minHeight(), gridItemStyle.maxHeight(), gridItemStyle.marginTop(), gridItemStyle.marginBottom() })
+    , m_usedInlineBorderAndPadding(gridItemGeometry.horizontalBorderAndPadding())
+    , m_usedBlockBorderAndPadding(gridItemGeometry.verticalBorderAndPadding())
+    , m_inlineAxisAlignment(gridItemStyle.justifySelf().resolve(&gridContainerStyle))
+    , m_blockAxisAlignment(gridItemStyle.alignSelf().resolve(&gridContainerStyle))
+    , m_writingMode(gridItemStyle.writingMode())
+    , m_usedZoom(gridItemStyle.usedZoomForLength())
+    , m_gridAreaLines(gridAreaLines)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -50,9 +50,7 @@ struct ComputedSizes {
 
 class PlacedGridItem {
 public:
-    PlacedGridItem(const UnplacedGridItem&, GridAreaLines, const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes,
-        const LayoutUnit& usedInlineBorderAndPadding, const LayoutUnit& usedBlockBorderAndPadding, const StyleSelfAlignmentData& inlineAxisAlignment,
-        const StyleSelfAlignmentData& blockAxisAlignment, const WritingMode&, const Style::ZoomFactor& usedZoom);
+    PlacedGridItem(const ElementBox& gridItem, const GridAreaLines&, const BoxGeometry& gridItemGeometry,  const RenderStyle& gridContainerWritingMode);
 
     const ComputedSizes& inlineAxisSizes() const { return m_inlineAxisSizes; }
     const ComputedSizes& blockAxisSizes() const { return m_blockAxisSizes; }
@@ -80,6 +78,7 @@ public:
     const Style::ZoomFactor& usedZoom() const { return m_usedZoom; }
 
 private:
+    PlacedGridItem(const ElementBox& gridItem, const GridAreaLines&, const BoxGeometry& gridItemGeometry,  const RenderStyle& gridContainerWritingMode, const RenderStyle& gridItemWritingMode);
     const CheckedRef<const ElementBox> m_layoutBox;
 
     const ComputedSizes m_inlineAxisSizes;


### PR DESCRIPTION
#### aba6057fd09438d4902b0aa01c348e1208da87aa
<pre>
[GFC][Cleanup] Tidy up PlacedGridItem construction a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=308504">https://bugs.webkit.org/show_bug.cgi?id=308504</a>
<a href="https://rdar.apple.com/171024379">rdar://171024379</a>

Reviewed by Elika Etemad.

Currently, inside of GridFormattingContext::constructPlacedGridItems
much of the space is taken up by grabbing things off of the grid item&apos;s
style, potentially constructing some side structure, and passing the
data into the PlacedGridItemConstructor. Since this adds quite a bit of
noise to the rest of the implementation of this function and these are
fairly straightforward operations, we can just pass off this
responsibility to the constructor. The constructor can take in the
RenderStyles for the grid container and item to grab off whatever bits
that are needed. We continue to refrain from holding onto the
RenderStyle and BoxGeometry directly so that PlacedGridItem stays well
defined with just the data that is needed.

Canonical link: <a href="https://commits.webkit.org/308172@main">https://commits.webkit.org/308172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd5979168d8eda6a5382c236db87f607c0d87b52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/838911b6-5261-42b6-b71a-86c82a7a0a36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1679b7e-4168-4d54-87fd-84126fa35c86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93687 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82ccefff-bc53-4574-be95-11766e138f10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14437 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12206 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157576 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120953 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31049 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74873 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16797 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8237 "Too many flaky failures: http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/misc/percent-sign-in-form-field-name.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html, http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/webshare/webshare-allow-attribute-share.https.html, http/tests/websocket/tests/hybi/contentextensions/block-worker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18410 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18469 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->