### PR TITLE
[GStreamer] Add quirk for missing Hardware classifier in Qualcomm decoder

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
@@ -70,6 +70,15 @@ bool GStreamerQuirkQualcomm::isVideoCapsGLCompatible(const GRefPtr<GstCaps>& cap
     return !gst_caps_features_contains(gst_caps_get_features(caps.get(), 0), "memory:GBM");
 }
 
+std::optional<bool> GStreamerQuirkQualcomm::isHardwareAccelerated(GstElementFactory* factory)
+{
+    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    if (view.startsWith("qtic2vdec"_s))
+        return true;
+
+    return std::nullopt;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
@@ -34,6 +34,8 @@ public:
     [[nodiscard]] GRefPtr<GstCaps> videoSinkGLCapsFormat() const final { return m_glCaps; }
     bool isVideoCapsGLCompatible(const GRefPtr<GstCaps>&) const final;
 
+    std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
+
 private:
     mutable GRefPtr<GstCaps> m_glCaps;
 };

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -250,7 +250,8 @@ std::optional<bool> GStreamerQuirksManager::isHardwareAccelerated(GstElementFact
         return *result;
     }
 
-    return std::nullopt;
+    auto klassStr = CStringView::unsafeFromUTF8(gst_element_factory_get_klass(factory));
+    return contains(klassStr.span(), "Hardware"_s);
 }
 
 bool GStreamerQuirksManager::supportsVideoHolePunchRendering() const


### PR DESCRIPTION
#### 50d89910f1130545b06fae24f246e2b0187236ec
<pre>
[GStreamer] Add quirk for missing Hardware classifier in Qualcomm decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=308547">https://bugs.webkit.org/show_bug.cgi?id=308547</a>

Reviewed by Xabier Rodriguez-Calvar.

Also driving-by, make the quirks manager look-up the Hardware classifier if none of the quirks
handled the query.

* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp:
(WebCore::GStreamerQuirkQualcomm::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::isHardwareAccelerated const):

Canonical link: <a href="https://commits.webkit.org/308192@main">https://commits.webkit.org/308192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a65312f466d3c70608eb14f17da8a41095e4cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112888 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14400 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157533 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/680 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120925 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121125 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31057 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74819 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8204 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82398 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->