### PR TITLE
[JSC] Carefully remove costly access through microtask queue path

### DIFF
--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -117,7 +117,13 @@ public:
         ASSERT(m_jitCodeForConstruct);
         return *m_jitCodeForConstruct;
     }
-        
+
+    void* generatedJITCodeAddressForCall() const
+    {
+        ASSERT(m_jitCodeForCall);
+        return m_jitCodeForCall->addressForCall();
+    }
+
     Ref<JSC::JITCode> generatedJITCodeFor(CodeSpecializationKind kind) const
     {
         if (kind == CodeSpecializationKind::CodeForCall)

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -112,7 +112,7 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
         }
 #if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
         if ((sizeof...(args) + 1) >= newCodeBlock->numParameters()) [[likely]] {
-            auto* entry = functionExecutable->generatedJITCodeForCall()->addressForCall();
+            auto* entry = functionExecutable->generatedJITCodeAddressForCall();
             auto* callee = asObject(functionObject.asCell());
             if constexpr (!sizeof...(args))
                 return JSValue::decode(vmEntryToJavaScriptWith0Arguments(entry, &vm, newCodeBlock, callee, thisValue, context));

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -48,10 +48,9 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(DebuggableMicrotaskDispatcher);
 
 bool QueuedTask::isRunnable() const
 {
-    auto* dispatcher = this->dispatcher();
-    if (dispatcher->type() == JSMicrotaskDispatcherType) [[unlikely]]
-        return jsCast<JSMicrotaskDispatcher*>(dispatcher)->dispatcher()->isRunnable();
-    return jsCast<JSGlobalObject*>(dispatcher)->microtaskRunnability() == QueuedTaskResult::Executed;
+    if (isJSMicrotaskDispatcher()) [[unlikely]]
+        return jsCast<JSMicrotaskDispatcher*>(dispatcher())->dispatcher()->isRunnable();
+    return jsCast<JSGlobalObject*>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
 }
 
 QueuedTaskResult DebuggableMicrotaskDispatcher::run(QueuedTask& task)
@@ -106,7 +105,7 @@ void MicrotaskQueue::visitAggregateImpl(Visitor& visitor)
 }
 DEFINE_VISIT_AGGREGATE(MicrotaskQueue);
 
-void MicrotaskQueue::enqueue(QueuedTask&& task)
+void MicrotaskQueue::enqueueSlow(QueuedTask&& task)
 {
     auto* globalObject = task.globalObject();
     auto identifier = task.identifier();


### PR DESCRIPTION
#### 113e989f0ab0cc532236a591ac5212f25ac46800
<pre>
[JSC] Carefully remove costly access through microtask queue path
<a href="https://bugs.webkit.org/show_bug.cgi?id=308536">https://bugs.webkit.org/show_bug.cgi?id=308536</a>
<a href="https://rdar.apple.com/171058055">rdar://171058055</a>

Reviewed by Keith Miller.

1. generatedJITCodeForCall()&apos;s ref/deref becomes really costly. Do not
   do it.
2. accessing JSCell::type() is costly when it is not in the cache line.
   When creating QueuedTask, we already know that it is
   JSMicrotaskDispatcher or JSGlobalObject. So let&apos;s add one bit in the
   pointer which says it is JSMicrotaskDispatcher. So we can avoid
   accessing memory and instead we can switch based on this pointer&apos;s
   flag. We split MicrotaskQueue::enqueue to enqueue and enqueueSlow.
   And enqueueSlow does more slower operation when it is
   JSMicrotaskDispatcher.

* Source/JavaScriptCore/runtime/ExecutableBase.h:
(JSC::ExecutableBase::generatedJITCodeAddressForCall const):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::callMicrotask):
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::QueuedTask::isRunnable const):
(JSC::MicrotaskQueue::enqueueSlow):
(JSC::MicrotaskQueue::enqueue): Deleted.
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::QueuedTask::QueuedTask):
(JSC::QueuedTask::setDispatcher):
(JSC::QueuedTask::isJSMicrotaskDispatcher const):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::QueuedTask::dispatcher const):
(JSC::QueuedTask::globalObject const):
(JSC::QueuedTask::jsMicrotaskDispatcher const):
(JSC::MicrotaskQueue::enqueue):

Canonical link: <a href="https://commits.webkit.org/308140@main">https://commits.webkit.org/308140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83b6d9831c091a7e4e9d0f69769ed7958d56c2f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146518 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99916 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42a1629c-7f89-4e47-b8fd-f273fd03600a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80629 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6d327ef-6c54-489d-8280-e3b07af534b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93633 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12144 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2626 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138485 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157506 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7304 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/656 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120912 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121103 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131269 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74795 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22613 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8176 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177809 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18614 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82362 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45600 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->