### PR TITLE
[JSC] The pcrtoaddr offlineasm instruction should be lowered differently to support global labels

### DIFF
--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -1416,7 +1416,20 @@ class Instruction
         when "bfiq"
             $asm.puts "bfi #{operands[3].arm64Operand(:quad)}, #{operands[0].arm64Operand(:quad)}, #{operands[1].value}, #{operands[2].value}"
         when "pcrtoaddr"
-            $asm.puts "adr #{operands[1].arm64Operand(:quad)}, #{operands[0].value}"
+            labelRef = operands[0]
+            register = operands[1].arm64Operand(:quad)
+            if labelRef.externOrGlobal?
+                $asm.putStr("#if OS(DARWIN)")
+                $asm.puts "adrp #{register}, #{labelRef.asmLabel}@PAGE"
+                $asm.puts "add #{register}, #{register}, #{labelRef.asmLabel}@PAGEOFF"
+                $asm.putStr("#else")
+                $asm.puts "adrp #{register}, #{labelRef.asmLabel}"
+                $asm.puts "add #{register}, #{register}, :lo12:#{labelRef.asmLabel}"
+                $asm.putStr("#endif")
+            else
+                $asm.puts "adr #{register}, #{labelRef.value}"
+            end
+
         when "globaladdr"
             uid = $asm.newUID
 

--- a/Source/JavaScriptCore/offlineasm/ast.rb
+++ b/Source/JavaScriptCore/offlineasm/ast.rb
@@ -1327,6 +1327,10 @@ class LabelReference < Node
         $labelMapping[name].is_a? Label and $labelMapping[name].extern?
     end
 
+    def externOrGlobal?
+        extern? or label.global?
+    end
+
     def used
         if !$referencedExternLabels.include?(@label) and extern?
             $referencedExternLabels.push(@label)

--- a/Source/JavaScriptCore/offlineasm/backends.rb
+++ b/Source/JavaScriptCore/offlineasm/backends.rb
@@ -154,7 +154,7 @@ class LabelReference
         # For historical reasons a LabelReference may reference a label which is neither
         # extern nor global, in which case it should act as a LocalLabelReference.
         # See https://bugs.webkit.org/show_bug.cgi?id=131205.
-        if extern? || label.global?
+        if externOrGlobal?
             Assembler.externOrGlobalLabelReference(name[1..-1])
         else
             Assembler.localLabelReference(name[1..-1])


### PR DESCRIPTION
#### 586f364e7e1475375a458aa830fed85b69be4438
<pre>
[JSC] The pcrtoaddr offlineasm instruction should be lowered differently to support global labels
<a href="https://rdar.apple.com/170991136">rdar://170991136</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308517">https://bugs.webkit.org/show_bug.cgi?id=308517</a>

Reviewed by Yusuke Suzuki.

The `pcrtoaddr` instruction is lowered for arm64 into a single `adr` instruction. This works
reliably for local labels. JSPI implementation adds a case where the instruction is used to load an
address of a global label. In this situation, `adr` appears to work only in some build
configurations and in others causes an &quot;unknown fixup kind&quot; build error.

This patch augments `pcrtoaddr` implementation so that for global labels it translates into an
`adrp`/`add` instruction sequence. For local labels it keeps the existing single-instruction scheme.
It also adds a useful externOrGlobal? predicate to LabelReference, used elsewhere for a similar
conditional.

Testing: integration-tested at its call sites.
Canonical link: <a href="https://commits.webkit.org/308139@main">https://commits.webkit.org/308139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d37b07f8a5ed510afa3e31416e360c1327738619

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99877 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b1acff2-0ba3-45af-8db6-a58237ffafef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112777 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80596 "Exiting early after 60 failures. 15405 tests run. 60 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6848df77-d997-4913-a368-a8128c11e602) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93583 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c6621af-7f9a-41d9-8543-b0c1cdc99295) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14333 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12098 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2574 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138432 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157453 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7252 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120809 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31032 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74748 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8128 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82316 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18295 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->