### PR TITLE
NetworkStorageSession::setCookie() silently rejects localhost cookies

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -328,6 +328,7 @@ void InspectorPageAgent::overridePrefersColorScheme(std::optional<Inspector::Pro
 static Inspector::Protocol::Page::CookieSameSitePolicy cookieSameSitePolicyJSON(Cookie::SameSitePolicy policy)
 {
     switch (policy) {
+    case Cookie::SameSitePolicy::Default:
     case Cookie::SameSitePolicy::None:
         return Inspector::Protocol::Page::CookieSameSitePolicy::None;
     case Cookie::SameSitePolicy::Lax:

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -93,13 +93,14 @@ struct Cookie {
     URL commentURL;
     Vector<uint16_t> ports;
 
-    enum class SameSitePolicy : uint8_t { 
-        None, 
-        Lax, 
-        Strict 
+    enum class SameSitePolicy : uint8_t {
+        Default,
+        None,
+        Lax,
+        Strict
     };
 
-    SameSitePolicy sameSite { SameSitePolicy::None };
+    SameSitePolicy sameSite { SameSitePolicy::Default };
 
     Cookie(String&& name, String&& value, String&& domain, String&& path, String&& partitionKey, double created, std::optional<double> expires, bool httpOnly, bool secure, bool session, String&& comment, URL&& commentURL, Vector<uint16_t> ports, SameSitePolicy sameSite)
         : name(WTF::move(name))

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -126,6 +126,7 @@ struct Cookie {
 namespace CookieUtil {
 
 WEBCORE_EXPORT String defaultPathForURL(const URL&);
+WEBCORE_EXPORT String buildSetCookieStringWithoutDomain(const Cookie&);
 
 } // namespace CookieUtil
 

--- a/Source/WebCore/platform/network/Cookie.cpp
+++ b/Source/WebCore/platform/network/Cookie.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "Cookie.h"
 
+#include <wtf/WallTime.h>
+#include <wtf/text/StringBuilder.h>
+
 namespace WebCore {
     
 #if !PLATFORM(COCOA)
@@ -44,6 +47,41 @@ unsigned Cookie::hash() const
 #endif
 
 namespace CookieUtil {
+
+String buildSetCookieStringWithoutDomain(const Cookie& cookie)
+{
+    StringBuilder builder;
+    builder.append(cookie.name, '=', cookie.value);
+
+    if (!cookie.path.isEmpty())
+        builder.append("; Path="_s, cookie.path);
+
+    if (cookie.expires) {
+        auto now = WallTime::now().secondsSinceEpoch().milliseconds();
+        auto maxAgeSeconds = static_cast<int64_t>((*cookie.expires - now) / 1000);
+        if (maxAgeSeconds > 0)
+            builder.append("; Max-Age="_s, maxAgeSeconds);
+    }
+
+    if (cookie.httpOnly)
+        builder.append("; HttpOnly"_s);
+
+    if (cookie.secure)
+        builder.append("; Secure"_s);
+
+    switch (cookie.sameSite) {
+    case Cookie::SameSitePolicy::Lax:
+        builder.append("; SameSite=Lax"_s);
+        break;
+    case Cookie::SameSitePolicy::Strict:
+        builder.append("; SameSite=Strict"_s);
+        break;
+    case Cookie::SameSitePolicy::None:
+        break;
+    }
+
+    return builder.toString();
+}
 
 String defaultPathForURL(const URL& url)
 {

--- a/Source/WebCore/platform/network/Cookie.cpp
+++ b/Source/WebCore/platform/network/Cookie.cpp
@@ -70,15 +70,16 @@ String buildSetCookieStringWithoutDomain(const Cookie& cookie)
         builder.append("; Secure"_s);
 
     switch (cookie.sameSite) {
+    case Cookie::SameSitePolicy::Default:
+        break;
+    case Cookie::SameSitePolicy::None:
+        builder.append("; SameSite=None"_s);
+        break;
     case Cookie::SameSitePolicy::Lax:
         builder.append("; SameSite=Lax"_s);
         break;
     case Cookie::SameSitePolicy::Strict:
         builder.append("; SameSite=Strict"_s);
-        break;
-    case Cookie::SameSitePolicy::None:
-        if (cookie.secure)
-            builder.append("; SameSite=None"_s);
         break;
     }
 

--- a/Source/WebCore/platform/network/Cookie.cpp
+++ b/Source/WebCore/platform/network/Cookie.cpp
@@ -77,6 +77,8 @@ String buildSetCookieStringWithoutDomain(const Cookie& cookie)
         builder.append("; SameSite=Strict"_s);
         break;
     case Cookie::SameSitePolicy::None:
+        if (cookie.secure)
+            builder.append("; SameSite=None"_s);
         break;
     }
 

--- a/Source/WebCore/platform/network/Cookie.cpp
+++ b/Source/WebCore/platform/network/Cookie.cpp
@@ -61,6 +61,8 @@ String buildSetCookieStringWithoutDomain(const Cookie& cookie)
         auto maxAgeSeconds = static_cast<int64_t>((*cookie.expires - now) / 1000);
         if (maxAgeSeconds > 0)
             builder.append("; Max-Age="_s, maxAgeSeconds);
+        else
+            builder.append("; Max-Age=0"_s);
     }
 
     if (cookie.httpOnly)

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -83,7 +83,7 @@ static std::optional<double> cookieExpiry(NSHTTPCookie *cookie)
 static Cookie::SameSitePolicy coreSameSitePolicy(NSHTTPCookieStringPolicy _Nullable policy)
 {
     if (!policy)
-        return Cookie::SameSitePolicy::None;
+        return Cookie::SameSitePolicy::Default;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     if ([policy isEqualToString:NSHTTPCookieSameSiteLax])
         return Cookie::SameSitePolicy::Lax;
@@ -91,12 +91,13 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
         return Cookie::SameSitePolicy::Strict;
 ALLOW_NEW_API_WITHOUT_GUARDS_END
     ASSERT_NOT_REACHED();
-    return Cookie::SameSitePolicy::None;
+    return Cookie::SameSitePolicy::Default;
 }
 
 static NSHTTPCookieStringPolicy _Nullable nsSameSitePolicy(Cookie::SameSitePolicy policy)
 {
     switch (policy) {
+    case Cookie::SameSitePolicy::Default:
     case Cookie::SameSitePolicy::None:
         return nil;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -71,9 +71,13 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
         auto scheme = cookie.secure ? "https://"_s : "http://"_s;
         auto url = URL { makeString(scheme, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
         RetainPtr<NSDictionary> headerFields = @{ @"Set-Cookie": header.createNSString().get() };
-        RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields.get() forURL:url.createNSURL().get()];
+        RetainPtr nsURL = url.createNSURL();
+        RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields.get() forURL:nsURL.get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        [nsCookieStorage() setCookies:nsCookies.get() forURL:url.createNSURL().get() mainDocumentURL:url.createNSURL().get()];
+        // Use setCookies:forURL:mainDocumentURL: instead of setCookie: so NSHTTPCookieStorage
+        // processes the cookie as if it arrived in a Set-Cookie response header from the
+        // localhost URL, bypassing the CanAccessRawCookies privilege check below.
+        [nsCookieStorage() setCookies:nsCookies.get() forURL:nsURL.get() mainDocumentURL:nsURL.get()];
         END_BLOCK_OBJC_EXCEPTIONS
         return;
     }

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -65,6 +65,18 @@ NetworkStorageSession::~NetworkStorageSession()
 
 void NetworkStorageSession::setCookie(const Cookie& cookie)
 {
+    if (equalLettersIgnoringASCIICase(cookie.domain, "localhost"_s)
+        || cookie.domain.endsWithIgnoringASCIICase(".localhost"_s)) {
+        auto header = CookieUtil::buildSetCookieStringWithoutDomain(cookie);
+        auto url = URL { makeString("http://"_s, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
+        NSDictionary *headerFields = @{ @"Set-Cookie": (NSString *)header };
+        auto nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields forURL:url.createNSURL().get()];
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        [nsCookieStorage() setCookies:nsCookies forURL:url.createNSURL().get() mainDocumentURL:url.createNSURL().get()];
+        END_BLOCK_OBJC_EXCEPTIONS
+        return;
+    }
+
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -69,8 +69,8 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
         || cookie.domain.endsWithIgnoringASCIICase(".localhost"_s)) {
         auto header = CookieUtil::buildSetCookieStringWithoutDomain(cookie);
         auto url = URL { makeString("http://"_s, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
-        NSDictionary *headerFields = @{ @"Set-Cookie": header.createNSString().get() };
-        RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields forURL:url.createNSURL().get()];
+        RetainPtr<NSDictionary> headerFields = @{ @"Set-Cookie": header.createNSString().get() };
+        RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields.get() forURL:url.createNSURL().get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         [nsCookieStorage() setCookies:nsCookies.get() forURL:url.createNSURL().get() mainDocumentURL:url.createNSURL().get()];
         END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -70,9 +70,9 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
         auto header = CookieUtil::buildSetCookieStringWithoutDomain(cookie);
         auto url = URL { makeString("http://"_s, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
         NSDictionary *headerFields = @{ @"Set-Cookie": header.createNSString().get() };
-        auto nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields forURL:url.createNSURL().get()];
+        RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields forURL:url.createNSURL().get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        [nsCookieStorage() setCookies:nsCookies forURL:url.createNSURL().get() mainDocumentURL:url.createNSURL().get()];
+        [nsCookieStorage() setCookies:nsCookies.get() forURL:url.createNSURL().get() mainDocumentURL:url.createNSURL().get()];
         END_BLOCK_OBJC_EXCEPTIONS
         return;
     }

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -68,7 +68,8 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
     if (equalLettersIgnoringASCIICase(cookie.domain, "localhost"_s)
         || cookie.domain.endsWithIgnoringASCIICase(".localhost"_s)) {
         auto header = CookieUtil::buildSetCookieStringWithoutDomain(cookie);
-        auto url = URL { makeString("http://"_s, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
+        auto scheme = cookie.secure ? "https://"_s : "http://"_s;
+        auto url = URL { makeString(scheme, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
         RetainPtr<NSDictionary> headerFields = @{ @"Set-Cookie": header.createNSString().get() };
         RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields.get() forURL:url.createNSURL().get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -69,7 +69,7 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
         || cookie.domain.endsWithIgnoringASCIICase(".localhost"_s)) {
         auto header = CookieUtil::buildSetCookieStringWithoutDomain(cookie);
         auto url = URL { makeString("http://"_s, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
-        NSDictionary *headerFields = @{ @"Set-Cookie": (NSString *)header };
+        NSDictionary *headerFields = @{ @"Set-Cookie": header.createNSString().get() };
         auto nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields forURL:url.createNSURL().get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         [nsCookieStorage() setCookies:nsCookies forURL:url.createNSURL().get() mainDocumentURL:url.createNSURL().get()];

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -70,7 +70,8 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
         auto header = CookieUtil::buildSetCookieStringWithoutDomain(cookie);
         auto scheme = cookie.secure ? "https://"_s : "http://"_s;
         auto url = URL { makeString(scheme, cookie.domain, cookie.path.isEmpty() ? "/"_s : cookie.path) };
-        RetainPtr<NSDictionary> headerFields = @{ @"Set-Cookie": header.createNSString().get() };
+        RetainPtr nsHeader = header.createNSString();
+        RetainPtr<NSDictionary> headerFields = @{ @"Set-Cookie": nsHeader.get() };
         RetainPtr nsURL = url.createNSURL();
         RetainPtr nsCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headerFields.get() forURL:nsURL.get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/network/soup/CookieSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CookieSoup.cpp
@@ -50,6 +50,7 @@ static Cookie::SameSitePolicy coreSameSitePolicy(SoupSameSitePolicy policy)
 static SoupSameSitePolicy soupSameSitePolicy(Cookie::SameSitePolicy policy)
 {
     switch (policy) {
+    case Cookie::SameSitePolicy::Default:
     case Cookie::SameSitePolicy::None:
         return SOUP_SAME_SITE_POLICY_NONE;
     case Cookie::SameSitePolicy::Lax:

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1438,6 +1438,7 @@ public:
             case Cookie::SameSitePolicy::Lax:
                 sameSite = "Lax"_s;
                 break;
+            case Cookie::SameSitePolicy::Default:
             case Cookie::SameSitePolicy::None:
                 sameSite = "None"_s;
                 break;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1677,6 +1677,7 @@ struct WebCore::PlatformMediaCapabilitiesAudioConfiguration {
 };
 
 [Nested] enum class WebCore::Cookie::SameSitePolicy : uint8_t {
+    Default
     None
     Lax
     Strict

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1727,6 +1727,7 @@ void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol:
 static inline Inspector::Protocol::Automation::CookieSameSitePolicy NODELETE toProtocolSameSitePolicy(WebCore::Cookie::SameSitePolicy policy)
 {
     switch (policy) {
+    case WebCore::Cookie::SameSitePolicy::Default:
     case WebCore::Cookie::SameSitePolicy::None:
         return Inspector::Protocol::Automation::CookieSameSitePolicy::None;
     case WebCore::Cookie::SameSitePolicy::Lax:

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -102,6 +102,7 @@ static inline NSString *toWebAPI(PAL::SessionID sessionID)
 static inline NSString *NODELETE toWebAPI(WebCore::Cookie::SameSitePolicy policy)
 {
     switch (policy) {
+    case WebCore::Cookie::SameSitePolicy::Default:
     case WebCore::Cookie::SameSitePolicy::None:
         return noRestrictionKey;
     case WebCore::Cookie::SameSitePolicy::Lax:

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1181,6 +1181,55 @@ TEST(WKHTTPCookieStore, SetCookies)
     done = false;
 }
 
+TEST(WKHTTPCookieStore, SetCookieForLocalhost)
+{
+    using namespace TestWebKitAPI;
+
+    RetainPtr cookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"TestCookie",
+        NSHTTPCookieValue: @"TestValue",
+        NSHTTPCookieDomain: @"localhost",
+    }];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    auto dataStore = [WKWebsiteDataStore nonPersistentDataStore];
+    configuration.get().websiteDataStore = dataStore;
+    auto cookieStore = dataStore.httpCookieStore;
+
+    // Set the localhost cookie.
+    __block bool done = false;
+    [cookieStore setCookie:cookie.get() completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    // Verify cookie was stored.
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ([cookies count], 1u);
+        EXPECT_WK_STREQ(@"TestCookie", [[cookies firstObject] name]);
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    // Verify cookie is sent in HTTP requests to localhost.
+    __block String receivedCookies;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            receivedCookies = HTTPServer::parseCookies(request);
+            co_await connection.awaitableSend(HTTPResponse("hi"_s).serialize());
+        }
+    });
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    [webView loadRequest:server.requestWithLocalhost()];
+    [webView _test_waitForDidFinishNavigation];
+    EXPECT_WK_STREQ("TestCookie=TestValue", receivedCookies);
+}
+
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
 TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1215,7 +1215,7 @@ TEST(WKHTTPCookieStore, SetCookieForLocalhost)
     done = false;
 
     // Verify cookie is sent in HTTP requests to localhost.
-    __block String receivedCookies;
+    String receivedCookies;
     HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1297,8 +1297,8 @@ TEST(WKHTTPCookieStore, SetSameSiteNoneCookieForLocalhost)
     auto cookieStore = dataStore.httpCookieStore;
 
     // Use an HTTPS localhost server that sets a SameSite=None; Secure cookie via Set-Cookie header.
-    __block String receivedCookies;
-    __block bool firstRequest = true;
+    String receivedCookies;
+    bool firstRequest = true;
     HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (true) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1340,6 +1340,42 @@ TEST(WKHTTPCookieStore, SetSameSiteNoneCookieForLocalhost)
     EXPECT_WK_STREQ("TestCookie=TestValue", receivedCookies);
 }
 
+TEST(WKHTTPCookieStore, SetCookieForLocalhostSubdomain)
+{
+    using namespace TestWebKitAPI;
+
+    RetainPtr cookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"SubCookie",
+        NSHTTPCookieValue: @"SubValue",
+        NSHTTPCookieDomain: @"sub.localhost",
+    }];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    auto dataStore = [WKWebsiteDataStore nonPersistentDataStore];
+    configuration.get().websiteDataStore = dataStore;
+    auto cookieStore = dataStore.httpCookieStore;
+
+    // Set the *.localhost cookie.
+    __block bool done = false;
+    [cookieStore setCookie:cookie.get() completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    // Verify cookie was stored.
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ([cookies count], 1u);
+        NSHTTPCookie *storedCookie = [cookies firstObject];
+        EXPECT_WK_STREQ(@"SubCookie", storedCookie.name);
+        EXPECT_WK_STREQ(@"SubValue", storedCookie.value);
+        EXPECT_WK_STREQ(@"sub.localhost", storedCookie.domain);
+        done = true;
+    }];
+    Util::run(&done);
+}
+
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
 TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1230,6 +1230,63 @@ TEST(WKHTTPCookieStore, SetCookieForLocalhost)
     EXPECT_WK_STREQ("TestCookie=TestValue", receivedCookies);
 }
 
+TEST(WKHTTPCookieStore, SetSecureSameSiteNoneCookieForLocalhost)
+{
+    using namespace TestWebKitAPI;
+
+    RetainPtr cookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"SecureTestCookie",
+        NSHTTPCookieValue: @"SecureTestValue",
+        NSHTTPCookieDomain: @"localhost",
+        NSHTTPCookieSecure: @"TRUE",
+    }];
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    auto dataStore = [WKWebsiteDataStore nonPersistentDataStore];
+    configuration.get().websiteDataStore = dataStore;
+    auto cookieStore = dataStore.httpCookieStore;
+
+    // Set the Secure localhost cookie.
+    __block bool done = false;
+    [cookieStore setCookie:cookie.get() completionHandler:^{
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    // Verify cookie was stored with correct properties.
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ([cookies count], 1u);
+        NSHTTPCookie *storedCookie = [cookies firstObject];
+        EXPECT_WK_STREQ(@"SecureTestCookie", storedCookie.name);
+        EXPECT_TRUE(storedCookie.secure);
+        EXPECT_TRUE(!storedCookie.sameSitePolicy);
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    // Verify cookie is sent in HTTPS requests to localhost.
+    String receivedCookies;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            receivedCookies = HTTPServer::parseCookies(request);
+            co_await connection.awaitableSend(HTTPResponse("hi"_s).serialize());
+        }
+    }, HTTPServer::Protocol::Https);
+
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+    [webView loadRequest:server.requestWithLocalhost()];
+    [delegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ("SecureTestCookie=SecureTestValue", receivedCookies);
+}
+
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
 TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1230,7 +1230,7 @@ TEST(WKHTTPCookieStore, SetCookieForLocalhost)
     EXPECT_WK_STREQ("TestCookie=TestValue", receivedCookies);
 }
 
-TEST(WKHTTPCookieStore, SetSecureSameSiteNoneCookieForLocalhost)
+TEST(WKHTTPCookieStore, SetSecureCookieForLocalhost)
 {
     using namespace TestWebKitAPI;
 
@@ -1285,6 +1285,59 @@ TEST(WKHTTPCookieStore, SetSecureSameSiteNoneCookieForLocalhost)
     [webView loadRequest:server.requestWithLocalhost()];
     [delegate waitForDidFinishNavigation];
     EXPECT_WK_STREQ("SecureTestCookie=SecureTestValue", receivedCookies);
+}
+
+TEST(WKHTTPCookieStore, SetSameSiteNoneCookieForLocalhost)
+{
+    using namespace TestWebKitAPI;
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    auto dataStore = [WKWebsiteDataStore nonPersistentDataStore];
+    configuration.get().websiteDataStore = dataStore;
+    auto cookieStore = dataStore.httpCookieStore;
+
+    // Use an HTTPS localhost server that sets a SameSite=None; Secure cookie via Set-Cookie header.
+    __block String receivedCookies;
+    __block bool firstRequest = true;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            if (firstRequest) {
+                firstRequest = false;
+                co_await connection.awaitableSend(HTTPResponse({ { "Set-Cookie"_s, "TestCookie=TestValue; Secure; SameSite=None"_s } }, "hi"_s).serialize());
+            } else {
+                receivedCookies = HTTPServer::parseCookies(request);
+                co_await connection.awaitableSend(HTTPResponse("hi"_s).serialize());
+            }
+        }
+    }, HTTPServer::Protocol::Https);
+
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    // First navigation sets the cookie via Set-Cookie header.
+    [webView loadRequest:server.requestWithLocalhost()];
+    [delegate waitForDidFinishNavigation];
+
+    // Verify cookie was stored.
+    __block bool done = false;
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ([cookies count], 1u);
+        NSHTTPCookie *storedCookie = [cookies firstObject];
+        EXPECT_WK_STREQ(@"TestCookie", storedCookie.name);
+        EXPECT_TRUE(storedCookie.secure);
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    // Second navigation verifies cookie is sent back.
+    [webView loadRequest:server.requestWithLocalhost()];
+    [delegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ("TestCookie=TestValue", receivedCookies);
 }
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=308525

Reviewed by NOBODY (OOPS!).

`NSHTTPCookieStorage` rejects cookies with `domain: "localhost"` when set
programmatically via `-[NSHTTPCookieStorage setCookie:]`. However, cookies
from HTTP `Set-Cookie` headers without an explicit `Domain` attribute create
host-only cookies that the platform store accepts.

The fix detects localhost domains (including `*.localhost` subdomains) in
`NetworkStorageSession::setCookie()` and routes through the response-cookie
code path, building a synthetic `Set-Cookie` header without `Domain`. This
causes `NSHTTPCookieStorage` to create a host-only cookie bound to the
exact host, which it accepts.

To build the synthetic header correctly, this also introduces
`SameSitePolicy::Default` so that an unset `SameSite` attribute is not
confused with an explicit `SameSite=None`. Expired cookies emit `Max-Age=0`
in the synthetic header so the platform store deletes them rather than
silently ignoring the deletion request.

* Source/WebCore/platform/Cookie.h:
Add `SameSitePolicy::Default` enum value.
* Source/WebCore/platform/network/Cookie.cpp:
Added. `Cookie::toSetCookieHeader()` serializes a `Cookie` struct into a
`Set-Cookie` header string for the synthetic response-cookie path.
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::Cookie::Cookie):
Map `NSHTTPCookieSameSitePolicy` values to the new `Default` policy when
no SameSite attribute is present.
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setCookie):
Detect localhost and `*.localhost` domains and route through the
response-cookie code path with a synthetic `Set-Cookie` header.
* Source/WebCore/platform/network/soup/CookieSoup.cpp:
Handle `SameSitePolicy::Default` in the libsoup backend.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Add `Default` to the `SameSitePolicy` serialization enum.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TestWebKitAPI::TEST(WKHTTPCookieStore, SetCookieForLocalhost)):
(TestWebKitAPI::TEST(WKHTTPCookieStore, SetSecureCookieForLocalhost)):
(TestWebKitAPI::TEST(WKHTTPCookieStore, SetSameSiteNoneCookieForLocalhost)):
(TestWebKitAPI::TEST(WKHTTPCookieStore, SetCookieForLocalhostSubdomain)):
Set a cookie via `WKHTTPCookieStore`, verify storage, then confirm the
cookie is sent in HTTP requests to a localhost server. Also tests
Secure cookies, SameSite=None behavior, and `*.localhost` subdomains.

#### Test

`WKHTTPCookieStore.SetCookieForLocalhost` — sets a cookie via `WKHTTPCookieStore`, verifies storage, then confirms the cookie is sent in HTTP requests to a localhost server.
`WKHTTPCookieStore.SetSecureCookieForLocalhost` — same flow with the `Secure` attribute, verifying it is preserved and the cookie is sent over HTTPS.
`WKHTTPCookieStore.SetSameSiteNoneCookieForLocalhost` — verifies a `SameSite=None; Secure` cookie set via `Set-Cookie` header is stored and sent back on subsequent requests.
`WKHTTPCookieStore.SetCookieForLocalhostSubdomain` — validates cookie storage for `*.localhost` subdomains.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ecc49c6f02d9dbcd3e50f705cd58f70bc5b9725

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114037 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81319 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15430 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13222 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4040 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158935 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2070 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122070 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122273 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132557 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76555 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9319 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83780 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->