### PR TITLE
[JSC] Fix WebAssembly.compileStreaming and .instantiateStreaming to accept compileOptions

### DIFF
--- a/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming-expected.txt
+++ b/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming-expected.txt
@@ -1,0 +1,17 @@
+Test that WebAssembly.compileStreaming and .instantiateStreaming can accept compile options for JS String Builtins
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS compileStreaming with builtins option succeeded
+PASS instantiateStreaming with builtins option succeeded
+PASS compileStreaming without builtins, import via importObject succeeded
+PASS instantiateStreaming without builtins, import via importObject succeeded
+PASS compileStreaming with invalid options threw TypeError
+PASS instantiateStreaming with invalid options threw TypeError
+PASS compileStreaming with wrong builtin signature threw CompileError
+PASS instantiateStreaming with wrong builtin signature threw CompileError
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming.html
+++ b/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming.html
@@ -1,0 +1,183 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmJSStringBuiltins=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>WebAssembly JS String Builtins Streaming Test</title>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Test that WebAssembly.compileStreaming and .instantiateStreaming can accept compile options for JS String Builtins");
+window.jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function runTest() {
+    /*
+    (module
+        (; 0000000b ;)    (type (; 0 ;)
+        (; 0000000b ;)      (func
+        (; 0000000d ;)        (param i32)
+        (; 0000000f ;)        (result (ref extern)
+                            )
+                        )
+        (; 00000011 ;)    (import "wasm:js-string" "fromCharCode" (func (; 0 ;) (type 0)
+                            (param  (; 0 ;) i32)
+                            (result (ref extern)
+                        ))
+                        )
+        )
+    */
+    let bytes = new Int8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 7, 1, 96, 1, 127, 1, 100, 111, 2, 31, 1, 14, 119, 97,
+        115, 109, 58, 106, 115, 45, 115, 116, 114, 105, 110, 103, 12, 102, 114, 111, 109, 67, 104, 97, 114, 67, 111,
+        100, 101, 0, 0, 3, 1, 0, 5, 4, 1, 1, 0, 0, 7, 10, 1, 6, 109, 101, 109, 111, 114, 121, 2, 0, 10,
+        -127, -128, -128, 0, 0]);
+
+    // Test WebAssembly.compileStreaming with builtins option
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        let module = await WebAssembly.compileStreaming(response, { builtins: ["js-string"] });
+        await WebAssembly.instantiate(module, {}, { builtins: ["js-string"] });
+        testPassed("compileStreaming with builtins option succeeded");
+    } catch (e) {
+        testFailed("compileStreaming with builtins option threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Test WebAssembly.instantiateStreaming with builtins option
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, {}, { builtins: ["js-string"] });
+        testPassed("instantiateStreaming with builtins option succeeded");
+    } catch (e) {
+        testFailed("instantiateStreaming with builtins option threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Import object to satisfy the wasm:js-string import manually
+    let importObject = {
+        "wasm:js-string": {
+            fromCharCode: (code) => String.fromCharCode(code)
+        }
+    };
+
+    // Test WebAssembly.compileStreaming without builtins, import satisfied via importObject
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        let module = await WebAssembly.compileStreaming(response);
+        await WebAssembly.instantiate(module, importObject);
+        testPassed("compileStreaming without builtins, import via importObject succeeded");
+    } catch (e) {
+        testFailed("compileStreaming without builtins, import via importObject threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Test WebAssembly.instantiateStreaming without builtins, import satisfied via importObject
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, importObject);
+        testPassed("instantiateStreaming without builtins, import via importObject succeeded");
+    } catch (e) {
+        testFailed("instantiateStreaming without builtins, import via importObject threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Test WebAssembly.compileStreaming with invalid options (number instead of object)
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.compileStreaming(response, 42);
+        testFailed("compileStreaming with invalid options should throw, but did not");
+    } catch (e) {
+        if (e instanceof TypeError)
+            testPassed("compileStreaming with invalid options threw TypeError");
+        else
+            testFailed("compileStreaming with invalid options threw " + e.constructor.name + " instead of TypeError");
+    }
+
+    // Test WebAssembly.instantiateStreaming with invalid options (number instead of object)
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, {}, 42);
+        testFailed("instantiateStreaming with invalid options should throw, but did not");
+    } catch (e) {
+        if (e instanceof TypeError)
+            testPassed("instantiateStreaming with invalid options threw TypeError");
+        else
+            testFailed("instantiateStreaming with invalid options threw " + e.constructor.name + " instead of TypeError");
+    }
+
+    // Module that imports "fromCharCode" but with the wrong signature (two i32 params instead of one).
+    // This should cause a CompileError when compiled with { builtins: ["js-string"] } because
+    // the signature doesn't match the expected builtin signature.
+    /*
+    (module
+      (type (func (param i32 i32) (result externref)))
+      (import "wasm:js-string" "fromCharCode" (func (type 0)))
+    )
+    */
+    let wrongSignatureBytes = new Int8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60,
+        0x02, 0x7f, 0x7f, 0x01, 0x6f, 0x02, 0x1f, 0x01, 0x0e, 0x77, 0x61, 0x73, 0x6d, 0x3a, 0x6a, 0x73, 0x2d, 0x73,
+        0x74, 0x72, 0x69, 0x6e, 0x67, 0x0c, 0x66, 0x72, 0x6f, 0x6d, 0x43, 0x68, 0x61, 0x72, 0x43, 0x6f, 0x64, 0x65,
+        0x00, 0x00]);
+
+    // Test WebAssembly.compileStreaming with wrong builtin signature throws CompileError
+    try {
+        let response = new Response(wrongSignatureBytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.compileStreaming(response, { builtins: ["js-string"] });
+        testFailed("compileStreaming with wrong builtin signature should throw, but did not");
+    } catch (e) {
+        if (e instanceof WebAssembly.CompileError)
+            testPassed("compileStreaming with wrong builtin signature threw CompileError");
+        else
+            testFailed("compileStreaming with wrong builtin signature threw " + e.constructor.name + " instead of CompileError");
+    }
+
+    // Test WebAssembly.instantiateStreaming with wrong builtin signature throws CompileError
+    try {
+        let response = new Response(wrongSignatureBytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, {}, { builtins: ["js-string"] });
+        testFailed("instantiateStreaming with wrong builtin signature should throw, but did not");
+    } catch (e) {
+        if (e instanceof WebAssembly.CompileError)
+            testPassed("instantiateStreaming with wrong builtin signature threw CompileError");
+        else
+            testFailed("instantiateStreaming with wrong builtin signature threw " + e.constructor.name + " instead of CompileError");
+    }
+
+    finishJSTest();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1488,6 +1488,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/js/WebAssemblySuspending.h
     wasm/js/JSWebAssemblyTable.h
     wasm/js/WebAssemblyBuiltin.h
+    wasm/js/WebAssemblyCompileOptions.h
     wasm/js/WebAssemblyFunction.h
     wasm/js/WebAssemblyFunctionBase.h
     wasm/js/WebAssemblyGCStructure.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -809,7 +809,7 @@
 		237C93DE2E95A89A00F62455 /* WebAssemblySuspendingPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */; };
 		23863EEB2E5EC93E00E57879 /* WebAssemblyBuiltinTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 23863EEA2E5EC92900E57879 /* WebAssemblyBuiltinTrampoline.h */; };
 		2392A1302DD51DB100DD1CB9 /* WebAssemblyBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; };
+		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23968F0E2F295B1B001AED63 /* WebAssemblySuspending.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0C2F295B1B001AED63 /* WebAssemblySuspending.h */; };
 		23968F0F2F295B1B001AED63 /* WebAssemblyPromising.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0A2F295B1B001AED63 /* WebAssemblyPromising.h */; };
 		23A356912E9790F40039C82A /* PinballCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A3568E2E9790F40039C82A /* PinballCompletion.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/JavaScriptCore/builtins/WebAssembly.js
+++ b/Source/JavaScriptCore/builtins/WebAssembly.js
@@ -26,15 +26,19 @@
 function compileStreaming(source) {
     "use strict";
 
-    return @promiseResolve(@Promise, source).@then(@webAssemblyCompileStreamingInternal);
+    var compileOptions = @argument(1);
+    return @promiseResolve(@Promise, source).@then((source) => {
+        return @webAssemblyCompileStreamingInternal(source, compileOptions);
+    });
 }
 
 function instantiateStreaming(source) {
     "use strict";
 
     var importObject = @argument(1);
+    var compileOptions = @argument(2);
     return @promiseResolve(@Promise, source).@then((source) => {
-        return @webAssemblyInstantiateStreamingInternal(source, importObject);
+        return @webAssemblyInstantiateStreamingInternal(source, importObject, compileOptions);
     });
 }
 

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -24,6 +24,10 @@
 #include <JavaScriptCore/Exception.h>
 #include <wtf/Forward.h>
 
+#if ENABLE(WEBASSEMBLY)
+#include <JavaScriptCore/WebAssemblyCompileOptions.h>
+#endif
+
 namespace JSC {
 
 class Identifier;
@@ -71,8 +75,13 @@ struct GlobalObjectMethodTable {
     ScriptExecutionStatus (*scriptExecutionStatus)(JSGlobalObject*, JSObject* scriptExecutionOwner);
     void (*reportViolationForUnsafeEval)(JSGlobalObject*, const String&);
     String (*defaultLanguage)();
-    JSPromise* (*compileStreaming)(JSGlobalObject*, JSValue);
-    JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject*);
+#if ENABLE(WEBASSEMBLY)
+    JSPromise* (*compileStreaming)(JSGlobalObject*, JSValue, std::optional<WebAssemblyCompileOptions>&&);
+    JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&);
+#else
+    void* compileStreamingPlaceholder; // placeholders to make positional initializers consistent
+    void* instantiateStreamingPlaceholder;
+#endif
     JSGlobalObject* (*deriveShadowRealmGlobalObject)(JSGlobalObject*);
     String (*codeForEval)(JSGlobalObject*, JSValue);
     bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, const ArgList&);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2019,10 +2019,10 @@ public:
         return &vm.destructibleObjectSpace();
     }
 
-    WasmStreamingCompiler(VM& vm, Structure* structure, Wasm::CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, const SourceCode& source)
+    WasmStreamingCompiler(VM& vm, Structure* structure, Wasm::CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source)
         : Base(vm, structure)
         , m_promise(promise, WriteBarrierEarlyInit)
-        , m_streamingCompiler(Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, source))
+        , m_streamingCompiler(Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source))
     {
         DollarVMAssertScope assertScope;
     }
@@ -2032,7 +2032,7 @@ public:
         DollarVMAssertScope assertScope;
         JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
         Structure* structure = createStructure(vm, globalObject, jsNull());
-        WasmStreamingCompiler* result = new (NotNull, allocateCell<WasmStreamingCompiler>(vm)) WasmStreamingCompiler(vm, structure, compilerMode, globalObject, promise, importObject, source);
+        WasmStreamingCompiler* result = new (NotNull, allocateCell<WasmStreamingCompiler>(vm)) WasmStreamingCompiler(vm, structure, compilerMode, globalObject, promise, importObject, std::nullopt, source);
         result->finishCreation(vm);
         return result;
     }

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/WasmStreamingParser.h>
+#include <JavaScriptCore/WebAssemblyCompileOptions.h>
 #include <wtf/Platform.h>
 
 #if ENABLE(WEBASSEMBLY)
@@ -48,7 +49,7 @@ class StreamingPlan;
 
 class StreamingCompiler final : public StreamingParserClient, public ThreadSafeRefCounted<StreamingCompiler> {
 public:
-    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject*, const SourceCode&);
+    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&);
 
     JS_EXPORT_PRIVATE ~StreamingCompiler();
 
@@ -60,7 +61,7 @@ public:
     void didCompileFunction(StreamingPlan&);
 
 private:
-    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject*, const SourceCode&);
+    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&);
 
     bool didReceiveFunctionData(FunctionCodeIndex, const FunctionData&) final;
     void didFinishParsing() final;
@@ -72,6 +73,7 @@ private:
     bool m_eagerFailed WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_finalized WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_threadedCompilationStarted { false };
+    std::optional<WebAssemblyCompileOptions> m_compileOptions;
     Lock m_lock;
     unsigned m_remainingCompilationRequests { 0 };
     DeferredWorkTimer::Ticket m_ticket;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -444,20 +444,52 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyValidateFunc, (JSGlobalObject* globalObject,
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileStreamingInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    std::optional<WebAssemblyCompileOptions> compileOptions;
+    if (Options::useWasmJSStringBuiltins()) {
+        JSValue compileOptionsArgument = callFrame->argument(1);
+        JSObject* compileOptionsObject = compileOptionsArgument.getObject();
+        if (!compileOptionsArgument.isUndefined() && !compileOptionsObject) [[unlikely]]
+            RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.compileStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)))));
+        compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
+        if (scope.exception()) [[unlikely]] {
+            auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+        }
+    }
+
     ASSERT(globalObject->globalObjectMethodTable()->compileStreaming);
-    return JSValue::encode(globalObject->globalObjectMethodTable()->compileStreaming(globalObject, callFrame->argument(0)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(globalObject->globalObjectMethodTable()->compileStreaming(globalObject, callFrame->argument(0), WTF::move(compileOptions))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue importArgument = callFrame->argument(1);
     JSObject* importObject = importArgument.getObject();
     if (!importArgument.isUndefined() && !importObject) [[unlikely]]
-        return JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument))));
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument)))));
+
+    std::optional<WebAssemblyCompileOptions> compileOptions;
+    if (Options::useWasmJSStringBuiltins()) {
+        JSValue compileOptionsArgument = callFrame->argument(2);
+        JSObject* compileOptionsObject = compileOptionsArgument.getObject();
+        if (!compileOptionsArgument.isUndefined() && !compileOptionsObject) [[unlikely]]
+            RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "third argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)))));
+        compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
+        if (scope.exception()) [[unlikely]] {
+            auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+        }
+    }
 
     ASSERT(globalObject->globalObjectMethodTable()->instantiateStreaming);
     // FIXME: <http://webkit.org/b/184888> if there's an importObject and it contains a Memory, then we can compile the module with the right memory type (fast or not) by looking at the memory's type.
-    return JSValue::encode(globalObject->globalObjectMethodTable()->instantiateStreaming(globalObject, callFrame->argument(0), importObject));
+    RELEASE_AND_RETURN(scope, JSValue::encode(globalObject->globalObjectMethodTable()->instantiateStreaming(globalObject, callFrame->argument(0), importObject, WTF::move(compileOptions))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyGetterJSTag, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "IteratorOperations.h"
-#include "WasmModule.h"
+#include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/WasmModule.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -28,6 +28,9 @@
 
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/WeakGCMap.h>
+#if ENABLE(WEBASSEMBLY)
+#include <JavaScriptCore/WebAssemblyCompileOptions.h>
+#endif
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
 
@@ -126,8 +129,8 @@ protected:
     static void promiseRejectionTracker(JSC::JSGlobalObject*, JSC::JSPromise*, JSC::JSPromiseRejectionOperation);
 
 #if ENABLE(WEBASSEMBLY)
-    static JSC::JSPromise* compileStreaming(JSC::JSGlobalObject*, JSC::JSValue);
-    static JSC::JSPromise* instantiateStreaming(JSC::JSGlobalObject*, JSC::JSValue, JSC::JSObject*);
+    static JSC::JSPromise* compileStreaming(JSC::JSGlobalObject*, JSC::JSValue, std::optional<JSC::WebAssemblyCompileOptions>&&);
+    static JSC::JSPromise* instantiateStreaming(JSC::JSGlobalObject*, JSC::JSValue, JSC::JSObject* importObject, std::optional<JSC::WebAssemblyCompileOptions>&&);
 #endif
 
     static JSC::Identifier moduleLoaderResolve(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSValue, JSC::JSValue);


### PR DESCRIPTION
#### e075761ea48ff88ff275318677b6df79250fdb2d
<pre>
[JSC] Fix WebAssembly.compileStreaming and .instantiateStreaming to accept compileOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308136">https://bugs.webkit.org/show_bug.cgi?id=308136</a>
<a href="https://rdar.apple.com/170989896">rdar://170989896</a>

Reviewed by Yusuke Suzuki.

This patch adds the support required by the JS string builtin proposal to the streaming
compilation and instantiation APIs of WebAssembly (defined in the Web Embedding rather
than the JavaScript Embedding document of the proposal).

Highlights:

Added support for the optional compileOptions parameter to the JS builtins and
the underlying internal functions in:

    * Source/JavaScriptCore/builtins/WebAssembly.js
    * Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:

Added the plumbing to carry the options from the JS builtins to the streaming
compiler (function signature changes in multiple places).

Added the handling of compileOptions to:

    * Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
    * Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:

Added tests:

    http/tests/wasm/wasm-js-string-builtins-streaming.html

Canonical link: <a href="https://commits.webkit.org/308234@main">https://commits.webkit.org/308234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6863491916eaecd03f78086f9fa081e4d8a59047

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eddad3c4-5332-4293-b59b-28868ae972d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113090 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80736 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/575674ec-45f0-4f3a-b096-9bb11a78c0ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93835 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34ad4a29-506b-48bb-8c82-132f34729c09) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14569 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12342 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2878 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138739 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157765 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7559 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/905 "Found 169 new failures in JSWebExtensionAPIScripting.mm, JSWebExtensionAPICommands.mm, JSWebExtensionAPIPermissions.mm, JSWebExtensionAPIWindowsEvent.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, JSWebExtensionAPIWebRequest.mm, JSWebExtensionAPIWebRequestEvent.mm, JSWebExtensionAPIWebPageRuntime.mm, JSWebExtensionAPIDOM.mm, JSWebExtensionAPIWebPageNamespace.mm ...") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121096 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/146174 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121309 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31095 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75070 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8380 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178059 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18865 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82612 "Found 188 new failures in JSWebExtensionAPIDevToolsPanels.mm, JSWebExtensionAPIScripting.mm, JSWebExtensionAPICommands.mm, JSWebExtensionAPIWindowsEvent.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, JSWebExtensionAPIWebRequest.mm, JSWebExtensionAPIWebRequestEvent.mm, JSWebExtensionAPIDevTools.mm, JSWebExtensionAPIWebPageRuntime.mm, JSWebExtensionAPIDOM.mm ...") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45628 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->