### PR TITLE
Make MouseEvent.{cpp|h} a lot easier to read and maintain by separating arguments/parameters more clearly

### DIFF
--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -57,7 +57,15 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& type, const MouseEventInit&
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, initializer, IsTrusted::No));
 }
 
-Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowProxy>&& view, const PlatformMouseEvent& event, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, int detail, Node* relatedTarget)
+Ref<MouseEvent> MouseEvent::create(
+    const AtomString& eventType,
+    RefPtr<WindowProxy>&& view,
+    const PlatformMouseEvent& event,
+    const Vector<Ref<MouseEvent>>& coalescedEvents,
+    const Vector<Ref<MouseEvent>>& predictedEvents,
+    int detail,
+    Node* relatedTarget
+)
 {
     auto& eventNames = WebCore::eventNames();
     bool isMouseEnterOrLeave = eventType == eventNames.mouseenterEvent || eventType == eventNames.mouseleaveEvent;
@@ -65,22 +73,99 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowPro
     auto canBubble = !isMouseEnterOrLeave ? CanBubble::Yes : CanBubble::No;
     auto isComposed = !isMouseEnterOrLeave ? IsComposed::Yes : IsComposed::No;
 
-    return MouseEvent::create(eventType, canBubble, isCancelable, isComposed, event.timestamp(), WTF::move(view), detail,
-        event.globalPosition(), event.position(), event.movementDelta().x(), event.movementDelta().y(),
-        event.modifiers(), event.button(), event.buttons(), relatedTarget, event.force(), event.syntheticClickType(), coalescedEvents, predictedEvents);
+    return MouseEvent::create(
+        eventType,
+        canBubble,
+        isCancelable,
+        isComposed,
+        event.timestamp(),
+        WTF::move(view),
+        detail,
+        event.globalPosition(),
+        event.position(),
+        event.movementDelta().x(),
+        event.movementDelta().y(),
+        event.modifiers(),
+        event.button(),
+        event.buttons(),
+        relatedTarget,
+        event.force(),
+        event.syntheticClickType(),
+        coalescedEvents,
+        predictedEvents
+    );
 }
 
-Ref<MouseEvent> MouseEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const DoublePoint& screenLocation, const DoublePoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
-    EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated isSimulated, IsTrusted isTrusted)
+Ref<MouseEvent> MouseEvent::create(
+    const AtomString& type,
+    CanBubble canBubble,
+    IsCancelable isCancelable,
+    IsComposed isComposed,
+    MonotonicTime timestamp,
+    RefPtr<WindowProxy>&& view,
+    int detail,
+    const DoublePoint& screenLocation,
+    const DoublePoint& windowLocation,
+    double movementX,
+    double movementY,
+    OptionSet<Modifier> modifiers,
+    MouseButton button,
+    unsigned short buttons,
+    EventTarget* relatedTarget,
+    double force,
+    SyntheticClickType syntheticClickType,
+    const Vector<Ref<MouseEvent>>& coalescedEvents,
+    const Vector<Ref<MouseEvent>>& predictedEvents,
+    IsSimulated isSimulated,
+    IsTrusted isTrusted
+)
 {
-    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, canBubble, isCancelable, isComposed, timestamp, WTF::move(view), detail,
-        screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, coalescedEvents, predictedEvents, isSimulated, isTrusted));
+    return adoptRef(
+        *new MouseEvent(
+            EventInterfaceType::MouseEvent,
+            type,
+            canBubble,
+            isCancelable,
+            isComposed,
+            timestamp,
+            WTF::move(view),
+            detail,
+            screenLocation,
+            windowLocation,
+            movementX,
+            movementY,
+            modifiers,
+            button,
+            buttons,
+            relatedTarget,
+            force,
+            syntheticClickType,
+            coalescedEvents,
+            predictedEvents,
+            isSimulated,
+            isTrusted
+        )
+    );
 }
 
-Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    double screenX, double screenY, double clientX, double clientY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
-    SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
+Ref<MouseEvent> MouseEvent::create(
+    const AtomString& eventType,
+    CanBubble canBubble,
+    IsCancelable isCancelable,
+    IsComposed isComposed,
+    MonotonicTime timestamp,
+    RefPtr<WindowProxy>&& view,
+    int detail,
+    double screenX,
+    double screenY,
+    double clientX,
+    double clientY,
+    OptionSet<Modifier> modifiers,
+    MouseButton button,
+    unsigned short buttons,
+    SyntheticClickType syntheticClickType,
+    EventTarget* relatedTarget
+)
 {
     if (!std::isfinite(clientX))
         clientX = 0;
@@ -91,7 +176,27 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBub
     if (!std::isfinite(screenY))
         screenY = 0;
 
-    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, eventType, canBubble, isCancelable, isComposed, timestamp, WTF::move(view), detail, { screenX, screenY }, { clientX, clientY }, 0, 0, modifiers, button, buttons, syntheticClickType, relatedTarget));
+    return adoptRef(
+        *new MouseEvent(
+            EventInterfaceType::MouseEvent,
+            eventType,
+            canBubble,
+            isCancelable,
+            isComposed,
+            timestamp,
+            WTF::move(view),
+            detail,
+            { screenX, screenY },
+            { clientX, clientY },
+            0,
+            0,
+            modifiers,
+            button,
+            buttons,
+            syntheticClickType,
+            relatedTarget
+        )
+    );
 }
 
 Ref<MouseEvent> MouseEvent::createForBindings()
@@ -104,11 +209,47 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface)
 {
 }
 
-MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
-    MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const DoublePoint& screenLocation, const DoublePoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
-    EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseRelatedEvent(eventInterface, eventType, canBubble, isCancelable, isComposed, timestamp, WTF::move(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, isSimulated, isTrusted)
+MouseEvent::MouseEvent(
+    enum EventInterfaceType eventInterface,
+    const AtomString& eventType,
+    CanBubble canBubble,
+    IsCancelable isCancelable,
+    IsComposed isComposed,
+    MonotonicTime timestamp,
+    RefPtr<WindowProxy>&& view,
+    int detail,
+    const DoublePoint& screenLocation,
+    const DoublePoint& windowLocation,
+    double movementX,
+    double movementY,
+    OptionSet<Modifier> modifiers,
+    MouseButton button,
+    unsigned short buttons,
+    EventTarget* relatedTarget,
+    double force,
+    SyntheticClickType syntheticClickType,
+    const Vector<Ref<MouseEvent>>& coalescedEvents,
+    const Vector<Ref<MouseEvent>>& predictedEvents,
+    IsSimulated isSimulated,
+    IsTrusted isTrusted
+)
+    : MouseRelatedEvent(
+        eventInterface,
+        eventType,
+        canBubble,
+        isCancelable,
+        isComposed,
+        timestamp,
+        WTF::move(view),
+        detail,
+        screenLocation,
+        windowLocation,
+        movementX,
+        movementY,
+        modifiers,
+        isSimulated,
+        isTrusted
+    )
     , m_button(std::to_underlying(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
     , m_syntheticClickType(button == MouseButton::None ? SyntheticClickType::NoTap : syntheticClickType)
@@ -120,11 +261,41 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString&
 {
 }
 
-MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
-    MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const DoublePoint& screenLocation, const DoublePoint& clientLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
-    SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
-    : MouseRelatedEvent(eventInterface, eventType, canBubble, isCancelable, isComposed, timestamp, WTF::move(view), detail, screenLocation, { }, movementX, movementY, modifiers, IsSimulated::No)
+MouseEvent::MouseEvent(
+    enum EventInterfaceType eventInterface,
+    const AtomString& eventType,
+    CanBubble canBubble,
+    IsCancelable isCancelable,
+    IsComposed isComposed,
+    MonotonicTime timestamp,
+    RefPtr<WindowProxy>&& view,
+    int detail,
+    const DoublePoint& screenLocation,
+    const DoublePoint& clientLocation,
+    double movementX,
+    double movementY,
+    OptionSet<Modifier> modifiers,
+    MouseButton button,
+    unsigned short buttons,
+    SyntheticClickType syntheticClickType,
+    EventTarget* relatedTarget
+)
+    : MouseRelatedEvent(
+        eventInterface,
+        eventType,
+        canBubble,
+        isCancelable,
+        isComposed,
+        timestamp,
+        WTF::move(view),
+        detail,
+        screenLocation,
+        { },
+        movementX,
+        movementY,
+        modifiers,
+        IsSimulated::No
+    )
     , m_button(std::to_underlying(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
     , m_syntheticClickType(button == MouseButton::None ? SyntheticClickType::NoTap : syntheticClickType)
@@ -134,7 +305,12 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString&
     initCoordinates(clientLocation);
 }
 
-MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseEventInit& initializer, IsTrusted isTrusted)
+MouseEvent::MouseEvent(
+    enum EventInterfaceType eventInterface,
+    const AtomString& eventType,
+    const MouseEventInit& initializer,
+    IsTrusted isTrusted
+)
     : MouseRelatedEvent(eventInterface, eventType, initializer, isTrusted)
     , m_button(initializer.button == std::to_underlying(MouseButton::None) ? std::to_underlying(MouseButton::Left) : initializer.button)
     , m_buttons(initializer.buttons)
@@ -146,8 +322,23 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString&
 
 MouseEvent::~MouseEvent() = default;
 
-void MouseEvent::initMouseEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&& view, int detail,
-    double screenX, double screenY, double clientX, double clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, int16_t button, EventTarget* relatedTarget)
+void MouseEvent::initMouseEvent(
+    const AtomString& type,
+    bool canBubble,
+    bool cancelable,
+    RefPtr<WindowProxy>&& view,
+    int detail,
+    double screenX,
+    double screenY,
+    double clientX,
+    double clientY,
+    bool ctrlKey,
+    bool altKey,
+    bool shiftKey,
+    bool metaKey,
+    int16_t button,
+    EventTarget* relatedTarget
+)
 {
     if (isBeingDispatched())
         return;

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -56,15 +56,58 @@ bool isAnyClick(const Event&);
 class MouseEvent : public MouseRelatedEvent {
     WTF_MAKE_TZONE_ALLOCATED(MouseEvent);
 public:
-    WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const DoublePoint& screenLocation, const DoublePoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
-        EventTarget* relatedTarget, double force, SyntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
+    WEBCORE_EXPORT static Ref<MouseEvent> create(
+        const AtomString& type,
+        CanBubble,
+        IsCancelable,
+        IsComposed,
+        MonotonicTime timestamp,
+        RefPtr<WindowProxy>&&,
+        int detail,
+        const DoublePoint& screenLocation,
+        const DoublePoint& windowLocation,
+        double movementX,
+        double movementY,
+        OptionSet<Modifier>,
+        MouseButton,
+        unsigned short buttons,
+        EventTarget* relatedTarget,
+        double force,
+        SyntheticClickType,
+        const Vector<Ref<MouseEvent>>& coalescedEvents,
+        const Vector<Ref<MouseEvent>>& predictedEvents,
+        IsSimulated = IsSimulated::No,
+        IsTrusted = IsTrusted::Yes
+    );
 
-    WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& eventType, RefPtr<WindowProxy>&&, const PlatformMouseEvent&, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, int detail, Node* relatedTarget);
+    WEBCORE_EXPORT static Ref<MouseEvent> create(
+        const AtomString& eventType,
+        RefPtr<WindowProxy>&&,
+        const PlatformMouseEvent&,
+        const Vector<Ref<MouseEvent>>& coalescedEvents,
+        const Vector<Ref<MouseEvent>>& predictedEvents,
+        int detail,
+        Node* relatedTarget
+    );
 
-    static Ref<MouseEvent> create(const AtomString& eventType, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        double screenX, double screenY, double clientX, double clientY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
-        SyntheticClickType, EventTarget* relatedTarget);
+    static Ref<MouseEvent> create(
+        const AtomString& eventType,
+        CanBubble,
+        IsCancelable,
+        IsComposed,
+        MonotonicTime timestamp,
+        RefPtr<WindowProxy>&&,
+        int detail,
+        double screenX,
+        double screenY,
+        double clientX,
+        double clientY,
+        OptionSet<Modifier>,
+        MouseButton,
+        unsigned short buttons,
+        SyntheticClickType,
+        EventTarget* relatedTarget
+    );
 
     static Ref<MouseEvent> createForBindings();
 
@@ -76,9 +119,23 @@ public:
 
     virtual ~MouseEvent();
 
-    WEBCORE_EXPORT void initMouseEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&&,
-        int detail, double screenX, double screenY, double clientX, double clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey,
-        int16_t button, EventTarget* relatedTarget);
+    WEBCORE_EXPORT void initMouseEvent(
+        const AtomString& type,
+        bool canBubble,
+        bool cancelable,
+        RefPtr<WindowProxy>&&,
+        int detail,
+        double screenX,
+        double screenY,
+        double clientX,
+        double clientY,
+        bool ctrlKey,
+        bool altKey,
+        bool shiftKey,
+        bool metaKey,
+        int16_t button,
+        EventTarget* relatedTarget
+    );
 
     MouseButton button() const;
     int16_t buttonAsShort() const { return m_button; }
@@ -101,13 +158,50 @@ public:
     Vector<Ref<MouseEvent>> predictedEvents() const { return m_predictedEvents; }
 
 protected:
-    MouseEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const DoublePoint& screenLocation, const DoublePoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
-        EventTarget* relatedTarget, double force, SyntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated, IsTrusted);
+    MouseEvent(
+        enum EventInterfaceType,
+        const AtomString& type,
+        CanBubble,
+        IsCancelable,
+        IsComposed,
+        MonotonicTime timestamp,
+        RefPtr<WindowProxy>&&,
+        int detail,
+        const DoublePoint& screenLocation,
+        const DoublePoint& windowLocation,
+        double movementX,
+        double movementY,
+        OptionSet<Modifier>,
+        MouseButton,
+        unsigned short buttons,
+        EventTarget* relatedTarget,
+        double force,
+        SyntheticClickType,
+        const Vector<Ref<MouseEvent>>& coalescedEvents,
+        const Vector<Ref<MouseEvent>>& predictedEvents,
+        IsSimulated,
+        IsTrusted
+    );
 
-    MouseEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const DoublePoint& screenLocation, const DoublePoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
-        SyntheticClickType, EventTarget* relatedTarget);
+    MouseEvent(
+        enum EventInterfaceType,
+        const AtomString& type,
+        CanBubble,
+        IsCancelable,
+        IsComposed,
+        MonotonicTime timestamp,
+        RefPtr<WindowProxy>&&,
+        int detail,
+        const DoublePoint& screenLocation,
+        const DoublePoint& clientLocation,
+        double movementX,
+        double movementY,
+        OptionSet<Modifier>,
+        MouseButton,
+        unsigned short buttons,
+        SyntheticClickType,
+        EventTarget* relatedTarget
+    );
 
     MouseEvent(enum EventInterfaceType, const AtomString& type, const MouseEventInit&, IsTrusted);
 


### PR DESCRIPTION
#### 0b40ffb30b051bef12d7b2485c59ab12243e8c5e
<pre>
Make MouseEvent.{cpp|h} a lot easier to read and maintain by separating arguments/parameters more clearly
<a href="https://bugs.webkit.org/show_bug.cgi?id=308514">https://bugs.webkit.org/show_bug.cgi?id=308514</a>
<a href="https://rdar.apple.com/171035373">rdar://171035373</a>

Reviewed by Abrar Rahman Protyasha.

By
adding
a
lot
of
newlines

* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::MouseEvent):
(WebCore::MouseEvent::initMouseEvent):
* Source/WebCore/dom/MouseEvent.h:

Canonical link: <a href="https://commits.webkit.org/308107@main">https://commits.webkit.org/308107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f4b16c472753b5f93f952fb75c12aa042a86eff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146477 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155141 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112764 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/694c8cfe-566a-4d5b-90f0-0059ac4fc986) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93592 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2586 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157465 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10907 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121060 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31010 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74759 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22595 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8139 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18577 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18306 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->