### PR TITLE
Switch to TextIndicator for UnifiedPDFPlugin.

### DIFF
--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -61,12 +61,19 @@ namespace WebCore {
 
 static bool initializeIndicator(TextIndicatorData&, LocalFrame&, const SimpleRange&, FloatSize margin, bool indicatesCurrentSelection);
 
+TextIndicator::TextIndicator() = default;
+
 TextIndicator::TextIndicator(const TextIndicatorData& data)
     : m_data(data)
 {
 }
 
 TextIndicator::~TextIndicator() = default;
+
+Ref<TextIndicator> TextIndicator::create()
+{
+    return adoptRef(*new TextIndicator());
+}
 
 Ref<TextIndicator> TextIndicator::create(const TextIndicatorData& data)
 {

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -152,6 +152,7 @@ public:
     constexpr static float defaultHorizontalMargin { 2 };
     constexpr static float defaultVerticalMargin { 1 };
 
+    WEBCORE_EXPORT static Ref<TextIndicator> create();
     WEBCORE_EXPORT static Ref<TextIndicator> create(const TextIndicatorData&);
     WEBCORE_EXPORT static RefPtr<TextIndicator> createWithSelectionInFrame(LocalFrame&, OptionSet<TextIndicatorOption>, TextIndicatorPresentationTransition, FloatSize margin = FloatSize(defaultHorizontalMargin, defaultVerticalMargin));
     WEBCORE_EXPORT static RefPtr<TextIndicator> createWithRange(const SimpleRange&, OptionSet<TextIndicatorOption>, TextIndicatorPresentationTransition, FloatSize margin = FloatSize(defaultHorizontalMargin, defaultVerticalMargin));
@@ -159,14 +160,27 @@ public:
     WEBCORE_EXPORT ~TextIndicator();
 
     FloatRect selectionRectInRootViewCoordinates() const { return m_data.selectionRectInRootViewCoordinates; }
+    void setSelectionRectInRootViewCoordinates(FloatRect selectionRectInRootViewCoordinates) { m_data.selectionRectInRootViewCoordinates = selectionRectInRootViewCoordinates; }
+
     FloatRect textBoundingRectInRootViewCoordinates() const { return m_data.textBoundingRectInRootViewCoordinates; }
+    void setTextRectsInBoundingRectCoordinates(Vector<FloatRect>&& textRectsInBoundingRectCoordinates) { m_data.textRectsInBoundingRectCoordinates = WTF::move(textRectsInBoundingRectCoordinates); }
+
     void setTextBoundingRectInRootViewCoordinates(FloatRect textBoundingRectInRootViewCoordinates) { m_data.textBoundingRectInRootViewCoordinates = textBoundingRectInRootViewCoordinates; }
+
     FloatRect contentImageWithoutSelectionRectInRootViewCoordinates() const { return m_data.contentImageWithoutSelectionRectInRootViewCoordinates; }
+    void setContentImageWithoutSelectionRectInRootViewCoordinates(FloatRect contentImageWithoutSelectionRectInRootViewCoordinates) { m_data.contentImageWithoutSelectionRectInRootViewCoordinates = contentImageWithoutSelectionRectInRootViewCoordinates; }
+
     const Vector<FloatRect>& textRectsInBoundingRectCoordinates() const { return m_data.textRectsInBoundingRectCoordinates; }
+
     float contentImageScaleFactor() const { return m_data.contentImageScaleFactor; }
+    void setContentImageScaleFactor(float contentImageScaleFactor) { m_data.contentImageScaleFactor = contentImageScaleFactor; }
+
     Image* contentImageWithHighlight() const { return m_data.contentImageWithHighlight.get(); }
     Image* contentImageWithoutSelection() const { return m_data.contentImageWithoutSelection.get(); }
+    void setContentImageWithoutSelection(Image* contentImageWithoutSelection) { m_data.contentImageWithoutSelection = contentImageWithoutSelection; }
+
     Image* contentImage() const { return m_data.contentImage.get(); }
+    void setContentImage(Image* contentImage) { m_data.contentImage = contentImage; }
 
     TextIndicatorPresentationTransition presentationTransition() const { return m_data.presentationTransition; }
     void setPresentationTransition(TextIndicatorPresentationTransition transition) { m_data.presentationTransition = transition; }
@@ -181,6 +195,7 @@ public:
     TextIndicatorData data() const { return m_data; }
 
 private:
+    TextIndicator();
     TextIndicator(const TextIndicatorData&);
 
     TextIndicatorData m_data;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3582,16 +3582,16 @@ RefPtr<TextIndicator> UnifiedPDFPlugin::textIndicatorForPageRect(FloatRect pageR
     if (highlightColor)
         context.fillRect({ { 0, 0 }, bufferSize }, *highlightColor, CompositeOperator::SourceOver, BlendMode::Multiply);
 
-    TextIndicatorData data;
-    data.contentImage = BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTF::move(buffer)));
-    data.contentImageScaleFactor = deviceScaleFactor;
-    data.contentImageWithoutSelection = data.contentImage;
-    data.contentImageWithoutSelectionRectInRootViewCoordinates = rectInRootViewCoordinates;
-    data.selectionRectInRootViewCoordinates = rectInRootViewCoordinates;
-    data.textBoundingRectInRootViewCoordinates = rectInRootViewCoordinates;
-    data.textRectsInBoundingRectCoordinates = { { { 0, 0, }, rectInRootViewCoordinates.size() } };
+    RefPtr textIndicator = TextIndicator::create();
+    textIndicator->setContentImage(BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTF::move(buffer))));
+    textIndicator->setContentImageScaleFactor(deviceScaleFactor);
+    textIndicator->setContentImageWithoutSelection(protect(textIndicator->contentImage()).get());
+    textIndicator->setContentImageWithoutSelectionRectInRootViewCoordinates(rectInRootViewCoordinates);
+    textIndicator->setSelectionRectInRootViewCoordinates(rectInRootViewCoordinates);
+    textIndicator->setTextBoundingRectInRootViewCoordinates(rectInRootViewCoordinates);
+    textIndicator->setTextRectsInBoundingRectCoordinates({ { { 0, 0, }, rectInRootViewCoordinates.size() } });
 
-    return TextIndicator::create(data);
+    return textIndicator;
 }
 
 Color UnifiedPDFPlugin::selectionTextIndicatorHighlightColor()


### PR DESCRIPTION
#### 2642a3a053e7ae672307a234f235405c2d0f9ce0
<pre>
Switch to TextIndicator for UnifiedPDFPlugin.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308511">https://bugs.webkit.org/show_bug.cgi?id=308511</a>
<a href="https://rdar.apple.com/171033013">rdar://171033013</a>

Reviewed by Abrar Rahman Protyasha.

Continuing the removal of TextIndicatorData.
This fix required adding a new blank constructor
as well as several setters. I may add all the other
setters in a future patch, but as of now they are not
needed. Adding any needed ones in the future should
be trivial.

* Source/WebCore/page/TextIndicator.cpp:
(WebCore::TextIndicator::create):
* Source/WebCore/page/TextIndicator.h:
(WebCore::TextIndicator::setSelectionRectInRootViewCoordinates):
(WebCore::TextIndicator::setTextRectsInBoundingRectCoordinates):
(WebCore::TextIndicator::setContentImageWithoutSelectionRectInRootViewCoordinates):
(WebCore::TextIndicator::setContentImageScaleFactor):
(WebCore::TextIndicator::setContentImageWithoutSelection):
(WebCore::TextIndicator::setContentImage):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::textIndicatorForPageRect):

Canonical link: <a href="https://commits.webkit.org/308394@main">https://commits.webkit.org/308394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f00ad7b2dc0266b64d84e3f0dbf18fe618fb304

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100794 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113591 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81010 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed58c79a-391d-41ff-b70e-b11cfd5a7cb0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94350 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82da72b7-2d73-427f-ad77-3dcc61cd1649) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14986 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12772 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3502 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158393 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1531 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121617 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31201 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75853 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8851 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->