### PR TITLE
Throttle visible content rect updates when changing obscured insets interactively.

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -196,7 +196,7 @@ public:
 
     bool isHandlingProgrammaticScroll() const { return m_isHandlingProgrammaticScroll; }
     void setIsHandlingProgrammaticScroll(bool isHandlingProgrammaticScroll) { m_isHandlingProgrammaticScroll = isHandlingProgrammaticScroll; }
-    
+
     void setScrollPinningBehavior(ScrollPinningBehavior);
     WEBCORE_EXPORT ScrollPinningBehavior scrollPinningBehavior();
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -457,6 +457,10 @@ struct PerWebProcessState {
     BOOL _didScrollSinceLastTimerFire;
     BOOL _needsScrollend;
 
+#if PLATFORM(IOS_FAMILY)
+    RefPtr<RunLoop::DispatchTimer> _pendingInteractiveObscuredInsetsChangeTimer;
+#endif
+
     // This value tracks the current adjustment added to the bottom inset due to the keyboard sliding out from the bottom
     // when computing obscured content insets. This is used when updating the visible content rects where we should not
     // include this adjustment.

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -102,6 +102,8 @@
 
 - (UIView *)_colorExtensionViewForTesting:(UIRectEdge)edge;
 
+@property (nonatomic, readonly) BOOL _hasPendingVisibleContentRectUpdateTimerForTesting;
+
 @end
 
 #endif // TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -544,6 +544,11 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
 #endif
 }
 
+- (BOOL)_hasPendingVisibleContentRectUpdateTimerForTesting
+{
+    return _pendingInteractiveObscuredInsetsChangeTimer && _pendingInteractiveObscuredInsetsChangeTimer->isActive();
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1176,6 +1176,7 @@ public:
 
 #if ENABLE(UI_SIDE_COMPOSITING)
     void updateVisibleContentRects(const VisibleContentRectUpdateInfo&, bool sendEvenIfUnchanged);
+    void updateVisibleContentRectsLocally(const VisibleContentRectUpdateInfo&);
 #endif
         
     void adjustLayersForLayoutViewport(const WebCore::FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale);

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -200,6 +200,11 @@ void WebPageProxy::updateVisibleContentRects(const VisibleContentRectUpdateInfo&
     protect(m_legacyMainFrameProcess)->send(Messages::ViewUpdateDispatcher::VisibleContentRectUpdate(webPageIDInMainFrameProcess(), visibleContentRectUpdate), 0);
 }
 
+void WebPageProxy::updateVisibleContentRectsLocally(const VisibleContentRectUpdateInfo& visibleContentRectUpdate)
+{
+    internals().lastVisibleContentRectUpdate = visibleContentRectUpdate;
+}
+
 void WebPageProxy::resendLastVisibleContentRects()
 {
     if (internals().lastVisibleContentRectUpdate)


### PR DESCRIPTION
#### de6e12d23e001e314af5f10b62e7b978bd4c9e42
<pre>
Throttle visible content rect updates when changing obscured insets interactively.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307463">https://bugs.webkit.org/show_bug.cgi?id=307463</a>
<a href="https://rdar.apple.com/156417823">rdar://156417823</a>

Reviewed by Simon Fraser.

When changing obscured insets interactively we will get visible content rect updates every frame.
We update bookkeeping, scrolling tree state, trigger rendering update and tile painting,
as well as firing resize and viewport events. These things all add up to be expensive in terms
of power use. By throttling these updates we can save significant power, up to 2% as measured by
an iOS browsing power benchmark on iPhones.

A previous attempt at improving the efficiency of this in 307417@main led to a bad regression when there
were fixed elements at the top or bottom of the view. During an interactive insets change the fixed
elements would be stuck in place until the throttle interval elapsed, at which time the layers would jump
into the correct position. This is fixed by throttling updates to WebContent still but we will update UI
process side bookkeeping so that the layer positions will continute to stay fixed relative to the viewport
and not fixed to the last, now stale, commit we got from WebContent. A new API test
(WKScrollViewTests.FixedLayerPositionDoesNotFreezeDuringInteractiveObscuredInsetsChange) verifies that the
layer does not have an egregious delta in position when in this state.

* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scheduleForcedVisibleContentRectUpdate]):
(-[WKWebView _cancelPendingVisibleContentRectUpdateTimer]):
(-[WKWebView _scheduleVisibleContentRectUpdateWithDelay:]):
(-[WKWebView _updateVisibleContentRects]):
(-[WKWebView _endInteractiveObscuredInsetsChange]):
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _hasPendingVisibleContentRectUpdateTimerForTesting]):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::updateVisibleContentRectsLocally):
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, VisibleContentRectUpdatesDuringInteractiveObscuredInsetsChangeAreThrottled)):
(TestWebKitAPI::TEST(WKScrollViewTests, ThrottledVisibleContentRectUpdateTimerCancelledWhenEndingInteractiveUpdates)):
(TestWebKitAPI::TEST(WKScrollViewTests, ForcedVisibleContentRectUpdateCancelsPendingThrottleTimer)):
(TestWebKitAPI::TEST(WKScrollViewTests, FixedLayerPositionDoesNotFreezeDuringInteractiveObscuredInsetsChange)):

Canonical link: <a href="https://commits.webkit.org/308209@main">https://commits.webkit.org/308209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b05b8dcfc152774719992feab23137e0820977ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99984 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4db5dbeb-1372-4052-9da7-13ead181eab6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112951 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80663 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58c45391-8f90-4250-acb5-a130fd30077d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93698 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6beb9c3-fed4-4785-b69e-5614e0b419e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12212 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2705 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157588 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120960 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121170 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31071 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131337 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74885 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8247 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82439 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18422 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18481 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->