### PR TITLE
[GStreamer][LibWebRTC] Revamp video decoder factory

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -85,11 +85,11 @@ webrtc::VideoFrame convertGStreamerSampleToLibWebRTCVideoFrame(GRefPtr<GstSample
 webrtc::scoped_refptr<webrtc::VideoFrameBuffer> GStreamerVideoFrameLibWebRTC::create(GRefPtr<GstSample>&& sample)
 {
     GstVideoInfo info;
-
-    if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get())))
+    if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get()))) {
         ASSERT_NOT_REACHED();
-
-    return webrtc::scoped_refptr<webrtc::VideoFrameBuffer>(new GStreamerVideoFrameLibWebRTC(WTF::move(sample), info));
+        return nullptr;
+    }
+    return webrtc::scoped_refptr<webrtc::VideoFrameBuffer>(new GStreamerVideoFrameLibWebRTC(WTF::move(sample), WTF::move(info)));
 }
 
 webrtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::ToI420()
@@ -125,7 +125,7 @@ webrtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC:
         inFrame.componentData(1).data(), inFrame.componentStride(1), inFrame.componentData(2).data(), inFrame.componentStride(2));
 }
 
-}
+} // namespace WebCore
 
 #undef GST_CAT_DEFAULT
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h
@@ -39,7 +39,7 @@ class GStreamerVideoFrameLibWebRTC : public webrtc::RefCountedObject<webrtc::Vid
 public:
     static webrtc::scoped_refptr<webrtc::VideoFrameBuffer> create(GRefPtr<GstSample>&&);
 
-    GRefPtr<GstSample>& sample() { return m_sample; }
+    const GRefPtr<GstSample>& sample() const { return m_sample; }
 
     // webrtc::VideoFrameBuffer interface.
     webrtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() final;
@@ -47,9 +47,9 @@ public:
     int height() const final { return GST_VIDEO_INFO_HEIGHT(&m_info); }
 
 private:
-    GStreamerVideoFrameLibWebRTC(GRefPtr<GstSample>&& sample, GstVideoInfo info)
+    GStreamerVideoFrameLibWebRTC(GRefPtr<GstSample>&& sample, GstVideoInfo&& info)
         : m_sample(WTF::move(sample))
-        , m_info(info)
+        , m_info(WTF::move(info))
     {
     }
     webrtc::VideoFrameBuffer::Type type() const final { return Type::kNative; }
@@ -58,6 +58,6 @@ private:
     GstVideoInfo m_info;
 };
 
-}
+} // namespace WebCore
 
 #endif // USE(GSTREAMER) && USE(LIBWEBRTC)


### PR DESCRIPTION
#### 76299fd18606bedb1445c53d44f1b5aee7334330
<pre>
[GStreamer][LibWebRTC] Revamp video decoder factory
<a href="https://bugs.webkit.org/show_bug.cgi?id=308550">https://bugs.webkit.org/show_bug.cgi?id=308550</a>

Reviewed by Xabier Rodriguez-Calvar.

This new version performs less allocations because the reference timestamp meta is no longer needed.
Input buffers are no longer memdup&apos;d either. Raw pointer usage decreased and various coding style
fixes were applied.

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerWebRTCVideoDecoder::GStreamerWebRTCVideoDecoder):
(WebCore::GStreamerWebRTCVideoDecoder::pipeline const):
(WebCore::GStreamerWebRTCVideoDecoder::makeElement):
(WebCore::GStreamerWebRTCVideoDecoder::updateCapsFromImageSize):
(WebCore::GStreamerWebRTCVideoDecoder::addDecoderIfSupported):
(WebCore::GStreamerWebRTCVideoDecoder::configureSupportedDecoder):
(WebCore::GStreamerWebRTCVideoDecoder::hasGStreamerDecoder):
(WebCore::VP8Decoder::Create):
(WebCore::GStreamerVideoDecoderFactory::GetSupportedFormats const):
(WebCore::GStreamerWebRTCVideoDecoder::pipeline): Deleted.
(WebCore::GStreamerWebRTCVideoDecoder::CreateFilter): Deleted.
(WebCore::GStreamerWebRTCVideoDecoder::pullSample): Deleted.
(WebCore::GStreamerWebRTCVideoDecoder::AddDecoderIfSupported): Deleted.
(WebCore::GStreamerWebRTCVideoDecoder::ConfigureSupportedDecoder): Deleted.
(WebCore::GStreamerWebRTCVideoDecoder::HasGstDecoder): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::GStreamerVideoFrameLibWebRTC::create):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h:
(WebCore::GStreamerVideoFrameLibWebRTC::sample const):
(WebCore::GStreamerVideoFrameLibWebRTC::GStreamerVideoFrameLibWebRTC):
(WebCore::GStreamerVideoFrameLibWebRTC::sample): Deleted.

Canonical link: <a href="https://commits.webkit.org/308196@main">https://commits.webkit.org/308196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92601a521b3aa3ae0bae5c32e1f9806e7b8f4124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155416 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113072 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15321 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93817 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2860 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157747 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11157 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121292 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31062 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75042 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8361 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82594 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->