### PR TITLE
Fix inconsistency between marker position info and marker resources

### DIFF
--- a/LayoutTests/svg/non-scaling-stroke-with-dynamic-marker-expected.txt
+++ b/LayoutTests/svg/non-scaling-stroke-with-dynamic-marker-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/svg/non-scaling-stroke-with-dynamic-marker.svg
+++ b/LayoutTests/svg/non-scaling-stroke-with-dynamic-marker.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" onload="runTest()">
+<path id="path" marker-start="url(#marker)" vector-effect="non-scaling-stroke"></path>
+<marker id="marker"></marker>
+<script>
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  testRunner.dumpAsText();
+}
+function runTest() {
+  requestAnimationFrame(() => {
+    let path = document.getElementById("path");
+    path.removeAttribute("marker-start");
+    testRunner.notifyDone();
+  });
+}
+</script>
+<text>PASS if no crash</text>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -309,6 +309,8 @@ bool LegacyRenderSVGPath::isRenderingDisabled() const
 
 void LegacyRenderSVGPath::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)
 {
+    if (oldStyle && oldStyle->hasMarkers() && !style().hasMarkers())
+        m_markerPositions.clear();
     if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(graphicsElement())) {
         if (!oldStyle || style().d() != oldStyle->d())
             pathElement->pathDidChange();


### PR DESCRIPTION
#### a10422abf224ff37e55cf048baec35b37e44973f
<pre>
Fix inconsistency between marker position info and marker resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=308543">https://bugs.webkit.org/show_bug.cgi?id=308543</a>

Reviewed by Brent Fulgham.

After 307282@main non-scaling-stroke repaint logic was changed to not rely
as much on cached repaint bounding boxes. This exposes a problem where as
part of repainting after layout, marker rects are being calculated on basis
of out of date marker position data, i.e. in the test case marker position
information was still present but the marker itself was already removed as a used resource
(because the marker-start attribute was removed), leading to an ASSERT being hit, since some
places assume if there is marker position information we must have marker resources.

To fix this, clear the marker position information when all marker properties are removed.

Test: svg/non-scaling-stroke-with-dynamic-marker.svg

* LayoutTests/svg/non-scaling-stroke-with-dynamic-marker-expected.txt: Added.
* LayoutTests/svg/non-scaling-stroke-with-dynamic-marker.svg: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/308541@main">https://commits.webkit.org/308541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e34deb26d04d2f120269d4f3a353706bb1d005df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113972 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15368 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3960 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158855 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122002 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31299 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76463 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9251 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83699 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19666 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->