### PR TITLE
Reduce use of protected functions in Source/WebCore/page

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 
 static NavigatorGamepad& navigatorGamepadFromDOMWindow(LocalDOMWindow& window)
 {
-    return NavigatorGamepad::from(window.protectedNavigator().get());
+    return NavigatorGamepad::from(protect(window.navigator()).get());
 }
 
 GamepadManager& GamepadManager::singleton()

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -992,7 +992,7 @@ RefPtr<MediaSession> MediaControlsHost::mediaSession() const
     if (!window)
         return { };
 
-    return NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator());
+    return NavigatorMediaSession::mediaSessionIfExists(protect(window->navigator()));
 }
 
 void MediaControlsHost::ensureMediaSessionObserver()

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -163,7 +163,7 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
 
     Ref document = downcast<Document>(*scriptExecutionContext());
     RefPtr localWindow = document->window();
-    RefPtr mediaDevices = localWindow ? NavigatorMediaDevices::mediaDevices(localWindow->protectedNavigator()) : nullptr;
+    RefPtr mediaDevices = localWindow ? NavigatorMediaDevices::mediaDevices(protect(localWindow->navigator())) : nullptr;
     if (mediaDevices)
         mediaDevices->willStartMediaCapture(!!audioDevice, !!videoDevice);
 

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -254,7 +254,7 @@ static std::optional<PermissionState> determineGeolocationPermissionState(Permis
     if (!window)
         return std::nullopt;
 
-    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(window->protectedNavigator());
+    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(protect(window->navigator()));
 
     switch (permissionState) {
     case PermissionState::Granted:

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -612,7 +612,7 @@ std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
         return nowPlayingInfo;
 
 #if ENABLE(MEDIA_SESSION)
-    if (RefPtr mediaSession = NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator()))
+    if (RefPtr mediaSession = NavigatorMediaSession::mediaSessionIfExists(protect(window->navigator())))
         mediaSession->updateNowPlayingInfo(nowPlayingInfo);
 #endif
 

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -201,7 +201,7 @@ Ref<Document> DOMImplementation::createDocument(const String& contentType, Local
 
     // The following is the relatively costly lookup that requires initializing the plug-in database.
     if (frame && frame->page()) {
-        if (protect(frame->page())->protectedPluginData()->supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))
+        if (protect(protect(frame->page())->pluginData())->supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))
             return PluginDocument::create(*frame, url);
     }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6154,7 +6154,7 @@ void Document::processCaptureStateDidChange(Function<bool(const Page&)>&& isPage
         return;
 
     RefPtr window = this->window();
-    RefPtr mediaSession = window ? NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator()) : nullptr;
+    RefPtr mediaSession = window ? NavigatorMediaSession::mediaSessionIfExists(protect(window->navigator())) : nullptr;
     if (!mediaSession)
         return;
 
@@ -6228,7 +6228,7 @@ void Document::voiceActivityDetected()
         return;
 
     RefPtr window = this->window();
-    RefPtr mediaSession = window ? NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator()) : nullptr;
+    RefPtr mediaSession = window ? NavigatorMediaSession::mediaSessionIfExists(protect(window->navigator())) : nullptr;
     if (!mediaSession)
         return;
 

--- a/Source/WebCore/dom/VisitedLinkState.cpp
+++ b/Source/WebCore/dom/VisitedLinkState.cpp
@@ -126,7 +126,7 @@ InsideLink VisitedLinkState::determineLinkStateSlowCase(const Element& element)
 
     m_linksCheckedForVisitedState.add(hash);
 
-    if (!page->protectedVisitedLinkStore()->isLinkVisited(*page, hash, element.document().baseURL(), attribute))
+    if (!protect(page->visitedLinkStore())->isLinkVisited(*page, hash, element.document().baseURL(), attribute))
         return InsideLink::InsideUnvisited;
 
     return InsideLink::InsideVisited;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4309,7 +4309,7 @@ void Editor::scanSelectionForTelephoneNumbers()
     
     auto notifyController = makeScopeExit([&] {
         if (RefPtr page = document().page())
-            page->protectedServicesOverlayController()->selectedTelephoneNumberRangesChanged();
+            protect(page->servicesOverlayController())->selectedTelephoneNumberRangesChanged();
     });
 
     auto selection = document().selection().selection();

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -78,8 +78,8 @@ SelectionGeometryGatherer::Notifier::~Notifier()
     if (!page)
         return;
 
-    page->protectedServicesOverlayController()->selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
-    page->protectedImageOverlayController()->selectionQuadsDidChange(frame, m_gatherer.m_quads);
+    protect(page->servicesOverlayController())->selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
+    protect(page->imageOverlayController())->selectionQuadsDidChange(frame, m_gatherer.m_quads);
 }
 
 Vector<LayoutRect> SelectionGeometryGatherer::boundingRects() const

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -205,7 +205,7 @@ void CachedPage::restoreNavigationAPIHistoryItems(LocalFrame& frame, BackForward
         auto allItems = checkedBackForwardController->allItems(frame.frameID());
         auto filteredItems = Navigation::filterHistoryItemsForNavigationAPI(WTF::move(allItems), *currentItem);
 
-        window->protectedNavigation()->updateForReactivation(WTF::move(filteredItems), *currentItem, previousItem.get());
+        protect(window->navigation())->updateForReactivation(WTF::move(filteredItems), *currentItem, previousItem.get());
     }
 
     for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -323,7 +323,7 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         RefPtr<GPU> gpu;
         if (RefPtr window = document().window()) {
             // FIXME: Should we be instead getting this through jsDynamicCast<JSDOMWindow*>(state)->wrapped().navigator().gpu()?
-            gpu = window->protectedNavigator()->gpu();
+            gpu = protect(window->navigator())->gpu();
         }
         RefPtr context = createContextWebGPU(contextId, gpu.get());
         if (!context)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1650,7 +1650,7 @@ MediaSession* MediaElementSession::mediaSession() const
     RefPtr window = element->document().window();
     if (!window)
         return nullptr;
-    return &NavigatorMediaSession::mediaSession(window->protectedNavigator());
+    return &NavigatorMediaSession::mediaSession(protect(window->navigator()));
 #else
     return nullptr;
 #endif

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -250,7 +250,7 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
                     m_context = GPUCanvasContext::create(*this, *gpu, nullptr);
             } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
                 if (RefPtr window = document->window()) {
-                    if (RefPtr gpu = window->protectedNavigator()->gpu())
+                    if (RefPtr gpu = protect(window->navigator())->gpu())
                         m_context = GPUCanvasContext::create(*this, *gpu, document.get());
                 }
             }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -606,7 +606,7 @@ void FrameLoader::stopLoading(UnloadEventPolicy unloadEventPolicy)
 
         if (document->settings().navigationAPIEnabled() && !m_doNotAbortNavigationAPI && unloadEventPolicy != UnloadEventPolicy::UnloadAndPageHide) {
             RefPtr window = frame->document()->window();
-            window->protectedNavigation()->abortOngoingNavigationIfNeeded();
+            protect(window->navigation())->abortOngoingNavigationIfNeeded();
         }
     }
 
@@ -2193,7 +2193,7 @@ void FrameLoader::stopForUserCancel(bool deferCheckLoadComplete)
 
     if (m_frame->document()->settings().navigationAPIEnabled()) {
         RefPtr window = m_frame->document()->window();
-        window->protectedNavigation()->abortOngoingNavigationIfNeeded();
+        protect(window->navigation())->abortOngoingNavigationIfNeeded();
     }
 
 #if PLATFORM(IOS_FAMILY)
@@ -2363,7 +2363,7 @@ void FrameLoader::commitProvisionalLoad()
                 if (RefPtr page = frame->page(); page && *navigationAPIType != NavigationNavigationType::Reload)
                     newItem = history().createItemWithLoader(page->historyItemClient(), pdl.get());
 
-                activation = window->protectedNavigation()->createForPageswapEvent(newItem.get(), pdl.get(), !!cachedPage);
+                activation = protect(window->navigation())->createForPageswapEvent(newItem.get(), pdl.get(), !!cachedPage);
             }
         }
         document->dispatchPageswapEvent(canTriggerCrossDocumentViewTransition, WTF::move(activation));
@@ -4426,7 +4426,7 @@ bool FrameLoader::dispatchNavigateEvent(FrameLoadType loadType, const FrameLoadR
 
     RefPtr sourceElement = event ? dynamicDowncast<Element>(event->target()) : nullptr;
 
-    return window->protectedNavigation()->dispatchPushReplaceReloadNavigateEvent(newURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
+    return protect(window->navigation())->dispatchPushReplaceReloadNavigateEvent(newURL, navigationType, isSameDocument, formState, classicHistoryAPIState, sourceElement.get());
 }
 
 void FrameLoader::loadSameDocumentItem(HistoryItem& item)

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -63,7 +63,7 @@ namespace WebCore {
 
 static inline void addVisitedLink(Page& page, const URL& url)
 {
-    page.protectedVisitedLinkStore()->addVisitedLink(page, computeSharedStringHash(url.string()));
+    protect(page.visitedLinkStore())->addVisitedLink(page, computeSharedStringHash(url.string()));
 }
 
 static inline bool canRecordHistoryForFrame(const LocalFrame& frame)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -355,7 +355,7 @@ public:
 
     std::optional<Ref<HistoryItem>> findBackForwardItemByKey(const LocalFrame& localFrame) const
     {
-        RefPtr entry = localFrame.window()->protectedNavigation()->findEntryByKey(m_key);
+        RefPtr entry = protect(localFrame.window()->navigation())->findEntryByKey(m_key);
         if (!entry)
             return std::nullopt;
 

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -234,7 +234,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
         RefPtr document = frame->document();
         if (document && document->settings().navigationAPIEnabled()) {
             if (RefPtr window = document->window()) {
-                if (!window->protectedNavigation()->dispatchDownloadNavigateEvent(request.url(), action.downloadAttribute(), action.sourceElement()))
+                if (!protect(window->navigation())->dispatchDownloadNavigateEvent(request.url(), action.downloadAttribute(), action.sourceElement()))
                     return function({ }, nullptr, NavigationPolicyDecision::IgnoreLoad);
             }
         }

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -177,7 +177,7 @@ static String findPluginMIMETypeFromURL(Page& page, const URL& url)
 
     auto extensionFromURL = lastPathComponent.substring(dotIndex + 1);
 
-    for (auto& type : page.protectedPluginData()->webVisibleMimeTypes()) {
+    for (auto& type : protect(page.pluginData())->webVisibleMimeTypes()) {
         for (auto& extension : type.extensions) {
             if (equalIgnoringASCIICase(extensionFromURL, extension))
                 return type.type;
@@ -221,7 +221,7 @@ static void logPluginRequest(Page* page, const String& mimeType, const URL& url)
             return;
     }
 
-    String pluginFile = page->protectedPluginData()->pluginFileForWebVisibleMimeType(newMIMEType);
+    String pluginFile = protect(page->pluginData())->pluginFileForWebVisibleMimeType(newMIMEType);
     String description = !pluginFile ? newMIMEType : pluginFile;
     page->sawPlugin(description);
 }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -726,11 +726,6 @@ Navigation& LocalDOMWindow::navigation()
     return *m_navigation;
 }
 
-Ref<Navigation> LocalDOMWindow::protectedNavigation()
-{
-    return navigation();
-}
-
 Crypto& LocalDOMWindow::crypto() const
 {
     if (!m_crypto)
@@ -788,11 +783,6 @@ Navigator& LocalDOMWindow::navigator()
     ASSERT(m_navigator->scriptExecutionContext() == document());
 
     return *m_navigator;
-}
-
-Ref<Navigator> LocalDOMWindow::protectedNavigator()
-{
-    return navigator();
 }
 
 Performance& LocalDOMWindow::performance() const

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -136,7 +136,6 @@ public:
     BarProp& statusbar();
     BarProp& toolbar();
     WEBCORE_EXPORT Navigator& navigator();
-    WEBCORE_EXPORT Ref<Navigator> protectedNavigator();
     Navigator* optionalNavigator() const { return m_navigator.get(); }
 
     WEBCORE_EXPORT static void NODELETE overrideTransientActivationDurationForTesting(std::optional<Seconds>&&);
@@ -351,7 +350,6 @@ public:
 
     // Navigation API
     WEBCORE_EXPORT Navigation& navigation();
-    Ref<Navigation> protectedNavigation();
 
     void willDetachDocumentFromFrame();
     void willDestroyCachedFrame();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -651,7 +651,7 @@ void Navigation::updateNavigationEntry(Ref<HistoryItem>&& item, ShouldCopyStateO
             if (!window)
                 continue;
 
-            window->protectedNavigation()->updateNavigationEntry(childItem.releaseNonNull(), shouldCopyStateObjectFromCurrentEntry);
+            protect(window->navigation())->updateNavigationEntry(childItem.releaseNonNull(), shouldCopyStateObjectFromCurrentEntry);
         }
     }
 }
@@ -666,7 +666,7 @@ void Navigation::disposeOfForwardEntriesInParents(BackForwardItemIdentifier item
     if (!localMainFrameWindow)
         return;
 
-    localMainFrameWindow->protectedNavigation()->recursivelyDisposeOfForwardEntriesInParents(itemID, protect(frame()).get());
+    protect(localMainFrameWindow->navigation())->recursivelyDisposeOfForwardEntriesInParents(itemID, protect(frame()).get());
 }
 
 void Navigation::recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIdentifier itemID, LocalFrame* navigatedFrame)
@@ -700,7 +700,7 @@ void Navigation::recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIden
         if (!window)
             continue;
 
-        window->protectedNavigation()->recursivelyDisposeOfForwardEntriesInParents(itemID, navigatedFrame);
+        protect(window->navigation())->recursivelyDisposeOfForwardEntriesInParents(itemID, navigatedFrame);
     }
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -410,7 +410,6 @@ public:
 
     static void refreshPlugins(bool reload);
     WEBCORE_EXPORT PluginData& pluginData();
-    WEBCORE_EXPORT Ref<PluginData> protectedPluginData();
     void clearPluginData();
 
     OpportunisticTaskScheduler& opportunisticTaskScheduler() const { return m_opportunisticTaskScheduler.get(); }
@@ -500,7 +499,6 @@ public:
     const ContextMenuController& contextMenuController() const { return m_contextMenuController.get(); }
 #endif
     PageInspectorController& inspectorController() { return m_inspectorController.get(); }
-    WEBCORE_EXPORT Ref<PageInspectorController> NODELETE protectedInspectorController();
     PointerCaptureController& pointerCaptureController() { return m_pointerCaptureController.get(); }
 #if ENABLE(POINTER_LOCK)
     PointerLockController& pointerLockController() { return m_pointerLockController.get(); }
@@ -733,21 +731,17 @@ public:
 
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
     ServicesOverlayController& servicesOverlayController() { return m_servicesOverlayController.get(); }
-    Ref<ServicesOverlayController> NODELETE protectedServicesOverlayController();
 #endif
     ImageOverlayController& imageOverlayController();
-    Ref<ImageOverlayController> protectedImageOverlayController();
     ImageOverlayController* imageOverlayControllerIfExists() { return m_imageOverlayController.get(); }
 
 #if ENABLE(IMAGE_ANALYSIS)
     WEBCORE_EXPORT ImageAnalysisQueue& imageAnalysisQueue();
-    WEBCORE_EXPORT Ref<ImageAnalysisQueue> protectedImageAnalysisQueue();
     ImageAnalysisQueue* imageAnalysisQueueIfExists() { return m_imageAnalysisQueue.get(); }
 #endif
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
     ScrollLatchingController& scrollLatchingController();
-    Ref<ScrollLatchingController> protectedScrollLatchingController();
     ScrollLatchingController* scrollLatchingControllerIfExists() { return m_scrollLatchingController.get(); }
 #endif // ENABLE(WHEEL_EVENT_LATCHING)
 
@@ -991,13 +985,11 @@ public:
     PluginInfoProvider& NODELETE pluginInfoProvider();
 
     UserContentProvider& userContentProviderForFrame() { return m_userContentProvider; }
-    WEBCORE_EXPORT Ref<UserContentProvider> NODELETE protectedUserContentProviderForFrame();
     WEBCORE_EXPORT void setUserContentProviderForWebKitLegacy(Ref<UserContentProvider>&&);
 
     ScreenOrientationManager* NODELETE screenOrientationManager() const;
 
     VisitedLinkStore& NODELETE visitedLinkStore();
-    Ref<VisitedLinkStore> NODELETE protectedVisitedLinkStore();
     WEBCORE_EXPORT void setVisitedLinkStore(Ref<VisitedLinkStore>&&);
 
     std::optional<uint64_t> noiseInjectionHashSaltForDomain(const RegistrableDomain&);
@@ -1409,8 +1401,6 @@ private:
     void setIsVisuallyIdleInternal(bool);
 
     void stopKeyboardScrollAnimation();
-
-    Ref<DocumentSyncData> NODELETE protectedTopDocumentSyncData() const;
 
     enum ShouldHighlightMatches { DoNotHighlightMatches, HighlightMatches };
     enum ShouldMarkMatches { DoNotMarkMatches, MarkMatches };

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -475,7 +475,7 @@ void ScrollerMac::visibilityChanged(bool isVisible)
     m_isVisible = isVisible;
 
     RefPtr pair = m_pair.get();
-    if (RefPtr node = pair->protectedNode())
+    if (RefPtr node = pair->node())
         node->scrollbarVisibilityDidChange(m_orientation, isVisible);
 }
 
@@ -486,7 +486,7 @@ void ScrollerMac::updateMinimumKnobLength(int minimumKnobLength)
     m_minimumKnobLength = minimumKnobLength;
 
     RefPtr pair = m_pair.get();
-    if (RefPtr node = pair->protectedNode())
+    if (RefPtr node = pair->node())
         node->scrollbarMinimumThumbLengthDidChange(m_orientation, m_minimumKnobLength);
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -114,7 +114,7 @@ public:
 
     NSScrollerImpPair *scrollerImpPair() const { return m_scrollerImpPair.get(); }
     void ensureOnMainThreadWithProtectedThis(Function<void(ScrollerPairMac&)>&&);
-    RefPtr<ScrollingTreeScrollingNode> protectedNode() const { return m_scrollingNode; }
+    RefPtr<ScrollingTreeScrollingNode> node() const { return m_scrollingNode.get(); }
 
     bool mouseInContentArea() const { return m_mouseInContentArea; }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -372,7 +372,7 @@ void ScrollerPairMac::ensureOnMainThreadWithProtectedThis(Function<void(Scroller
 
 void ScrollerPairMac::mouseEnteredContentArea()
 {
-    LOG_WITH_STREAM(OverlayScrollbars, stream << "ScrollerPairMac for [" << protectedNode()->scrollingNodeID() << "] mouseEnteredContentArea");
+    LOG_WITH_STREAM(OverlayScrollbars, stream << "ScrollerPairMac for [" << protect(m_scrollingNode)->scrollingNodeID() << "] mouseEnteredContentArea");
 
     ensureOnMainThreadWithProtectedThis([](auto& scrollerPair) {
         if ([scrollerPair.m_scrollerImpPair overlayScrollerStateIsLocked])
@@ -385,7 +385,7 @@ void ScrollerPairMac::mouseEnteredContentArea()
 void ScrollerPairMac::mouseExitedContentArea()
 {
     m_mouseInContentArea = false;
-    LOG_WITH_STREAM(OverlayScrollbars, stream << "ScrollerPairMac for [" << protectedNode()->scrollingNodeID() << "] mouseExitedContentArea");
+    LOG_WITH_STREAM(OverlayScrollbars, stream << "ScrollerPairMac for [" << protect(m_scrollingNode)->scrollingNodeID() << "] mouseExitedContentArea");
 
     ensureOnMainThreadWithProtectedThis([](auto& scrollerPair) {
         if ([scrollerPair.m_scrollerImpPair overlayScrollerStateIsLocked])

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -499,7 +499,7 @@ InspectorStubFrontend::InspectorStubFrontend(Page& inspectedPage, LocalFrame& ma
     ASSERT_ARG(frontendWindow, frontendWindow);
 
     frontendPage()->inspectorController().setInspectorFrontendClient(this);
-    inspectedPage.protectedInspectorController()->connectFrontend(*this);
+    protect(inspectedPage.inspectorController())->connectFrontend(*this);
     protect(mainFrame.inspectorController())->connectFrontend(*this);
 }
 
@@ -517,7 +517,7 @@ void InspectorStubFrontend::closeWindow()
     if (RefPtr controller = m_mainFrameInspectorController.get())
         controller->disconnectFrontend(*this);
     if (RefPtr page = inspectedPage())
-        page->protectedInspectorController()->disconnectFrontend(*this);
+        protect(page->inspectorController())->disconnectFrontend(*this);
 
     m_frontendWindow->close();
     m_frontendWindow = nullptr;

--- a/Source/WebKit/WebProcess/Inspector/PageInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/PageInspectorTarget.cpp
@@ -58,7 +58,7 @@ void PageInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType con
     Ref page = m_page.get();
     m_channel = makeUnique<UIProcessForwardingFrontendChannel>(page, identifier(), connectionType);
     if (RefPtr corePage = page->corePage())
-        corePage->protectedInspectorController()->connectFrontend(*m_channel);
+        protect(corePage->inspectorController())->connectFrontend(*m_channel);
 }
 
 void PageInspectorTarget::disconnect()
@@ -66,14 +66,14 @@ void PageInspectorTarget::disconnect()
     if (!m_channel)
         return;
     if (RefPtr corePage = m_page->corePage())
-        corePage->protectedInspectorController()->disconnectFrontend(*m_channel);
+        protect(corePage->inspectorController())->disconnectFrontend(*m_channel);
     m_channel.reset();
 }
 
 void PageInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
     if (RefPtr corePage = m_page->corePage())
-        corePage->protectedInspectorController()->dispatchMessageFromFrontend(message);
+        protect(corePage->inspectorController())->dispatchMessageFromFrontend(message);
 }
 
 String PageInspectorTarget::toTargetID(WebCore::PageIdentifier pageID)

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -253,7 +253,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     if (!window)
         return;
 
-    RefPtr gpu = window->protectedNavigator()->gpu();
+    RefPtr gpu = protect(window->navigator())->gpu();
     if (!gpu)
         return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1702,7 +1702,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
         if (mimeType.isEmpty()) {
             // Check if there's a plug-in around that can handle the extension.
             if (RefPtr webPage = m_frame->page()) {
-                if (pluginSupportsExtension(protect(webPage->corePage())->protectedPluginData(), extension))
+                if (pluginSupportsExtension(protect(protect(webPage->corePage())->pluginData()), extension))
                     return ObjectContentType::PlugIn;
             }
             return ObjectContentType::Frame;
@@ -1719,7 +1719,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
 
     if (RefPtr webPage = m_frame->page()) {
         auto allowedPluginTypes = PluginData::OnlyApplicationPlugins;
-        if (protect(webPage->corePage())->protectedPluginData()->supportsMimeType(mimeType, allowedPluginTypes))
+        if (protect(protect(webPage->corePage())->pluginData())->supportsMimeType(mimeType, allowedPluginTypes))
             return ObjectContentType::PlugIn;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9267,7 +9267,7 @@ void WebPage::startVisualTranslation(const String& sourceLanguageIdentifier, con
     if (!frame)
         return;
 
-    protect(corePage())->protectedImageAnalysisQueue()->enqueueAllImagesIfNeeded(*frame, sourceLanguageIdentifier, targetLanguageIdentifier);
+    protect(protect(corePage())->imageAnalysisQueue())->enqueueAllImagesIfNeeded(*frame, sourceLanguageIdentifier, targetLanguageIdentifier);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -586,7 +586,7 @@ void PlaybackSessionManager::setMediaSessionAndRegisterAsObserver()
         return;
     }
 
-    auto mediaSession = NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator().get());
+    auto mediaSession = NavigatorMediaSession::mediaSessionIfExists(protect(window->navigator()).get());
     if (!mediaSession) {
         m_mediaSession = nullptr;
         return;

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
@@ -111,7 +111,7 @@ void LegacyWebPageDebuggable::setIndicating(bool indicating)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, indicating] {
         if (RefPtr page = m_page)
-            page->protectedInspectorController()->setIndicating(indicating);
+            protect(page->inspectorController())->setIndicating(indicating);
     });
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
@@ -111,7 +111,7 @@ public:
             return;
 
         m_channel = makeUnique<FrontendChannel>(identifier(), connectionType, m_handler);
-        Ref { m_page.get() }->protectedInspectorController()->connectFrontend(*m_channel);
+        protect(protect(m_page)->inspectorController())->connectFrontend(*m_channel);
     }
 
     void disconnect() override
@@ -119,13 +119,13 @@ public:
         if (!m_channel)
             return;
 
-        Ref { m_page.get() }->protectedInspectorController()->disconnectFrontend(*m_channel);
+        protect(protect(m_page)->inspectorController())->disconnectFrontend(*m_channel);
         m_channel = nullptr;
     }
 
     void sendMessageToTargetBackend(const String& message) override
     {
-        Ref { m_page.get() }->protectedInspectorController()->dispatchMessageFromFrontend(message);
+        protect(protect(m_page)->inspectorController())->dispatchMessageFromFrontend(message);
     }
 
 private:


### PR DESCRIPTION
#### 364d59a33f8d796765c368531aa4e28afb23d42d
<pre>
Reduce use of protected functions in Source/WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=308523">https://bugs.webkit.org/show_bug.cgi?id=308523</a>

Reviewed by Charlie Wolfe.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::navigatorGamepadFromDOMWindow):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::mediaSession const):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::determineGeolocationPermissionState):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::nowPlayingInfo const):
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createDocument):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processCaptureStateDidChange):
(WebCore::Document::voiceActivityDetected):
* Source/WebCore/dom/VisitedLinkState.cpp:
(WebCore::VisitedLinkState::determineLinkStateSlowCase):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::scanSelectionForTelephoneNumbers):
* Source/WebCore/editing/SelectionGeometryGatherer.cpp:
(WebCore::SelectionGeometryGatherer::Notifier::~Notifier):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restoreNavigationAPIHistoryItems):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::mediaSession const):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::stopForUserCancel):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::dispatchNavigateEvent):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::addVisitedLink):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey const):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::findPluginMIMETypeFromURL):
(WebCore::logPluginRequest):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::protectedNavigation): Deleted.
(WebCore::LocalDOMWindow::protectedNavigator): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::updateNavigationEntry):
(WebCore::Navigation::disposeOfForwardEntriesInParents):
(WebCore::Navigation::recursivelyDisposeOfForwardEntriesInParents):
* Source/WebCore/page/Page.cpp:
(WebCore::m_mediaSessionManagerFactory):
(WebCore::Page::~Page):
(WebCore::Page::updateTopDocumentSyncData):
(WebCore::Page::setVisitedLinkStore):
(WebCore::Page::startMonitoringWheelEvents):
(WebCore::Page::didChangeMainDocument):
(WebCore::Page::protectedPluginData): Deleted.
(WebCore::Page::protectedTopDocumentSyncData const): Deleted.
(WebCore::Page::protectedUserContentProviderForFrame): Deleted.
(WebCore::Page::protectedVisitedLinkStore): Deleted.
(WebCore::Page::protectedScrollLatchingController): Deleted.
(WebCore::Page::protectedImageOverlayController): Deleted.
(WebCore::Page::protectedImageAnalysisQueue): Deleted.
(WebCore::Page::protectedInspectorController): Deleted.
(WebCore::Page::protectedServicesOverlayController): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::inspectorController):
(WebCore::Page::servicesOverlayController):
(WebCore::Page::userContentProviderForFrame):
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::visibilityChanged):
(WebCore::ScrollerMac::updateMinimumKnobLength):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::node const):
(WebCore::ScrollerPairMac::protectedNode const): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::mouseEnteredContentArea):
(WebCore::ScrollerPairMac::mouseExitedContentArea):
* Source/WebCore/testing/Internals.cpp:
(WebCore::InspectorStubFrontend::InspectorStubFrontend):
(WebCore::InspectorStubFrontend::closeWindow):
* Source/WebKit/WebProcess/Inspector/PageInspectorTarget.cpp:
(WebKit::PageInspectorTarget::connect):
(WebKit::PageInspectorTarget::disconnect):
(WebKit::PageInspectorTarget::sendMessageToTargetBackend):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::objectContentType):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::startVisualTranslation):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::setMediaSessionAndRegisterAsObserver):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp:
(LegacyWebPageDebuggable::setIndicating):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp:

Canonical link: <a href="https://commits.webkit.org/308149@main">https://commits.webkit.org/308149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76ec3841072601fc63b47d18dbeed90a521e4cb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99904 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b742efdc-aaca-4162-a8d7-9b2bed9dde9f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112821 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80616 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c312fbe8-f891-4693-9b68-080303e1dae7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93619 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f82748ed-77c4-431a-8753-27b7f14507a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12136 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2611 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157491 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121085 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31039 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74782 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16738 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8166 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82350 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18329 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18485 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->