### PR TITLE
Ref-counted classes should not have public constructors

### DIFF
--- a/Source/WebCore/page/UserMessageHandlerDescriptor.h
+++ b/Source/WebCore/page/UserMessageHandlerDescriptor.h
@@ -44,7 +44,6 @@ class UserMessageHandler;
 
 class UserMessageHandlerDescriptor : public RefCounted<UserMessageHandlerDescriptor> {
 public:
-    WEBCORE_EXPORT explicit UserMessageHandlerDescriptor(const AtomString&, DOMWrapperWorld&);
     WEBCORE_EXPORT virtual ~UserMessageHandlerDescriptor();
 
     WEBCORE_EXPORT const AtomString& NODELETE name() const;
@@ -52,6 +51,10 @@ public:
 
     virtual void didPostMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue, Function<void(JSC::JSValue, const String&)>&&) const = 0;
     virtual JSC::JSValue didPostLegacySynchronousMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue) const = 0;
+
+protected:
+    WEBCORE_EXPORT explicit UserMessageHandlerDescriptor(const AtomString&, DOMWrapperWorld&);
+
 private:
     const AtomString m_name;
     const Ref<DOMWrapperWorld> m_world;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -104,8 +104,8 @@ GPUProcess::~GPUProcess()
 
 GPUProcess& GPUProcess::singleton()
 {
-    static NeverDestroyed<GPUProcess> gpuProcess;
-    return gpuProcess.get();
+    static NeverDestroyed<Ref<GPUProcess>> gpuProcess = adoptRef(*new GPUProcess);
+    return gpuProcess.get().get();
 }
 
 void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier identifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, GPUProcessConnectionParameters&& parameters, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -96,7 +96,6 @@ class GPUProcess final : public AuxiliaryProcess, public ThreadSafeRefCounted<GP
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(GPUProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GPUProcess);
 public:
-    GPUProcess();
     ~GPUProcess();
 
     static GPUProcess& singleton();
@@ -178,7 +177,10 @@ public:
 #endif
 
     void terminateWebProcess(WebCore::ProcessIdentifier);
+
 private:
+    GPUProcess();
+
     void lowMemoryHandler(Critical, Synchronous);
 
     // AuxiliaryProcess

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
@@ -45,7 +45,7 @@ public:
 template<>
 void initializeAuxiliaryProcess<ModelProcess>(AuxiliaryProcessInitializationParameters&& parameters)
 {
-    static NeverDestroyed<ModelProcess> modelProcess(WTF::move(parameters));
+    static NeverDestroyed<Ref<ModelProcess>> modelProcess = ModelProcess::create(WTF::move(parameters));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -67,6 +67,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcess);
 // work in the ModelProcess.
 constexpr Seconds minimumLifetimeBeforeIdleExit { 5_s };
 
+Ref<ModelProcess> ModelProcess::create(AuxiliaryProcessInitializationParameters&& parameters)
+{
+    return adoptRef(*new ModelProcess(WTF::move(parameters)));
+}
+
 ModelProcess::ModelProcess(AuxiliaryProcessInitializationParameters&& parameters)
     : m_idleExitTimer(*this, &ModelProcess::tryExitIfUnused)
 {

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -56,8 +56,9 @@ class ModelProcess final : public AuxiliaryProcess, public ThreadSafeRefCounted<
     WTF_MAKE_TZONE_ALLOCATED(ModelProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ModelProcess);
 public:
-    explicit ModelProcess(AuxiliaryProcessInitializationParameters&&);
+    static Ref<ModelProcess> create(AuxiliaryProcessInitializationParameters&&);
     ~ModelProcess();
+
     static constexpr WTF::AuxiliaryProcessType processType = WTF::AuxiliaryProcessType::Model;
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
@@ -86,6 +87,8 @@ public:
     void modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&&);
 
 private:
+    explicit ModelProcess(AuxiliaryProcessInitializationParameters&&);
+
     void lowMemoryHandler(Critical, Synchronous);
 
     // AuxiliaryProcess

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -43,7 +43,7 @@ public:
 template<>
 void initializeAuxiliaryProcess<NetworkProcess>(AuxiliaryProcessInitializationParameters&& parameters)
 {
-    static NeverDestroyed<NetworkProcess> networkProcess(WTF::move(parameters));
+    static NeverDestroyed<Ref<NetworkProcess>> networkProcess = NetworkProcess::create(WTF::move(parameters));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -167,6 +167,11 @@ static void callExitSoon(IPC::Connection*)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkProcess);
 
+Ref<NetworkProcess> NetworkProcess::create(AuxiliaryProcessInitializationParameters&& parameters)
+{
+    return adoptRef(*new NetworkProcess(WTF::move(parameters)));
+}
+
 NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parameters)
     : m_downloadManager(*this)
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -157,7 +157,7 @@ public:
     using DomainInNeedOfStorageAccess = WebCore::RegistrableDomain;
     using OpenerDomain = WebCore::RegistrableDomain;
 
-    NetworkProcess(AuxiliaryProcessInitializationParameters&&);
+    static Ref<NetworkProcess> create(AuxiliaryProcessInitializationParameters&&);
     ~NetworkProcess();
     static constexpr WTF::AuxiliaryProcessType processType = WTF::AuxiliaryProcessType::Network;
 
@@ -491,6 +491,8 @@ public:
 #endif
 
 private:
+    explicit NetworkProcess(AuxiliaryProcessInitializationParameters&&);
+
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 
     void didReceiveNetworkProcessMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/Shared/AuxiliaryProcessMain.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessMain.h
@@ -88,7 +88,7 @@ public:
 
     void initializeAuxiliaryProcess(AuxiliaryProcessInitializationParameters&& parameters) override
     {
-        m_process = adoptRef(new AuxiliaryProcessType(WTF::move(parameters)));
+        m_process = AuxiliaryProcessType::create(WTF::move(parameters));
     }
 
 protected:

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
@@ -47,10 +47,6 @@ public:
         return adoptRef(*new WebExtensionLocalization(std::forward<Args>(args)...));
     }
 
-    explicit WebExtensionLocalization(WebKit::WebExtension&);
-    explicit WebExtensionLocalization(RefPtr<JSON::Object> localizedJSON, const String& uniqueIdentifier);
-    explicit WebExtensionLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& withBestLocale, const String& uniqueIdentifier);
-
     const String& uniqueIdentifier() { return m_uniqueIdentifier; };
     RefPtr<JSON::Object> localizationJSON() { return m_localizationJSON; };
 
@@ -59,6 +55,10 @@ public:
     String localizedStringForString(String);
 
 private:
+    explicit WebExtensionLocalization(WebKit::WebExtension&);
+    explicit WebExtensionLocalization(RefPtr<JSON::Object> localizedJSON, const String& uniqueIdentifier);
+    explicit WebExtensionLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& withBestLocale, const String& uniqueIdentifier);
+
     void loadRegionalLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& withBestLocale = { }, const String& uniqueIdentifier = { });
 
     RefPtr<JSON::Object> localizationJSONForWebExtension(WebKit::WebExtension&, const String& withLocale);

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -55,7 +55,6 @@ public:
         return adoptRef(*new WebExtensionSQLiteDatabase(std::forward<Args>(args)...));
     }
 
-    explicit WebExtensionSQLiteDatabase(const URL&, Ref<WorkQueue>&&);
     ~WebExtensionSQLiteDatabase()
     {
         ASSERT(!m_db);
@@ -91,6 +90,8 @@ public:
     WorkQueue& queue() const { return m_queue; };
 
 private:
+    WebExtensionSQLiteDatabase(const URL&, Ref<WorkQueue>&&);
+
     RefPtr<API::Error> errorWithSQLiteErrorCode(int errorCode);
     URL privateOnDiskDatabaseURL();
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h
@@ -47,7 +47,6 @@ public:
     {
         return adoptRef(*new WebExtensionSQLiteRow(std::forward<Args>(args)...));
     }
-    explicit WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement>);
 
     String getString(int index);
     int getInt(int index);
@@ -57,6 +56,8 @@ public:
     RefPtr<API::Data> getData(int index);
 
 private:
+    explicit WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement>);
+
     bool isNullAtIndex(int index);
 
     Ref<WebExtensionSQLiteStatement> m_statement;
@@ -74,12 +75,12 @@ public:
         return adoptRef(*new WebExtensionSQLiteRowEnumerator(std::forward<Args>(args)...));
     }
 
-    explicit WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement>);
-
     RefPtr<WebExtensionSQLiteRow> next();
     Ref<WebExtensionSQLiteStatement> statement() { return m_statement; };
 
 private:
+    explicit WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement>);
+
     Ref<WebExtensionSQLiteStatement> m_statement;
     RefPtr<WebExtensionSQLiteRow> m_row;
 };

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
@@ -51,8 +51,6 @@ public:
         return adoptRef(*new WebExtensionSQLiteStatement(std::forward<Args>(args)...));
     }
 
-    explicit WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase>, const String& query, RefPtr<API::Error>&);
-
     ~WebExtensionSQLiteStatement();
 
     void bind(const String&, int parameterIndex);
@@ -77,7 +75,10 @@ public:
 
     Vector<String> columnNames();
     HashMap<String, int> columnNamesToIndicies();
+
 private:
+    explicit WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase>, const String& query, RefPtr<API::Error>&);
+
     sqlite3_stmt* m_handle;
     const Ref<WebExtensionSQLiteDatabase> m_db;
 

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -74,8 +74,7 @@ public:
         return adoptRef(*new FrameState(std::forward<Args>(args)...));
     }
 
-    // These are used to help debug <rdar://problem/48634553>.
-    FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
+    // This is used to help debug <rdar://problem/48634553>.
     ~FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
 
     Ref<FrameState> copy();
@@ -128,6 +127,9 @@ public:
     bool isEqualForTesting(const FrameState&) const;
 
 private:
+    // This is used to help debug <rdar://problem/48634553>.
+    FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
+
     FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&&,
 #if PLATFORM(IOS_FAMILY)
         WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -96,9 +96,10 @@ public:
         return adoptRef(*new WebExtensionDataRecordHolder(std::forward<Args>(args)...));
     }
 
-    WebExtensionDataRecordHolder() { };
-
     HashMap<String, Ref<WebExtensionDataRecord>> recordsMap;
+
+private:
+    WebExtensionDataRecordHolder() = default;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 8a7116ac339928e6debf6f6ae742e4c187c69678
<pre>
Ref-counted classes should not have public constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=308530">https://bugs.webkit.org/show_bug.cgi?id=308530</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/page/UserMessageHandlerDescriptor.h:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::singleton):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm:
(WebKit::initializeAuxiliaryProcess&lt;ModelProcess&gt;):
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::create):
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm:
(WebKit::initializeAuxiliaryProcess&lt;NetworkProcess&gt;):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::create):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/Shared/AuxiliaryProcessMain.h:
* Source/WebKit/Shared/Extensions/WebExtensionLocalization.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h:
(WebKit::WebExtensionSQLiteRow::create):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h:
* Source/WebKit/Shared/SessionState.h:
(WebKit::FrameState::FrameState):
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
(WebKit::WebExtensionDataRecordHolder::WebExtensionDataRecordHolder): Deleted.

Canonical link: <a href="https://commits.webkit.org/308119@main">https://commits.webkit.org/308119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b923894aeca83edda213ed05432e53e864b1734

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155160 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c11c56c-cdb9-46e2-a942-814f18b6cca2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112796 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b24e67d6-40d4-4a34-9269-aa0af23035e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93610 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c189597c-d025-402c-b870-497d544a7ac3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12123 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2604 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157484 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/636 "Found 2 new failures in UIProcess/API/ios/WKWebViewIOS.mm, UIProcess/ios/WKContentViewInteraction.mm") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120830 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/145901 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31016 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74775 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16727 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8162 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82343 "Built successfully") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18478 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->