### PR TITLE
[WebDriver BiDi] Add foundation implementation for script.disown command

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -382,6 +382,54 @@ void BidiScriptAgent::callFunction(const String& functionDeclaration, bool await
     });
 }
 
+void BidiScriptAgent::disown(Ref<JSON::Array>&& handles, Ref<JSON::Object>&& target, CommandCallback<void>&& callback)
+{
+    // FIXME: WebProcess forwarding to actually release JavaScript objects will be added
+    // once resultOwnership="root" support is implemented. https://bugs.webkit.org/show_bug.cgi?id=288059
+
+    RefPtr session = m_session.get();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+    BrowsingContext browsingContext;
+    String realmID;
+    String sandbox;
+    bool hasBrowsingContext = target->find("context"_s) != target->end();
+    bool hasRealm = target->find("realm"_s) != target->end();
+    bool hasSandbox = target->find("sandbox"_s) != target->end();
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(hasBrowsingContext && !target->getString("context"_s, browsingContext), InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(hasRealm && !target->getString("realm"_s, realmID), InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(hasSandbox && !target->getString("sandbox"_s, sandbox), InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!hasRealm && !hasBrowsingContext, InvalidParameter);
+
+    // Validate realm identifier early, even when context is also provided.
+    std::optional<RealmIdentifier> realmIdentifier;
+    if (hasRealm) {
+        realmIdentifier = parseRealmIdentifier(realmID);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!realmIdentifier, FrameNotFound);
+    }
+
+    // Resolve target to a valid browsing context.
+    if (!hasBrowsingContext) {
+        auto resolvedBrowsingContext = browsingContextForRealm(*realmIdentifier);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!resolvedBrowsingContext, FrameNotFound);
+        browsingContext = *resolvedBrowsingContext;
+    }
+
+    auto pageAndFrameHandles = session->extractBrowsingContextHandles(browsingContext);
+    ASYNC_FAIL_IF_UNEXPECTED_RESULT(pageAndFrameHandles);
+
+    // Validate handles array elements.
+    for (size_t i = 0; i < handles->length(); ++i) {
+        String handleString;
+        if (!handles->get(i)->asString(handleString))
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+    }
+
+    // FIXME: Implement WebProcess forwarding to release JavaScript objects.
+    // https://bugs.webkit.org/show_bug.cgi?id=288059
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR(NotImplemented);
+}
+
 void BidiScriptAgent::evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&&, std::optional<bool>&&, CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&& callback)
 {
     RefPtr session = m_session.get();
@@ -969,6 +1017,27 @@ void BidiScriptAgent::emitEventsForActiveRealms(const HashSet<String>& contextFi
         String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
         sendRealmCreatedEvent(realmID, realmInfo.origin, realmInfo.type, realmInfo.context);
     }
+}
+
+std::optional<RealmIdentifier> BidiScriptAgent::parseRealmIdentifier(const String& realmID)
+{
+    if (!realmID.startsWith("realm-"_s))
+        return std::nullopt;
+
+    auto idValue = parseInteger<uint64_t>(realmID.substring(6));
+    if (!idValue || !RealmIdentifier::isValidIdentifier(*idValue))
+        return std::nullopt;
+
+    return RealmIdentifier(*idValue);
+}
+
+std::optional<String> BidiScriptAgent::browsingContextForRealm(RealmIdentifier realmIdentifier) const
+{
+    auto it = m_activeRealms.find(realmIdentifier);
+    if (it == m_activeRealms.end())
+        return std::nullopt;
+
+    return it->value.context;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -39,6 +39,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Variant.h>
@@ -75,6 +76,7 @@ public:
     void addPreloadScript(const String& functionDeclaration, RefPtr<JSON::Array>&& optionalArguments, RefPtr<JSON::Array>&& optionalContexts, const String& optionalSandbox, RefPtr<JSON::Array>&& optionalUserContexts, Inspector::CommandCallback<String>&&) override;
     void removePreloadScript(const String& script, Inspector::CommandCallback<void>&&) override;
     void callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& optionalArguments, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
+    void disown(Ref<JSON::Array>&& handles, Ref<JSON::Object>&& target, Inspector::CommandCallback<void>&&) override;
     void evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions,  std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
     void getRealms(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalBrowsingContext , std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&) override;
 
@@ -117,6 +119,8 @@ private:
 
     void finishEvaluateBidiScriptResult(const String& realmID, const String& expression, Inspector::CommandResult<String>&&, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&);
 
+    static std::optional<RealmIdentifier> parseRealmIdentifier(const String& realmID);
+    std::optional<String> browsingContextForRealm(RealmIdentifier) const;
     WeakPtr<WebAutomationSession> m_session;
     Ref<Inspector::BidiScriptBackendDispatcher> m_scriptDomainDispatcher;
 

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -256,6 +256,19 @@
             ]
         },
         {
+            "name": "disown",
+            "description": "Disowns the given handles. This removes the handles from the realm, allowing the garbage collector to reclaim the associated objects.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-script-disown",
+            "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/script/disown",
+            "bug": "https://bugs.webkit.org/show_bug.cgi?id=288059",
+            "async": true,
+            "parameters": [
+                { "name": "handles", "type": "array", "items": { "$ref": "BidiScript.Handle" }, "description": "The handles to disown." },
+                { "name": "target", "$ref": "BidiScript.Target", "description": "The target realm or context where the handles are located." }
+            ],
+            "returns": []
+        },
+        {
             "name": "getRealms",
             "description": "Returns a list of all realms.",
             "spec": "https://w3c.github.io/webdriver-bidi/#command-script-getRealms",

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -3760,9 +3760,6 @@
     "imported/w3c/webdriver/tests/bidi/script/disown/handles.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288059"}}
     },
-    "imported/w3c/webdriver/tests/bidi/script/disown/invalid.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288059"}}
-    },
     "imported/w3c/webdriver/tests/bidi/script/disown/target.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288059"}}
     },


### PR DESCRIPTION
#### 45357243b63d563a66741b70de401ff70ea6eadd
<pre>
[WebDriver BiDi] Add foundation implementation for script.disown command
<a href="https://bugs.webkit.org/show_bug.cgi?id=288059">https://bugs.webkit.org/show_bug.cgi?id=288059</a>

Reviewed by BJ Burg.

This patch adds a foundation implementation of the script.disown command that validates
parameters but returns NotImplemented, as the core functionality (WebProcess forwarding
to release JavaScript objects) requires resultOwnership=&quot;root&quot; support (bug 288059).

The implementation provides:
- Parameter validation for handles array and target (realm/context)
- Target resolution using parseRealmIdentifier and browsingContextForRealm
- Proper JSON field presence detection using find() to avoid getString returning
  empty strings for missing keys
- Clean NotImplemented return without side effects

Implementation details:
- parseRealmIdentifier() validates and parses realm ID strings (&quot;realm-&lt;number&gt;&quot;)
  into strongly typed RealmIdentifier values
- browsingContextForRealm() looks up the browsing context for a RealmIdentifier
  via m_activeRealms, keeping realm IDs as opaque identifiers
- Realm validation occurs early, even when a browsing context is also provided
- All validation occurs before the NotImplemented return
- No state mutation to maintain consistency with &quot;not implemented&quot; semantics

* Source/WebKit/UIProcess/Automation/protocol/BidiScript.json:
Add bug field to script.disown command.

* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
Add disown, parseRealmIdentifier, and browsingContextForRealm declarations.

* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::disown): Implement parameter validation, return NotImplemented.
(WebKit::BidiScriptAgent::parseRealmIdentifier): Parse realm ID strings into
strongly typed RealmIdentifier values.
(WebKit::BidiScriptAgent::browsingContextForRealm): Look up browsing context for
a RealmIdentifier via the active realms registry.

* WebDriverTests/TestExpectations.json:
Update disown/invalid.py test expectations to reflect passing subtests.

Canonical link: <a href="https://commits.webkit.org/311598@main">https://commits.webkit.org/311598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d80cda521f7ace96610547951c97fcc6de16ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110645 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13159 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132225 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167870 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129382 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35263 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140213 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87227 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17015 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->