### PR TITLE
Further reduce use of protected functions in Source/WebCore

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -437,9 +437,9 @@ RefPtr<AXCoreObject> AccessibilityScrollView::accessibilityHitTest(const IntPoin
     if (!webArea)
         return nullptr;
 
-    if (m_horizontalScrollbar && protectedHorizontalScrollbar()->elementRect().contains(point))
+    if (m_horizontalScrollbar && protect(m_horizontalScrollbar)->elementRect().contains(point))
         return m_horizontalScrollbar.get();
-    if (m_verticalScrollbar && protectedVerticalScrollbar()->elementRect().contains(point))
+    if (m_verticalScrollbar && protect(m_verticalScrollbar)->elementRect().contains(point))
         return m_verticalScrollbar.get();
 
     return webArea->accessibilityHitTest(point);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -105,8 +105,8 @@ private:
     LayoutRect elementRect() const final;
     LayoutRect boundingBoxRect() const final { return elementRect(); }
     AccessibilityObject* parentObject() const final;
-    RefPtr<AccessibilityObject> protectedHorizontalScrollbar() const { return m_horizontalScrollbar; }
-    RefPtr<AccessibilityObject> protectedVerticalScrollbar() const { return m_verticalScrollbar; }
+    AccessibilityObject* horizontalScrollbar() const { return m_horizontalScrollbar.get(); }
+    AccessibilityObject* verticalScrollbar() const { return m_verticalScrollbar.get(); }
     HTMLFrameOwnerElement* frameOwnerElement() const { return m_frameOwnerElement; }
 
     AccessibilityObject* firstChild() const final { return webAreaObject(); }

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -214,7 +214,7 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
     }
 
     // 3. Perform a microtask checkpoint.
-    protect(protectedDocument()->eventLoop())->performMicrotaskCheckpoint();
+    protect(protect(document())->eventLoop())->performMicrotaskCheckpoint();
 
     if (RefPtr documentTimeline = m_document->existingTimeline()) {
         // FIXME: pending animation events should be owned by this controller rather
@@ -315,7 +315,7 @@ void AnimationTimelinesController::resumeAnimations()
 
 ReducedResolutionSeconds AnimationTimelinesController::liveCurrentTime() const
 {
-    return protect(protectedDocument()->window())->nowTimestamp();
+    return protect(protect(document())->window())->nowTimestamp();
 }
 
 std::optional<Seconds> AnimationTimelinesController::currentTime(UseCachedCurrentTime useCachedCurrentTime)
@@ -355,7 +355,7 @@ void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds new
     // start time.
     if (!m_pendingAnimationsProcessingTaskCancellationGroup.hasPendingTask()) {
         CancellableTask task(m_pendingAnimationsProcessingTaskCancellationGroup, std::bind(&AnimationTimelinesController::processPendingAnimations, this));
-        protect(protectedDocument()->eventLoop())->queueTask(TaskSource::InternalAsyncTask, WTF::move(task));
+        protect(protect(document())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, WTF::move(task));
     }
 
     if (!m_isSuspended) {
@@ -389,7 +389,7 @@ void AnimationTimelinesController::processPendingAnimations()
 
 bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimation& animation) const
 {
-    CheckedPtr styleOriginatedTimelinesController = protectedDocument()->styleOriginatedTimelinesController();
+    CheckedPtr styleOriginatedTimelinesController = protect(document())->styleOriginatedTimelinesController();
     return styleOriginatedTimelinesController && styleOriginatedTimelinesController->isPendingTimelineAttachment(animation);
 }
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -89,7 +89,7 @@ private:
     void processPendingAnimations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
 
-    Ref<Document> protectedDocument() const { return m_document.get(); }
+    Document& document() const { return m_document; }
 
 #if ENABLE(THREADED_ANIMATIONS)
     std::unique_ptr<AcceleratedEffectStackUpdater> m_acceleratedEffectStackUpdater;

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -112,7 +112,7 @@ const Settings* CSSComputedStyleDeclaration::settings() const
 
 const FixedVector<CSSPropertyID>& CSSComputedStyleDeclaration::exposedComputedCSSPropertyIDs() const
 {
-    return protect(protectedElement()->document())->exposedComputedCSSPropertyIDs();
+    return protect(protect(element())->document())->exposedComputedCSSPropertyIDs();
 }
 
 String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) const
@@ -130,7 +130,7 @@ unsigned CSSComputedStyleDeclaration::length() const
 
     Style::Extractor::updateStyleIfNeededForProperty(m_element.get(), CSSPropertyCustom);
 
-    CheckedPtr style = protectedElement()->computedStyle(m_pseudoElementIdentifier);
+    CheckedPtr style = protect(element())->computedStyle(m_pseudoElementIdentifier);
     if (!style)
         return 0;
 
@@ -148,7 +148,7 @@ String CSSComputedStyleDeclaration::item(unsigned i) const
     if (i < exposedComputedCSSPropertyIDs().size())
         return nameString(exposedComputedCSSPropertyIDs().at(i));
 
-    CheckedPtr style = protectedElement()->computedStyle(m_pseudoElementIdentifier);
+    CheckedPtr style = protect(element())->computedStyle(m_pseudoElementIdentifier);
     if (!style)
         return String();
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -73,7 +73,7 @@ private:
     ExceptionOr<void> NODELETE setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
     Ref<MutableStyleProperties> copyProperties() const final;
 
-    Ref<Element> protectedElement() const { return m_element; }
+    Element& element() const { return m_element; }
 
     const Settings* NODELETE settings() const final;
     const FixedVector<CSSPropertyID>& exposedComputedCSSPropertyIDs() const;

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -446,7 +446,7 @@ void CSSFontFace::timeoutFired()
     fontLoadEventOccurred();
 }
 
-RefPtr<Document> CSSFontFace::protectedDocument()
+Document* CSSFontFace::document() const
 {
     if (m_wrapper)
         return dynamicDowncast<Document>(m_wrapper->scriptExecutionContext());
@@ -649,7 +649,7 @@ size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
             if (policy == ExternalResourceDownloadPolicy::Allow || !source->requiresExternalResource()) {
                 if (policy == ExternalResourceDownloadPolicy::Allow && m_status == Status::Pending)
                     setStatus(Status::Loading);
-                source->load(m_trustedType, protectedDocument().get());
+                source->load(m_trustedType, protect(document()).get());
             }
         }
 
@@ -721,7 +721,7 @@ RefPtr<Font> CSSFontFace::font(const FontDescription& fontDescription, bool synt
     for (size_t i = startIndex; i < m_sources.size(); ++i) {
         auto& source = m_sources[i];
         if (source->status() == CSSFontFaceSource::Status::Pending && (policy == ExternalResourceDownloadPolicy::Allow || !source->requiresExternalResource()))
-            source->load(m_trustedType, protectedDocument().get());
+            source->load(m_trustedType, protect(document()).get());
 
         switch (source->status()) {
         case CSSFontFaceSource::Status::Pending:

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -171,7 +171,7 @@ private:
     const StyleProperties& properties() const;
     MutableStyleProperties& mutableProperties();
 
-    RefPtr<Document> protectedDocument();
+    Document* document() const;
 
     const Variant<Ref<MutableStyleProperties>, Ref<StyleRuleFontFace>> m_propertiesOrCSSConnection;
     RefPtr<CSSValue> m_family;

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -126,7 +126,7 @@ void CSSFontFaceSource::deref() const
 
 bool CSSFontFaceSource::shouldIgnoreFontLoadCompletions() const
 {
-    return protectedCSSFontFace()->shouldIgnoreFontLoadCompletions();
+    return protect(cssFontFace())->shouldIgnoreFontLoadCompletions();
 }
 
 void CSSFontFaceSource::opportunisticallyStartFontDataURLLoading(DownloadableBinaryFontTrustedTypes trustedType)
@@ -156,7 +156,7 @@ void CSSFontFaceSource::fontLoaded(FontLoadRequest& fontRequest)
     else
         setStatus(Status::Success);
 
-    protectedCSSFontFace()->fontLoaded(*this);
+    protect(cssFontFace())->fontLoaded(*this);
 }
 
 RefPtr<FontCustomPlatformData> CSSFontFaceSource::loadCustomFont(SharedBuffer& buffer, DownloadableBinaryFontTrustedTypes trustedTypes)
@@ -201,7 +201,7 @@ void CSSFontFaceSource::load(DownloadableBinaryFontTrustedTypes trustedTypes, Do
             FontCascadeDescription fontDescription;
             fontDescription.setOneFamily(m_fontFaceName);
             fontDescription.setComputedSize(1);
-            fontDescription.setShouldAllowUserInstalledFonts(protectedCSSFontFace()->allowUserInstalledFonts());
+            fontDescription.setShouldAllowUserInstalledFonts(protect(cssFontFace())->allowUserInstalledFonts());
             success = FontCache::forCurrentThread()->fontForFamily(fontDescription, m_fontFaceName, { }, FontLookupOptions::ExactFamilyNameMatch);
             if (document && document->settings().webAPIStatisticsEnabled())
                 ResourceLoadObserver::singleton().logFontLoad(*document, m_fontFaceName.string(), success);
@@ -261,9 +261,4 @@ bool CSSFontFaceSource::isSVGFontFaceSource() const
     return fontRequest && is<CachedSVGFont>(fontRequest->cachedFont());
 }
 
-Ref<CSSFontFace> CSSFontFaceSource::protectedCSSFontFace() const
-{
-    return m_owningCSSFontFace.get();
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -89,7 +89,7 @@ private:
 
     void NODELETE setStatus(Status);
 
-    Ref<CSSFontFace> NODELETE protectedCSSFontFace() const;
+    CSSFontFace& cssFontFace() const { return m_owningCSSFontFace.get(); }
 
     RefPtr<FontCustomPlatformData> loadCustomFont(SharedBuffer&, DownloadableBinaryFontTrustedTypes);
 

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -66,7 +66,7 @@ template<NumericRaw CSSType> struct StyleImageIsUncacheable<CSSType> {
 };
 
 template<Calc CSSType> struct StyleImageIsUncacheable<CSSType> {
-    constexpr bool operator()(const auto& value) { return value.protectedCalc()->requiresConversionData(); }
+    constexpr bool operator()(const auto& value) { return protect(value.calcValue())->requiresConversionData(); }
 };
 
 template<OptionalLike CSSType> struct StyleImageIsUncacheable<CSSType> {

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -95,7 +95,7 @@ void CSSPositionTryRule::reattach(StyleRuleBase& rule)
 {
     m_positionTryRule = downcast<StyleRulePositionTry>(rule);
     if (RefPtr propertiesCSSOMWrapper = m_propertiesCSSOMWrapper)
-        propertiesCSSOMWrapper->reattach(protect(protectedPositionTryRule()->mutableProperties()));
+        propertiesCSSOMWrapper->reattach(protect(protect(positionTryRule())->mutableProperties()));
 }
 
 AtomString CSSPositionTryRule::name() const
@@ -105,7 +105,7 @@ AtomString CSSPositionTryRule::name() const
 
 CSSPositionTryDescriptors& CSSPositionTryRule::style()
 {
-    Ref mutableProperties = protectedPositionTryRule()->mutableProperties();
+    Ref mutableProperties = protect(positionTryRule())->mutableProperties();
 
     if (!m_propertiesCSSOMWrapper)
         m_propertiesCSSOMWrapper = CSSPositionTryDescriptors::create(mutableProperties.get(), *this);

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -64,7 +64,7 @@ public:
     String cssText() const;
     void reattach(StyleRuleBase&);
 
-    Ref<StyleRulePositionTry> protectedPositionTryRule() const { return m_positionTryRule; }
+    StyleRulePositionTry& positionTryRule() const { return m_positionTryRule; }
 
     WEBCORE_EXPORT AtomString NODELETE name() const;
     WEBCORE_EXPORT CSSPositionTryDescriptors& style();

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -596,11 +596,6 @@ void CSSStyleSheet::removeAdoptingTreeScope(ContainerNode& treeScope)
     styleScopeFor(treeScope).didChangeStyleSheetContents();
 }
 
-Ref<StyleSheetContents> CSSStyleSheet::protectedContents()
-{
-    return m_contents;
-}
-
 void CSSStyleSheet::getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>& childStyleSheets)
 {
     RefPtr ruleList = cssRules();

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -149,7 +149,6 @@ public:
     void reattachChildRuleCSSOMWrappers();
 
     StyleSheetContents& contents() { return m_contents; }
-    Ref<StyleSheetContents> NODELETE protectedContents();
 
     bool isInline() const { return m_isInlineStylesheet; }
     TextPosition startPosition() const { return m_startPosition; }

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -80,7 +80,6 @@ public:
     // Consider removing these functions and having callers use size() and operator[] instead.
     unsigned length() const { return size(); }
     const CSSValue* item(unsigned index) const LIFETIME_BOUND { return index < size() ? &(*this)[index] : nullptr; }
-    RefPtr<const CSSValue> protectedItem(unsigned index) const { return item(index); }
     const CSSValue* itemWithoutBoundsCheck(unsigned index) const LIFETIME_BOUND { return &(*this)[index]; }
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 String DeprecatedCSSOMPrimitiveValue::cssText() const
 {
-    return protectedValue()->cssText(CSS::defaultSerializationContext());
+    return protect(value())->cssText(CSS::defaultSerializationContext());
 }
 
 unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h
@@ -96,7 +96,7 @@ private:
     {
     }
 
-    Ref<const CSSValue> protectedValue() const { return m_value; }
+    const CSSValue& value() const { return m_value; }
 
     Ref<const CSSValue> m_value;
 };

--- a/Source/WebCore/css/PropertySetCSSDescriptors.cpp
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.cpp
@@ -53,11 +53,6 @@ PropertySetCSSDescriptors::PropertySetCSSDescriptors(MutableStyleProperties& pro
 
 PropertySetCSSDescriptors::~PropertySetCSSDescriptors() = default;
 
-Ref<MutableStyleProperties> PropertySetCSSDescriptors::protectedPropertySet() const
-{
-    return m_propertySet;
-}
-
 unsigned PropertySetCSSDescriptors::length() const
 {
     Ref propertySet = m_propertySet;
@@ -87,7 +82,7 @@ String PropertySetCSSDescriptors::item(unsigned i) const
 
 String PropertySetCSSDescriptors::cssText() const
 {
-    return protectedPropertySet()->asText(CSS::defaultSerializationContext());
+    return protect(propertySet())->asText(CSS::defaultSerializationContext());
 }
 
 ExceptionOr<void> PropertySetCSSDescriptors::setCssText(const String& text)
@@ -96,7 +91,7 @@ ExceptionOr<void> PropertySetCSSDescriptors::setCssText(const String& text)
     if (!willMutate())
         return { };
 
-    bool changed = protectedPropertySet()->parseDeclaration(text, cssParserContext());
+    bool changed = protect(propertySet())->parseDeclaration(text, cssParserContext());
     didMutate(changed ? MutationType::PropertyChanged : MutationType::StyleAttributeChanged);
 
     mutationScope.enqueueMutationRecord();
@@ -108,13 +103,13 @@ RefPtr<DeprecatedCSSOMValue> PropertySetCSSDescriptors::getPropertyCSSValue(cons
     auto propertyID = cssPropertyID(propertyName);
     if (!isExposed(propertyID))
         return nullptr;
-    return wrapForDeprecatedCSSOM(protectedPropertySet()->getPropertyCSSValue(propertyID).get());
+    return wrapForDeprecatedCSSOM(protect(propertySet())->getPropertyCSSValue(propertyID).get());
 }
 
 String PropertySetCSSDescriptors::getPropertyValue(const String& propertyName)
 {
     if (styleDeclarationType() == StyleDeclarationType::Function && isCustomPropertyName(propertyName))
-        return protectedPropertySet()->getCustomPropertyValue(propertyName);
+        return protect(propertySet())->getCustomPropertyValue(propertyName);
 
     auto propertyID = cssPropertyID(propertyName);
     if (!isExposed(propertyID))
@@ -127,7 +122,7 @@ String PropertySetCSSDescriptors::getPropertyPriority(const String& propertyName
     auto propertyID = cssPropertyID(propertyName);
     if (!isExposed(propertyID))
         return emptyString();
-    return protectedPropertySet()->propertyIsImportant(propertyID) ? "important"_s : emptyString();
+    return protect(propertySet())->propertyIsImportant(propertyID) ? "important"_s : emptyString();
 }
 
 String PropertySetCSSDescriptors::getPropertyShorthand(const String& propertyName)
@@ -135,12 +130,12 @@ String PropertySetCSSDescriptors::getPropertyShorthand(const String& propertyNam
     auto propertyID = cssPropertyID(propertyName);
     if (!isExposed(propertyID))
         return String();
-    return protectedPropertySet()->getPropertyShorthand(propertyID);
+    return protect(propertySet())->getPropertyShorthand(propertyID);
 }
 
 bool PropertySetCSSDescriptors::isPropertyImplicit(const String& propertyName)
 {
-    return protectedPropertySet()->isPropertyImplicit(cssPropertyID(propertyName));
+    return protect(propertySet())->isPropertyImplicit(cssPropertyID(propertyName));
 }
 
 ExceptionOr<void> PropertySetCSSDescriptors::setProperty(const String& propertyName, const String& value, const String& priority)
@@ -158,7 +153,7 @@ ExceptionOr<void> PropertySetCSSDescriptors::setProperty(const String& propertyN
     if (!important && !priority.isEmpty())
         return { };
 
-    bool changed = protectedPropertySet()->setProperty(propertyID, value, cssParserContext(), important ? IsImportant::Yes : IsImportant::No);
+    bool changed = protect(propertySet())->setProperty(propertyID, value, cssParserContext(), important ? IsImportant::Yes : IsImportant::No);
 
     didMutate(changed ? MutationType::PropertyChanged : MutationType::NoChanges);
 
@@ -183,7 +178,7 @@ ExceptionOr<String> PropertySetCSSDescriptors::removeProperty(const String& prop
         return String();
 
     String result;
-    bool changed = protectedPropertySet()->removeProperty(propertyID, &result);
+    bool changed = protect(propertySet())->removeProperty(propertyID, &result);
 
     didMutate(changed ? MutationType::PropertyChanged : MutationType::NoChanges);
 
@@ -197,7 +192,7 @@ String PropertySetCSSDescriptors::getPropertyValueInternal(CSSPropertyID propert
     if (!isExposed(propertyID))
         return { };
 
-    auto value = protectedPropertySet()->getPropertyValue(propertyID);
+    auto value = protect(propertySet())->getPropertyValue(propertyID);
 
     if (!value.isEmpty())
         return value;
@@ -214,7 +209,7 @@ ExceptionOr<void> PropertySetCSSDescriptors::setPropertyInternal(CSSPropertyID p
     if (!isExposed(propertyID))
         return { };
 
-    if (protectedPropertySet()->setProperty(propertyID, value, cssParserContext(), important)) {
+    if (protect(propertySet())->setProperty(propertyID, value, cssParserContext(), important)) {
         didMutate(MutationType::PropertyChanged);
         mutationScope.enqueueMutationRecord();
     } else
@@ -304,7 +299,7 @@ CSSRule* PropertySetCSSDescriptors::parentRule() const
 CSSParserContext PropertySetCSSDescriptors::cssParserContext() const
 {
     RefPtr cssStyleSheet = parentStyleSheet();
-    auto context = cssStyleSheet ? cssStyleSheet->contents().parserContext() : CSSParserContext(protectedPropertySet()->cssParserMode());
+    auto context = cssStyleSheet ? cssStyleSheet->contents().parserContext() : CSSParserContext(protect(propertySet())->cssParserMode());
 
     context.enclosingRuleType = ruleType();
 

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -81,7 +81,7 @@ protected:
     virtual ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant);
 
     CSSParserContext cssParserContext() const;
-    Ref<MutableStyleProperties> NODELETE protectedPropertySet() const;
+    MutableStyleProperties& propertySet() const { return m_propertySet; }
 
     WeakPtr<CSSRule> m_parentRule;
     HashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -691,11 +691,6 @@ Ref<StyleRuleBase> CSSParser::createNestedDeclarationsRule()
     return StyleRuleNestedDeclarations::create(WTF::move(properties));
 }
 
-RefPtr<StyleSheetContents> CSSParser::protectedStyleSheet() const
-{
-    return m_styleSheet;
-}
-
 Vector<Ref<StyleRuleBase>> CSSParser::consumeNestedGroupRules(CSSParserTokenRange block)
 {
     NestingLevelIncrementer incrementer { m_ruleListNestingLevel };
@@ -1025,7 +1020,7 @@ RefPtr<StyleRuleKeyframes> CSSParser::consumeKeyframesRule(CSSParserTokenRange p
 
 RefPtr<StyleRulePage> CSSParser::consumePageRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    auto selectorList = parsePageSelector(prelude, protectedStyleSheet().get());
+    auto selectorList = parsePageSelector(prelude, protect(styleSheet()).get());
     if (selectorList.isEmpty())
         return nullptr; // Parse error, invalid @page selector
 
@@ -1226,7 +1221,7 @@ RefPtr<StyleRuleScope> CSSParser::consumeScopeRule(CSSParserTokenRange prelude, 
                 auto selectorListRange = selectorListRangeStart.rangeUntil(prelude);
 
                 // Parse the selector list range
-                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), ancestorRuleType, CSSParserEnum::IsForgiving::No, CSSSelectorParser::DisallowPseudoElement::Yes);
+                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protect(styleSheet()).get(), ancestorRuleType, CSSParserEnum::IsForgiving::No, CSSSelectorParser::DisallowPseudoElement::Yes);
                 if (mutableSelectorList.isEmpty())
                     return false;
 
@@ -1515,7 +1510,7 @@ RefPtr<StyleRuleBase> CSSParser::consumeStyleRule(CSSParserTokenRange prelude, C
         return nullptr;
 
     auto preludeCopyForInspector = prelude;
-    auto mutableSelectorList = parseMutableCSSSelectorList(prelude, m_context, protectedStyleSheet().get(), lastAncestorRuleType(), CSSParserEnum::IsForgiving::No, CSSSelectorParser::DisallowPseudoElement::No);
+    auto mutableSelectorList = parseMutableCSSSelectorList(prelude, m_context, protect(styleSheet()).get(), lastAncestorRuleType(), CSSParserEnum::IsForgiving::No, CSSSelectorParser::DisallowPseudoElement::No);
 
     if (mutableSelectorList.isEmpty())
         return nullptr; // Parse error, invalid selector list

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -198,7 +198,7 @@ private:
     void consumeDeclarationValue(CSSParserTokenRange, CSSPropertyID, IsImportant, StyleRuleType);
     void consumeCustomPropertyValue(CSSParserTokenRange, const AtomString& propertyName, IsImportant);
 
-    RefPtr<StyleSheetContents> protectedStyleSheet() const;
+    StyleSheetContents* styleSheet() const { return m_styleSheet.get(); }
 
     Ref<StyleRuleBase> createNestedDeclarationsRule();
     void runInNewNestingContext(auto&& run);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -52,7 +52,7 @@ struct CSSPrimitiveValueResolverBase {
 
     static RefPtr<CSSPrimitiveValue> resolve(CSS::Calc auto value, CSSPropertyParserOptions = { })
     {
-        return CSSPrimitiveValue::create(value.protectedCalc());
+        return CSSPrimitiveValue::create(protect(value.calcValue()));
     }
 
     static RefPtr<CSSPrimitiveValue> resolve(CSS::Numeric auto value, CSSPropertyParserOptions options = { })

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -183,8 +183,8 @@ static bool isGridTrackFixedSized(const CSSValue& value)
     if (function.name() == CSSValueFitContent || function.length() < 2)
         return false;
 
-    return isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*function.protectedItem(0)))
-        || isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*function.protectedItem(1)));
+    return isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*protect(function.item(0))))
+        || isGridTrackFixedSized(downcast<CSSPrimitiveValue>(*protect(function.item(1))));
 }
 
 static RefPtr<CSSPrimitiveValue> consumeGridBreadth(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -234,14 +234,9 @@ bool SizesAttributeParser::mediaConditionMatches(const MQ::MediaQuery& mediaCond
     return MQ::MediaQueryEvaluator { screenAtom(), document, style.ptr() }.evaluate(mediaCondition);
 }
 
-Ref<const Document> SizesAttributeParser::protectedDocument() const
-{
-    return m_document.get();
-}
-
 std::optional<CSSToLengthConversionData> SizesAttributeParser::conversionData() const
 {
-    CheckedPtr renderer = protectedDocument()->renderView();
+    CheckedPtr renderer = protect(document())->renderView();
     if (!renderer)
         return std::nullopt;
     CheckedRef style = renderer->style();

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -58,7 +58,7 @@ private:
 
     bool mediaConditionMatches(const MQ::MediaQuery&);
 
-    Ref<const Document> NODELETE protectedDocument() const;
+    const Document& document() const { return m_document.get(); }
     std::optional<CSSToLengthConversionData> conversionData() const;
     float effectiveSizeDefaultValue();
 

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
@@ -44,7 +44,7 @@ public:
 private:
     explicit ComputedStylePropertyMapReadOnly(Element&);
 
-    RefPtr<Element> protectedElement() const { return m_element; }
+    Element* element() const { return m_element.get(); }
 
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
@@ -251,7 +251,7 @@ template<Numeric N, PrimitiveKeyword... Ks> struct PrimitiveData {
     }
 
     PrimitiveData(Calc calc)
-        : payload { &calc.protectedCalc().leakRef() }
+        : payload { &protect(calc.calcValue()).leakRef() }
         , index { calc }
     {
     }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
@@ -44,7 +44,7 @@ template<NumericRaw CSSType> struct CSSValueCreation<CSSType> {
 template<Calc CSSType> struct CSSValueCreation<CSSType> {
     Ref<CSSValue> operator()(CSSValuePool&, const CSSType& calc)
     {
-        return CSSPrimitiveValue::create(calc.protectedCalc());
+        return CSSPrimitiveValue::create(protect(calc.calcValue()));
     }
 };
 

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -63,11 +63,6 @@ UnevaluatedCalcBase& UnevaluatedCalcBase::operator=(UnevaluatedCalcBase&&) = def
 
 UnevaluatedCalcBase::~UnevaluatedCalcBase() = default;
 
-Ref<CSSCalc::Value> UnevaluatedCalcBase::protectedCalc() const
-{
-    return calc;
-}
-
 CSSCalc::Value& UnevaluatedCalcBase::leakRef()
 {
     return calc.leakRef();
@@ -75,27 +70,27 @@ CSSCalc::Value& UnevaluatedCalcBase::leakRef()
 
 bool UnevaluatedCalcBase::equal(const UnevaluatedCalcBase& other) const
 {
-    return protectedCalc()->equals(other.calc.get());
+    return protect(calcValue())->equals(other.calc.get());
 }
 
 bool UnevaluatedCalcBase::requiresConversionData() const
 {
-    return protectedCalc()->requiresConversionData();
+    return protect(calcValue())->requiresConversionData();
 }
 
 void UnevaluatedCalcBase::serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context) const
 {
-    builder.append(protectedCalc()->cssText(context));
+    builder.append(protect(calcValue())->cssText(context));
 }
 
 void UnevaluatedCalcBase::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
-    protectedCalc()->collectComputedStyleDependencies(dependencies);
+    protect(calcValue())->collectComputedStyleDependencies(dependencies);
 }
 
 UnevaluatedCalcBase UnevaluatedCalcBase::simplifyBase(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
-    return UnevaluatedCalcBase { protectedCalc()->copySimplified(conversionData, symbolTable) };
+    return UnevaluatedCalcBase { protect(calcValue())->copySimplified(conversionData, symbolTable) };
 }
 
 double UnevaluatedCalcBase::evaluate(CSS::Category category, const Style::BuilderState& state) const
@@ -115,8 +110,8 @@ double UnevaluatedCalcBase::evaluate(CSS::Category category, const CSSToLengthCo
 
 double UnevaluatedCalcBase::evaluate(CSS::Category category, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
-    ASSERT_UNUSED(category, protectedCalc()->category() == category);
-    return protectedCalc()->doubleValue(conversionData, symbolTable);
+    ASSERT_UNUSED(category, protect(calcValue())->category() == category);
+    return protect(calcValue())->doubleValue(conversionData, symbolTable);
 }
 
 double UnevaluatedCalcBase::evaluate(CSS::Category category, NoConversionDataRequiredToken token) const
@@ -126,8 +121,8 @@ double UnevaluatedCalcBase::evaluate(CSS::Category category, NoConversionDataReq
 
 double UnevaluatedCalcBase::evaluate(CSS::Category category, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) const
 {
-    ASSERT_UNUSED(category, protectedCalc()->category() == category);
-    return protectedCalc()->doubleValue(token, symbolTable);
+    ASSERT_UNUSED(category, protect(calcValue())->category() == category);
+    return protect(calcValue())->doubleValue(token, symbolTable);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -70,7 +70,7 @@ struct UnevaluatedCalcBase {
     UnevaluatedCalcBase& operator=(UnevaluatedCalcBase&&);
     ~UnevaluatedCalcBase();
 
-    Ref<CSSCalc::Value> NODELETE protectedCalc() const;
+    CSSCalc::Value& calcValue() const { return calc; }
     [[nodiscard]] CSSCalc::Value& NODELETE leakRef();
 
     bool requiresConversionData() const;

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -233,7 +233,7 @@ void ProcessingInstruction::parseStyleSheet(const String& sheet)
 {
     Ref styleSheet = *m_sheet;
     if (m_isCSS)
-        downcast<CSSStyleSheet>(styleSheet.get()).protectedContents()->parseString(sheet);
+        protect(downcast<CSSStyleSheet>(styleSheet.get()).contents())->parseString(sheet);
 #if ENABLE(XSLT)
     else if (m_isXSL)
         downcast<XSLStyleSheet>(styleSheet.get()).parseString(sheet);
@@ -245,7 +245,7 @@ void ProcessingInstruction::parseStyleSheet(const String& sheet)
     m_loading = false;
 
     if (m_isCSS)
-        downcast<CSSStyleSheet>(styleSheet.get()).protectedContents()->checkLoaded();
+        protect(downcast<CSSStyleSheet>(styleSheet.get()).contents())->checkLoaded();
 #if ENABLE(XSLT)
     else if (m_isXSL)
         downcast<XSLStyleSheet>(styleSheet.get()).checkLoaded();

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -177,7 +177,7 @@ void HTMLStyleElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
     HTMLElement::addSubresourceAttributeURLs(urls);
 
     if (RefPtr sheet = this->sheet()) {
-        sheet->protectedContents()->traverseSubresources([&] (auto& resource) {
+        protect(sheet->contents())->traverseSubresources([&] (auto& resource) {
             urls.add(resource.url());
             return false;
         });

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -274,14 +274,14 @@ void InspectorFrontendClientLocal::setDockingUnavailable(bool unavailable)
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockingUnavailable"_s, { JSON::Value::create(unavailable) });
 }
 
-RefPtr<PageInspectorController> InspectorFrontendClientLocal::protectedInspectedPageController() const
+PageInspectorController* InspectorFrontendClientLocal::inspectedPageController() const
 {
     return m_inspectedPageController.get();
 }
 
 void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 {
-    unsigned totalHeight = protect(protect(protect(frontendPage())->mainFrame())->virtualView())->visibleHeight() + protect(protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->virtualView())->visibleHeight();
+    unsigned totalHeight = protect(protect(protect(frontendPage())->mainFrame())->virtualView())->visibleHeight() + protect(protect(protect(protect(inspectedPageController())->inspectedPage())->mainFrame())->virtualView())->visibleHeight();
     unsigned attachedHeight = constrainedAttachedWindowHeight(height, totalHeight);
     m_settings->setProperty(inspectorAttachedHeightSetting, String::number(attachedHeight));
     setAttachedWindowHeight(attachedHeight);
@@ -289,7 +289,7 @@ void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 
 void InspectorFrontendClientLocal::changeAttachedWindowWidth(unsigned width)
 {
-    unsigned totalWidth = protect(protect(protect(frontendPage())->mainFrame())->virtualView())->visibleWidth() + protect(protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->virtualView())->visibleWidth();
+    unsigned totalWidth = protect(protect(protect(frontendPage())->mainFrame())->virtualView())->visibleWidth() + protect(protect(protect(protect(inspectedPageController())->inspectedPage())->mainFrame())->virtualView())->visibleWidth();
     unsigned attachedWidth = constrainedAttachedWindowWidth(width, totalWidth);
     setAttachedWindowWidth(attachedWidth);
 }
@@ -301,7 +301,7 @@ void InspectorFrontendClientLocal::changeSheetRect(const FloatRect& rect)
 
 void InspectorFrontendClientLocal::openURLExternally(const String& url)
 {
-    RefPtr localMainFrame = protect(protectedInspectedPageController()->inspectedPage())->localMainFrame();
+    RefPtr localMainFrame = protect(protect(inspectedPageController())->inspectedPage())->localMainFrame();
     if (!localMainFrame)
         return;
     Ref mainFrame = *localMainFrame;
@@ -359,7 +359,7 @@ void InspectorFrontendClientLocal::setAttachedWindow(DockSide dockSide)
 
 void InspectorFrontendClientLocal::restoreAttachedWindowHeight()
 {
-    unsigned inspectedPageHeight = protect(protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->virtualView())->visibleHeight();
+    unsigned inspectedPageHeight = protect(protect(protect(protect(inspectedPageController())->inspectedPage())->mainFrame())->virtualView())->visibleHeight();
     String value = m_settings->getProperty(inspectorAttachedHeightSetting);
     unsigned preferredHeight = value.isEmpty() ? defaultAttachedHeight : parseIntegerAllowingTrailingJunk<unsigned>(value).value_or(0);
 
@@ -430,7 +430,7 @@ void InspectorFrontendClientLocal::showResources()
 
 void InspectorFrontendClientLocal::showMainResourceForFrame(LocalFrame* frame)
 {
-    String frameId = CheckedRef { protectedInspectedPageController()->ensurePageAgent() }->frameId(frame);
+    String frameId = CheckedRef { protect(inspectedPageController())->ensurePageAgent() }->frameId(frame);
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("showMainResourceForFrame"_s, { JSON::Value::create(frameId) });
 }
 
@@ -456,7 +456,7 @@ bool InspectorFrontendClientLocal::isUnderTest()
 
 unsigned InspectorFrontendClientLocal::inspectionLevel() const
 {
-    return protectedInspectedPageController()->inspectionLevel() + 1;
+    return protect(inspectedPageController())->inspectionLevel() + 1;
 }
 
 Page* InspectorFrontendClientLocal::inspectedPage() const

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -147,7 +147,7 @@ private:
     friend class FrontendMenuProvider;
     std::optional<bool> evaluationResultToBoolean(InspectorFrontendAPIDispatcher::EvaluationResult);
 
-    RefPtr<PageInspectorController> protectedInspectedPageController() const;
+    PageInspectorController* NODELETE inspectedPageController() const;
 
     WeakPtr<PageInspectorController> m_inspectedPageController;
     WeakPtr<Page> m_frontendPage;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -278,7 +278,7 @@ private:
 
     void relayoutDocument();
 
-    Ref<InspectorOverlay> protectedOverlay() const;
+    InspectorOverlay& overlay() const { return m_overlay.get(); }
 
     const CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
     const UniqueRef<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h
@@ -65,7 +65,7 @@ public:
     void clearObjectStore(const String& securityOrigin, const String& databaseName, const String& objectStoreName, Ref<ClearObjectStoreCallback>&&);
 
 private:
-    Ref<Page> protectedInspectedPage() const;
+    Page& inspectedPage() const { return m_inspectedPage.get(); }
 
     const CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::IndexedDBBackendDispatcher> m_backendDispatcher;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -99,7 +99,7 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorPageAgent);
 
-Ref<InspectorOverlay> InspectorPageAgent::protectedOverlay() const
+InspectorOverlay& InspectorPageAgent::overlay() const
 {
     return m_overlay.get();
 }
@@ -645,7 +645,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::
 #if !PLATFORM(IOS_FAMILY)
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setShowRulers(bool showRulers)
 {
-    protectedOverlay()->setShowRulers(showRulers);
+    protect(overlay())->setShowRulers(showRulers);
 
     return { };
 }
@@ -659,7 +659,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setShowPaintRects(b
     if (m_client->overridesShowPaintRects())
         return { };
 
-    protectedOverlay()->setShowPaintRects(show);
+    protect(overlay())->setShowPaintRects(show);
 
     return { };
 }
@@ -804,7 +804,7 @@ void InspectorPageAgent::didPaint(RenderObject& renderer, const LayoutRect& rect
         return;
     }
 
-    protectedOverlay()->showPaintRect(rootRect);
+    protect(overlay())->showPaintRect(rootRect);
 }
 
 void InspectorPageAgent::didLayout()
@@ -813,7 +813,7 @@ void InspectorPageAgent::didLayout()
     if (isFirstLayout)
         m_isFirstLayoutAfterOnLoad = false;
 
-    protectedOverlay()->update();
+    protect(overlay())->update();
 }
 
 void InspectorPageAgent::didScroll()
@@ -823,7 +823,7 @@ void InspectorPageAgent::didScroll()
 
 void InspectorPageAgent::didRecalculateStyle()
 {
-    protectedOverlay()->update();
+    protect(overlay())->update();
 }
 
 Ref<Inspector::Protocol::Page::Frame> InspectorPageAgent::buildObjectForFrame(LocalFrame* frame)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -129,7 +129,7 @@ public:
 private:
     double timestamp();
 
-    Ref<InspectorOverlay> protectedOverlay() const;
+    InspectorOverlay& NODELETE overlay() const;
 
     void overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
@@ -52,14 +52,9 @@ WorkerDebuggerAgent::WorkerDebuggerAgent(WorkerAgentContext& context)
 
 WorkerDebuggerAgent::~WorkerDebuggerAgent() = default;
 
-Ref<WorkerOrWorkletGlobalScope> WorkerDebuggerAgent::protectedGlobalScope() const
-{
-    return m_globalScope.get();
-}
-
 void WorkerDebuggerAgent::breakpointActionLog(JSGlobalObject* lexicalGlobalObject, const String& message)
 {
-    protectedGlobalScope()->addConsoleMessage(makeUnique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Log, message, createScriptCallStack(lexicalGlobalObject)));
+    protect(globalScope())->addConsoleMessage(makeUnique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Log, message, createScriptCallStack(lexicalGlobalObject)));
 }
 
 InjectedScript WorkerDebuggerAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
@@ -71,7 +66,7 @@ InjectedScript WorkerDebuggerAgent::injectedScriptForEval(Inspector::Protocol::E
 
     // FIXME: What guarantees m_globalScope.script() is non-null?
     // FIXME: What guarantees globalScopeWrapper() is non-null?
-    return injectedScriptManager().injectedScriptFor(protectedGlobalScope()->script()->globalScopeWrapper());
+    return injectedScriptManager().injectedScriptFor(protect(globalScope())->script()->globalScopeWrapper());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h
@@ -49,7 +49,7 @@ private:
     void muteConsole() { }
     void unmuteConsole() { }
 
-    Ref<WorkerOrWorkletGlobalScope> protectedGlobalScope() const;
+    WorkerOrWorkletGlobalScope& globalScope() const { return m_globalScope.get(); }
 
     Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
 

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -135,7 +135,7 @@ bool RenderMarquee::isHorizontal() const
 
 int RenderMarquee::computePosition(MarqueeDirection dir, bool stopAtContentEdge)
 {
-    CheckedPtr box = protectedLayer()->renderBox();
+    CheckedPtr box = protect(layer())->renderBox();
     ASSERT(box);
     CheckedRef boxStyle = box->style();
     if (isHorizontal()) {
@@ -216,7 +216,7 @@ void RenderMarquee::updateMarqueePosition()
 {
     bool activate = (m_totalLoops <= 0 || m_currentLoop < m_totalLoops);
     if (activate) {
-        MarqueeBehavior behavior = protectedLayer()->renderer().style().marqueeBehavior();
+        MarqueeBehavior behavior = protect(layer())->renderer().style().marqueeBehavior();
         m_start = computePosition(direction(), behavior == MarqueeBehavior::Alternate);
         m_end = computePosition(reverseDirection(direction()), behavior == MarqueeBehavior::Alternate || behavior == MarqueeBehavior::Slide);
         if (!m_stopped)

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -83,7 +83,7 @@ private:
 
     void timerFired();
 
-    CheckedRef<RenderLayer> protectedLayer() { return m_layer.get(); }
+    RenderLayer& layer() { return m_layer.get(); }
 
     InlineWeakRef<RenderLayer> m_layer;
     Timer m_timer;

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -123,7 +123,7 @@ void RenderSearchField::showPopup()
     FloatPoint absTopLeft = localToAbsolute(FloatPoint(), UseTransforms);
     IntRect absBounds = absoluteBoundingBoxRectIgnoringTransforms();
     absBounds.setLocation(roundedIntPoint(absTopLeft));
-    protect(protectedSearchPopup()->popupMenu())->show(absBounds, view().frameView(), -1);
+    protect(protect(m_searchPopup)->popupMenu())->show(absBounds, view().frameView(), -1);
 }
 
 void RenderSearchField::hidePopup()
@@ -158,7 +158,7 @@ std::span<const RecentSearch> RenderSearchField::recentSearches()
     auto& recentSearches = downcast<SearchInputType>(*protect(inputElement())->inputType()).recentSearches();
 
     const AtomString& name = autosaveName();
-    protectedSearchPopup()->loadRecentSearches(name, recentSearches);
+    protect(m_searchPopup)->loadRecentSearches(name, recentSearches);
 
     return recentSearches.span();
 }
@@ -171,7 +171,7 @@ void RenderSearchField::updateFromElement()
         updateCancelButtonVisibility();
 
     if (m_searchPopupIsVisible)
-        protect(protectedSearchPopup()->popupMenu())->updateFromElement();
+        protect(protect(m_searchPopup)->popupMenu())->updateFromElement();
 }
 
 void RenderSearchField::updateCancelButtonVisibility() const
@@ -204,7 +204,7 @@ void RenderSearchField::updatePopup(const AtomString& name, const Vector<RecentS
 {
     if (!m_searchPopup)
         m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
-    protectedSearchPopup()->saveRecentSearches(name, searchItems);
+    protect(m_searchPopup)->saveRecentSearches(name, searchItems);
 }
 
 void RenderSearchField::popupDidHide()

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -61,7 +61,7 @@ private:
     Visibility visibilityForCancelButton() const;
     const AtomString& autosaveName() const;
 
-    RefPtr<SearchPopupMenu> protectedSearchPopup() const { return m_searchPopup; };
+    SearchPopupMenu* searchPopup() const { return m_searchPopup.get(); }
 
     HTMLElement* resultsButtonElement() const;
     HTMLElement* cancelButtonElement() const;

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -344,7 +344,7 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePerce
         // NOTE: Simplification is needed here for the case of the user using the Typed CSSOM
         // to explicitly specify a CSSMath* value for a specified value.
 
-        Ref simplifiedCalc = value.protectedCalc()->copySimplified(rest...);
+        Ref simplifiedCalc = protect(value.calcValue())->copySimplified(rest...);
 
         // FIXME: This ASSERT and the following extra cases for Category::Angle and Category::Percentage
         // should go away once the typed CSSOM learns to set the correct category when creating internal
@@ -378,7 +378,7 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPerc
         // NOTE: Simplification is needed here for the case of the user using the Typed CSSOM
         // to explicitly specify a CSSMath* value for a specified value.
 
-        Ref simplifiedCalc = value.protectedCalc()->copySimplified(rest...);
+        Ref simplifiedCalc = protect(value.calcValue())->copySimplified(rest...);
 
         // FIXME: This ASSERT and the following extra cases for Category::Length and Category::Percentage
         // should go away once the typed CSSOM learns to set the correct category when creating internal

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
@@ -71,7 +71,7 @@ auto CSSValueConversion<SVGPaint>::operator()(BuilderState& state, const CSSValu
             }
         }
 
-        return SVGPaint::URLColor { url, toStyleFromCSSValue<Color>(state, *list->protectedItem(1), forVisitedLink) };
+        return SVGPaint::URLColor { url, toStyleFromCSSValue<Color>(state, *protect(list->item(1)), forVisitedLink) };
     }
 
     if (RefPtr urlValue = dynamicDowncast<CSSURLValue>(value))

--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -235,7 +235,7 @@ void WorkerConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, R
 
     if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         if (dataURL.isEmpty()) {
-            InspectorInstrumentation::addMessageToConsole(protectedGlobalScope(), makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Image, MessageLevel::Error, "Could not capture screenshot"_s, WTF::move(arguments)));
+            InspectorInstrumentation::addMessageToConsole(protect(globalScope()), makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Image, MessageLevel::Error, "Could not capture screenshot"_s, WTF::move(arguments)));
             return;
         }
     }
@@ -245,12 +245,7 @@ void WorkerConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, R
     adjustedArguments.append({ vm, target ? target : JSC::jsNontrivialString(vm, "Viewport"_s) });
     for (size_t i = (!target ? 0 : 1); i < arguments->argumentCount(); ++i)
         adjustedArguments.append({ vm, arguments->argumentAt(i) });
-    InspectorInstrumentation::addMessageToConsole(protectedGlobalScope(), makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Image, MessageLevel::Log, dataURL, ScriptArguments::create(lexicalGlobalObject, WTF::move(adjustedArguments)), lexicalGlobalObject, /* requestIdentifier */ 0, timestamp));
-}
-
-Ref<WorkerOrWorkletGlobalScope> WorkerConsoleClient::protectedGlobalScope()
-{
-    return m_globalScope.get();
+    InspectorInstrumentation::addMessageToConsole(protect(globalScope()), makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Image, MessageLevel::Log, dataURL, ScriptArguments::create(lexicalGlobalObject, WTF::move(adjustedArguments)), lexicalGlobalObject, /* requestIdentifier */ 0, timestamp));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerConsoleClient.h
+++ b/Source/WebCore/workers/WorkerConsoleClient.h
@@ -60,7 +60,7 @@ private:
     void recordEnd(JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) override;
     void screenshot(JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) override;
 
-    Ref<WorkerOrWorkletGlobalScope> protectedGlobalScope();
+    WorkerOrWorkletGlobalScope& globalScope() { return m_globalScope; }
 
     WeakRef<WorkerOrWorkletGlobalScope> m_globalScope;
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -62,11 +62,6 @@ static inline IDBClient::IDBConnectionProxy* idbConnectionProxy(Document& docume
     return document.idbConnectionProxy();
 }
 
-static inline RefPtr<IDBClient::IDBConnectionProxy> protectedIDBConnectionProxy(Document& document)
-{
-    return idbConnectionProxy(document);
-}
-
 static ThreadSafeWeakHashSet<ServiceWorkerThreadProxy>& allServiceWorkerThreadProxies()
 {
     static MainThreadNeverDestroyed<ThreadSafeWeakHashSet<ServiceWorkerThreadProxy>> set;
@@ -79,7 +74,7 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWork
 #if ENABLE(REMOTE_INSPECTOR)
     , m_remoteDebuggable(ServiceWorkerDebuggable::create(*this, contextData))
 #endif
-    , m_serviceWorkerThread(ServiceWorkerThread::create(WTF::move(contextData), WTF::move(workerData), WTF::move(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, protectedIDBConnectionProxy(m_document).get(), protect(m_document->socketProvider()).get(), WTF::move(notificationClient), m_page->sessionID(), m_document->noiseInjectionHashSalt(), m_document->advancedPrivacyProtections()))
+    , m_serviceWorkerThread(ServiceWorkerThread::create(WTF::move(contextData), WTF::move(workerData), WTF::move(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, protect(idbConnectionProxy(m_document)).get(), protect(m_document->socketProvider()).get(), WTF::move(notificationClient), m_page->sessionID(), m_document->noiseInjectionHashSalt(), m_document->advancedPrivacyProtections()))
     , m_cacheStorageProvider(cacheStorageProvider)
     , m_inspectorProxy(*this)
 {

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -206,7 +206,6 @@ public:
     WEBCORE_EXPORT void addConnection(Ref<Connection>&&);
     WEBCORE_EXPORT void removeConnection(SWServerConnectionIdentifier);
     Connection* connection(SWServerConnectionIdentifier identifier) const { return m_connections.get(identifier); }
-    RefPtr<Connection> protectedConnection(SWServerConnectionIdentifier identifier) const { return connection(identifier); }
 
     const HashMap<SWServerConnectionIdentifier, Ref<Connection>>& connections() const { return m_connections; }
     WEBCORE_EXPORT bool canHandleScheme(StringView) const;

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -108,7 +108,7 @@ void SWServerJobQueue::scriptFetchFinished(const ServiceWorkerJobDataIdentifier&
         auto scriptURLs = newestWorker->importedScriptURLs();
         if (!scriptURLs.isEmpty()) {
             m_workerFetchResult = WTF::move(result);
-            protectedServer()->refreshImportedScripts(job, *registration, scriptURLs, requestingProcessIdentifier);
+            server->refreshImportedScripts(job, *registration, scriptURLs, requestingProcessIdentifier);
             return;
         }
 
@@ -119,7 +119,7 @@ void SWServerJobQueue::scriptFetchFinished(const ServiceWorkerJobDataIdentifier&
         return;
     }
 
-    protectedServer()->updateWorker(job.identifier(), requestingProcessIdentifier, *registration, job.scriptURL, result.script, result.certificateInfo, result.contentSecurityPolicy, result.crossOriginEmbedderPolicy, result.referrerPolicy, job.workerType, { }, job.serviceWorkerPageIdentifier());
+    server->updateWorker(job.identifier(), requestingProcessIdentifier, *registration, job.scriptURL, result.script, result.certificateInfo, result.contentSecurityPolicy, result.crossOriginEmbedderPolicy, result.referrerPolicy, job.workerType, { }, job.serviceWorkerPageIdentifier());
 }
 
 void SWServerJobQueue::importedScriptsFetchFinished(const ServiceWorkerJobDataIdentifier& jobDataIdentifier, const Vector<std::pair<URL, ScriptBuffer>>& importedScripts, const std::optional<ProcessIdentifier>& requestingProcessIdentifier)
@@ -129,7 +129,7 @@ void SWServerJobQueue::importedScriptsFetchFinished(const ServiceWorkerJobDataId
 
     auto& job = firstJob();
 
-    RefPtr registration = protectedServer()->getRegistration(m_registrationKey);
+    RefPtr registration = protect(server())->getRegistration(m_registrationKey);
     if (!registration)
         return;
 
@@ -140,13 +140,13 @@ void SWServerJobQueue::importedScriptsFetchFinished(const ServiceWorkerJobDataId
         return;
     }
 
-    protectedServer()->updateWorker(job.identifier(), requestingProcessIdentifier, *registration, job.scriptURL, m_workerFetchResult.script, m_workerFetchResult.certificateInfo, m_workerFetchResult.contentSecurityPolicy, m_workerFetchResult.crossOriginEmbedderPolicy, m_workerFetchResult.referrerPolicy, job.workerType, { }, job.serviceWorkerPageIdentifier());
+    protect(server())->updateWorker(job.identifier(), requestingProcessIdentifier, *registration, job.scriptURL, m_workerFetchResult.script, m_workerFetchResult.certificateInfo, m_workerFetchResult.contentSecurityPolicy, m_workerFetchResult.crossOriginEmbedderPolicy, m_workerFetchResult.referrerPolicy, job.workerType, { }, job.serviceWorkerPageIdentifier());
 }
 
 void SWServerJobQueue::scriptAndImportedScriptsFetchFinished(const ServiceWorkerJobData& job, SWServerRegistration& registration)
 {
     // Invoke Resolve Job Promise with job and registration.
-    protectedServer()->resolveRegistrationJob(job, registration.data(), ShouldNotifyWhenResolved::No);
+    protect(server())->resolveRegistrationJob(job, registration.data(), ShouldNotifyWhenResolved::No);
 
     // Invoke Finish Job with job and abort these steps.
     finishCurrentJob();
@@ -187,7 +187,7 @@ void SWServerJobQueue::scriptContextStarted(const ServiceWorkerJobDataIdentifier
     if (!isCurrentlyProcessingJob(jobDataIdentifier))
         return;
 
-    RefPtr registration = protectedServer()->getRegistration(m_registrationKey);
+    RefPtr registration = protect(server())->getRegistration(m_registrationKey);
     ASSERT(registration);
     if (!registration) {
         RELEASE_LOG_ERROR(ServiceWorker, "SWServerJobQueue::scriptContextStarted registration is null");
@@ -407,7 +407,7 @@ void SWServerJobQueue::runUpdateJob(const ServiceWorkerJobData& job)
 
 void SWServerJobQueue::rejectCurrentJob(const ExceptionData& exceptionData)
 {
-    protectedServer()->rejectJob(firstJob(), exceptionData);
+    protect(server())->rejectJob(firstJob(), exceptionData);
 
     finishCurrentJob();
 }

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -80,7 +80,7 @@ private:
     void removeAllJobsMatching(NOESCAPE const Function<bool(ServiceWorkerJobData&)>&);
     void scriptAndImportedScriptsFetchFinished(const ServiceWorkerJobData&, SWServerRegistration&);
 
-    Ref<SWServer> protectedServer() const { return m_server.get(); }
+    SWServer& server() const { return m_server.get(); }
 
     Deque<ServiceWorkerJobData> m_jobQueue;
 

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -129,7 +129,7 @@ private:
     void handleClientUnload();
     void softUpdate();
 
-    RefPtr<SWServer> protectedServer() const { return m_server; }
+    SWServer* server() const { return m_server.get(); }
 
     ServiceWorkerRegistrationKey m_registrationKey;
     ServiceWorkerUpdateViaCache m_updateViaCache;


### PR DESCRIPTION
#### 120364b3db55cc45878e03dd71b560170363761c
<pre>
Further reduce use of protected functions in Source/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=308526">https://bugs.webkit.org/show_bug.cgi?id=308526</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::accessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
(WebCore::AnimationTimelinesController::liveCurrentTime const):
(WebCore::AnimationTimelinesController::cacheCurrentTime):
(WebCore::AnimationTimelinesController::isPendingTimelineAttachment const):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::exposedComputedCSSPropertyIDs const):
(WebCore::CSSComputedStyleDeclaration::length const):
(WebCore::CSSComputedStyleDeclaration::item const):
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::document const):
(WebCore::CSSFontFace::pump):
(WebCore::CSSFontFace::font):
(WebCore::CSSFontFace::protectedDocument): Deleted.
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::shouldIgnoreFontLoadCompletions const):
(WebCore::CSSFontFaceSource::fontLoaded):
(WebCore::CSSFontFaceSource::load):
(WebCore::CSSFontFaceSource::protectedCSSFontFace const): Deleted.
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::CSSPositionTryRule::reattach):
(WebCore::CSSPositionTryRule::style):
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::protectedContents): Deleted.
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSValueList.h:
(WebCore::CSSValueContainingVector::protectedItem const): Deleted.
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
(WebCore::DeprecatedCSSOMPrimitiveValue::cssText const):
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h:
(WebCore::DeprecatedCSSOMPrimitiveValue::value const):
(WebCore::DeprecatedCSSOMPrimitiveValue::protectedValue const): Deleted.
* Source/WebCore/css/PropertySetCSSDescriptors.cpp:
(WebCore::PropertySetCSSDescriptors::cssText const):
(WebCore::PropertySetCSSDescriptors::setCssText):
(WebCore::PropertySetCSSDescriptors::getPropertyCSSValue):
(WebCore::PropertySetCSSDescriptors::getPropertyValue):
(WebCore::PropertySetCSSDescriptors::getPropertyPriority):
(WebCore::PropertySetCSSDescriptors::getPropertyShorthand):
(WebCore::PropertySetCSSDescriptors::isPropertyImplicit):
(WebCore::PropertySetCSSDescriptors::setProperty):
(WebCore::PropertySetCSSDescriptors::removeProperty):
(WebCore::PropertySetCSSDescriptors::getPropertyValueInternal const):
(WebCore::PropertySetCSSDescriptors::setPropertyInternal):
(WebCore::PropertySetCSSDescriptors::cssParserContext const):
(WebCore::PropertySetCSSDescriptors::protectedPropertySet const): Deleted.
* Source/WebCore/css/PropertySetCSSDescriptors.h:
(WebCore::PropertySetCSSDescriptors::propertySet const):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumePageRule):
(WebCore::CSSParser::consumeScopeRule):
(WebCore::CSSParser::consumeStyleRule):
(WebCore::CSSParser::protectedStyleSheet const): Deleted.
* Source/WebCore/css/parser/CSSParser.h:
(WebCore::CSSParser::styleSheet const):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
(WebCore::CSSPropertyParserHelpers::isGridTrackFixedSized):
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::conversionData const):
(WebCore::SizesAttributeParser::protectedDocument const): Deleted.
* Source/WebCore/css/parser/SizesAttributeParser.h:
(WebCore::SizesAttributeParser::document const):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveData.h:
(WebCore::CSS::PrimitiveData::PrimitiveData):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h:
(WebCore::CSS::CSSValueCreation&lt;CSSType&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
(WebCore::CSS::UnevaluatedCalcBase::equal const):
(WebCore::CSS::UnevaluatedCalcBase::requiresConversionData const):
(WebCore::CSS::UnevaluatedCalcBase::serializationForCSS const):
(WebCore::CSS::UnevaluatedCalcBase::collectComputedStyleDependencies const):
(WebCore::CSS::UnevaluatedCalcBase::simplifyBase const):
(WebCore::CSS::UnevaluatedCalcBase::evaluate const):
(WebCore::CSS::UnevaluatedCalcBase::protectedCalc const): Deleted.
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
(WebCore::CSS::UnevaluatedCalcBase::calcValue const):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::parseStyleSheet):
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::addSubresourceAttributeURLs const):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::inspectedPageController const):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowWidth):
(WebCore::InspectorFrontendClientLocal::openURLExternally):
(WebCore::InspectorFrontendClientLocal::restoreAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::showMainResourceForFrame):
(WebCore::InspectorFrontendClientLocal::inspectionLevel const):
(WebCore::InspectorFrontendClientLocal::protectedInspectedPageController const): Deleted.
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::handleMousePress):
(WebCore::InspectorDOMAgent::handleTouchEvent):
(WebCore::InspectorDOMAgent::highlightMousedOverNode):
(WebCore::InspectorDOMAgent::setSearchingForNode):
(WebCore::InspectorDOMAgent::innerHighlightQuad):
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::InspectorDOMAgent::highlightNode):
(WebCore::InspectorDOMAgent::highlightNodeList):
(WebCore::InspectorDOMAgent::highlightFrame):
(WebCore::InspectorDOMAgent::hideHighlight):
(WebCore::InspectorDOMAgent::showGridOverlay):
(WebCore::InspectorDOMAgent::hideGridOverlay):
(WebCore::InspectorDOMAgent::showFlexOverlay):
(WebCore::InspectorDOMAgent::hideFlexOverlay):
(WebCore::InspectorDOMAgent::protectedOverlay const): Deleted.
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::InspectorIndexedDBAgent::requestDatabaseNames):
(WebCore::InspectorIndexedDBAgent::requestDatabase):
(WebCore::InspectorIndexedDBAgent::requestData):
(WebCore::InspectorIndexedDBAgent::clearObjectStore):
(WebCore::InspectorIndexedDBAgent::protectedInspectedPage const): Deleted.
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::overlay const):
(WebCore::InspectorPageAgent::setShowRulers):
(WebCore::InspectorPageAgent::setShowPaintRects):
(WebCore::InspectorPageAgent::didPaint):
(WebCore::InspectorPageAgent::didLayout):
(WebCore::InspectorPageAgent::didRecalculateStyle):
(WebCore::InspectorPageAgent::protectedOverlay const): Deleted.
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp:
(WebCore::WorkerDebuggerAgent::breakpointActionLog):
(WebCore::WorkerDebuggerAgent::injectedScriptForEval):
(WebCore::WorkerDebuggerAgent::protectedGlobalScope const): Deleted.
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h:
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::computePosition):
(WebCore::RenderMarquee::updateMarqueePosition):
* Source/WebCore/rendering/RenderMarquee.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::showPopup):
(WebCore::RenderSearchField::recentSearches):
(WebCore::RenderSearchField::updateFromElement):
(WebCore::RenderSearchField::updatePopup):
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/svg/StyleSVGPaint.cpp:
(WebCore::Style::CSSValueConversion&lt;SVGPaint&gt;::operator):
* Source/WebCore/workers/WorkerConsoleClient.cpp:
(WebCore::WorkerConsoleClient::screenshot):
(WebCore::WorkerConsoleClient::protectedGlobalScope): Deleted.
* Source/WebCore/workers/WorkerConsoleClient.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
(WebCore::protectedIDBConnectionProxy): Deleted.
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::connection const):
(WebCore::SWServer::protectedConnection const): Deleted.
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptFetchFinished):
(WebCore::SWServerJobQueue::importedScriptsFetchFinished):
(WebCore::SWServerJobQueue::scriptAndImportedScriptsFetchFinished):
(WebCore::SWServerJobQueue::scriptContextStarted):
(WebCore::SWServerJobQueue::rejectCurrentJob):
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::forEachConnection):
(WebCore::SWServerRegistration::notifyClientsOfControllerChange):
(WebCore::SWServerRegistration::clear):
(WebCore::SWServerRegistration::activate):
(WebCore::SWServerRegistration::isUnregistered const):
(WebCore::SWServerRegistration::controlClient):
(WebCore::SWServerRegistration::softUpdate):
(WebCore::SWServerRegistration::enableNavigationPreload):
(WebCore::SWServerRegistration::disableNavigationPreload):
(WebCore::SWServerRegistration::setNavigationPreloadHeaderValue):
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::server const):
(WebCore::SWServerRegistration::protectedServer const): Deleted.

Canonical link: <a href="https://commits.webkit.org/308120@main">https://commits.webkit.org/308120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/420edde04e1731bd40756df022d07fecaad8be84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155158 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d41a296-a119-46b6-9ff8-bab323bda19b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19071 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81567302-26ff-4b58-acc9-bf797f7f03bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93607 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4d418f2-d992-441b-9d4c-73a5ea9f1537) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12127 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2602 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157482 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/634 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120826 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31015 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74773 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8163 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82341 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18378 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->