### PR TITLE
AX: Add AXLogMessage convenience function

### DIFF
--- a/Source/WebCore/accessibility/AXLogger.h
+++ b/Source/WebCore/accessibility/AXLogger.h
@@ -27,6 +27,7 @@
 
 #include "AXCoreObject.h"
 #include "AXObjectCache.h"
+#include <tuple>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
@@ -95,5 +96,42 @@ private:
 
 void streamAXCoreObject(TextStream&, const AXCoreObject&, const OptionSet<AXStreamOptions>&);
 void streamSubtree(TextStream&, const Ref<AXCoreObject>&, const OptionSet<AXStreamOptions>&);
+
+// Converts the following types to strings:
+//  - AXCoreObject& and AXCoreObject*
+//  - RefPtr/Ref AXCoreObject
+//  - WTF::String
+//  - Everything else -> passed through
+template<typename T>
+decltype(auto) convertAXLogArg(T&& arg)
+{
+    if constexpr (std::is_pointer_v<std::remove_cvref_t<T>> && std::derived_from<std::remove_pointer_t<std::remove_cvref_t<T>>, AXCoreObject>)
+        return arg ? arg->debugDescription().utf8() : CString("(null)"_s);
+    else if constexpr (std::derived_from<std::remove_cvref_t<T>, AXCoreObject>)
+        return arg.debugDescription().utf8();
+    else if constexpr (requires { { *arg } -> std::convertible_to<const AXCoreObject&>; })
+        return arg ? arg->debugDescription().utf8() : CString("(null)"_s);
+    else if constexpr (std::same_as<std::remove_cvref_t<T>, String>)
+        return arg.utf8();
+    else
+        return std::forward<T>(arg);
+}
+
+inline const char* extractAXLogArg(const CString& string) { return string.data(); }
+
+template<typename T> requires (!std::same_as<std::remove_cvref_t<T>, CString>)
+decltype(auto) extractAXLogArg(T&& arg) { return std::forward<T>(arg); }
+
+// Used like WTFLogAlways, but auto-converts String and AXCoreObject arguments for use with the %s format specifier.
+template<typename... Args>
+ALWAYS_INLINE void AXLogMessage(const char* format, Args&&... args)
+{
+    auto holder = std::tuple { convertAXLogArg(std::forward<Args>(args))... };
+    std::apply([&](auto&&... held) {
+        ALLOW_NONLITERAL_FORMAT_BEGIN
+        WTFLogAlways(format, extractAXLogArg(std::forward<decltype(held)>(held))...);
+        ALLOW_NONLITERAL_FORMAT_END
+    }, WTF::move(holder));
+}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 56bab82b80b9b1dac46a36110ab05f0b72020157
<pre>
AX: Add AXLogMessage convenience function
<a href="https://bugs.webkit.org/show_bug.cgi?id=308554">https://bugs.webkit.org/show_bug.cgi?id=308554</a>
<a href="https://rdar.apple.com/171076967">rdar://171076967</a>

Reviewed by Tyler Wilcock.

This adds AXLogMessage (a wrapper over WTFLogAlways) for writing cleaner logs in accessibility
code. This will auto-convert AXCoreObjects (and subclasses) and WTF::Strings to be used with
the `%s` format specifier. Some examples:

```
AccessibilityObject* myObject = { . . . };
String myString = String(&quot;Hello world&quot;_s);

AXLogMessage(&quot;My object: %s, my string: %s&quot;, myObject, myString);

```

* Source/WebCore/accessibility/AXLogger.h:
(WebCore::convertAXLogArg):
(WebCore::extractAXLogArg):
(WebCore::AXLogMessage):

Canonical link: <a href="https://commits.webkit.org/308566@main">https://commits.webkit.org/308566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8521cc901e1b077366d8011a13af2c05bda0a7fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146843 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100232 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abb7cb1c-9ed3-498e-a254-ae6693226255) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80770 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62ecbdb7-979f-4818-8ad4-ceb325da7c30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93905 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b1305a8-dd34-4979-843e-d217ee26caba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2968 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157856 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/988 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121171 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16233 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121373 "Found 1 new API test failure: WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31320 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75334 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8506 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18941 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82696 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18671 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18822 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->