### PR TITLE
Change DocumentSharedObjectPool's static map keys from RegistrableDomain to SecurityOriginData

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4394,7 +4394,7 @@ void Document::setParsing(bool b)
     m_bParsing = b;
 
     if (m_bParsing && !m_sharedObjectPool)
-        m_sharedObjectPool = makeUnique<DocumentSharedObjectPool>(RegistrableDomain { securityOrigin().data() });
+        m_sharedObjectPool = makeUnique<DocumentSharedObjectPool>(securityOrigin());
 
     if (!m_bParsing && view() && !view()->needsLayout())
         protect(view())->fireLayoutRelatedMilestonesIfNeeded();

--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -29,6 +29,7 @@
 
 #include "Element.h"
 #include "ElementData.h"
+#include "SecurityOrigin.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -36,14 +37,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentSharedObjectPool);
 
-static HashMap<RegistrableDomain, size_t>& NODELETE peakSizeInPast()
+static HashMap<SecurityOriginData, size_t>& NODELETE peakSizeInPast()
 {
-    static MainThreadNeverDestroyed<HashMap<RegistrableDomain, size_t>> map;
+    static MainThreadNeverDestroyed<HashMap<SecurityOriginData, size_t>> map;
     return map;
 }
 
-DocumentSharedObjectPool::DocumentSharedObjectPool(RegistrableDomain&& domain)
-    : m_domain(WTF::move(domain))
+DocumentSharedObjectPool::DocumentSharedObjectPool(const SecurityOrigin& origin)
+    : m_domain(origin.data())
 {
     m_shareableElementDataCache.reserveInitialCapacity(peakSizeInPast().get(m_domain));
 }

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -26,10 +26,9 @@
 
 #pragma once
 
-#include "RegistrableDomain.h"
+#include "SecurityOriginData.h"
 #include <memory>
 #include <wtf/HashSet.h>
-#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
@@ -41,7 +40,7 @@ class ShareableElementData;
 class DocumentSharedObjectPool {
     WTF_MAKE_TZONE_ALLOCATED(DocumentSharedObjectPool);
 public:
-    explicit DocumentSharedObjectPool(RegistrableDomain&&);
+    explicit DocumentSharedObjectPool(const SecurityOrigin&);
     ~DocumentSharedObjectPool();
     Ref<ShareableElementData> cachedShareableElementDataWithAttributes(std::span<const Attribute>);
 
@@ -49,7 +48,7 @@ private:
     struct ShareableElementDataHash;
     using ShareableElementDataCache = HashSet<Ref<ShareableElementData>, ShareableElementDataHash>;
     ShareableElementDataCache m_shareableElementDataCache;
-    RegistrableDomain m_domain;
+    SecurityOriginData m_domain;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### bd6ef2dd8d797d798fb45fd451909361fdd18873
<pre>
Change DocumentSharedObjectPool&apos;s static map keys from RegistrableDomain to SecurityOriginData
<a href="https://bugs.webkit.org/show_bug.cgi?id=308503">https://bugs.webkit.org/show_bug.cgi?id=308503</a>
<a href="https://rdar.apple.com/171023988">rdar://171023988</a>

Reviewed by Ryosuke Niwa.

The DocumentSharedObjectPool maintains a static map that remembers
the peak cache size for previously seen domains, so future pools for
the same domain can pre-allocate capacity. Previously this was keyed
by RegistrableDomain, meaning subdomains like a.example.com and
b.example.com would share the same capacity hint. This is a potential
side-channel leak — one origin could theoretically infer information
about another origin&apos;s DOM size under the same registrable
domain by observing allocation behavior somehow.

Keying by SecurityOriginData (scheme + host + port) scopes the hint
to the exact origin so that this leak is not possible.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setParsing):
* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::peakSizeInPast):
(WebCore::DocumentSharedObjectPool::DocumentSharedObjectPool):
* Source/WebCore/dom/DocumentSharedObjectPool.h:

Canonical link: <a href="https://commits.webkit.org/308095@main">https://commits.webkit.org/308095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dfbfef3724dee89c1f5aef843155fb5b240be1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155107 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0263d121-f7b9-40b9-b018-1c98e2faea67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1843f226-61cf-4212-8100-9e15ce354d76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93563 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27ac78d9-095d-4b8a-824b-712070002e4c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2552 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157431 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120741 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121031 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31003 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131198 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74729 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82297 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18273 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->