### PR TITLE
Limit maximum render tree depth in maild

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -207,6 +207,7 @@ WTF_EXPORT_PRIVATE bool isHoYoLAB();
 WTF_EXPORT_PRIVATE bool isMailCompositionService();
 WTF_EXPORT_PRIVATE bool isMiniBrowser();
 WTF_EXPORT_PRIVATE bool isMobileMail();
+WTF_EXPORT_PRIVATE bool isMaild();
 WTF_EXPORT_PRIVATE bool isMobileSafari();
 WTF_EXPORT_PRIVATE bool isNews();
 WTF_EXPORT_PRIVATE bool isSafariViewService();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -528,6 +528,12 @@ bool IOSApplication::isMobileMail()
     return isMobileMail;
 }
 
+bool IOSApplication::isMaild()
+{
+    static bool isMaild = applicationBundleIsEqualTo("com.apple.email.maild"_s);
+    return isMaild;
+}
+
 bool IOSApplication::isMailCompositionService()
 {
     static bool isMailCompositionService = applicationBundleIsEqualTo("com.apple.MailCompositionService"_s);

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -55,6 +55,10 @@
 #include "MockRealtimeMediaSourceCenter.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SettingsBase);
@@ -100,6 +104,17 @@ uint64_t SettingsBase::defaultMaximumSourceBufferSize()
 #endif
 
 #endif
+
+unsigned SettingsBase::maximumRenderTreeDepth()
+{
+#if PLATFORM(IOS)
+    if (IOSApplication::isMaild()) {
+        static const unsigned maximumMaildRenderTreeDepth = 200;
+        return maximumMaildRenderTreeDepth;
+    }
+#endif
+    return defaultMaximumRenderTreeDepth;
+}
 
 const String& SettingsBase::standardFontFamily(UScriptCode script) const
 {

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -73,6 +73,8 @@ public:
     static const unsigned defaultMaximumHTMLParserDOMTreeDepth = 512;
     static const unsigned defaultMaximumRenderTreeDepth = 512;
 
+    static unsigned maximumRenderTreeDepth();
+
     virtual FontGenericFamilies& fontGenericFamilies() = 0;
     virtual const FontGenericFamilies& fontGenericFamilies() const = 0;
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1288,7 +1288,7 @@ void TreeResolver::resolveComposedTree()
 
         Ref element = Ref { downcast<Element>(node.get()) };
 
-        if (it.depth() > Settings::defaultMaximumRenderTreeDepth) {
+        if (it.depth() > Settings::maximumRenderTreeDepth()) {
             resetStyleForNonRenderedDescendants(element.get());
             it.traverseNextSkippingChildren();
             continue;


### PR DESCRIPTION
#### 2212d3b89992c5f58a45d3cfdbf9e81e647e0679
<pre>
Limit maximum render tree depth in maild
<a href="https://bugs.webkit.org/show_bug.cgi?id=308552">https://bugs.webkit.org/show_bug.cgi?id=308552</a>
<a href="https://rdar.apple.com/170948760">rdar://170948760</a>

Reviewed by NOBODY (OOPS!).

Maild is sometimes seeing some mails with unreasonable DOM/render tree depth and crashes to stack exhaustion.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::IOSApplication::isMaild):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::maximumRenderTreeDepth):

Paper this over for now by limiting the render tree futher (200 instead of 512) specifically in maild.

* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2212d3b89992c5f58a45d3cfdbf9e81e647e0679

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146557 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19230 "Hash 2212d3b8 for PR 59329 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155220 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99949 "Failed to checkout and rebase branch from PR 59328") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a056ddf-23ab-480e-8d42-ee1867855c94) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148432 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19691 "Hash 2212d3b8 for PR 59329 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112905 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99949 "Failed to checkout and rebase branch from PR 59328") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fd3399f-7e48-461d-b27d-8e985df7c85a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149520 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/19691 "Hash 2212d3b8 for PR 59329 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93666 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/573ba6ba-80e9-4ecd-91b9-b02f75ff8bd8) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/19691 "Hash 2212d3b8 for PR 59329 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12188 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2664 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138524 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/19691 "Hash 2212d3b8 for PR 59329 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7343 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/697 "Failed to checkout and rebase branch from PR 59328") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120934 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121137 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19042 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74831 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/16779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18652 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82404 "Failed to checkout and rebase branch from PR 59328") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45603 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18382 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->