### PR TITLE
Remove NODELETE annotations from some non-trivial WTF functions

### DIFF
--- a/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,7 +1,2 @@
-[ macOS ] wtf/FilePrintStream.cpp
-[ macOS ] wtf/LockedPrintStream.cpp
-[ macOS ] wtf/ObjectIdentifier.cpp
-[ macOS ] wtf/cocoa/RuntimeApplicationChecksCocoa.mm
 [ macOS ] wtf/text/StringImpl.cpp
 [ macOS ] wtf/text/StringView.cpp
-[ macOS ] wtf/unicode/UTF8Conversion.cpp

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -40,7 +40,7 @@ struct ObjectIdentifierThreadSafeAccessTraits {
 
 template<>
 struct ObjectIdentifierThreadSafeAccessTraits<uint64_t> {
-    WTF_EXPORT_PRIVATE static uint64_t NODELETE generateIdentifierInternal();
+    WTF_EXPORT_PRIVATE static uint64_t generateIdentifierInternal();
 };
 
 template<>

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -65,7 +65,7 @@ public:
 
     // Typically a no-op for many subclasses of PrintStream, this is a hint that
     // the implementation should flush its buffers if it had not done so already.
-    WTF_EXPORT_PRIVATE virtual void NODELETE flush();
+    WTF_EXPORT_PRIVATE virtual void flush();
     
     template<typename Func>
     void atomically(NOESCAPE const Func& func)
@@ -100,7 +100,7 @@ protected:
     }
     
     WTF_EXPORT_PRIVATE virtual PrintStream& begin();
-    WTF_EXPORT_PRIVATE virtual void NODELETE end();
+    WTF_EXPORT_PRIVATE virtual void end();
 };
 
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const char*);

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -152,10 +152,10 @@ WTF_EXPORT_PRIVATE bool linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior);
 WTF_EXPORT_PRIVATE bool NODELETE processIsExtension();
 WTF_EXPORT_PRIVATE void NODELETE setProcessIsExtension(bool);
 
-WTF_EXPORT_PRIVATE void NODELETE setApplicationBundleIdentifier(const String&);
-WTF_EXPORT_PRIVATE void NODELETE setApplicationBundleIdentifierOverride(const String&);
+WTF_EXPORT_PRIVATE void setApplicationBundleIdentifier(const String&);
+WTF_EXPORT_PRIVATE void setApplicationBundleIdentifierOverride(const String&);
 WTF_EXPORT_PRIVATE String applicationBundleIdentifier();
-WTF_EXPORT_PRIVATE void NODELETE clearApplicationBundleIdentifierTestingOverride();
+WTF_EXPORT_PRIVATE void clearApplicationBundleIdentifierTestingOverride();
 
 #if USE(SOURCE_APPLICATION_AUDIT_DATA)
 WTF_EXPORT_PRIVATE void setApplicationAuditToken(audit_token_t);

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -45,12 +45,12 @@ template<typename CharacterType> struct ConversionResult {
     bool isAllASCII { };
 };
 
-WTF_EXPORT_PRIVATE ConversionResult<char16_t> NODELETE convert(std::span<const char8_t>, std::span<char16_t>);
+WTF_EXPORT_PRIVATE ConversionResult<char16_t> convert(std::span<const char8_t>, std::span<char16_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convert(std::span<const char16_t>, std::span<char8_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convert(std::span<const Latin1Character>, std::span<char8_t>);
 
 // Invalid sequences are converted to the replacement character.
-WTF_EXPORT_PRIVATE ConversionResult<char16_t> NODELETE convertReplacingInvalidSequences(std::span<const char8_t>, std::span<char16_t>);
+WTF_EXPORT_PRIVATE ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char8_t>, std::span<char16_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convertReplacingInvalidSequences(std::span<const char16_t>, std::span<char8_t>);
 
 WTF_EXPORT_PRIVATE bool equal(std::span<const char16_t>, std::span<const char8_t>);


### PR DESCRIPTION
#### 9e89f5d2f015d619bcecd8e4e271222d22d1510c
<pre>
Remove NODELETE annotations from some non-trivial WTF functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308534">https://bugs.webkit.org/show_bug.cgi?id=308534</a>

Reviewed by Chris Dumez.

Removed NODELETE annotations from some of WTF functions that are non-trivial.

No new tests since there should be no behavioral changes.

* Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WTF/wtf/PrintStream.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/unicode/UTF8Conversion.h:

Canonical link: <a href="https://commits.webkit.org/308131@main">https://commits.webkit.org/308131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bff633e15f5c1efa8febbf4e371324309dc518cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99912 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ce49af6-bf2f-4fc9-9aae-55823c0a6e6a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112831 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80623 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1045199b-a078-463d-988e-244f3e3905ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a04dc90-2bfa-427a-a7d3-26880c726f65) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12140 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2620 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157500 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7299 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/652 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120855 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121093 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74791 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16742 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8173 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177804 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18609 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82358 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45598 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18338 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->