### PR TITLE
Allow enum members with patterns like I32 in style checker

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1373,6 +1373,7 @@ class _EnumState(object):
         expr_starts_lowercase = r'\s*[a-jl-z]'
         expr_enum_end = r'}\s*(?:[a-zA-Z0-9]+\s*(?:=\s*[a-zA-Z0-9]+)?)?\s*;\s*'
         expr_enum_start = r'\s*(?:enum(?:\s+class)?(?:\s+(?P<identifier>[a-zA-Z0-9]+))?)(?:\s*:\s*(?P<underlying>[a-zA-Z0-9_]+)?)?\s*\{?\s*'
+        expr_capital_with_digits = r'[A-Z][0-9]+$'
 
         def check_case_error(enum_name, value_declaration):
             def is_case_error(enum_name, value_declaration):
@@ -1384,6 +1385,8 @@ class _EnumState(object):
                     if enum_name in _ALLOW_ALL_UPPERCASE_ENUM:
                         return False
                     if len(all_uppercase.group('value')) < 2:
+                        return False
+                    if match(expr_capital_with_digits, all_uppercase.group('value')):
                         return False
                     return not all_uppercase.group('value') in _ALLOW_ABBREVIATION_ENUM_VALUES
                 return match(expr_starts_lowercase, value_declaration)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -4461,6 +4461,18 @@ class NoNonVirtualDestructorsTest(CppStyleTestBase):
             '')
 
         self.assert_lint(
+            '''enum class Type : uint8_t { I32, I64 };''',
+            '')
+
+        self.assert_lint(
+            '''enum class Type : uint8_t { A, B };''',
+            '')
+
+        self.assert_lint(
+            '''enum class Type : uint8_t { A1, B2 };''',
+            '')
+
+        self.assert_lint(
             '''enum { aOne = 1, zTwo = 2 };''',
             'enum members should use InterCaps with an initial capital letter or initial \'k\' for C-style enums.  [readability/enum_casing] [4]')
 


### PR DESCRIPTION
#### 73b09f0b6bdee7f2e98d337c6a93ecab192250e1
<pre>
Allow enum members with patterns like I32 in style checker
<a href="https://bugs.webkit.org/show_bug.cgi?id=308513">https://bugs.webkit.org/show_bug.cgi?id=308513</a>
<a href="https://rdar.apple.com/171035277">rdar://171035277</a>

Reviewed by Gerald Squelart.

I32, U64, U8, etc. are common patterns for enum members in JavaScriptCore.
I allowed this pattern in the cpp style checker.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(_EnumState.process_clean_line.check_case_error.is_case_error):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(NoNonVirtualDestructorsTest):

Canonical link: <a href="https://commits.webkit.org/308124@main">https://commits.webkit.org/308124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3897e41f77405accc060b82d95ce5fd5f2dd6c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99893 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1903b494-c7a3-450a-87a0-664596b0d23b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80610 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/245ea154-b354-4886-b04c-a3fc63d19eea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7eaad55-edd1-4759-bddd-a63dd360c669) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/145815 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12117 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2597 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157477 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10911 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31019 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74769 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8143 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18587 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->