### PR TITLE
[Site Isolation] AX: Setup screen position infrastructure for remote frames

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -373,6 +373,9 @@ media/deactivate-audio-session.html [ Skip ]
 # Skip isolated-tree specific tests.
 accessibility/isolated-tree [ Skip ]
 
+# Skipped because ACCESSIBILITY_LOCAL_FRAME doesn't support dynamic updates yet.
+accessibility/dynamic-changes-update-position.html [ Failure ]
+
 # ApplePay is only available on iOS (greater than iOS 10) and macOS (greater than macOS 10.12) and only for WebKit2.
 fast/css/appearance-apple-pay-button.html [ Skip ]
 fast/css/appearance-apple-pay-button-div.html [ Skip ]

--- a/LayoutTests/accessibility/mac/client/absolute-position-iframe-expected.txt
+++ b/LayoutTests/accessibility/mac/client/absolute-position-iframe-expected.txt
@@ -1,0 +1,9 @@
+Validates the absolute (screen) position of text inside an iframe.
+
+PASS: textX === 120
+PASS: textY === 80
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/client/absolute-position-iframe.html
+++ b/LayoutTests/accessibility/mac/client/absolute-position-iframe.html
@@ -1,0 +1,58 @@
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+#frame {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 400px;
+    height: 300px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<iframe id="frame" src="resources/frame-content.html"></iframe>
+
+<script>
+var output = "Validates the absolute (screen) position of text inside an iframe.\n\n";
+
+var text, webArea, textX, textY;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setForceInitialFrameCaching(true);
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            webArea = accessibilityController.rootElement.childAtIndex(0);
+            return webArea;
+        });
+
+        // Web area -> iframe -> paragraph -> static text.
+        var text = webArea.childAtIndex(0).childAtIndex(0).childAtIndex(0);
+
+        var pageOrigin = { x: webArea.x, y: webArea.y };
+
+        // The text in the iframe is offset by (20, 30).
+        await waitFor(() => {
+            textX = text.x - pageOrigin.x;
+            textY = text.y - pageOrigin.y;
+            return textX == 120 && textY == 80;
+        });
+
+        output += expect("textX", "120");
+        output += expect("textY", "80");
+
+        debug(output);
+        document.getElementById("frame").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/client/resources/frame-content.html
+++ b/LayoutTests/accessibility/mac/client/resources/frame-content.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; padding: 0;">
+<p id="text" style="position: absolute; left: 20px; top: 30px; margin: 0;">Hello from iframe</p>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/line-range-for-text-marker.html
+++ b/LayoutTests/accessibility/mac/line-range-for-text-marker.html
@@ -30,22 +30,29 @@ function lineTextForPoint(x, y) {
 }
 
 if (window.accessibilityController) {
-    var line = accessibilityController.accessibleElementById("line");
-    // Line text from first text marker (add one to make sure we get the first marker for THIS line).
-    lineText = lineTextForPoint(line.x + 1, line.y + 1);
-    output += expect("lineText", "expectedText");
+    window.jsTestIsAsync = true;
 
-    // Line text from center text marker.
-    lineText = lineTextForPoint(line.x + line.width / 2, line.y + line.height / 2);
-    output += expect("lineText", "expectedText");
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.rootElement.x != 0);
 
-    // Line text from last text marker (subtract one to make sure we get the last marker for THIS line).
-    lineText = lineTextForPoint(line.x + line.width - 1, line.y + line.height - 1);
-    output += expect("lineText", "expectedText");
+        var line = accessibilityController.accessibleElementById("line");
+        // Line text from first text marker (add one to make sure we get the first marker for THIS line).
+        lineText = lineTextForPoint(line.x + 1, line.y + 1);
+        output += expect("lineText", "expectedText");
 
-    // Hide superfluous text.
-    document.getElementById("container").style.display = "none";
-    debug(output);
+        // Line text from center text marker.
+        lineText = lineTextForPoint(line.x + line.width / 2, line.y + line.height / 2);
+        output += expect("lineText", "expectedText");
+
+        // Line text from last text marker (subtract one to make sure we get the last marker for THIS line).
+        lineText = lineTextForPoint(line.x + line.width - 1, line.y + line.height - 1);
+        output += expect("lineText", "expectedText");
+
+        // Hide superfluous text.
+        document.getElementById("container").style.display = "none";
+        debug(output);
+        finishJSTest();
+    });
 }
 </script>
 </body>

--- a/LayoutTests/accessibility/mac/text-marker-for-bounds.html
+++ b/LayoutTests/accessibility/mac/text-marker-for-bounds.html
@@ -11,18 +11,28 @@
 <script>
 var output = "This tests that endTextMarkerForBounds and startTextMarkerForBounds work correctly.\n\n";
 
+var startMarker, endMarker, rangeFromBounds, rangeFromElement;
 if (window.accessibilityController) {
-    var text = accessibilityController.accessibleElementById("text");
+    window.jsTestIsAsync = true;
 
-    var startMarker = text.startTextMarkerForBounds(text.x, text.y, text.width, text.height);
-    var endMarker = text.endTextMarkerForBounds(text.x, text.y, text.width, text.height);
-    // Get text range from boundary markers.
-    var rangeFromBounds = text.textMarkerRangeLength(text.textMarkerRangeForMarkers(startMarker, endMarker));
-    // Get text range from element.
-    var rangeFromElement = text.textMarkerRangeLength(text.textMarkerRangeForElement(text));
+    setTimeout(async function() {
+        await waitFor(() => {
+            return accessibilityController.rootElement.childAtIndex(0).x != 0;
+        });
 
-    output += expect("rangeFromBounds", "rangeFromElement");
-    debug(output);
+        var text = accessibilityController.accessibleElementById("text");
+        startMarker = text.startTextMarkerForBounds(text.x, text.y, text.width, text.height);
+        endMarker = text.endTextMarkerForBounds(text.x, text.y, text.width, text.height);
+
+        // Get text range from boundary markers.
+        rangeFromBounds = text.textMarkerRangeLength(text.textMarkerRangeForMarkers(startMarker, endMarker));
+        // Get text range from element.
+        rangeFromElement = text.textMarkerRangeLength(text.textMarkerRangeForElement(text));
+
+        output += expect("rangeFromBounds", "rangeFromElement");
+        debug(output);
+        finishJSTest();
+    })
 }
 </script>
 </body>

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/absolute-position-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/absolute-position-iframe-expected.txt
@@ -1,0 +1,9 @@
+Validates the absolute (screen) position of text inside an iframe with site isolation.
+
+PASS: textX === 120
+PASS: textY === 80
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/absolute-position-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/absolute-position-iframe.html
@@ -1,0 +1,64 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+#frame {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 400px;
+    height: 300px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<iframe id="frame" src="http://localhost:8000/site-isolation/resources/frame-with-text.html"></iframe>
+
+<script>
+var output = "Validates the absolute (screen) position of text inside an iframe with site isolation.\n\n";
+
+var webArea, container, textX, textY;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setForceInitialFrameCaching(true);
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            webArea = accessibilityController.rootElement.childAtIndex(0);
+            return webArea;
+        })
+
+        // Wait for the text element to exist AND have the correct position.
+        // The async frame screen position update may not have arrived yet,
+        // so we poll until the values are correct.
+        await waitFor(() => {
+            var pageOrigin = { x: webArea.x, y: webArea.y };
+            container = accessibilityController.accessibleElementById("container");
+            if (!container || !container.childAtIndex(0))
+                return false;
+
+            var textNode = container.childAtIndex(0);
+            textX = textNode.x - pageOrigin.x;
+            textY = textNode.y - pageOrigin.y;
+
+            // The text is at (20, 30) inside the iframe, and iframe is at (100, 50).
+            // So text should be at (120, 80) relative to the page origin.
+            return textX === 120 && textY === 80;
+        });
+
+        output += expect("textX", "120");
+        output += expect("textY", "80");
+
+        debug(output);
+        document.getElementById("frame").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds-expected.txt
@@ -1,0 +1,9 @@
+Test iframe bounds (in screen position) in site isolation.
+
+PASS: iframeX === 100
+PASS: iframeY === 50
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds.html
@@ -1,0 +1,58 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+#iframe {
+    position: absolute;
+    left: 100px;
+    top: 50px;
+    width: 400px;
+    height: 300px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<iframe id="iframe" src="http://localhost:8000/site-isolation/resources/frame-with-text.html"></iframe>
+
+<script>
+var output = "Test iframe bounds (in screen position) in site isolation.\n\n";
+
+var iframe, iframeX, iframeY, webArea;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setForceInitialFrameCaching(true);
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            webArea = accessibilityController.rootElement.childAtIndex(0);
+            return webArea;
+        });
+
+        var pageOrigin = { x: webArea.x, y: webArea.y };
+
+        await waitFor(() => {
+            iframe = webArea.childAtIndex(0);
+            if (!iframe)
+                return false;
+
+            iframeX = iframe.x - pageOrigin.x;
+            iframeY = iframe.y - pageOrigin.y;
+
+            return iframeX == 100 && iframeY == 50;
+        });
+
+        output += expect("iframeX", "100");
+        output += expect("iframeY", "50");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-with-text.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-with-text.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; padding: 0;">
+<p id="container" style="position: absolute; left: 20px; top: 30px; margin: 0;">Hello from iframe</p>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -800,6 +800,12 @@ webkit.org/b/167607 [ Debug ] http/tests/inspector/worker/blob-script-with-cross
 
 webkit.org/b/160042 accessibility/mac/value-change/value-change-user-info-contenteditable.html [ Pass Failure ]
 
+# Skipped because ACCESSIBILITY_LOCAL_FRAME is not compatable with relative frames.
+accessibility/mac/iframe-relative-frame.html [ Failure ]
+
+# Skipped because ACCESSIBILITY_LOCAL_FRAME doesn't yet account for dynamic position changes (like scroll).
+accessibility/mac/scroll-to-visible-action.html [ Failure ]
+
 webkit.org/b/160309 fast/dom/Window/child-window-focus.html [ Pass Failure ]
 
 webkit.org/b/161148 gamepad/gamepad-timestamp.html [ Pass Failure ]

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -29,6 +29,7 @@
 #include <WebCore/AXStitchGroup.h>
 #include <WebCore/AXTextRun.h>
 #include <WebCore/AccessibilityRole.h>
+#include <WebCore/AffineTransform.h>
 #include <WebCore/CharacterRange.h>
 #include <WebCore/Color.h>
 #include <WebCore/ColorConversion.h>
@@ -980,6 +981,11 @@ public:
     virtual FloatPoint screenRelativePosition() const = 0;
     // This is the amount that the RemoteFrame is offset from its containing parent.
     virtual IntPoint remoteFrameOffset() const = 0;
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    virtual IntPoint frameScreenPosition() const = 0;
+    virtual AffineTransform frameScreenTransform() const = 0;
+#endif
 
     virtual FloatRect convertFrameToSpace(const FloatRect&, AccessibilityConversionSpace) const = 0;
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1006,14 +1006,39 @@ AXCoreObject* AXObjectCache::rootObjectForFrame(LocalFrame& frame)
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+RefPtr<AccessibilityScrollView> AXObjectCache::scrollViewForFrame(LocalFrame& frame)
+{
+    return dynamicDowncast<AccessibilityScrollView>(rootObjectForFrame(frame));
+}
+
 void AXObjectCache::setFrameInheritedState(LocalFrame& frame, const InheritedFrameState& state)
 {
-    RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(rootObjectForFrame(frame));
+    RefPtr scrollView = scrollViewForFrame(frame);
     if (!scrollView)
         return;
 
     scrollView->setInheritedFrameState(state);
 }
+
+void AXObjectCache::setFrameGeometry(LocalFrame& frame, const FrameGeometry& geometry)
+{
+    UNUSED_PARAM(frame);
+    m_frameGeometry = geometry;
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+        tree->setFrameGeometry(FrameGeometry { geometry });
+#endif
+}
+
+const std::optional<FrameGeometry>& AXObjectCache::getAndUpdateFrameGeometry()
+{
+    if (RefPtr page = document()->page())
+        page->chrome().client().requestFrameScreenPosition(frameID());
+
+    return frameGeometry();
+}
+
 #endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -29,6 +29,7 @@
 #include <WebCore/AXTextMarker.h>
 #include <WebCore/AXTreeStore.h>
 #include <WebCore/AccessibilityRemoteToken.h>
+#include <WebCore/AffineTransform.h>
 #include <WebCore/Document.h>
 #include <WebCore/RenderView.h>
 #include <WebCore/SimpleRange.h>
@@ -228,6 +229,12 @@ struct InheritedFrameState {
     bool isInert { false };
     bool isRenderHidden { false };
 };
+
+// When this is updated, WebCoreArgumentCoders.serialization.in must be updated as well.
+struct FrameGeometry {
+    IntPoint screenPosition;
+    AffineTransform screenTransform;
+};
 #endif
 
 struct AXNotificationWithData {
@@ -314,6 +321,9 @@ public:
     AccessibilityObject* rootWebArea();
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     WEBCORE_EXPORT void setFrameInheritedState(LocalFrame&, const InheritedFrameState&);
+    WEBCORE_EXPORT void setFrameGeometry(LocalFrame&, const FrameGeometry&);
+    const std::optional<FrameGeometry>& frameGeometry() const { return m_frameGeometry; }
+    const std::optional<FrameGeometry>& getAndUpdateFrameGeometry();
 #endif
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     WEBCORE_EXPORT void buildIsolatedTreeIfNeeded();
@@ -409,6 +419,10 @@ private:
     void attachWrapper(AccessibilityObject&);
 
     AccessibilityObject* getOrCreateSlow(Node&, IsPartOfRelation);
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    RefPtr<AccessibilityScrollView> scrollViewForFrame(LocalFrame&);
+#endif
 
 public:
     void onPageActivityStateChange(OptionSet<ActivityState>);
@@ -919,6 +933,9 @@ private:
 
     const WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const FrameIdentifier m_frameID; // constant for object's lifetime.
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    std::optional<FrameGeometry> m_frameGeometry;
+#endif
     OptionSet<ActivityState> m_pageActivityState;
     HashMap<AXID, Ref<AccessibilityObject>> m_objects;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -563,6 +563,40 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
     RefPtr parentScrollView = parentAccessibilityScrollView ? parentAccessibilityScrollView->scrollView() : nullptr;
 
     auto snappedFrameRect = snappedIntRect(IntRect(frameRect));
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (conversionSpace == AccessibilityConversionSpace::Screen) {
+        // For screen space, use contentsToView() to adjust for scroll *within* this frame,
+        // then apply the frame's screen transform and position (which account for iframe offsets and viewport scale).
+        if (parentScrollView)
+            snappedFrameRect = parentScrollView->contentsToView(snappedFrameRect);
+
+        RefPtr rootScrollView = dynamicDowncast<AccessibilityScrollView>(ancestorAccessibilityScrollView(true /* includeSelf */));
+        if (!rootScrollView)
+            return snappedFrameRect;
+
+        auto geometry = rootScrollView->frameGeometry();
+
+        auto scaledRect = geometry.screenTransform.mapRect(FloatRect(snappedFrameRect));
+
+        // macOS uses bottom-left origin, non-macOS assumes top-left origin.
+        FloatPoint position = {
+            geometry.screenPosition.x() + scaledRect.x(),
+#if PLATFORM(MAC)
+            geometry.screenPosition.y() - scaledRect.maxY()
+#else
+            geometry.screenPosition.y() + scaledRect.y()
+#endif
+        };
+        return { position, scaledRect.size() };
+    }
+
+    // FIXME: ENABLE(ACCESSIBILITY_LOCAL_FRAME) doesn't support page-relative frame, but this is used for old tests. Remove this once all tests are updated.
+    if (parentScrollView)
+        snappedFrameRect = parentScrollView->contentsToRootView(snappedFrameRect);
+#else
+    // Legacy behavior: contentsToRootView walks up through all frames for local frames.
+    // For remote frames, the caller (e.g., relativeFrame()) adds remoteFrameOffset().
     if (parentScrollView)
         snappedFrameRect = parentScrollView->contentsToRootView(snappedFrameRect);
 
@@ -578,6 +612,7 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
 
         snappedFrameRect = page->chrome().rootViewToAccessibilityScreen(snappedFrameRect);
     }
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
     return snappedFrameRect;
 }
@@ -585,7 +620,9 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
 FloatRect AccessibilityObject::relativeFrame() const
 {
     auto rect = elementRect();
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     rect.moveBy(remoteFrameOffset());
+#endif
     return convertFrameToSpace(rect, AccessibilityConversionSpace::Page);
 }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -484,6 +484,10 @@ public:
 #else
     FloatPoint screenRelativePosition() const final { return convertFrameToSpace(elementRect(), AccessibilityConversionSpace::Screen).location(); }
 #endif
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    IntPoint frameScreenPosition() const override { return IntPoint(); }
+    AffineTransform frameScreenTransform() const override { return { }; }
+#endif
     IntSize size() const final { return snappedIntRect(elementRect()).size(); }
     IntPoint clickPoint() final;
     IntPoint clickPointFromElementRect() const;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2348,9 +2348,11 @@ RefPtr<AXCoreObject> AccessibilityRenderObject::accessibilityHitTest(const IntPo
     if (!m_renderer || !m_renderer->hasLayer())
         return nullptr;
 
-    // Adjust point for the remoteFrameOffset
     IntPoint adjustedPoint = point;
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // Adjust point for the remoteFrameOffset.
     adjustedPoint.moveBy(-remoteFrameOffset());
+#endif
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AccessibilityHitTest };
     HitTestResult hitTestResult { adjustedPoint };

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -32,12 +32,15 @@
 #include "AXRemoteFrame.h"
 #include "AccessibilityObjectInlines.h"
 #include "AccessibilityScrollbar.h"
+#include "Chrome.h"
+#include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentView.h"
 #include "FrameInlines.h"
 #include "HTMLFrameOwnerElement.h"
 #include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
+#include "Page.h"
 #include "RemoteFrameView.h"
 #include "RenderElement.h"
 #include "Widget.h"
@@ -328,17 +331,23 @@ void AccessibilityScrollView::addLocalFrameChild()
         if (!frameAXObjectCache)
             return;
 
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-        frameAXObjectCache->buildIsolatedTreeIfNeeded();
-#endif
-
-        RefPtr frameRoot = frameAXObjectCache->rootObjectForFrame(*localFrame);
+        RefPtr frameRoot = frameAXObjectCache->getOrCreate(localFrame->view());
         if (!frameRoot)
             return;
 
         // Set the initial hosting node state on the child frame's root scroll view.
-        if (RefPtr childScrollView = dynamicDowncast<AccessibilityScrollView>(frameRoot.get()))
-            childScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() });
+        if (RefPtr childScrollView = dynamicDowncast<AccessibilityScrollView>(frameRoot.get())) {
+            InheritedFrameState state { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };
+            childScrollView->setInheritedFrameState(state);
+
+            // Request the screen position for the UI process to update asynchronously.
+            if (RefPtr page = this->page())
+                page->chrome().client().requestFrameScreenPosition(localFrame->frameID());
+        }
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        frameAXObjectCache->buildIsolatedTreeIfNeeded();
+#endif
 
         m_localFrame = downcast<AXLocalFrame>(cache->create(AccessibilityRole::LocalFrame));
         m_localFrame->setLocalFrameView(localFrameView.get());
@@ -378,13 +387,22 @@ void AccessibilityScrollView::addRemoteFrameChild()
             if (!scrollFrame)
                 return;
 
-            // Update the remote side with the offset of this object so it can calculate frames correctly.
-            auto location = elementRect().location();
-            scrollFrame->updateRemoteFrameAccessibilityOffset(flooredIntPoint(location));
+            // Update the remote side with the offset so it can calculate frames correctly.
+            // This is the position of this iframe element within its parent frame,
+            // adjusted for scroll via contentsToView().
+            auto iframePosition = flooredIntPoint(elementRect().location());
+            RefPtr parentAXScrollView = frameRootScrollView();
+            if (RefPtr parentScrollView = parentAXScrollView ? parentAXScrollView->scrollView() : nullptr)
+                iframePosition = parentScrollView->contentsToView(iframePosition);
+            scrollFrame->updateRemoteFrameAccessibilityOffset(iframePosition);
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-            // Send initial InheritedFrameState via IPC.
-            scrollFrame->updateRemoteFrameAccessibilityInheritedState({ isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() });
+            InheritedFrameState state { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };
+            scrollFrame->updateRemoteFrameAccessibilityInheritedState(state);
+
+            // Request the screen position for the UI process to update asynchronously.
+            if (RefPtr page = this->page())
+                page->chrome().client().requestFrameScreenPosition(scrollFrame->frameID());
 #endif
         });
 #endif // PLATFORM(COCOA)
@@ -448,7 +466,23 @@ RefPtr<AXCoreObject> AccessibilityScrollView::accessibilityHitTest(const IntPoin
 LayoutRect AccessibilityScrollView::elementRect() const
 {
     RefPtr scrollView = currentScrollView();
-    return scrollView ? scrollView->frameRectShrunkByInset() : LayoutRect();
+    if (!scrollView)
+        return LayoutRect();
+
+    auto rect = scrollView->frameRectShrunkByInset();
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // For the root scroll view of a subframe (local or remote), the frameRect includes
+    // the iframe's position in the parent page. We want to zero it out.
+    if (isRoot() && !rect.location().isZero())
+        rect.setLocation(IntPoint());
+#else
+    auto offset = remoteFrameOffset();
+    if (isRoot() && !offset.isZero())
+        rect.move(-offset.x(), -offset.y());
+#endif
+
+    return rect;
 }
 
 Document* AccessibilityScrollView::document() const
@@ -557,6 +591,18 @@ AccessibilityObject* AccessibilityScrollView::crossFrameChildObject() const
     return nullptr;
 }
 
+FrameGeometry AccessibilityScrollView::frameGeometry() const
+{
+    if (CheckedPtr cache = axObjectCache()) {
+        if (std::optional geometry = cache->frameGeometry())
+            return *geometry;
+        // Geometry hasn't been populated yet — request it asynchronously.
+        if (RefPtr page = this->page())
+            page->chrome().client().requestFrameScreenPosition(cache->frameID());
+    }
+    return { };
+}
+
 bool AccessibilityScrollView::isAXHidden() const
 {
     // If this is the root scroll view, use the inherited state from the parent frame.
@@ -636,7 +682,7 @@ void AccessibilityScrollView::updateHostedFrameInheritedState()
         if (!hostedFrameScrollView)
             return;
 
-        InheritedFrameState state = { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };
+        InheritedFrameState state { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };
         hostedFrameScrollView->setInheritedFrameState(state);
     }
 
@@ -646,13 +692,20 @@ void AccessibilityScrollView::updateHostedFrameInheritedState()
             return;
 
         Ref remoteFrame = remoteFrameView->frame();
-        InheritedFrameState state = { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };
+        InheritedFrameState state { isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() };
         remoteFrame->updateRemoteFrameAccessibilityInheritedState(state);
     }
 }
 
 #endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
+const AccessibilityScrollView* AccessibilityScrollView::frameRootScrollView() const
+{
+    if (isRoot())
+        return this;
+
+    return dynamicDowncast<AccessibilityScrollView>(ancestorAccessibilityScrollView(/* includeSelf */ false));
+}
 
 void AccessibilityScrollView::scrollTo(const IntPoint& point) const
 {

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/AXObjectCache.h>
 #include <WebCore/AXRemoteFrame.h>
 #include <WebCore/AccessibilityObject.h>
 #include <WebCore/ScrollView.h>
@@ -57,6 +58,13 @@ public:
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AccessibilityObject* crossFrameParentObject() const final;
     AccessibilityObject* crossFrameChildObject() const final;
+
+    // Returns the screen position and transform for this frame.
+    // Reads from the AXObjectCache's cached value, populated asynchronously via IPC.
+    // On first access when cache is empty, fires an async requestFrameScreenPosition.
+    FrameGeometry frameGeometry() const;
+    IntPoint frameScreenPosition() const final { return frameGeometry().screenPosition; }
+    AffineTransform frameScreenTransform() const final { return frameGeometry().screenTransform; }
 
     void setInheritedFrameState(InheritedFrameState);
     const InheritedFrameState& inheritedFrameState() const { return m_inheritedFrameState; }
@@ -100,6 +108,7 @@ private:
     bool isFocused() const final;
     void NODELETE addLocalFrameChild();
     void addRemoteFrameChild();
+    const AccessibilityScrollView* frameRootScrollView() const;
 
     Document* document() const final;
     LocalFrameView* documentFrameView() const final;

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -80,10 +80,7 @@ FloatRect AccessibilityObject::convertRectToPlatformSpace(const FloatRect& rect,
     auto* frameView = documentFrameView();
     WAKView *documentView = frameView ? frameView->documentView() : nullptr;
     if (documentView) {
-        CGPoint point = CGPointMake(rect.x(), rect.y());
-        CGSize size = CGSizeMake(rect.size().width(), rect.size().height());
-        CGRect cgRect = CGRectMake(point.x, point.y, size.width, size.height);
-
+        CGRect cgRect = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
         cgRect = [documentView convertRect:cgRect toView:nil];
 
         // we need the web document view to give us our final screen coordinates

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -656,7 +656,9 @@ RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& po
     }
 
     IntPoint adjustedPoint = point;
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     adjustedPoint.moveBy(-remoteFrameOffset());
+#endif
 
     if (!bounds.contains(adjustedPoint) && !bounds.isEmpty()) {
         // If our bounds are empty, we cannot possibly contain the hit-point. However, this may happen
@@ -1194,6 +1196,18 @@ FloatRect AXIsolatedObject::screenRelativeRect() const
     return convertFrameToSpace(relativeFrame(), AccessibilityConversionSpace::Screen);
 }
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+IntPoint AXIsolatedObject::frameScreenPosition() const
+{
+    return tree().frameGeometry().screenPosition;
+}
+
+AffineTransform AXIsolatedObject::frameScreenTransform() const
+{
+    return tree().frameGeometry().screenTransform;
+}
+#endif
+
 static Seconds relativeFrameTimeout(bool shouldServeInitialFrame)
 {
     // If the request demands that we don't serve the (probably somewhat inaccurate) initial frame, use a much
@@ -1338,6 +1352,23 @@ FloatRect AXIsolatedObject::relativeFrameFromChildren() const
 FloatRect AXIsolatedObject::convertFrameToSpace(const FloatRect& rect, AccessibilityConversionSpace space) const
 {
     if (space == AccessibilityConversionSpace::Screen) {
+#if !PLATFORM(MAC)
+        // This function assumes we are in macOS coordinate space (bottom-left origin).
+        // If this code ever runs on iOS, it will be wrong and need to be fixed.
+        AX_ASSERT_NOT_REACHED();
+#endif
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        auto screenPosition = frameScreenPosition();
+        auto screenTransform = frameScreenTransform();
+        auto scaledRect = screenTransform.mapRect(rect);
+
+        // Screen coordinates use bottom-left origin (on macOS).
+        FloatPoint position = {
+            screenPosition.x() + scaledRect.x(),
+            screenPosition.y() - scaledRect.maxY()
+        };
+        return { position, scaledRect.size() };
+#else
         if (RefPtr rootNode = tree().rootNode()) {
             auto rootPoint = rootNode->propertyValue<FloatPoint>(AXProperty::ScreenRelativePosition);
             auto rootRelativeFrame = rootNode->relativeFrame();
@@ -1345,6 +1376,7 @@ FloatRect AXIsolatedObject::convertFrameToSpace(const FloatRect& rect, Accessibi
             FloatPoint position = { rootPoint.x() + rect.x(), rootPoint.y() + (rootRelativeFrame.maxY() - rect.maxY()) };
             return { WTF::move(position), rect.size() };
         }
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     }
 
     return Accessibility::retrieveValueFromMainThreadWithTimeoutAndDefault([&rect, &space, context = mainThreadContext()] () -> FloatRect {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -284,6 +284,10 @@ private:
     FloatPoint screenRelativePosition() const final;
     FloatRect screenRelativeRect() const;
     IntPoint remoteFrameOffset() const final;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    IntPoint frameScreenPosition() const final;
+    AffineTransform frameScreenTransform() const final;
+#endif
     std::optional<IntRect> cachedRelativeFrame() const { return optionalAttributeValue<IntRect>(AXProperty::RelativeFrame); }
 #if PLATFORM(MAC)
     FloatRect primaryScreenRect() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -40,6 +40,9 @@
 #include "AXUtilities.h"
 #include "AccessibilityObjectInlines.h"
 #include "AccessibilityNodeObject.h"
+#include "AccessibilityScrollView.h"
+#include "Chrome.h"
+#include "ChromeClient.h"
 #include "DocumentPage.h"
 #include "DocumentView.h"
 #include "FrameSelection.h"
@@ -188,6 +191,11 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     tree->setInitialSortedLiveRegions(axIDs(axObjectCache.sortedLiveRegions()));
     tree->setInitialSortedNonRootWebAreas(axIDs(axObjectCache.sortedNonRootWebAreas()));
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (std::optional geometry = axObjectCache.getAndUpdateFrameGeometry())
+        tree->setFrameGeometry(FrameGeometry { *geometry });
+#endif
 
     auto relations = axObjectCache.relations();
     // Add unconnected nodes for relation origins and targets that are either
@@ -1242,6 +1250,14 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
     m_pendingSelectedTextMarkerRange = WTF::move(range);
 }
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+void AXIsolatedTree::setFrameGeometry(FrameGeometry&& geometry)
+{
+    Locker locker { m_changeLogLock };
+    m_pendingFrameGeometry = WTF::move(geometry);
+}
+#endif
+
 void AXIsolatedTree::updateLoadingProgress(double newProgressValue)
 {
     AXTRACE("AXIsolatedTree::updateLoadingProgress"_s);
@@ -1273,8 +1289,15 @@ void AXIsolatedTree::updateRootScreenRelativePosition()
     AX_ASSERT(isMainThread());
 
     CheckedPtr cache = m_axObjectCache.get();
-    if (RefPtr axRoot = cache && cache->document() ? cache->getOrCreate(cache->document()->view()) : nullptr)
+    if (RefPtr axRoot = cache && cache->document() ? dynamicDowncast<AccessibilityScrollView>(cache->getOrCreate(cache->document()->view())) : nullptr) {
         queueNodeUpdate(axRoot->objectID(), { AXProperty::ScreenRelativePosition });
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        // Sync current cache value to isolated tree and fire async request to keep it up-to-date.
+        if (std::optional geometry = cache->getAndUpdateFrameGeometry())
+            setFrameGeometry(FrameGeometry { *geometry });
+#endif
+    }
 }
 
 void AXIsolatedTree::removeNode(AXID axID, std::optional<AXID> parentID)
@@ -1525,6 +1548,11 @@ void AXIsolatedTree::applyPendingChangesLocked()
 
     if (m_pendingSelectedTextMarkerRange)
         m_selectedTextMarkerRange = std::exchange(m_pendingSelectedTextMarkerRange, std::nullopt).value();
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (m_pendingFrameGeometry)
+        m_frameGeometry = std::exchange(m_pendingFrameGeometry, std::nullopt).value();
+#endif
 
     // Do this at the end because it requires looking up the root node by ID, so doing it at the end
     // ensures all additions to m_readerThreadNodeMap have been made by now.
@@ -2024,14 +2052,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         bool isWebArea = axObject->isWebArea();
         bool isScrollArea = axObject->isScrollArea();
         if (isScrollArea && !axObject->parentObject()) {
-            // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
-            // of non-root objects depend on the root object's screen relative position, so make sure it's there
-            // from the start. We keep this up-to-date via AXIsolatedTree::updateRootScreenRelativePosition().
-            setProperty(AXProperty::ScreenRelativePosition, axObject->screenRelativePosition());
-            // FIXME: We never update this property, e.g. when the iframe is moved in the hosting web content process.
-            setProperty(AXProperty::RemoteFrameOffset, object.remoteFrameOffset());
-
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
             RefPtr crossFrameParent = axObject->crossFrameParentObject();
             if (crossFrameParent) {
                 WeakPtr parentCache = crossFrameParent->axObjectCache();
@@ -2040,7 +2061,14 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
                     setProperty(AXProperty::CrossFrameParentAXID, Markable { crossFrameParent->objectID() });
                 }
             }
-#endif // ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#endif
+            // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
+            // of non-root objects depend on the root object's screen relative position, so make sure it's there
+            // from the start. We keep this up-to-date via AXIsolatedTree::updateRootScreenRelativePosition().
+            setProperty(AXProperty::ScreenRelativePosition, axObject->screenRelativePosition());
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+            setProperty(AXProperty::RemoteFrameOffset, object.remoteFrameOffset());
+#endif //
         }
 
         RefPtr geometryManager = tree->geometryManager();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/AXCoreObject.h>
 #include <WebCore/AXLoggerBase.h>
+#include <WebCore/AXObjectCache.h>
 #include <WebCore/AXTextMarker.h>
 #include <WebCore/AXTextRun.h>
 #include <WebCore/AXTreeStore.h>
@@ -437,6 +438,11 @@ public:
     AXObjectCache* axObjectCache() const;
     constexpr AXGeometryManager* geometryManager() const { return m_geometryManager.get(); }
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    FrameGeometry frameGeometry() const { return m_frameGeometry; }
+    void setFrameGeometry(FrameGeometry&&);
+#endif
+
     AXIsolatedObject* rootNode() { AX_ASSERT(!isMainThread()); return m_rootNode.get(); }
     std::optional<AXID> pendingRootNodeID();
     RefPtr<AXIsolatedObject> rootWebArea();
@@ -668,6 +674,9 @@ private:
     std::optional<HashMap<AXID, LineRange>> m_pendingMostRecentlyPaintedText WTF_GUARDED_BY_LOCK(m_changeLogLock);
     std::optional<HashMap<AXID, AXRelations>> m_pendingRelations WTF_GUARDED_BY_LOCK(m_changeLogLock);
     std::optional<AXTextMarkerRange> m_pendingSelectedTextMarkerRange WTF_GUARDED_BY_LOCK(m_changeLogLock);
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    std::optional<FrameGeometry> m_pendingFrameGeometry WTF_GUARDED_BY_LOCK(m_changeLogLock);
+#endif
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };
     std::atomic<double> m_processingProgress { 1 };
@@ -677,6 +686,9 @@ private:
     Vector<AXID> m_sortedNonRootWebAreaIDs;
     HashMap<AXID, LineRange> m_mostRecentlyPaintedText;
     HashMap<AXID, AXRelations> m_relations;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    FrameGeometry m_frameGeometry;
+#endif
 
     // Set to true by the AXObjectCache and false by AXIsolatedTree.
     // Both are only to be used on the main-thread.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -667,7 +667,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         NSAccessibilityTextInputMarkedRangeAttribute,
         NSAccessibilityTextInputMarkedTextMarkerRangeAttribute,
         NSAccessibilityVisibleCharacterRangeAttribute,
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        // With local frames enabled, all positions are returned in screen-space so
+        // that VoiceOver doesn't have to convert from relative -> screen space.
         NSAccessibilityRelativeFrameAttribute,
+#endif
         // AppKit needs to know the screen height in order to do the coordinate conversion.
         NSAccessibilityPrimaryScreenHeightAttribute,
         // All objects should expose the ARIA busy attribute (ARIA 1.1 with ISSUE-538).
@@ -2887,9 +2891,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
     if (backingObject->isStaticText())
         return staticTextParamAttrs.get().get();
 
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     // The object that serves up the remote frame also is the one that does the frame conversion.
     if (backingObject->hasRemoteFrameChild())
         return [paramAttrs.get().get() arrayByAddingObject:NSAccessibilityConvertRelativeFrameParameterizedAttribute];
+#endif
 
     return paramAttrs.get().get();
 }
@@ -4107,11 +4113,13 @@ static id handleCellForColumnAndRowParameterizedAttribute(WebAccessibilityObject
     return cell ? cell->wrapper() : nil;
 }
 
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 static id handleConvertRelativeFrameParameterizedAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject, const ParameterizedAttributeContext& context)
 {
     RefPtr parent = backingObject.parentObject();
     return parent ? [NSValue valueWithRect:parent->convertFrameToSpace(FloatRect(context.rect), AccessibilityConversionSpace::Page)] : nil;
 }
+#endif
 
 static MemoryCompactLookupOnlyRobinHoodHashMap<String, ParameterizedAttributeHandlerEntry> createParameterizedAttributeHandlerMap()
 {
@@ -4173,7 +4181,9 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<String, ParameterizedAttributeHan
         { NSAccessibilityLengthForTextMarkerRangeAttribute, { handleLengthForTextMarkerRangeAttribute } },
         { NSAccessibilityIntersectTextMarkerRangesAttribute, { handleIntersectTextMarkerRangesAttribute } },
         { NSAccessibilityCellForColumnAndRowParameterizedAttribute, { handleCellForColumnAndRowParameterizedAttribute, ParameterizedAttributePrecondition::IsExposableTable } },
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
         { NSAccessibilityConvertRelativeFrameParameterizedAttribute, { handleConvertRelativeFrameParameterizedAttribute } },
+#endif
     });
 
     MemoryCompactLookupOnlyRobinHoodHashMap<String, ParameterizedAttributeHandlerEntry> map;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -292,6 +292,9 @@ public:
     virtual std::optional<IntPoint> screenToRootViewUsingCachedPosition(const IntPoint&, const IntSize&) const { return std::nullopt; }
     virtual IntPoint accessibilityScreenToRootView(const IntPoint&) const = 0;
     virtual IntRect rootViewToAccessibilityScreen(const IntRect&) const = 0;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    virtual void requestFrameScreenPosition(FrameIdentifier) const { }
+#endif
 #if PLATFORM(IOS_FAMILY)
     virtual void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const = 0;
     virtual void relayAriaNotifyNotification(AriaNotifyData&&) const = 0;

--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -115,8 +115,14 @@ void AccessibilityRegionContext::takeBounds(const RenderInline* renderInline, La
 
 void AccessibilityRegionContext::takeBoundsInternal(const RenderBoxModelObject& renderObject, IntRect&& paintRect)
 {
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // contentsToView() just applies *this* frame's scroll position. Scroll from other frames will be accounted for in  frameScreenPosition.
+    if (RefPtr view = renderObject.document().view())
+        paintRect = view->contentsToView(paintRect);
+#else
     if (RefPtr view = renderObject.document().view())
         paintRect = view->contentsToRootView(paintRect);
+#endif
 
     if (CheckedPtr cache = renderObject.document().axObjectCache())
         cache->onPaint(renderObject, WTF::move(paintRect));
@@ -128,8 +134,14 @@ void AccessibilityRegionContext::takeBoundsInternal(const RenderBoxModelObject& 
 void AccessibilityRegionContext::takeBounds(const RenderText& renderText, FloatRect paintRect, size_t lineIndex)
 {
     auto mappedPaintRect = enclosingIntRect(mapRect(WTF::move(paintRect)));
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // contentsToView() just applies *this* frame's scroll position. Scroll from other frames will be accounted for in  frameScreenPosition.
+    if (RefPtr view = renderText.document().view())
+        mappedPaintRect = view->contentsToView(mappedPaintRect);
+#else
     if (RefPtr view = renderText.document().view())
         mappedPaintRect = view->contentsToRootView(mappedPaintRect);
+#endif
 
     auto accumulatedRectIterator = m_accumulatedRenderTextRects.find(renderText);
     if (accumulatedRectIterator == m_accumulatedRenderTextRects.end())
@@ -158,8 +170,18 @@ void AccessibilityRegionContext::onPaint(const ScrollView& scrollView)
     auto relativeFrame = frameView->frameRectShrunkByInset();
     // Only normalize the rect to the root view if this scrollview isn't already associated with the root view (i.e. it has a frame owner).
     if (RefPtr frameOwnerElement = frameView->frame().ownerElement()) {
-        if (RefPtr ownerDocumentFrameView = frameOwnerElement->document().view())
+        if (RefPtr ownerDocumentFrameView = frameOwnerElement->document().view()) {
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+            // contentsToView() just applies *this* frame's scroll position. Scroll from other frames will be accounted for in frameScreenPosition.
+            relativeFrame = ownerDocumentFrameView->contentsToView(relativeFrame);
+            // Zero out the iframe position since frameScreenPosition accounts for it.
+            // This matches AccessibilityScrollView::elementRect() which also zeros the
+            // location for subframe root scroll views.
+            relativeFrame.setLocation(IntPoint());
+#else
             relativeFrame = ownerDocumentFrameView->contentsToRootView(relativeFrame);
+#endif
+        }
     }
 
     if (CheckedPtr cache = frameView->axObjectCache())

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1225,6 +1225,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::FontSmoothingMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::FoundElementInRemoteFrame': ['<WebCore/FocusControllerTypes.h>'],
         'WebCore::FragmentedSharedBuffer': ['<WebCore/SharedBuffer.h>'],
+        'WebCore::FrameGeometry': ['<WebCore/AXObjectCache.h>'],
         'WebCore::FrameIdentifierID': ['"GeneratedSerializers.h"'],
         'WebCore::FrameLoadType': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::FrameTreeSyncSerializationData': ['<WebCore/FrameTreeSyncData.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9331,6 +9331,12 @@ header: <WebCore/AXObjectCache.h>
     bool isInert;
     bool isRenderHidden;
 };
+
+header: <WebCore/AXObjectCache.h>
+[CustomHeader] struct WebCore::FrameGeometry {
+    WebCore::IntPoint screenPosition;
+    WebCore::AffineTransform screenTransform;
+};
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9865,6 +9865,36 @@ void WebPageProxy::rootViewToAccessibilityScreen(const IntRect& viewRect, Comple
     completionHandler(pageClient->rootViewToAccessibilityScreen(viewRect));
 }
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+void WebPageProxy::requestFrameScreenPosition(FrameIdentifier frameID)
+{
+    static constexpr float unitRectSize = 1000;
+    convertRectToMainFrameCoordinates(FloatRect(0, 0, unitRectSize, unitRectSize), frameID, [weakThis = WeakPtr { *this }, frameID](std::optional<FloatRect> finalRect) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !finalRect)
+            return;
+
+        RefPtr pageClient = protectedThis->pageClient();
+        if (!pageClient)
+            return;
+
+        auto screenRect = pageClient->rootViewToAccessibilityScreen(enclosingIntRect(*finalRect));
+
+        FrameGeometry geometry;
+#if PLATFORM(MAC)
+        // On macOS, NSRect origin is the bottom-left corner, so screenRect.location()
+        // is offset downward by the rect's height. Add it back to get the content origin.
+        geometry.screenPosition = { screenRect.x(), screenRect.y() + screenRect.height() };
+#else
+        geometry.screenPosition = screenRect.location();
+#endif
+        geometry.screenTransform = AffineTransform::makeScale({ screenRect.width() / unitRectSize, screenRect.height() / unitRectSize });
+
+        protectedThis->sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateRemotePageAccessibilityScreenPosition(frameID, geometry));
+    });
+}
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+
 void WebPageProxy::runBeforeUnloadConfirmPanel(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(bool)>&& reply)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameID);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3112,6 +3112,9 @@ private:
     void rootViewRectToScreen(const WebCore::IntRect& viewRect, CompletionHandler<void(const WebCore::IntRect&)>&&);
     void accessibilityScreenToRootView(const WebCore::IntPoint& screenPoint, CompletionHandler<void(WebCore::IntPoint)>&&);
     void rootViewToAccessibilityScreen(const WebCore::IntRect& viewRect, CompletionHandler<void(WebCore::IntRect)>&&);
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    void requestFrameScreenPosition(WebCore::FrameIdentifier);
+#endif
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, std::span<const uint8_t>);
     void relayAriaNotifyNotification(WebCore::AriaNotifyData&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -53,6 +53,9 @@ messages -> WebPageProxy {
     RootViewRectToScreen(WebCore::IntRect rect) -> (WebCore::IntRect screenFrame) Synchronous
     AccessibilityScreenToRootView(WebCore::IntPoint screenPoint) -> (WebCore::IntPoint windowPoint) Synchronous
     RootViewToAccessibilityScreen(WebCore::IntRect rect) -> (WebCore::IntRect screenFrame) Synchronous
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    RequestFrameScreenPosition(WebCore::FrameIdentifier frameID)
+#endif
 #if PLATFORM(IOS_FAMILY)
     RelayAccessibilityNotification(String notificationName, std::span<const uint8_t> notificationData)
     RelayAriaNotifyNotification(struct WebCore::AriaNotifyData notificationData)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -830,6 +830,14 @@ IntRect WebChromeClient::rootViewToAccessibilityScreen(const IntRect& rect) cons
     return page ? page->rootViewToAccessibilityScreen(rect) : IntRect();
 }
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+void WebChromeClient::requestFrameScreenPosition(FrameIdentifier frameID) const
+{
+    if (RefPtr page = m_page.get())
+        page->requestFrameScreenPosition(frameID);
+}
+#endif
+
 void WebChromeClient::mainFrameDidChange()
 {
     if (RefPtr page = m_page.get())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -138,6 +138,9 @@ private:
 
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&) const final;
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) const final;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    void requestFrameScreenPosition(WebCore::FrameIdentifier) const final;
+#endif
 
     void mainFrameDidChange() final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1810,6 +1810,15 @@ void WebPage::updateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifi
 
     cache->setFrameInheritedState(*coreFrame, state);
 }
+
+void WebPage::updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, const WebCore::FrameGeometry& geometry)
+{
+    RefPtr frame = WebProcess::singleton().webFrame(frameID);
+    RefPtr coreFrame = frame ? frame->coreLocalFrame() : nullptr;
+    RefPtr document = coreFrame ? coreFrame->document() : nullptr;
+    if (WeakPtr cache = document ? document->axObjectCache() : nullptr)
+        cache->setFrameGeometry(*coreFrame, geometry);
+}
 #endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
 void WebPage::updateEditorStateAfterLayoutIfEditabilityChanged()
@@ -4567,6 +4576,13 @@ IntRect WebPage::rootViewToAccessibilityScreen(const IntRect& rect)
     auto [screenRect] = sendResult.takeReplyOr(IntRect { });
     return screenRect;
 }
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+void WebPage::requestFrameScreenPosition(FrameIdentifier frameID)
+{
+    send(Messages::WebPageProxy::RequestFrameScreenPosition(frameID));
+}
+#endif
 
 KeyboardUIMode WebPage::keyboardUIMode()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -321,6 +321,7 @@ class HTMLAttachmentElement;
 class HandleUserInputEventResult;
 #endif
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+struct FrameGeometry;
 struct InheritedFrameState;
 #endif
 struct InteractionRegion;
@@ -1020,6 +1021,10 @@ public:
     WebCore::IntRect rootViewToScreen(const WebCore::IntRect&);
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&);
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&);
+    // Allows remote web processes to request an asynchronous update to their screen position, computed in the UI process.
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    void requestFrameScreenPosition(WebCore::FrameIdentifier);
+#endif
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&);
     void relayAriaNotifyNotification(WebCore::AriaNotifyData&&);
@@ -2709,6 +2714,7 @@ private:
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&);
+    void updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier, const WebCore::FrameGeometry&);
 #endif
     void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -546,6 +546,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     UpdateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier frameID, struct WebCore::InheritedFrameState state);
+    UpdateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, struct WebCore::FrameGeometry geometry);
 #endif
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -73,6 +73,7 @@
 #import "WebProcess.h"
 #import "WebTouchEvent.h"
 #import <CoreText/CTFont.h>
+#import <WebCore/AXObjectCache.h>
 #import <WebCore/AXRemoteTokenIOS.h>
 #import <WebCore/AccessibilityObject.h>
 #import <WebCore/Autofill.h>
@@ -711,7 +712,12 @@ void WebPage::getSelectionContext(CompletionHandler<void(const String&, const St
     
 void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint offset)
 {
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // With local frame support, position data is sent from the UI process in frameScreenPosition.
+    UNUSED_PARAM(offset);
+#else
     [protect(accessibilityRemoteObject()) setRemoteFrameOffset:offset];
+#endif
 }
 
 static RetainPtr<NSDictionary> createAccessibillityTokenDictionary(WebCore::AccessibilityRemoteToken elementToken)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -433,9 +433,14 @@ bool WebPage::performNonEditingBehaviorForSelector(const String& selector, Keybo
     return didPerformAction;
 }
 
-void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
+void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint offset)
 {
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // With local frame support, position data is sent from the UI process in frameScreenPosition.
+    UNUSED_PARAM(offset);
+#else
     [protect(accessibilityRemoteObject()) setRemoteFrameOffset:offset];
+#endif
 }
 
 void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, WebCore::AccessibilityRemoteToken elementToken, WebCore::FrameIdentifier frameID)

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -32,6 +32,7 @@
 
 #import "AccessibilityCommonCocoa.h"
 #import "AccessibilityNotificationHandler.h"
+#import "AccessibilityUIElementClientMac.h"
 #import "InjectedBundle.h"
 #import "InjectedBundlePage.h"
 #import "JSBasics.h"
@@ -127,6 +128,25 @@ static id findAccessibleObjectById(id obj, NSString *idAttribute)
     return nil;
 }
 
+static RefPtr<AccessibilityUIElement> findElementByIdRecursive(AccessibilityUIElement* element, const String& targetId)
+{
+    if (!element || !element->isValid())
+        return nullptr;
+
+    if (JSRetainPtr<JSStringRef> domId = element->domIdentifier()) {
+        if (toWTFString(domId.get()) == targetId)
+            return element;
+    }
+
+    unsigned count = element->childrenCount();
+    for (unsigned i = 0; i < count; i++) {
+        if (RefPtr<AccessibilityUIElement> found = findElementByIdRecursive(element->childAtIndex(i).get(), targetId))
+            return found;
+    }
+
+    return nullptr;
+}
+
 void AccessibilityController::injectAccessibilityPreference(JSStringRef domain, JSStringRef key, JSStringRef value)
 {
     auto page = InjectedBundle::singleton().page()->page();
@@ -138,6 +158,11 @@ void AccessibilityController::injectAccessibilityPreference(JSStringRef domain, 
 
 RefPtr<AccessibilityUIElement> AccessibilityController::accessibleElementById(JSContextRef context, JSStringRef idAttribute)
 {
+    if (m_enableClientAccessibilityMode) {
+        auto root = AccessibilityUIElementClientMac::createForUIProcess();
+        return findElementByIdRecursive(root.ptr(), toWTFString(idAttribute));
+    }
+
     PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
 
     NSString *attributeName = [NSString stringWithJSStringRef:idAttribute];

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
@@ -51,6 +51,7 @@ public:
     JSRetainPtr<JSStringRef> title() override;
     JSRetainPtr<JSStringRef> description() override;
     JSRetainPtr<JSStringRef> stringValue() override;
+    JSRetainPtr<JSStringRef> domIdentifier() const override;
     unsigned childrenCount() override;
     RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
     int hierarchicalLevel() const override;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
@@ -233,6 +233,11 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::stringValue()
     return getStringAttribute("AXValue");
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::domIdentifier() const
+{
+    return getStringAttribute("AXDOMIdentifier");
+}
+
 double AccessibilityUIElementClientMac::getNumberAttribute(const char* attributeName) const
 {
     if (!isValid())

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -230,6 +230,7 @@ static id attributeValue(id element, NSString *attribute)
         @"AXKeyShortcutsValue",
         @"AXOwns",
         @"AXPopupValue",
+        @"AXRelativeFrame", // Continue to support this for testing purposes with ENABLE(ACCESSIBILITY_LOCAL_FRAME).
         @"AXValue",
     ];
 


### PR DESCRIPTION
#### 190312ee1df566632573fc0d568044de218ccb37
<pre>
[Site Isolation] AX: Setup screen position infrastructure for remote frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=308524">https://bugs.webkit.org/show_bug.cgi?id=308524</a>
<a href="https://rdar.apple.com/169469908">rdar://169469908</a>

Reviewed by Tyler Wilcock.

This PR sets up new infrastructure for computing and propagating the screen position and
screen relative positions of local and remote subframes. Importantly, this PR removes the
AXConvertRelativeFrame parameterized attribute when ENABLE(ACCESSIBILITY_LOCAL_FRAME) is
enabled, as well as removes AXRelativeFrame from attribute names, so that ATs just rely on
screen position.

In both the local and remote frame case, we now cache the screen-relative position of the
frames on the AXObjectCache as well as the transforms, and use it in convertFrameToSpace
(in both live and isolated objects) in order to serve the screen position for all elements.
This is also cached in the AXIsolatedTree, using the pending pattern seen elsewhere.

Also for both local and remote frames, during add[Remote/Local]FrameChild(), we send a
RequestFrameScreenPosition IPC message to the UIProcess. The UIProcess walks the frame tree
using convertRectToMainFrameCoordinates to compute the screen position of the frame, and
sends the result back to the frame&apos;s web content process via
UpdateRemotePageAccessibilityScreenPosition.

When ENABLE(ACCESSIBILITY_LOCAL_FRAME) is off, the legacy codepath and behavior is fully
supported.

One piece missing from this PR is updating these cached screen positions when the scroll
position of any frame changes. That will be addressed in a follow up, as it will require
large code additions that build on top of this PR. Test expectations have been updated to
reflect this.

Tests: accessibility/mac/client/absolute-position-iframe.html
       http/tests/site-isolation/accessibility/client/absolute-position-iframe.html
       http/tests/site-isolation/accessibility/client/iframe-bounds.html

* LayoutTests/TestExpectations:
* LayoutTests/accessibility/mac/client/absolute-position-iframe-expected.txt: Added.
* LayoutTests/accessibility/mac/client/absolute-position-iframe.html: Added.
* LayoutTests/accessibility/mac/client/resources/frame-content.html: Added.
* LayoutTests/accessibility/mac/line-range-for-text-marker.html:
* LayoutTests/accessibility/mac/text-marker-for-bounds.html:
* LayoutTests/http/tests/site-isolation/accessibility/client/absolute-position-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/client/absolute-position-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-with-text.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::scrollViewForFrame):
(WebCore::AXObjectCache::setFrameInheritedState):
(WebCore::AXObjectCache::setFrameGeometry):
(WebCore::AXObjectCache::getAndUpdateFrameGeometry):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::convertFrameToSpace const):
(WebCore::AccessibilityObject::relativeFrame const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addLocalFrameChild):
(WebCore::AccessibilityScrollView::addRemoteFrameChild):
(WebCore::AccessibilityScrollView::elementRect const):
(WebCore::AccessibilityScrollView::frameGeometry const):
(WebCore::AccessibilityScrollView::updateHostedFrameInheritedState):
(WebCore::AccessibilityScrollView::frameRootScrollView const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AccessibilityObject::convertRectToPlatformSpace const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::approximateHitTest const):
(WebCore::AXIsolatedObject::frameScreenPosition const):
(WebCore::AXIsolatedObject::frameScreenTransform const):
(WebCore::AXIsolatedObject::convertFrameToSpace const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::setFrameGeometry):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::frameGeometry const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):
(-[WebAccessibilityObjectWrapper accessibilityParameterizedAttributeNames]):
(createParameterizedAttributeHandlerMap):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::requestFrameScreenPosition const):
* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
(WebCore::AccessibilityRegionContext::takeBoundsInternal):
(WebCore::AccessibilityRegionContext::takeBounds):
(WebCore::AccessibilityRegionContext::onPaint):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestFrameScreenPosition):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::requestFrameScreenPosition const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateRemotePageAccessibilityScreenPosition):
(WebKit::WebPage::requestFrameScreenPosition):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateRemotePageAccessibilityOffset):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::updateRemotePageAccessibilityOffset):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::findElementByIdRecursive):
(WTR::AccessibilityController::accessibleElementById):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm:
(WTR::AccessibilityUIElementClientMac::domIdentifier const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::attributeValue):

Canonical link: <a href="https://commits.webkit.org/308698@main">https://commits.webkit.org/308698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/058307fe84a066a628244f1c972a08d52a516767

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101567 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7337a430-98ac-4d1e-bede-fdfbe26f67aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114217 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81429 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfe5484e-e949-4f7d-9e82-4a173fa8c5f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94984 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b91e581-2bf9-479b-9d21-c6a5f28953e0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147475 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13387 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4274 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159170 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2304 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122248 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122467 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33309 "Failed to checkout and rebase branch from PR 59301") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76798 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9505 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20255 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84014 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20041 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->