### PR TITLE
[JSC] Add emitBytecodeInConditionContext for ConditionalNode

### DIFF
--- a/JSTests/stress/conditional-in-condition-context.js
+++ b/JSTests/stress/conditional-in-condition-context.js
@@ -1,0 +1,147 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected: " + expected + ", actual: " + actual);
+}
+
+function testBasic(a, b, c) {
+    if (a ? b : c)
+        return 1;
+    return 0;
+}
+
+function testConstantThen(a) {
+    if (a ? true : false)
+        return 1;
+    return 0;
+}
+
+function testConstantElse(a) {
+    if (a ? false : true)
+        return 1;
+    return 0;
+}
+
+function testLogicalNot(a, b, c) {
+    if (a ? !b : c)
+        return 1;
+    return 0;
+}
+
+function testLogicalAnd(a, b, c, d, e) {
+    if (a ? b && c : d || e)
+        return 1;
+    return 0;
+}
+
+function testNested(a, b, c, d, e) {
+    if (a ? (b ? c : d) : e)
+        return 1;
+    return 0;
+}
+
+function testWhile(a, b, c) {
+    var count = 0;
+    while (a ? b : c) {
+        count++;
+        a = false;
+        b = false;
+        c = false;
+    }
+    return count;
+}
+
+function testFor(a, b, c) {
+    var count = 0;
+    for (; a ? b : c;) {
+        count++;
+        a = false;
+        b = false;
+        c = false;
+    }
+    return count;
+}
+
+function testLogicalOperand(a, b, c, d) {
+    if ((a ? b : c) && d)
+        return 1;
+    return 0;
+}
+
+function testLogicalOr(a, b, c, d) {
+    if ((a ? b : c) || d)
+        return 1;
+    return 0;
+}
+
+function testDoWhile(a, b, c) {
+    var count = 0;
+    do {
+        count++;
+        if (count > 1) {
+            a = false;
+            b = false;
+            c = false;
+        }
+    } while (a ? b : c);
+    return count;
+}
+
+for (var i = 0; i < 1e4; i++) {
+    shouldBe(testBasic(true, true, false), 1);
+    shouldBe(testBasic(true, false, true), 0);
+    shouldBe(testBasic(false, true, true), 1);
+    shouldBe(testBasic(false, true, false), 0);
+    shouldBe(testBasic(false, false, false), 0);
+    shouldBe(testBasic(true, true, true), 1);
+
+    shouldBe(testConstantThen(true), 1);
+    shouldBe(testConstantThen(false), 0);
+
+    shouldBe(testConstantElse(true), 0);
+    shouldBe(testConstantElse(false), 1);
+
+    shouldBe(testLogicalNot(true, true, false), 0);
+    shouldBe(testLogicalNot(true, false, true), 1);
+    shouldBe(testLogicalNot(false, true, true), 1);
+    shouldBe(testLogicalNot(false, true, false), 0);
+
+    shouldBe(testLogicalAnd(true, true, true, false, false), 1);
+    shouldBe(testLogicalAnd(true, true, false, false, false), 0);
+    shouldBe(testLogicalAnd(true, false, true, false, false), 0);
+    shouldBe(testLogicalAnd(false, false, false, true, false), 1);
+    shouldBe(testLogicalAnd(false, false, false, false, true), 1);
+    shouldBe(testLogicalAnd(false, false, false, false, false), 0);
+
+    shouldBe(testNested(true, true, true, false, false), 1);
+    shouldBe(testNested(true, true, false, true, false), 0);
+    shouldBe(testNested(true, false, true, true, false), 1);
+    shouldBe(testNested(true, false, false, false, true), 0);
+    shouldBe(testNested(false, true, true, true, true), 1);
+    shouldBe(testNested(false, true, true, true, false), 0);
+
+    shouldBe(testWhile(true, true, false), 1);
+    shouldBe(testWhile(false, false, true), 1);
+    shouldBe(testWhile(true, false, true), 0);
+    shouldBe(testWhile(false, false, false), 0);
+
+    shouldBe(testFor(true, true, false), 1);
+    shouldBe(testFor(false, false, true), 1);
+    shouldBe(testFor(true, false, true), 0);
+    shouldBe(testFor(false, false, false), 0);
+
+    shouldBe(testLogicalOperand(true, true, false, true), 1);
+    shouldBe(testLogicalOperand(true, true, false, false), 0);
+    shouldBe(testLogicalOperand(true, false, true, true), 0);
+    shouldBe(testLogicalOperand(false, false, true, true), 1);
+    shouldBe(testLogicalOperand(false, false, false, true), 0);
+
+    shouldBe(testLogicalOr(true, true, false, false), 1);
+    shouldBe(testLogicalOr(true, false, true, false), 0);
+    shouldBe(testLogicalOr(true, false, true, true), 1);
+    shouldBe(testLogicalOr(false, false, true, false), 1);
+    shouldBe(testLogicalOr(false, false, false, true), 1);
+    shouldBe(testLogicalOr(false, false, false, false), 0);
+
+    shouldBe(testDoWhile(true, true, false), 2);
+    shouldBe(testDoWhile(false, false, false), 1);
+}

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -3879,6 +3879,27 @@ RegisterID* ConditionalNode::emitBytecode(BytecodeGenerator& generator, Register
     return newDst.unsafeGet();
 }
 
+void ConditionalNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
+{
+    if (needsDebugHook()) [[unlikely]]
+        generator.emitDebugHook(this);
+
+    Ref<Label> beforeThen = generator.newLabel();
+    Ref<Label> beforeElse = generator.newLabel();
+    Ref<Label> end = generator.newLabel();
+
+    generator.emitNodeInConditionContext(m_logical, beforeThen.get(), beforeElse.get(), FallThroughMeansTrue);
+    generator.emitLabel(beforeThen.get());
+
+    generator.emitNodeInConditionContext(m_expr1, trueTarget, falseTarget, fallThroughMode);
+    generator.emitJump(end.get());
+
+    generator.emitLabel(beforeElse.get());
+    generator.emitNodeInConditionContext(m_expr2, trueTarget, falseTarget, fallThroughMode);
+
+    generator.emitLabel(end.get());
+}
+
 // ------------------------------ ReadModifyResolveNode -----------------------------------
 
 // FIXME: should this be moved to be a method on BytecodeGenerator?

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1490,6 +1490,7 @@ namespace JSC {
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
+        void emitBytecodeInConditionContext(BytecodeGenerator&, Label& trueTarget, Label& falseTarget, FallThroughMode) final;
 
         ExpressionNode* m_logical;
         ExpressionNode* m_expr1;


### PR DESCRIPTION
#### ee963cf3db75e4ef1dfbdecdebce8fc7e5e52251
<pre>
[JSC] Add emitBytecodeInConditionContext for ConditionalNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=308512">https://bugs.webkit.org/show_bug.cgi?id=308512</a>

Reviewed by Keith Miller.

When a ternary expression (a ? b : c) appears in a condition context
(e.g., if/while/for conditions, logical operator operands), the bytecode
generator previously fell back to ExpressionNode::emitBytecodeInConditionContext,
which materializes the ternary result into a temporary register and then
branches on it. This is redundant because the caller only needs to know
whether the result is truthy or falsy.

This patch adds ConditionalNode::emitBytecodeInConditionContext, which
propagates the condition context directly to m_expr1 and m_expr2,
allowing them to jump straight to the caller&apos;s true/false targets
without materializing an intermediate value.

For `if (a ? b : c) return 1; return 0;`, before:

    enter
    jfalse  arg1, @else
    mov     loc5, arg2          // materialize b into temp
    jmp     @afterTernary
  @else:
    mov     loc5, arg3          // materialize c into temp
  @afterTernary:
    jfalse  loc5, @ifFalse      // redundant branch on temp
    ret     1
  @ifFalse:
    ret     0

After:

    enter
    jfalse  arg1, @else
    jfalse  arg2, @ifFalse      // branch directly on b
    jmp     @end
  @else:
    jfalse  arg3, @ifFalse      // branch directly on c
  @end:
    ret     1
  @ifFalse:
    ret     0

This eliminates 1 instruction and 1 temporary register in the basic
case. The optimization also chains recursively with existing condition
context nodes: ConstantNode (e.g., `a ? true : false` saves 2
instructions), LogicalOpNode (e.g., `a ? b &amp;&amp; c : d || e` saves 3
instructions), LogicalNotNode, and nested ConditionalNodes.

Test: JSTests/stress/conditional-in-condition-context.js

* JSTests/stress/conditional-in-condition-context.js: Added.
(shouldBe):
(testBasic):
(testConstantThen):
(testConstantElse):
(testLogicalNot):
(testLogicalAnd):
(testNested):
(testWhile):
(testFor):
(testLogicalOperand):
(testLogicalOr):
(testDoWhile):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ConditionalNode::emitBytecodeInConditionContext):
* Source/JavaScriptCore/parser/Nodes.h:

Canonical link: <a href="https://commits.webkit.org/308606@main">https://commits.webkit.org/308606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/795a064bbb78a21e1750a8330a04bb5268922139

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99868 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112716 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80587 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14318 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12086 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2560 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138418 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157439 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7238 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120751 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31350 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74736 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8119 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18552 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82304 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45580 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->