### PR TITLE
Reduce use of protected functions in Source/WebCore/html

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -338,14 +338,4 @@ WebCoreOpaqueRoot root(CanvasBase* canvas)
     return WebCoreOpaqueRoot { canvas };
 }
 
-RefPtr<ScriptExecutionContext> CanvasBase::protectedCanvasBaseScriptExecutionContext() const
-{
-    return canvasBaseScriptExecutionContext();
-}
-
-RefPtr<ScriptExecutionContext> CanvasBase::protectedScriptExecutionContext() const
-{
-    return scriptExecutionContext();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -82,7 +82,6 @@ public:
 
     virtual SecurityOrigin* securityOrigin() const { return nullptr; }
     ScriptExecutionContext* scriptExecutionContext() const { return canvasBaseScriptExecutionContext();  }
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     virtual CanvasRenderingContext* renderingContext() const = 0;
 
@@ -130,7 +129,6 @@ protected:
     explicit CanvasBase(IntSize, ScriptExecutionContext&);
 
     virtual ScriptExecutionContext* canvasBaseScriptExecutionContext() const = 0;
-    RefPtr<ScriptExecutionContext> protectedCanvasBaseScriptExecutionContext() const;
     virtual std::unique_ptr<CSSParserContext> createCSSParserContext() const = 0;
 
     void setSize(const IntSize&);

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -95,7 +95,6 @@ protected:
     inline const CollectionNamedElementCache& namedItemCaches() const;
 
     inline Document& document() const;
-    inline Ref<Document> protectedDocument() const;
 
     void invalidateNamedElementCache(Document&) const;
 

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -96,22 +96,17 @@ inline Document& HTMLCollection::document() const
     return m_ownerNode->document();
 }
 
-inline Ref<Document> HTMLCollection::protectedDocument() const
-{
-    return document();
-}
-
 inline void HTMLCollection::invalidateCacheForAttribute(const QualifiedName& attributeName)
 {
     if (shouldInvalidateTypeOnAttributeChange(invalidationType(), attributeName))
         invalidateCache();
     else if (hasNamedElementCache() && (attributeName == HTMLNames::idAttr || attributeName == HTMLNames::nameAttr))
-        invalidateNamedElementCache(protectedDocument().get());
+        invalidateNamedElementCache(protect(document()).get());
 }
 
 inline void HTMLCollection::invalidateCache()
 {
-    invalidateCacheForDocument(protectedDocument().get());
+    invalidateCacheForDocument(protect(document()).get());
 }
 
 inline bool HTMLCollection::hasNamedElementCache() const
@@ -128,7 +123,7 @@ inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedEle
         Locker locker { m_namedElementCacheAssignmentLock };
         m_namedElementCache = WTF::move(cache);
     }
-    protectedDocument()->collectionCachedIdNameMap(*this);
+    protect(document())->collectionCachedIdNameMap(*this);
 }
 
 inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -132,7 +132,7 @@ void HTMLFrameElementBase::attributeChanged(const QualifiedName& name, const Ato
     } else if (name == srcAttr && !hasAttributeWithoutSynchronization(srcdocAttr))
         setLocation(newValue.string().trim(isASCIIWhitespace));
     else if (name == scrollingAttr && contentFrame())
-        protectedContentFrame()->updateScrollingMode();
+        protect(contentFrame())->updateScrollingMode();
     else
         HTMLFrameOwnerElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -96,11 +96,6 @@ HTMLFrameOwnerElement::~HTMLFrameOwnerElement()
         contentFrame->disconnectOwnerElement();
 }
 
-RefPtr<Frame> HTMLFrameOwnerElement::protectedContentFrame() const
-{
-    return m_contentFrame.get();
-}
-
 Document* HTMLFrameOwnerElement::contentDocument() const
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(m_contentFrame.get()))

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -40,7 +40,6 @@ public:
     virtual ~HTMLFrameOwnerElement();
 
     Frame* contentFrame() const { return m_contentFrame.get(); }
-    RefPtr<Frame> NODELETE protectedContentFrame() const;
     WEBCORE_EXPORT WindowProxy* NODELETE contentWindow() const;
     WEBCORE_EXPORT Document* NODELETE contentDocument() const;
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2111,7 +2111,7 @@ static bool eventTimeCueCompare(const std::pair<MediaTime, RefPtr<TextTrackCue>>
     // compare the two tracks by the relative cue order, so return the relative
     // track order.
     if (a.second->track() != b.second->track())
-        return trackIndexCompare(*a.second->protectedTrack(), *b.second->protectedTrack());
+        return trackIndexCompare(*protect(a.second->track()), *protect(b.second->track()));
 
     // 12 - Further sort tasks in events that have the same time by the
     // relative text track cue order of the text track cues associated
@@ -2441,7 +2441,7 @@ void HTMLMediaElement::speakCueText(TextTrackCue& cue)
         cancelSpeakingCueText();
 
     m_cueBeingSpoken = cue;
-    RefPtr { m_cueBeingSpoken }->prepareToSpeak(protectedSpeechSynthesis(), m_reportedPlaybackRate ? m_reportedPlaybackRate : m_requestedPlaybackRate, volume(), [weakThis = WeakPtr { *this }](const TextTrackCue&) {
+    protect(m_cueBeingSpoken)->prepareToSpeak(protect(speechSynthesis()), m_reportedPlaybackRate ? m_reportedPlaybackRate : m_requestedPlaybackRate, volume(), [weakThis = WeakPtr { *this }](const TextTrackCue&) {
         ASSERT(isMainThread());
         RefPtr<HTMLMediaElement> protectedThis = weakThis.get();
         if (!protectedThis)
@@ -2458,13 +2458,6 @@ void HTMLMediaElement::speakCueText(TextTrackCue& cue)
     UNUSED_PARAM(cue);
 #endif
 }
-
-#if ENABLE(SPEECH_SYNTHESIS)
-Ref<SpeechSynthesis> HTMLMediaElement::protectedSpeechSynthesis()
-{
-    return speechSynthesis();
-}
-#endif
 
 void HTMLMediaElement::pauseSpeakingCueText()
 {
@@ -2616,7 +2609,7 @@ void HTMLMediaElement::textTrackModeChanged(TextTrack& track)
     track.setHasBeenConfigured(true);
 
     if (track.mode() != TextTrack::Mode::Disabled && trackIsLoaded)
-        textTrackAddCues(track, *track.protectedCues());
+        textTrackAddCues(track, *protect(track.cues()));
 
     configureTextTrackDisplay(AssumeTextTrackVisibilityChanged);
 
@@ -2721,7 +2714,7 @@ void HTMLMediaElement::textTrackRemoveCues(TextTrack&, const TextTrackCueList& c
     TrackDisplayUpdateScope scope { *this };
     for (unsigned i = 0; i < cues.length(); ++i) {
         Ref cue = *cues.item(i);
-        textTrackRemoveCue(*cue->protectedTrack(), cue);
+        textTrackRemoveCue(*protect(cue->track()), cue);
     }
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -687,7 +687,6 @@ public:
     TextTrackCue* cueBeingSpoken() const { return m_cueBeingSpoken.get(); }
 #if ENABLE(SPEECH_SYNTHESIS)
     WEBCORE_EXPORT SpeechSynthesis& speechSynthesis();
-    Ref<SpeechSynthesis> protectedSpeechSynthesis();
 #endif
 
     bool hasSource() const { return hasCurrentSrc() || srcObject(); }

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -74,11 +74,6 @@ RenderProgress* HTMLProgressElement::renderProgress() const
     return downcast<RenderProgress>(descendantsOfType<Element>(*protect(userAgentShadowRoot())).first()->renderer());
 }
 
-RefPtr<ProgressValueElement> HTMLProgressElement::protectedValueElement()
-{
-    return m_valueElement.get();
-}
-
 void HTMLProgressElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == valueAttr) {
@@ -132,7 +127,7 @@ void HTMLProgressElement::updateDeterminateState()
 
 void HTMLProgressElement::didElementStateChange()
 {
-    protectedValueElement()->setInlineSizePercentage(position() * 100);
+    protect(m_valueElement)->setInlineSizePercentage(position() * 100);
     if (CheckedPtr renderer = renderProgress())
         renderer->updateFromElement();
 

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -66,8 +66,6 @@ private:
 
     bool canContainRangeEndPoint() const final { return false; }
 
-    RefPtr<ProgressValueElement> NODELETE protectedValueElement();
-
     WeakPtr<ProgressValueElement, WeakPtrImplWithEventTargetData> m_valueElement;
     bool m_isDeterminate { false };
 };

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -209,9 +209,4 @@ HTMLTableCellElement* HTMLTableCellElement::cellAbove() const
     return downcast<HTMLTableCellElement>(cellAboveRenderer->element());
 }
 
-RefPtr<HTMLTableCellElement> HTMLTableCellElement::protectedCellAbove() const
-{
-    return cellAbove();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -60,7 +60,6 @@ public:
     WEBCORE_EXPORT const AtomString& scope() const;
 
     WEBCORE_EXPORT HTMLTableCellElement* cellAbove() const;
-    WEBCORE_EXPORT RefPtr<HTMLTableCellElement> protectedCellAbove() const;
 
 private:
     HTMLTableCellElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -536,14 +536,9 @@ void HTMLTextAreaElement::updatePlaceholderText()
     }
     if (!m_placeholder) {
         m_placeholder = TextControlPlaceholderElement::create(protect(document()));
-        protect(userAgentShadowRoot())->insertBefore(*protectedPlaceholderElement(), protect(innerTextElement()->nextSibling()));
+        protect(userAgentShadowRoot())->insertBefore(*protect(m_placeholder), protect(innerTextElement()->nextSibling()));
     }
-    protectedPlaceholderElement()->setInnerText(String { placeholderText });
-}
-
-RefPtr<HTMLElement> HTMLTextAreaElement::protectedPlaceholderElement() const
-{
-    return m_placeholder;
+    protect(m_placeholder)->setInnerText(String { placeholderText });
 }
 
 RenderStyle HTMLTextAreaElement::createInnerTextStyle(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -75,7 +75,6 @@ private:
 
     bool supportsPlaceholder() const final { return true; }
     HTMLElement* placeholderElement() const final { return m_placeholder.get(); }
-    RefPtr<HTMLElement> NODELETE protectedPlaceholderElement() const;
     void updatePlaceholderText() final;
     bool isEmptyValue() const final { return value()->isEmpty(); }
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -96,7 +96,6 @@ private:
     }
 
     ImageDocument& document() const;
-    Ref<ImageDocument> protectedDocument() const;
 
     void appendBytes(DocumentWriter&, std::span<const uint8_t>) override;
     void finish() override;
@@ -213,19 +212,14 @@ inline ImageDocument& NODELETE ImageDocumentParser::document() const
     return downcast<ImageDocument>(*RawDataDocumentParser::document());
 }
 
-inline Ref<ImageDocument> NODELETE ImageDocumentParser::protectedDocument() const
-{
-    return document();
-}
-
 void ImageDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
-    protectedDocument()->updateDuringParsing();
+    protect(document())->updateDuringParsing();
 }
 
 void ImageDocumentParser::finish()
 {
-    protectedDocument()->finishedParsing();
+    protect(document())->finishedParsing();
 }
 
 ImageDocument::ImageDocument(LocalFrame& frame, const URL& url)

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -166,7 +166,7 @@ void RangeInputType::handleTouchEvent(TouchEvent& event)
         return;
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    protectedTypedSliderThumbElement()->handleTouchEvent(event);
+    protect(typedSliderThumbElement())->handleTouchEvent(event);
 #else
 
     if (element()->isDisabledFormControl())
@@ -180,7 +180,7 @@ void RangeInputType::handleTouchEvent(TouchEvent& event)
     RefPtr<TouchList> touches = event.targetTouches();
     if (touches->length() == 1) {
         auto touchPoint = touches->item(0)->absoluteLocation();
-        protectedTypedSliderThumbElement()->setPositionFromPoint(LayoutPoint(touchPoint));
+        protect(typedSliderThumbElement())->setPositionFromPoint(LayoutPoint(touchPoint));
         event.setDefaultHandled();
     }
 #endif // ENABLE(IOS_TOUCH_EVENTS)
@@ -191,7 +191,7 @@ void RangeInputType::disabledStateChanged()
 {
     if (!hasCreatedShadowSubtree())
         return;
-    protectedTypedSliderThumbElement()->hostDisabledStateChanged();
+    protect(typedSliderThumbElement())->hostDisabledStateChanged();
 }
 
 auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
@@ -303,11 +303,6 @@ SliderThumbElement& RangeInputType::typedSliderThumbElement() const
     return downcast<SliderThumbElement>(*sliderTrackElement()->firstChild());
 }
 
-Ref<SliderThumbElement> RangeInputType::protectedTypedSliderThumbElement() const
-{
-    return typedSliderThumbElement();
-}
-
 HTMLElement* RangeInputType::sliderThumbElement() const
 {
     return &typedSliderThumbElement();
@@ -351,7 +346,7 @@ void RangeInputType::attributeChanged(const QualifiedName& name)
                 element->setValue(element->value());
         }
         if (hasCreatedShadowSubtree())
-            protectedTypedSliderThumbElement()->setPositionFromValue();
+            protect(typedSliderThumbElement())->setPositionFromValue();
         break;
     default:
         break;
@@ -372,7 +367,7 @@ void RangeInputType::setValue(const String& value, bool valueChanged, TextFieldE
     }
 
     if (hasCreatedShadowSubtree())
-        protectedTypedSliderThumbElement()->setPositionFromValue();
+        protect(typedSliderThumbElement())->setPositionFromValue();
 }
 
 ValueOrReference<String> RangeInputType::fallbackValue() const

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -72,7 +72,6 @@ private:
     HTMLElement* sliderTrackElement() const final;
 
     SliderThumbElement& typedSliderThumbElement() const;
-    Ref<SliderThumbElement> protectedTypedSliderThumbElement() const;
 
     void dataListMayHaveChanged() final;
     void updateTickMarkValues();

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -212,9 +212,6 @@ private:
     void mergeAttributesFromTokenIntoElement(AtomHTMLToken&&, Element&);
     void dispatchDocumentElementAvailableIfNeeded();
 
-    Ref<Document> NODELETE protectedDocument() const;
-    Ref<ContainerNode> NODELETE protectedAttachmentRoot() const;
-
     // m_head has to be destroyed after destroying CheckedRef of m_document and m_attachmentRoot
     HTMLStackItem m_head;
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -277,7 +277,7 @@ bool HTMLDocumentParser::pumpTokenizerLoop(SynchronousMode mode, bool parsingFra
     RefPtr parserScheduler = m_parserScheduler;
     do {
         if (isWaitingForScripts()) [[unlikely]] {
-            if (mode == SynchronousMode::AllowYield && parserScheduler->shouldYieldBeforeExecutingScript(m_treeBuilder->protectedScriptToProcess().get(), session))
+            if (mode == SynchronousMode::AllowYield && parserScheduler->shouldYieldBeforeExecutingScript(protect(m_treeBuilder->scriptToProcess()).get(), session))
                 return true;
             
             runScriptsForPausedTreeBuilder();

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -3213,9 +3213,4 @@ bool HTMLTreeBuilder::isOnStackOfOpenElements(Element& element) const
     return m_tree.openElements().contains(element);
 }
 
-RefPtr<const ScriptElement> HTMLTreeBuilder::protectedScriptToProcess() const
-{
-    return m_scriptToProcess;
-}
-
 }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -72,7 +72,6 @@ public:
     // Must be called to take the parser-blocking script before calling the parser again.
     RefPtr<ScriptElement> takeScriptToProcess(TextPosition& scriptStartPosition);
     const ScriptElement* scriptToProcess() const { return m_scriptToProcess.get(); }
-    RefPtr<const ScriptElement> protectedScriptToProcess() const;
 
     std::unique_ptr<CustomElementConstructionData> takeCustomElementConstructionData() { return WTF::move(m_customElementToConstruct); }
     void didCreateCustomOrFallbackElement(Ref<Element>&&, CustomElementConstructionData&);

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -193,7 +193,7 @@ void DateTimeEditBuilder::visitLiteral(const String& text)
         element->setInlineStyleProperty(CSSPropertyMarginInlineEnd, -1, CSSUnitType::CSS_PX);
 
     element->appendChild(Text::create(document.get(), String { text }));
-    m_editElement->protectedFieldsWrapperElement()->appendChild(element);
+    protect(m_editElement->fieldsWrapperElement())->appendChild(element);
 }
 
 DateTimeEditElementEditControlOwner::~DateTimeEditElementEditControlOwner() = default;
@@ -213,17 +213,12 @@ inline Element& DateTimeEditElement::fieldsWrapperElement() const
     return downcast<Element>(*firstChild());
 }
 
-inline Ref<Element> DateTimeEditElement::protectedFieldsWrapperElement() const
-{
-    return fieldsWrapperElement();
-}
-
 void DateTimeEditElement::addField(Ref<DateTimeFieldElement> field)
 {
     if (m_fields.size() == m_fields.capacity())
         return;
     m_fields.append(field);
-    protectedFieldsWrapperElement()->appendChild(field);
+    protect(fieldsWrapperElement())->appendChild(field);
 }
 
 size_t DateTimeEditElement::fieldIndexOf(const DateTimeFieldElement& fieldToFind) const

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -79,7 +79,6 @@ public:
     virtual ~DateTimeEditElement();
     void addField(Ref<DateTimeFieldElement>);
     Element& NODELETE fieldsWrapperElement() const;
-    Ref<Element> NODELETE protectedFieldsWrapperElement() const;
     void focusByOwner();
     void resetFields();
     void setEmptyValue(const LayoutParameters&);

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -187,7 +187,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
         for (auto& interval : activeCues) {
             Ref cue = *interval.data();
 
-            if (cue->protectedTrack()->isSpoken())
+            if (protect(cue->track())->isSpoken())
                 continue;
 
             if (RefPtr vttCue = dynamicDowncast<VTTCue>(cue))
@@ -229,7 +229,7 @@ void MediaControlTextTrackContainerElement::processActiveVTTCue(VTTCue& cue)
 {
     DEBUG_LOG(LOGIDENTIFIER, "adding and positioning cue: \"", cue.text(), "\", start=", cue.startTime(), ", end=", cue.endTime());
 
-    if (RefPtr region = cue.track()->protectedRegions()->getRegionById(cue.regionId())) {
+    if (RefPtr region = protect(cue.track()->regions())->getRegionById(cue.regionId())) {
         // Let region be the WebVTT region whose region identifier
         // matches the text track cue region identifier of cue.
         Ref regionNode = region->getDisplayTree();

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -79,12 +79,7 @@ AudioTrack::AudioTrack(ScriptExecutionContext* context, AudioTrackPrivate& track
 
 AudioTrack::~AudioTrack()
 {
-    removeClientFromTrackPrivateBase(protectedPrivate());
-}
-
-Ref<AudioTrackPrivate> AudioTrack::protectedPrivate() const
-{
-    return m_private;
+    removeClientFromTrackPrivateBase(protect(m_private));
 }
 
 void AudioTrack::setPrivate(AudioTrackPrivate& trackPrivate)
@@ -92,7 +87,7 @@ void AudioTrack::setPrivate(AudioTrackPrivate& trackPrivate)
     if (m_private.ptr() == &trackPrivate)
         return;
 
-    removeClientFromTrackPrivateBase(protectedPrivate());
+    removeClientFromTrackPrivateBase(protect(m_private));
     m_private = trackPrivate;
     trackPrivate.setEnabled(m_enabled);
     addClientToTrackPrivateBase(*this, trackPrivate);
@@ -130,7 +125,7 @@ void AudioTrack::setEnabled(bool enabled)
     if (m_enabled == enabled)
         return;
 
-    protectedPrivate()->setEnabled(enabled);
+    protect(m_private)->setEnabled(enabled);
     m_clients.forEach([this] (auto& client) {
         client.audioTrackEnabledChanged(*this);
     });
@@ -150,7 +145,7 @@ void AudioTrack::clearClient(AudioTrackClient& client)
 
 size_t AudioTrack::inbandTrackIndex() const
 {
-    return protectedPrivate()->trackIndex();
+    return protect(m_private)->trackIndex();
 }
 
 void AudioTrack::enabledChanged(bool enabled)
@@ -203,7 +198,7 @@ void AudioTrack::willRemove()
 
 void AudioTrack::updateKindFromPrivate()
 {
-    switch (protectedPrivate()->kind()) {
+    switch (protect(m_private)->kind()) {
     case AudioTrackPrivate::Kind::Alternative:
         setKind("alternative"_s);
         break;
@@ -240,7 +235,7 @@ void AudioTrack::updateConfigurationFromPrivate()
 void AudioTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TrackBase::setLogger(logger, logIdentifier);
-    protectedPrivate()->setLogger(logger, this->logIdentifier());
+    protect(m_private)->setLogger(logger, this->logIdentifier());
 }
 #endif
 

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -64,7 +64,6 @@ public:
 
     size_t inbandTrackIndex() const;
 
-    Ref<AudioTrackPrivate> NODELETE protectedPrivate() const;
     const AudioTrackPrivate& privateTrack() const { return m_private; }
     void setPrivate(AudioTrackPrivate&);
 

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -83,12 +83,7 @@ void InbandTextTrack::setPrivate(InbandTextTrackPrivate& trackPrivate)
 
     setModeInternal(mode());
     updateKindFromPrivate();
-    setId(protectedPrivate()->id());
-}
-
-Ref<InbandTextTrackPrivate> InbandTextTrack::protectedPrivate() const
-{
-    return m_private;
+    setId(protect(m_private)->id());
 }
 
 void InbandTextTrack::setMode(Mode mode)
@@ -113,47 +108,47 @@ static inline InbandTextTrackPrivate::Mode NODELETE toPrivate(TextTrack::Mode mo
 
 void InbandTextTrack::setModeInternal(Mode mode)
 {
-    protectedPrivate()->setMode(toPrivate(mode));
+    protect(m_private)->setMode(toPrivate(mode));
 }
 
 bool InbandTextTrack::isClosedCaptions() const
 {
-    return protectedPrivate()->isClosedCaptions();
+    return protect(m_private)->isClosedCaptions();
 }
 
 bool InbandTextTrack::isSDH() const
 {
-    return protectedPrivate()->isSDH();
+    return protect(m_private)->isSDH();
 }
 
 bool InbandTextTrack::containsOnlyForcedSubtitles() const
 {
-    return protectedPrivate()->containsOnlyForcedSubtitles();
+    return protect(m_private)->containsOnlyForcedSubtitles();
 }
 
 bool InbandTextTrack::isMainProgramContent() const
 {
-    return protectedPrivate()->isMainProgramContent();
+    return protect(m_private)->isMainProgramContent();
 }
 
 bool InbandTextTrack::isEasyToRead() const
 {
-    return protectedPrivate()->isEasyToRead();
+    return protect(m_private)->isEasyToRead();
 }
 
 bool InbandTextTrack::isDefault() const
 {
-    return protectedPrivate()->isDefault();
+    return protect(m_private)->isDefault();
 }
 
 size_t InbandTextTrack::inbandTrackIndex()
 {
-    return protectedPrivate()->trackIndex();
+    return protect(m_private)->trackIndex();
 }
 
 String InbandTextTrack::inBandMetadataTrackDispatchType() const
 {
-    return protectedPrivate()->inBandMetadataTrackDispatchType();
+    return protect(m_private)->inBandMetadataTrackDispatchType();
 }
 
 void InbandTextTrack::idChanged(TrackID id)
@@ -180,7 +175,7 @@ void InbandTextTrack::willRemove()
 
 void InbandTextTrack::updateKindFromPrivate()
 {
-    switch (protectedPrivate()->kind()) {
+    switch (protect(m_private)->kind()) {
     case InbandTextTrackPrivate::Kind::Subtitles:
         setKind(Kind::Subtitles);
         return;
@@ -207,14 +202,14 @@ void InbandTextTrack::updateKindFromPrivate()
 
 MediaTime InbandTextTrack::startTimeVariance() const
 {
-    return protectedPrivate()->startTimeVariance();
+    return protect(m_private)->startTimeVariance();
 }
 
 #if !RELEASE_LOG_DISABLED
 void InbandTextTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TextTrack::setLogger(logger, logIdentifier);
-    protectedPrivate()->setLogger(logger, this->logIdentifier());
+    protect(m_private)->setLogger(logger, this->logIdentifier());
 }
 #endif
 

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -54,7 +54,6 @@ public:
     String inBandMetadataTrackDispatchType() const override;
 
     void setPrivate(InbandTextTrackPrivate&);
-    Ref<InbandTextTrackPrivate> NODELETE protectedPrivate() const;
 #if !RELEASE_LOG_DISABLED
     void setLogger(const Logger&, uint64_t) final;
 #endif

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -147,13 +147,8 @@ TextTrack::~TextTrack()
             client.textTrackRemoveCues(*this, *m_cues);
         });
         for (size_t i = 0; i < m_cues->length(); ++i)
-            m_cues->protectedItem(i)->setTrack(nullptr);
+            protect(m_cues->item(i))->setTrack(nullptr);
     }
-}
-
-inline RefPtr<TextTrackCueList> TextTrack::protectedCues() const
-{
-    return m_cues.copyRef();
 }
 
 void TextTrack::didMoveToNewDocument(Document& newDocument)
@@ -294,7 +289,7 @@ void TextTrack::setMode(Mode mode)
 
     if (mode != Mode::Showing && m_cues) {
         for (size_t i = 0; i < m_cues->length(); ++i)
-            m_cues->protectedItem(i)->removeDisplayTree();
+            protect(m_cues->item(i))->removeDisplayTree();
     }
 
     m_mode = mode;
@@ -316,11 +311,6 @@ TextTrackCueList* TextTrack::cues()
     return &ensureTextTrackCueList();
 }
 
-RefPtr<TextTrackCueList> TextTrack::protectedCues()
-{
-    return cues();
-}
-
 void TextTrack::removeAllCues()
 {
     if (!m_cues)
@@ -333,7 +323,7 @@ void TextTrack::removeAllCues()
     });
 
     for (size_t i = 0; i < m_cues->length(); ++i)
-        m_cues->protectedItem(i)->setTrack(nullptr);
+        protect(m_cues->item(i))->setTrack(nullptr);
 
     m_cues->clear();
 }
@@ -466,11 +456,6 @@ VTTRegionList* TextTrack::regions()
     return &ensureVTTRegionList();
 }
 
-RefPtr<VTTRegionList> TextTrack::protectedRegions()
-{
-    return regions();
-}
-
 void TextTrack::cueWillChange(TextTrackCue& cue)
 {
     m_clients.forEach([&](auto& client) {
@@ -563,7 +548,7 @@ RefPtr<TextTrackCue> TextTrack::matchCue(TextTrackCue& cue, TextTrackCue::CueMat
 
             // If there is more than one cue with the same start time, back up to first one so we
             // consider all of them.
-            while (searchStart >= 2 && cue.hasEquivalentStartTime(*m_cues->protectedItem(searchStart - 2)))
+            while (searchStart >= 2 && cue.hasEquivalentStartTime(*protect(m_cues->item(searchStart - 2))))
                 --searchStart;
             
             bool firstCompare = true;
@@ -658,11 +643,6 @@ void TextTrack::newCuesAvailable(const TextTrackCueList& list)
 ScriptExecutionContext* TextTrack::scriptExecutionContext() const
 {
     return ActiveDOMObject::scriptExecutionContext();
-}
-
-RefPtr<ScriptExecutionContext> TextTrack::protectedScriptExecutionContext() const
-{
-    return scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -85,11 +85,9 @@ public:
     void setReadinessState(ReadinessState state) { m_readinessState = state; }
 
     TextTrackCueList* cues();
-    RefPtr<TextTrackCueList> protectedCues();
     TextTrackCueList* activeCues() const LIFETIME_BOUND;
 
     TextTrackCueList* cuesInternal() const { return m_cues.get(); }
-    inline RefPtr<TextTrackCueList> protectedCues() const;
 
     void addClient(TextTrackClient&);
     void clearClient(TextTrackClient&);
@@ -98,7 +96,6 @@ public:
     virtual ExceptionOr<void> removeCue(TextTrackCue&);
 
     VTTRegionList* regions();
-    RefPtr<VTTRegionList> protectedRegions();
 
     void cueWillChange(TextTrackCue&);
     void cueDidChange(TextTrackCue&, bool);
@@ -145,7 +142,6 @@ public:
     virtual void removeCuesNotInTimeRanges(const PlatformTimeRanges&);
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
 protected:
     TextTrack(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language, TextTrackType);

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -247,11 +247,6 @@ Document* TextTrackCue::document() const
     return downcast<Document>(scriptExecutionContext());
 }
 
-RefPtr<Document> TextTrackCue::protectedDocument() const
-{
-    return document();
-}
-
 void TextTrackCue::willChange()
 {
     if (++m_processingCueChanges > 1)
@@ -274,11 +269,6 @@ void TextTrackCue::didChange(bool affectOrder)
 }
 
 TextTrack* TextTrackCue::track() const
-{
-    return m_track.get();
-}
-
-RefPtr<TextTrack> TextTrackCue::protectedTrack() const
 {
     return m_track.get();
 }

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -79,7 +79,6 @@ public:
     void didMoveToNewDocument(Document&);
 
     TextTrack* NODELETE track() const;
-    RefPtr<TextTrack> NODELETE protectedTrack() const;
     void setTrack(TextTrack*);
 
     const AtomString& id() const { return m_id; }
@@ -144,7 +143,6 @@ protected:
     TextTrackCue(Document&, const MediaTime& start, const MediaTime& end);
 
     Document* document() const;
-    RefPtr<Document> protectedDocument() const;
 
     virtual void toJSON(JSON::Object&) const;
 

--- a/Source/WebCore/html/track/TextTrackCueList.h
+++ b/Source/WebCore/html/track/TextTrackCueList.h
@@ -43,7 +43,6 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const;
     TextTrackCue* NODELETE item(unsigned index) const;
-    RefPtr<TextTrackCue> protectedItem(unsigned index) const { return item(index); }
     TextTrackCue* getCueById(const String&) const;
 
     unsigned cueIndex(const TextTrackCue&) const;

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -486,7 +486,7 @@ void VTTCue::setText(const String& text)
 void VTTCue::createWebVTTNodeTree()
 {
     if (!m_webVTTNodeTree && document())
-        m_webVTTNodeTree = WebVTTParser::createDocumentFragmentFromCueText(*protectedDocument().get(), m_content);
+        m_webVTTNodeTree = WebVTTParser::createDocumentFragmentFromCueText(*protect(document()), m_content);
 }
 
 static void copyWebVTTNodeToDOMTree(ContainerNode& webVTTNode, Node& parent)
@@ -1021,7 +1021,7 @@ void VTTCue::updateDisplayTree(const MediaTime& movieTime)
 {
     // The display tree may contain WebVTT timestamp objects representing
     // timestamps (processing instructions), along with displayable nodes.
-    if (!track() || !protectedTrack()->isRendered())
+    if (!track() || !protect(track())->isRendered())
         return;
 
     // Mutating the VTT contents is safe because it's never exposed to author scripts.
@@ -1046,7 +1046,7 @@ RefPtr<TextTrackCueBox> VTTCue::getDisplayTree()
     ASSERT(track());
 
     RefPtr displayTree = displayTreeInternal();
-    if (!displayTree || !m_displayTreeShouldChange || !track() || !protectedTrack()->isRendered())
+    if (!displayTree || !m_displayTreeShouldChange || !track() || !protect(track())->isRendered())
         return displayTree;
 
     if (region())

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -310,7 +310,7 @@ void VTTRegion::willRemoveTextTrackCueBox(VTTCueBox* box)
 HTMLDivElement& VTTRegion::getDisplayTree()
 {
     if (!m_regionDisplayTree) {
-        lazyInitialize(m_regionDisplayTree, HTMLDivElement::create(*protectedDocument()));
+        lazyInitialize(m_regionDisplayTree, HTMLDivElement::create(*protect(document())));
         m_regionDisplayTree->setUserAgentPart(UserAgentParts::webkitMediaTextTrackRegion());
         m_recalculateStyles = true;
     }
@@ -333,7 +333,7 @@ void VTTRegion::prepareRegionDisplayTree()
     // The cue container is used to wrap the cues and it is the object which is
     // gradually scrolled out as multiple cues are appended to the region.
     if (!m_cueContainer) {
-        lazyInitialize(m_cueContainer, HTMLDivElement::create(*protectedDocument()));
+        lazyInitialize(m_cueContainer, HTMLDivElement::create(*protect(document())));
         m_cueContainer->setUserAgentPart(UserAgentParts::webkitMediaTextTrackRegionContainer());
         m_regionDisplayTree->appendChild(*m_cueContainer);
     }
@@ -405,9 +405,9 @@ void VTTRegion::scrollTimerFired()
     displayLastTextTrackCueBox();
 }
 
-RefPtr<Document> VTTRegion::protectedDocument() const
+Document* VTTRegion::document() const
 {
-    return downcast<Document>(protect(scriptExecutionContext()));
+    return downcast<Document>(scriptExecutionContext());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -122,7 +122,7 @@ private:
 
     static const AtomString& textTrackCueContainerScrollingClass();
 
-    RefPtr<Document> protectedDocument() const;
+    Document* document() const;
 
     String m_id;
     String m_settings;

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -107,7 +107,7 @@ void VideoTrack::setSelected(const bool selected)
         return;
 
     m_selected = selected;
-    protectedPrivate()->setSelected(selected);
+    protect(m_private)->setSelected(selected);
 
     m_clients.forEach([this] (auto& client) {
         client.videoTrackSelectedChanged(*this);
@@ -128,7 +128,7 @@ void VideoTrack::clearClient(VideoTrackClient& client)
 
 size_t VideoTrack::inbandTrackIndex()
 {
-    return protectedPrivate()->trackIndex();
+    return protect(m_private)->trackIndex();
 }
 
 void VideoTrack::selectedChanged(bool selected)
@@ -217,7 +217,7 @@ void VideoTrack::setLanguage(const AtomString& language)
 
 void VideoTrack::updateKindFromPrivate()
 {
-    switch (protectedPrivate()->kind()) {
+    switch (protect(m_private)->kind()) {
     case VideoTrackPrivate::Kind::Alternative:
         setKind("alternative"_s);
         return;
@@ -248,16 +248,11 @@ void VideoTrack::updateConfigurationFromPrivate()
     m_configuration->setState(m_private->configuration());
 }
 
-Ref<VideoTrackPrivate> VideoTrack::protectedPrivate() const
-{
-    return m_private;
-}
-
 #if !RELEASE_LOG_DISABLED
 void VideoTrack::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
     TrackBase::setLogger(logger, logIdentifier);
-    protectedPrivate()->setLogger(logger, this->logIdentifier());
+    protect(m_private)->setLogger(logger, this->logIdentifier());
 }
 #endif
 

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -101,8 +101,6 @@ private:
     ASCIILiteral logClassName() const final { return "VideoTrack"_s; }
 #endif
 
-    Ref<VideoTrackPrivate> NODELETE protectedPrivate() const;
-
     WeakPtr<VideoTrackList> m_videoTrackList;
     WeakHashSet<VideoTrackClient> m_clients;
     Ref<VideoTrackPrivate> m_private;

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -332,7 +332,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these characters it is invalid.
     if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).containsOnly<isASCIIWhitespace>()) {
-        m_currentRegion = VTTRegion::create(protectedDocument().get());
+        m_currentRegion = VTTRegion::create(protect(m_document).get());
         return true;
     }
     return false;
@@ -419,11 +419,6 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         m_styleSheets.append(sanitizedStyleSheetBuilder.toString());
 
     return true;
-}
-
-Ref<Document> WebVTTParser::protectedDocument() const
-{
-    return m_document.get();
 }
 
 WebVTTParser::ParseState WebVTTParser::collectCueId(const String& line)

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -167,8 +167,6 @@ private:
 
     static bool collectTimeStamp(VTTScanner& input, MediaTime& timeStamp);
 
-    Ref<Document> NODELETE protectedDocument() const;
-
     const WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     ParseState m_state { Initial };
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -758,7 +758,7 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
 
         if (shouldFocusElement == ShouldFocusElement::Yes) {
             document->setFocusedElement(nullptr);
-            setFocusedFrame(owner->protectedContentFrame().get());
+            setFocusedFrame(protect(owner->contentFrame()).get());
         }
         return findResult;
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -429,7 +429,7 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::htmlTableCellElementC
     if (!tableCell)
         return nullptr;
 
-    return getOrCreate(tableCell->protectedCellAbove().get());
+    return getOrCreate(protect(tableCell->cellAbove()).get());
 }
 
 RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()


### PR DESCRIPTION
#### 57c298107d795144efe71451adb6471a126ec522
<pre>
Reduce use of protected functions in Source/WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=308518">https://bugs.webkit.org/show_bug.cgi?id=308518</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::protectedCanvasBaseScriptExecutionContext const): Deleted.
(WebCore::CanvasBase::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::scriptExecutionContext const):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::invalidateCacheForAttribute):
(WebCore::HTMLCollection::invalidateCache):
(WebCore::HTMLCollection::setNamedItemCache const):
(WebCore::HTMLCollection::protectedDocument const): Deleted.
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::attributeChanged):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::protectedContentFrame const): Deleted.
* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::HTMLFrameOwnerElement::contentFrame const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::eventTimeCueCompare):
(WebCore::HTMLMediaElement::speakCueText):
(WebCore::HTMLMediaElement::textTrackModeChanged):
(WebCore::HTMLMediaElement::textTrackRemoveCues):
(WebCore::HTMLMediaElement::protectedSpeechSynthesis): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::didElementStateChange):
(WebCore::HTMLProgressElement::protectedValueElement): Deleted.
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::protectedCellAbove const): Deleted.
* Source/WebCore/html/HTMLTableCellElement.h:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::updatePlaceholderText):
(WebCore::HTMLTextAreaElement::protectedPlaceholderElement const): Deleted.
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocumentParser::appendBytes):
(WebCore::ImageDocumentParser::finish):
(WebCore::ImageDocumentParser::protectedDocument const): Deleted.
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleTouchEvent):
(WebCore::RangeInputType::disabledStateChanged):
(WebCore::RangeInputType::attributeChanged):
(WebCore::RangeInputType::setValue):
(WebCore::RangeInputType::protectedTypedSliderThumbElement const): Deleted.
* Source/WebCore/html/RangeInputType.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLHtmlStartTagBeforeHTML):
(WebCore::HTMLConstructionSite::setCompatibilityMode):
(WebCore::HTMLConstructionSite::finishedParsing):
(WebCore::HTMLConstructionSite::insertDoctype):
(WebCore::HTMLConstructionSite::insertCommentOnDocument):
(WebCore::HTMLConstructionSite::protectedDocument const): Deleted.
(WebCore::HTMLConstructionSite::protectedAttachmentRoot const): Deleted.
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::pumpTokenizerLoop):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::protectedScriptToProcess const): Deleted.
* Source/WebCore/html/parser/HTMLTreeBuilder.h:
(WebCore::HTMLTreeBuilder::scriptToProcess const):
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditBuilder::visitLiteral):
(WebCore::DateTimeEditElement::addField):
(WebCore::DateTimeEditElement::protectedFieldsWrapperElement const): Deleted.
* Source/WebCore/html/shadow/DateTimeEditElement.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::processActiveVTTCue):
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::~AudioTrack):
(WebCore::AudioTrack::setPrivate):
(WebCore::AudioTrack::setEnabled):
(WebCore::AudioTrack::inbandTrackIndex const):
(WebCore::AudioTrack::updateKindFromPrivate):
(WebCore::AudioTrack::setLogger):
(WebCore::AudioTrack::protectedPrivate const): Deleted.
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::setPrivate):
(WebCore::InbandTextTrack::setModeInternal):
(WebCore::InbandTextTrack::isClosedCaptions const):
(WebCore::InbandTextTrack::isSDH const):
(WebCore::InbandTextTrack::containsOnlyForcedSubtitles const):
(WebCore::InbandTextTrack::isMainProgramContent const):
(WebCore::InbandTextTrack::isEasyToRead const):
(WebCore::InbandTextTrack::isDefault const):
(WebCore::InbandTextTrack::inbandTrackIndex):
(WebCore::InbandTextTrack::inBandMetadataTrackDispatchType const):
(WebCore::InbandTextTrack::updateKindFromPrivate):
(WebCore::InbandTextTrack::startTimeVariance const):
(WebCore::InbandTextTrack::setLogger):
(WebCore::InbandTextTrack::protectedPrivate const): Deleted.
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::~TextTrack):
(WebCore::TextTrack::setMode):
(WebCore::TextTrack::removeAllCues):
(WebCore::TextTrack::matchCue):
(WebCore::TextTrack::protectedCues const): Deleted.
(WebCore::TextTrack::protectedCues): Deleted.
(WebCore::TextTrack::protectedRegions): Deleted.
(WebCore::TextTrack::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/html/track/TextTrack.h:
(WebCore::TextTrack::cuesInternal const):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::protectedDocument const): Deleted.
(WebCore::TextTrackCue::protectedTrack const): Deleted.
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TextTrackCueList.h:
(WebCore::TextTrackCueList::protectedItem const): Deleted.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::createWebVTTNodeTree):
(WebCore::VTTCue::updateDisplayTree):
(WebCore::VTTCue::getDisplayTree):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::getDisplayTree):
(WebCore::VTTRegion::prepareRegionDisplayTree):
(WebCore::VTTRegion::document const):
(WebCore::VTTRegion::protectedDocument const): Deleted.
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::setSelected):
(WebCore::VideoTrack::inbandTrackIndex):
(WebCore::VideoTrack::updateKindFromPrivate):
(WebCore::VideoTrack::setLogger):
(WebCore::VideoTrack::protectedPrivate const): Deleted.
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndCreateRegion):
(WebCore::WebVTTParser::protectedDocument const): Deleted.
* Source/WebCore/html/track/WebVTTParser.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementInDocumentOrderStartingWithFrame):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::htmlTableCellElementCellAbove):

Canonical link: <a href="https://commits.webkit.org/308109@main">https://commits.webkit.org/308109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c407fb3eb6358d54e764e3ffd7170a355a676cbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99882 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e325182-6214-4014-9408-822a18833dc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112763 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3eddec6-1372-43e3-a1c9-0848fc4ca793) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93591 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/796b0d51-e6f0-4f8f-be6f-828f67d5914a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157459 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120785 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31012 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74754 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8134 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18572 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82322 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18301 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18358 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->