### PR TITLE
Implement overflow-clip-margin computed style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -232,7 +232,7 @@ PASS outline-style
 PASS outline-width
 PASS overflow-anchor
 PASS overflow-block
-FAIL overflow-clip-margin assert_not_equals: Should get a different computed value. got disallowed value "0px"
+PASS overflow-clip-margin
 PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-clip-margin-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-clip-margin-computed-expected.txt
@@ -1,16 +1,22 @@
 
 PASS Property overflow-clip-margin value '0px'
-FAIL Property overflow-clip-margin value '10px' assert_equals: expected "10px" but got "0px"
-FAIL Property overflow-clip-margin value 'content-box' assert_equals: expected "content-box" but got "0px"
-FAIL Property overflow-clip-margin value 'content-box 0px' assert_equals: expected "content-box" but got "0px"
-FAIL Property overflow-clip-margin value 'content-box 10px' assert_equals: expected "content-box 10px" but got "0px"
-FAIL Property overflow-clip-margin value '10px content-box' assert_equals: expected "content-box 10px" but got "0px"
+PASS Property overflow-clip-margin value '10px'
+PASS Property overflow-clip-margin value 'content-box'
+PASS Property overflow-clip-margin value 'content-box 0px'
+PASS Property overflow-clip-margin value 'content-box 10px'
+PASS Property overflow-clip-margin value '10px content-box'
 PASS Property overflow-clip-margin value 'padding-box'
 PASS Property overflow-clip-margin value 'padding-box 0px'
-FAIL Property overflow-clip-margin value 'padding-box 10px' assert_equals: expected "10px" but got "0px"
-FAIL Property overflow-clip-margin value '10px padding-box' assert_equals: expected "10px" but got "0px"
-FAIL Property overflow-clip-margin value 'border-box' assert_equals: expected "border-box" but got "0px"
-FAIL Property overflow-clip-margin value 'border-box 0px' assert_equals: expected "border-box" but got "0px"
-FAIL Property overflow-clip-margin value 'border-box 10px' assert_equals: expected "border-box 10px" but got "0px"
-FAIL Property overflow-clip-margin value '10px border-box' assert_equals: expected "border-box 10px" but got "0px"
+PASS Property overflow-clip-margin value 'padding-box 10px'
+PASS Property overflow-clip-margin value '10px padding-box'
+PASS Property overflow-clip-margin value 'border-box'
+PASS Property overflow-clip-margin value 'border-box 0px'
+PASS Property overflow-clip-margin value 'border-box 10px'
+PASS Property overflow-clip-margin value '10px border-box'
+PASS Property overflow-clip-margin value 'calc(100px - 50px)'
+PASS Property overflow-clip-margin value 'calc(100px - 100px)'
+PASS Property overflow-clip-margin value 'calc(0.5em + 100px)'
+PASS Property overflow-clip-margin value 'padding-box calc(0.5em + 100px)'
+PASS Property overflow-clip-margin value 'padding-box calc(100px - 100px)'
+PASS Property overflow-clip-margin value 'border-box calc(0.5em + 100px)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-clip-margin-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-clip-margin-computed.html
@@ -28,6 +28,14 @@ test_computed_value("overflow-clip-margin", "border-box");
 test_computed_value("overflow-clip-margin", "border-box 0px", "border-box");
 test_computed_value("overflow-clip-margin", "border-box 10px");
 test_computed_value("overflow-clip-margin", "10px border-box", "border-box 10px");
+
+test_computed_value("overflow-clip-margin", "calc(100px - 50px)", "50px");
+test_computed_value("overflow-clip-margin", "calc(100px - 100px)", "0px");
+test_computed_value("overflow-clip-margin", "calc(0.5em + 100px)", "108px");
+
+test_computed_value("overflow-clip-margin", "padding-box calc(0.5em + 100px)", "108px");
+test_computed_value("overflow-clip-margin", "padding-box calc(100px - 100px)", "0px");
+test_computed_value("overflow-clip-margin", "border-box calc(0.5em + 100px)", "border-box 108px");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin-expected.txt
@@ -4,9 +4,9 @@ PASS Can set 'overflow-clip-margin' to CSS-wide keywords: inherit
 PASS Can set 'overflow-clip-margin' to CSS-wide keywords: unset
 PASS Can set 'overflow-clip-margin' to CSS-wide keywords: revert
 PASS Can set 'overflow-clip-margin' to var() references:  var(--A)
-FAIL Can set 'overflow-clip-margin' to the 'border-box' keyword: border-box assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'overflow-clip-margin' to the 'content-box' keyword: content-box assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'overflow-clip-margin' to the 'padding-box' keyword: padding-box assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'overflow-clip-margin' to the 'border-box' keyword: border-box
+PASS Can set 'overflow-clip-margin' to the 'content-box' keyword: content-box
+PASS Can set 'overflow-clip-margin' to the 'padding-box' keyword: padding-box
 PASS Can set 'overflow-clip-margin' to a length: 0px
 FAIL Can set 'overflow-clip-margin' to a length: -3.14em Invalid values
 PASS Can set 'overflow-clip-margin' to a length: 3.14cm

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3174,6 +3174,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/box/StyleMargin.h
     style/values/box/StyleMarginTrim.h
     style/values/box/StylePadding.h
+    style/values/box/StyleVisualBox.h
 
     style/values/break/StyleOrphans.h
     style/values/break/StyleWidows.h

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -62,6 +62,7 @@
 #include "StyleTextTransform.h"
 #include "StyleTextUnderlinePosition.h"
 #include "StyleTouchAction.h"
+#include "StyleVisualBox.h"
 #include "StyleWebKitLineBoxContain.h"
 #include "StyleWebKitOverflowScrolling.h"
 #include "StyleWebKitTouchCallout.h"
@@ -2425,8 +2426,8 @@ constexpr CSSValueID toCSSValueIDForWebkitMaskSourceType(Style::MaskMode e)
     return CSSValueInvalid;
 }
 
-#define TYPE VisualBox
-#define FOR_EACH(CASE) CASE(ContentBox) CASE(BorderBox) CASE(PaddingBox)
+#define TYPE Style::VisualBox
+#define FOR_EACH(CASE) CASE(BorderBox) CASE(ContentBox) CASE(PaddingBox)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7310,7 +7310,7 @@
             }
         },
         "overflow-clip-margin": {
-            "animation-type": "not animatable",
+            "animation-type": "discrete",
             "animation-type-comment": "FIXME: Current spec animation type is 'see prose'",
             "inherited": false,
             "initial": "0px",

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1462,14 +1462,4 @@ TextStream& operator<<(TextStream& ts, VectorEffect value)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, VisualBox visualBox)
-{
-    switch (visualBox) {
-    case VisualBox::BorderBox: ts << "border-box"_s; break;
-    case VisualBox::ContentBox: ts << "content-box"_s; break;
-    case VisualBox::PaddingBox: ts << "padding-box"_s; break;
-    }
-    return ts;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -899,12 +899,6 @@ enum class CSSBoxType : uint8_t {
     ViewBox
 };
 
-enum class VisualBox : uint8_t {
-    BorderBox,
-    ContentBox,
-    PaddingBox
-};
-
 enum class ScrollSnapStrictness : bool {
     Proximity,
     Mandatory
@@ -1259,6 +1253,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, MaskType);
 WTF::TextStream& operator<<(WTF::TextStream&, ShapeRendering);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAnchor);
 WTF::TextStream& operator<<(WTF::TextStream&, VectorEffect);
-WTF::TextStream& operator<<(WTF::TextStream&, VisualBox);
 
 } // namespace WebCore

--- a/Source/WebCore/style/values/box/StyleVisualBox.h
+++ b/Source/WebCore/style/values/box/StyleVisualBox.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Suraj Thanugundla <contact@surajt.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+namespace Style {
+
+// <visual-box> = border-box | content-box | padding-box
+// https://drafts.csswg.org/css-box-4/#typedef-visual-box
+enum class VisualBox : uint8_t {
+    BorderBox,
+    ContentBox,
+    PaddingBox
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/overflow/StyleOverflowClipMargin.cpp
+++ b/Source/WebCore/style/values/overflow/StyleOverflowClipMargin.cpp
@@ -26,16 +26,73 @@
 #include "config.h"
 #include "StyleOverflowClipMargin.h"
 
-#include "StyleBuilderState.h"
+#include "CSSPrimitiveValueMappings.h"
+#include "StyleBuilderChecking.h"
 
 namespace WebCore {
 namespace Style {
 
-auto CSSValueConversion<OverflowClipMargin>::operator()(BuilderState& state, const CSSValue&) -> OverflowClipMargin
+auto CSSValueConversion<OverflowClipMargin>::operator()(BuilderState& state, const CSSValue& value) -> OverflowClipMargin
 {
     using namespace CSS::Literals;
-    state.setCurrentPropertyInvalidAtComputedValueTime();
-    return 0_css_px;
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->isLength())
+            return { toStyleFromCSSValue<OverflowClipMargin::Length>(state, *primitiveValue) };
+
+        if (primitiveValue->isValueID()) {
+            switch (primitiveValue->valueID()) {
+            case CSSValueBorderBox:
+            case CSSValueContentBox:
+            case CSSValuePaddingBox:
+                return fromCSSValue<VisualBox>(*primitiveValue);
+            default:
+                break;
+            }
+        }
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return 0_css_px;
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue, 2>(state, value);
+
+    if (!list) {
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return 0_css_px;
+    }
+
+    std::optional<VisualBox> referenceBox;
+    std::optional<OverflowClipMargin::Length> length;
+
+    for (Ref item : *list) {
+        if (item->isValueID()) {
+            if (referenceBox) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return 0_css_px;
+            }
+            switch (item->valueID()) {
+            case CSSValueBorderBox:
+            case CSSValueContentBox:
+            case CSSValuePaddingBox:
+                referenceBox = fromCSSValue<VisualBox>(item);
+                break;
+            default:
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return 0_css_px;
+            }
+        } else if (item->isLength()) {
+            if (length) {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return 0_css_px;
+            }
+            length = toStyleFromCSSValue<OverflowClipMargin::Length>(state, item);
+        } else {
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return 0_css_px;
+        }
+    }
+
+    return { *referenceBox, *length };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/overflow/StyleOverflowClipMargin.h
+++ b/Source/WebCore/style/values/overflow/StyleOverflowClipMargin.h
@@ -29,6 +29,7 @@
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StylePrimitiveNumericTypes.h>
 #include <WebCore/StyleValueTypes.h>
+#include <WebCore/StyleVisualBox.h>
 
 namespace WebCore {
 namespace Style {
@@ -40,6 +41,21 @@ struct OverflowClipMargin {
 
     OverflowClipMargin(CSS::ValueLiteral<CSS::LengthUnit::Px> length)
         : m_value { length }
+    {
+    }
+
+    OverflowClipMargin(Length length)
+        : m_value { length }
+    {
+    }
+
+    OverflowClipMargin(VisualBox referenceBox)
+        : m_value { referenceBox }
+    {
+    }
+
+    OverflowClipMargin(VisualBox referenceBox, Length length)
+        : m_value { SpaceSeparatedTuple { referenceBox, length } }
     {
     }
 


### PR DESCRIPTION
#### 08cff0128482a2280810f22d7481844404e8e4d9
<pre>
Implement overflow-clip-margin computed style
<a href="https://bugs.webkit.org/show_bug.cgi?id=308522">https://bugs.webkit.org/show_bug.cgi?id=308522</a>

Reviewed by Sam Weinig.

Add style value calculation for the overflow-clip-margin CSS property.

Added additional tests that use calc().

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-clip-margin-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-clip-margin-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/style/values/box/StyleVisualBox.h: Copied from Source/WebCore/style/values/overflow/StyleOverflowClipMargin.cpp.
* Source/WebCore/style/values/overflow/StyleOverflowClipMargin.cpp:
(WebCore::Style::CSSValueConversion&lt;OverflowClipMargin&gt;::operator):
* Source/WebCore/style/values/overflow/StyleOverflowClipMargin.h:
(WebCore::Style::OverflowClipMargin::OverflowClipMargin):

Canonical link: <a href="https://commits.webkit.org/308913@main">https://commits.webkit.org/308913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc26cc470bd46edf099b2e568d1c593cb7dc37a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113651 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15047 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12833 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158469 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121678 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132135 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75968 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8915 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19553 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->