### PR TITLE
Drop color-mix() color space in UA styles

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/resources/customizable-select-in-page.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/resources/customizable-select-in-page.css
@@ -7,9 +7,9 @@
 }
 
 .customizable-select-in-page.disabled {
-  color: color-mix(in lab, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }
 
 .customizable-select-in-page:not(.disabled) .customizable-select-legend.disabled {
-  color: color-mix(in lab, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/resources/customizable-select-styles.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/resources/customizable-select-styles.css
@@ -40,7 +40,7 @@
 }
 
 .customizable-select-option.disabled {
-  color: color-mix(in lab, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }
 
 .customizable-select-option::before {
@@ -74,15 +74,15 @@
 }
 
 .customizable-select-button.disabled {
-  color: color-mix(in srgb, currentColor 50%, transparent);
+  color: color-mix(currentColor 50%, transparent);
 }
 
 .customizable-select-button.hover {
-  background-color: color-mix(in lab, currentColor 10%, transparent);
+  background-color: color-mix(currentColor 10%, transparent);
 }
 
 .customizable-select-button.active {
-  background-color: color-mix(in lab, currentColor 20%, transparent);
+  background-color: color-mix(currentColor 20%, transparent);
 }
 
 .customizable-select-button::after {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles.html
@@ -40,14 +40,14 @@ promise_test(async () => {
   await new Promise(requestAnimationFrame);
   assert_equals(getComputedStyle(optionOne).color, 'rgb(0, 0, 0)',
     'Option color while hovering.');
-  assert_equals(getComputedStyle(optionOne).backgroundColor, 'lab(0 0 0 / 0.1)',
+  assert_equals(getComputedStyle(optionOne).backgroundColor, 'oklab(0 0 0 / 0.1)',
     'Option background-color while hovering.');
 
   await (new test_driver.Actions()
     .pointerMove(1, 1, {origin: disabledOption}))
     .send();
   await new Promise(requestAnimationFrame);
-  assert_equals(getComputedStyle(disabledOption).color, 'lab(0 0 0 / 0.5)',
+  assert_equals(getComputedStyle(disabledOption).color, 'oklab(0 0 0 / 0.5)',
     'Disabled option color while hovering.');
   assert_equals(getComputedStyle(disabledOption).backgroundColor, 'rgba(0, 0, 0, 0)',
     'Disabled option background-color while hovering.');

--- a/LayoutTests/platform/gtk/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/basic-inputs-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (8,1) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (200,4) size 27x18
           text run at (200,4) width 27: "text "
-        RenderTextControl {INPUT} at (227,1) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (227,1) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (418,4) size 19x18
           text run at (418,4) width 12: "b "
           text run at (430,4) width 7: "a"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 186x18
         RenderText {#text} at (193,28) size 64x18
           text run at (193,28) width 64: "password "
-        RenderTextControl {INPUT} at (257,25) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (257,25) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 185x18
             RenderBlock {DIV} at (0,0) size 185x18
         RenderText {#text} at (1,49) size 8x18
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 12x12
         RenderText {#text} at (24,2) size 65x17
           text run at (24,2) width 65: "checkbox "
-        RenderBlock {INPUT} at (91,4) size 12x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (91,4) size 12x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (105,2) size 8x17
           text run at (105,2) width 8: "b"
       RenderBlock {DIV} at (10,424) size 450x21 [border: (1px solid #FF0000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 12x12
         RenderText {#text} at (24,2) size 36x17
           text run at (24,2) width 36: "radio "
-        RenderBlock {INPUT} at (62,4) size 12x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (62,4) size 12x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (76,2) size 8x17
           text run at (76,2) width 8: "b"
 layer at (29,328) size 186x18 scrollWidth 214

--- a/LayoutTests/platform/gtk/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/basic-textareas-expected.txt
@@ -218,7 +218,7 @@ layer at (0,0) size 785x1787
               RenderText {#text} at (0,0) size 132x18
                 text run at (0,0) width 132: "Lorem ipsum dolor"
         layer at (204,75) size 201x42 clip at (205,76) size 184x40 scrollHeight 76
-          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
             RenderBlock {DIV} at (3,3) size 180x72
               RenderText {#text} at (0,0) size 171x72
                 text run at (0,0) width 140: "Lorem ipsum  dolor "
@@ -815,7 +815,7 @@ layer at (0,0) size 785x1787
               RenderText {#text} at (0,0) size 132x18
                 text run at (0,0) width 132: "Lorem ipsum dolor"
         layer at (204,75) size 201x42 clip at (205,76) size 184x40 scrollHeight 76
-          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
             RenderBlock {DIV} at (3,3) size 180x72
               RenderText {#text} at (0,0) size 171x72
                 text run at (0,0) width 140: "Lorem ipsum  dolor "

--- a/LayoutTests/platform/gtk/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/basic-textareas-quirks-expected.txt
@@ -238,7 +238,7 @@ layer at (24,85) size 201x42 clip at (25,86) size 184x40 scrollHeight 76
         text run at (0,36) width 119: "QRSTUVWXYZ "
         text run at (0,54) width 173: "abcdefghijklmnopqrstuv "
 layer at (24,145) size 201x42 clip at (25,146) size 184x40 scrollHeight 76
-  RenderTextControl {TEXTAREA} at (15,1) size 201x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (15,1) size 201x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 180x72
       RenderText {#text} at (0,0) size 173x72
         text run at (0,0) width 136: "Lorem ipsum dolor "

--- a/LayoutTests/platform/gtk/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/input-appearance-disabled-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 393x18
         text run at (0,0) width 393: "This tests that text can not be inserted into a disabled text field."
       RenderBR {BR} at (393,0) size 0x18
-      RenderTextControl {INPUT} at (0,18) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 185x18
   RenderBlock {DIV} at (3,3) size 185x18

--- a/LayoutTests/platform/gtk/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/input-disabled-color-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 509x18
         text run at (0,0) width 509: "This tests that the text color changes appropriately when the text field is disabled."
       RenderBR {BR} at (509,0) size 0x18
-      RenderTextControl {INPUT} at (0,18) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (191,21) size 4x18
         text run at (191,21) width 4: " "
       RenderTextControl {INPUT} at (195,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         text run at (191,45) width 4: " "
       RenderTextControl {INPUT} at (195,42) size 192x24 [color=#FF0000] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderBR {BR} at (387,45) size 0x18
-      RenderTextControl {INPUT} at (0,66) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#0000FF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,66) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderText {#text} at (191,69) size 4x18
         text run at (191,69) width 4: " "
       RenderTextControl {INPUT} at (195,66) size 192x24 [bgcolor=#0000FF] [border: (2px inset #808080)]
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         text run at (191,93) width 4: " "
       RenderTextControl {INPUT} at (195,90) size 192x24 [color=#FF0000] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderBR {BR} at (387,93) size 0x18
-      RenderTextControl {INPUT} at (0,114) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#000000] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,114) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderText {#text} at (191,117) size 4x18
         text run at (191,117) width 4: " "
       RenderTextControl {INPUT} at (195,114) size 192x24 [bgcolor=#000000] [border: (2px inset #808080)]
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         text run at (191,141) width 4: " "
       RenderTextControl {INPUT} at (195,138) size 192x24 [color=#FFFFFF] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderBR {BR} at (387,141) size 0x18
-      RenderTextControl {INPUT} at (0,162) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#808080] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,162) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#808080] [border: (2px inset #808080)]
       RenderText {#text} at (191,165) size 4x18
         text run at (191,165) width 4: " "
       RenderTextControl {INPUT} at (195,162) size 192x24 [bgcolor=#808080] [border: (2px inset #808080)]

--- a/LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 186x18
       RenderText {#text} at (584,21) size 4x18
         text run at (584,21) width 4: " "
-      RenderTextControl {INPUT} at (588,18) size 191x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (588,18) size 191x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
       RenderTextControl {INPUT} at (0,42) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (192,45) size 4x18

--- a/LayoutTests/platform/gtk/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -19,7 +19,7 @@ layer at (8,26) size 201x42 clip at (9,27) size 199x40
       RenderText {#text} at (0,0) size 25x18
         text run at (0,0) width 25: "text"
 layer at (213,26) size 201x42 clip at (214,27) size 199x40
-  RenderTextControl {TEXTAREA} at (205,18) size 201x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (205,18) size 201x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 195x18
     RenderBlock {DIV} at (3,3) size 195x18 [color=#640000]
       RenderText {#text} at (0,0) size 90x18
@@ -31,7 +31,7 @@ layer at (418,26) size 201x42 clip at (419,27) size 199x40
       RenderText {#text} at (0,0) size 48x18
         text run at (0,0) width 48: "default"
 layer at (8,72) size 201x42 clip at (9,73) size 199x40
-  RenderTextControl {TEXTAREA} at (0,63) size 201x43 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (0,63) size 201x43 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 195x18
     RenderBlock {DIV} at (3,3) size 195x18 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 113x18

--- a/LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt
@@ -54,7 +54,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 17x16 [bgcolor=#FFFFFF03]
         RenderText {#text} at (28,3) size 66x19
           text run at (28,3) width 66: "checkbox "
-        RenderBlock {INPUT} at (95,4) size 17x16 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF03]
+        RenderBlock {INPUT} at (95,4) size 17x16 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF03]
         RenderText {#text} at (113,3) size 9x19
           text run at (113,3) width 9: "b"
       RenderBlock {DIV} at (10,439) size 450x24 [border: (1px solid #FF0000)]
@@ -63,7 +63,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 17x16 [bgcolor=#FFFFFF03]
         RenderText {#text} at (28,3) size 37x19
           text run at (28,3) width 37: "radio "
-        RenderBlock {INPUT} at (66,4) size 17x16 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF03]
+        RenderBlock {INPUT} at (66,4) size 17x16 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF03]
         RenderText {#text} at (84,3) size 9x19
           text run at (84,3) width 9: "b"
 layer at (32,364) size 142x14 scrollWidth 161
@@ -75,13 +75,13 @@ layer at (25,385) size 142x14
     RenderText {#text} at (0,0) size 21x14
       text run at (0,0) width 21: "\x{F79A}\x{F79A}\x{F79A}"
 layer at (208,361) size 152x20
-  RenderTextControl {INPUT} at (189,2) size 153x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (189,2) size 153x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (214,364) size 140x14
   RenderBlock {DIV} at (6,3) size 140x14
     RenderText {#text} at (0,0) size 17x14
       text run at (0,0) width 17: "foo"
 layer at (237,382) size 152x20
-  RenderTextControl {INPUT} at (219,24) size 153x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (219,24) size 153x20 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
     RenderFlexibleBox {DIV} at (6,3) size 140x14
       RenderBlock {DIV} at (0,0) size 140x14
 layer at (243,385) size 140x14

--- a/LayoutTests/platform/ios/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/basic-textareas-expected.txt
@@ -559,7 +559,7 @@ layer at (0,0) size 800x1439
                 text run at (0,14) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,28) width 127: "abcdefghijklmnopqrstuv"
         layer at (170,77) size 167x34 clip at (171,78) size 150x32 scrollHeight 60
-          RenderTextControl {TEXTAREA} at (1,16) size 167x34 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+          RenderTextControl {TEXTAREA} at (1,16) size 167x34 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
             RenderBlock {DIV} at (6,3) size 140x56
               RenderText {#text} at (0,0) size 140x56
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -1204,7 +1204,7 @@ layer at (0,0) size 800x1439
                 text run at (0,14) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,28) width 127: "abcdefghijklmnopqrstuv"
         layer at (170,77) size 167x34 clip at (171,78) size 150x32 scrollHeight 60
-          RenderTextControl {TEXTAREA} at (1,16) size 167x34 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+          RenderTextControl {TEXTAREA} at (1,16) size 167x34 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
             RenderBlock {DIV} at (6,3) size 140x56
               RenderText {#text} at (0,0) size 140x56
                 text run at (0,0) width 104: "Lorem ipsum  dolor "

--- a/LayoutTests/platform/ios/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/basic-textareas-quirks-expected.txt
@@ -718,7 +718,7 @@ layer at (376,988) size 167x34 clip at (377,989) size 150x32 scrollHeight 424
         text run at (63,392) width 1: " "
       RenderBR {BR} at (0,406) size 0x14
 layer at (24,129) size 167x34 clip at (25,130) size 150x32 scrollHeight 60
-  RenderTextControl {TEXTAREA} at (14,1) size 168x34 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {TEXTAREA} at (14,1) size 168x34 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
     RenderBlock {DIV} at (6,3) size 140x56
       RenderText {#text} at (0,0) size 140x56
         text run at (0,0) width 101: "Lorem ipsum dolor "

--- a/LayoutTests/platform/ios/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-appearance-disabled-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (403,0) size 1x20
       RenderText {#text} at (0,0) size 0x0
 layer at (8,28) size 152x20
-  RenderTextControl {INPUT} at (0,20) size 152x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,20) size 152x20 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (14,31) size 140x14
   RenderBlock {DIV} at (6,3) size 140x14
     RenderText {#text} at (0,0) size 63x14

--- a/LayoutTests/platform/ios/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-disabled-color-expected.txt
@@ -119,7 +119,7 @@ layer at (171,326) size 141x14 scrollWidth 153
     RenderText {#text} at (0,0) size 151x14
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (8,30) size 152x20
-  RenderTextControl {INPUT} at (0,21) size 152x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,21) size 152x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (14,33) size 140x14 scrollWidth 343
   RenderBlock {DIV} at (6,3) size 140x14
     RenderText {#text} at (0,0) size 344x14
@@ -131,7 +131,7 @@ layer at (14,54) size 140x14 scrollWidth 343
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,72) size 153x22
-  RenderTextControl {INPUT} at (0,64) size 153x22 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#0000FF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,64) size 153x22 [color=oklab(0.34 0 0)] [bgcolor=#0000FF] [border: (1px solid #3C3C4399)]
 layer at (15,76) size 139x14 scrollWidth 343
   RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
@@ -143,7 +143,7 @@ layer at (15,98) size 139x14 scrollWidth 343
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,118) size 153x21
-  RenderTextControl {INPUT} at (0,109) size 153x23 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#000000] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,109) size 153x23 [color=oklab(0.34 0 0)] [bgcolor=#000000] [border: (1px solid #3C3C4399)]
 layer at (15,121) size 139x14 scrollWidth 343
   RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
@@ -155,7 +155,7 @@ layer at (15,144) size 139x14 scrollWidth 343
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,164) size 153x21
-  RenderTextControl {INPUT} at (0,155) size 153x22 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#808080] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,155) size 153x22 [color=oklab(0.34 0 0)] [bgcolor=#808080] [border: (1px solid #3C3C4399)]
 layer at (15,167) size 139x14 scrollWidth 343
   RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14

--- a/LayoutTests/platform/ios/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -30,7 +30,7 @@ layer at (19,144) size 241x25
     RenderText {#text} at (0,0) size 13x25
       text run at (0,0) width 13: "0"
 layer at (8,101) size 263x37
-  RenderTextControl {INPUT} at (0,0) size 263x37 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,0) size 263x37 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (19,107) size 241x25
   RenderBlock {DIV} at (11,6) size 241x25
     RenderText {#text} at (0,0) size 13x25

--- a/LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt
@@ -58,7 +58,7 @@ layer at (14,53) size 142x14
 layer at (14,53) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
 layer at (482,30) size 152x20
-  RenderTextControl {INPUT} at (473,21) size 153x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (473,21) size 153x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (488,33) size 140x14
   RenderBlock {DIV} at (6,3) size 140x14 [color=#640000]
     RenderText {#text} at (0,0) size 68x14

--- a/LayoutTests/platform/ios/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -26,13 +26,13 @@ layer at (350,28) size 167x34 clip at (351,29) size 165x32
       RenderText {#text} at (0,0) size 37x14
         text run at (0,0) width 37: "default"
 layer at (179,28) size 167x34 clip at (180,29) size 165x32
-  RenderTextControl {TEXTAREA} at (171,20) size 167x34 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {TEXTAREA} at (171,20) size 167x34 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
     RenderBlock {DIV} at (6,3) size 155x14
     RenderBlock {DIV} at (6,3) size 155x14 [color=#640000]
       RenderText {#text} at (0,0) size 68x14
         text run at (0,0) width 68: "disabled text"
 layer at (521,28) size 167x34 clip at (522,29) size 165x32
-  RenderTextControl {TEXTAREA} at (513,20) size 167x34 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {TEXTAREA} at (513,20) size 167x34 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
     RenderBlock {DIV} at (6,3) size 155x14
     RenderBlock {DIV} at (6,3) size 155x14 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 85x14

--- a/LayoutTests/platform/mac-wk2/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/basic-inputs-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (8,1) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (163,1) size 29x19
           text run at (163,1) width 29: "text "
-        RenderTextControl {INPUT} at (191,1) size 155x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (191,1) size 155x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (345,1) size 20x19
           text run at (345,1) width 13: "b "
           text run at (357,1) width 8: "a"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 142x13
         RenderText {#text} at (156,22) size 66x19
           text run at (156,22) width 66: "password "
-        RenderTextControl {INPUT} at (221,22) size 155x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (221,22) size 155x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 140x13
             RenderBlock {DIV} at (0,0) size 140x13
         RenderText {#text} at (375,22) size 9x19
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,5) size 13x12
         RenderText {#text} at (24,1) size 66x18
           text run at (24,1) width 66: "checkbox "
-        RenderBlock {INPUT} at (91,5) size 13x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (91,5) size 13x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (105,1) size 9x18
           text run at (105,1) width 9: "b"
       RenderBlock {DIV} at (10,401) size 450x21 [border: (1px solid #FF0000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,5) size 13x12
         RenderText {#text} at (24,1) size 37x18
           text run at (24,1) width 37: "radio "
-        RenderBlock {INPUT} at (62,5) size 13x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (62,5) size 13x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (76,1) size 9x18
           text run at (76,1) width 9: "b"
 layer at (33,329) size 142x13 scrollWidth 161

--- a/LayoutTests/platform/mac-wk2/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/basic-textareas-expected.txt
@@ -1,96 +1,96 @@
-layer at (0,0) size 785x1311
+layer at (0,0) size 785x1395
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1311
-  RenderBlock {HTML} at (0,0) size 785x1311
-    RenderBody {BODY} at (0,0) size 785x1311
-      RenderIFrame {IFRAME} at (0,0) size 785x681
-        layer at (0,0) size 785x681
-          RenderView at (0,0) size 785x681
-        layer at (0,0) size 785x669
-          RenderBlock {HTML} at (0,0) size 785x669
-            RenderBody {BODY} at (0,5) size 785x664
+layer at (0,0) size 785x1395
+  RenderBlock {HTML} at (0,0) size 785x1395
+    RenderBody {BODY} at (0,0) size 785x1395
+      RenderIFrame {IFRAME} at (0,0) size 785x727
+        layer at (0,0) size 785x727
+          RenderView at (0,0) size 785x727
+        layer at (0,0) size 785x727
+          RenderBlock {HTML} at (0,0) size 785x727
+            RenderBody {BODY} at (0,5) size 785x722
               RenderBlock {DIV} at (0,0) size 785x18
                 RenderText {#text} at (0,0) size 196x18
                   text run at (0,0) width 196: "CompatMode: CSS1Compat"
-              RenderBlock (anonymous) at (0,23) size 785x641
-                RenderBlock {DIV} at (0,14) size 169x51 [border: (1px solid #0000FF)]
+              RenderBlock (anonymous) at (0,23) size 785x699
+                RenderBlock {DIV} at (0,30) size 169x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,12) size 80x0
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (169,14) size 169x51 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,30) size 169x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 78x14
                       text run at (0,0) width 78: "disabled: \"true\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (338,0) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (338,0) size 179x81 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 79x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 79: "\"padding:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (507,0) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (517,20) size 159x61 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 73: "\"padding:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,79) size 189x85 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,111) size 189x85 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 74: "\"margin:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (189,99) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (189,131) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 68: "\"margin:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (358,99) size 82x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (358,131) size 82x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 68: "\"width:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (440,85) size 82x79 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (440,81) size 104x115 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 74x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 74: "padding:20px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (522,85) size 82x79 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (544,121) size 82x75 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 63x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 56: "padding:0\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (604,65) size 169x99 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,224) size 169x99 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 71x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 71: "\"height:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,178) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,210) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 66x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (82,226) size 154x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (251,258) size 154x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 92x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 92: "\"overflow:hidden\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (236,211) size 169x80 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (405,243) size 169x80 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 86x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 86: "\"overflow:scroll\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (405,164) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (574,196) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 87x56
                       text run at (0,0) width 26: "style:"
@@ -98,7 +98,7 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 59: "width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (487,164) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (656,196) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 81x56
                       text run at (0,0) width 26: "style:"
@@ -106,21 +106,21 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 59: "width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (569,178) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,337) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 74x42
                       text run at (0,0) width 74: "cols: \"5\", style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (651,178) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,337) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 78x42
                       text run at (0,0) width 78: "rows: \"4\", style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (0,291) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (164,323) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 75x56
                       text run at (0,0) width 75: "cols: \"5\", rows:"
@@ -128,84 +128,84 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 63: "\"width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (82,367) size 82x51 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (246,399) size 82x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 45x14
                       text run at (0,0) width 45: "cols: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (164,354) size 169x64 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (328,386) size 169x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (333,367) size 82x51 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (497,399) size 82x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 45x14
                       text run at (0,0) width 45: "cols: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (415,302) size 169x116 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (579,334) size 169x116 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (584,327) size 82x91 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,450) size 82x91 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 75x28
                       text run at (0,0) width 75: "cols: \"5\", rows:"
                       text run at (0,14) width 19: "\"4\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,432) size 169x51 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,490) size 169x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 57x14
                       text run at (0,0) width 57: "wrap: \"off\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (169,432) size 169x51 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (251,490) size 169x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 65x14
                       text run at (0,0) width 65: "wrap: \"hard\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (338,432) size 169x51 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (420,490) size 169x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 62x14
                       text run at (0,0) width 62: "wrap: \"soft\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (507,418) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (589,476) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 72x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 72: "space:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,483) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,541) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 65x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 54: "space:pre\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (169,483) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,541) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 78x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 78: "space:prewrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (338,483) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (338,541) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 74: "space:nowrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (507,483) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (507,541) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 76x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 76: "space:pre-line\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,576) size 169x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,634) size 169x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 70x28
                       text run at (0,0) width 63: "style: \"word-"
                       text run at (0,14) width 70: "wrap:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (169,548) size 169x93 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,606) size 169x93 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 65x56
                       text run at (0,0) width 57: "wrap: \"off\","
@@ -213,36 +213,36 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 50: "space:pre-"
                       text run at (0,42) width 32: "wrap\","
                   RenderBR {BR} at (81,43) size 0x14
-        layer at (1,57) size 167x32 clip at (2,58) size 165x30
+        layer at (1,73) size 167x32 clip at (2,74) size 165x30
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
-        layer at (170,57) size 167x32 clip at (171,58) size 150x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 167x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+        layer at (170,73) size 167x32 clip at (171,74) size 150x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 167x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (339,57) size 167x32 clip at (340,58) size 150x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 140x52
+        layer at (339,57) size 177x48 clip at (340,58) size 160x46 scrollHeight 72
+          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (11,11) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (508,57) size 167x32 clip at (509,58) size 150x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 140x52
+        layer at (518,77) size 157x28 clip at (519,78) size 140x26 scrollHeight 52
+          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (1,1) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (11,146) size 167x32 clip at (12,147) size 150x30 scrollHeight 56
+        layer at (11,178) size 167x32 clip at (12,179) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (11,39) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -250,7 +250,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (190,156) size 167x32 clip at (191,157) size 150x30 scrollHeight 56
+        layer at (190,188) size 167x32 clip at (191,189) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -258,7 +258,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (359,156) size 72x32 clip at (360,157) size 55x30 scrollHeight 147
+        layer at (359,188) size 72x32 clip at (360,189) size 55x30 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,29) size 72x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -273,9 +273,9 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (441,156) size 72x32 clip at (442,157) size 55x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,43) size 72x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 45x143
+        layer at (441,152) size 102x68 clip at (442,153) size 85x66 scrollHeight 183
+          RenderTextControl {TEXTAREA} at (1,43) size 102x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (21,21) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
                 text run at (0,13) width 38: "ipsum  "
@@ -288,9 +288,9 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (523,156) size 72x32 clip at (524,157) size 55x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,43) size 72x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 45x143
+        layer at (545,192) size 62x28 clip at (546,193) size 45x26 scrollHeight 143
+          RenderTextControl {TEXTAREA} at (1,43) size 62x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (1,1) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 36: "Lorem "
                 text run at (0,13) width 38: "ipsum  "
@@ -303,7 +303,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (605,122) size 167x66 clip at (606,123) size 165x64
+        layer at (1,281) size 167x66 clip at (2,282) size 165x64
           RenderTextControl {TEXTAREA} at (1,29) size 167x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
@@ -311,7 +311,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 155: "ABCDEFGHIJKLMNOPQRSTU"
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,249) size 72x66 clip at (2,250) size 55x64 scrollHeight 147
+        layer at (170,281) size 72x66 clip at (171,282) size 55x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,43) size 72x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -326,7 +326,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (83,283) size 152x32 clip at (84,284) size 150x30 scrollHeight 56
+        layer at (252,315) size 152x32 clip at (253,316) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 152x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -334,7 +334,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (237,268) size 167x47 clip at (238,269) size 150x30 scrollHeight 56
+        layer at (406,300) size 167x47 clip at (407,301) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -342,7 +342,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (406,249) size 72x66 clip at (407,250) size 70x64 scrollHeight 134
+        layer at (575,281) size 72x66 clip at (576,282) size 70x64 scrollHeight 134
           RenderTextControl {TEXTAREA} at (1,57) size 72x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 60x130
               RenderText {#text} at (0,0) size 60x130
@@ -356,7 +356,7 @@ layer at (0,0) size 785x1311
                 text run at (0,91) width 56: "abcdefghij"
                 text run at (0,104) width 60: "klmnopqrst"
                 text run at (0,117) width 13: "uv"
-        layer at (488,249) size 72x66 clip at (489,250) size 55x49 scrollHeight 147
+        layer at (657,281) size 72x66 clip at (658,282) size 55x49 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,57) size 72x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -371,7 +371,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (570,249) size 72x66 clip at (571,250) size 55x64 scrollHeight 147
+        layer at (1,408) size 72x66 clip at (2,409) size 55x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,43) size 72x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -386,7 +386,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (652,249) size 72x66 clip at (653,250) size 55x64 scrollHeight 147
+        layer at (83,408) size 72x66 clip at (84,409) size 55x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,43) size 72x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -401,7 +401,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (1,376) size 72x66 clip at (2,377) size 55x64 scrollHeight 147
+        layer at (165,408) size 72x66 clip at (166,409) size 55x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,57) size 72x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -416,7 +416,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (83,410) size 48x32 clip at (84,411) size 31x30 scrollHeight 329
+        layer at (247,442) size 48x32 clip at (248,443) size 31x30 scrollHeight 329
           RenderTextControl {TEXTAREA} at (1,15) size 48x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 21x325
               RenderText {#text} at (0,0) size 23x325
@@ -445,7 +445,7 @@ layer at (0,0) size 785x1311
                 text run at (0,286) width 20: "nop"
                 text run at (0,299) width 21: "qrst"
                 text run at (0,312) width 13: "uv"
-        layer at (165,397) size 167x45 clip at (166,398) size 150x43 scrollHeight 56
+        layer at (329,429) size 167x45 clip at (330,430) size 150x43 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,15) size 167x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -453,7 +453,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (334,410) size 76x32 clip at (335,411) size 59x30 scrollHeight 147
+        layer at (498,442) size 76x32 clip at (499,443) size 59x30 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,15) size 76x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 49x143
               RenderText {#text} at (0,0) size 49x143
@@ -468,7 +468,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (416,345) size 167x97 clip at (417,346) size 165x95
+        layer at (580,377) size 167x97 clip at (581,378) size 165x95
           RenderTextControl {TEXTAREA} at (1,15) size 167x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
@@ -476,7 +476,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 155: "ABCDEFGHIJKLMNOPQRSTU"
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (585,384) size 62x58 clip at (586,385) size 45x56 scrollHeight 186
+        layer at (1,507) size 62x58 clip at (2,508) size 45x56 scrollHeight 186
           RenderTextControl {TEXTAREA} at (1,29) size 62x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 35x182
               RenderText {#text} at (0,0) size 38x182
@@ -494,12 +494,12 @@ layer at (0,0) size 785x1311
                 text run at (0,143) width 32: "fghijkl"
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 34: "qrstuv"
-        layer at (1,475) size 167x32 clip at (2,476) size 150x15 scrollWidth 433 scrollHeight 17
+        layer at (83,533) size 167x32 clip at (84,534) size 150x15 scrollWidth 433 scrollHeight 17
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (170,475) size 167x32 clip at (171,476) size 150x30 scrollHeight 56
+        layer at (252,533) size 167x32 clip at (253,534) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -507,7 +507,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (339,475) size 167x32 clip at (340,476) size 150x30 scrollHeight 56
+        layer at (421,533) size 167x32 clip at (422,534) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -515,7 +515,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (508,475) size 167x32 clip at (509,476) size 150x30 scrollHeight 56
+        layer at (590,533) size 167x32 clip at (591,534) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -524,12 +524,12 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,540) size 167x32 clip at (2,541) size 150x15 scrollWidth 433 scrollHeight 17
+        layer at (1,598) size 167x32 clip at (2,599) size 150x15 scrollWidth 433 scrollHeight 17
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (170,540) size 167x32 clip at (171,541) size 150x30 scrollHeight 56
+        layer at (170,598) size 167x32 clip at (171,599) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -537,13 +537,13 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (339,540) size 167x32 clip at (340,541) size 150x15 scrollWidth 430 scrollHeight 17
+        layer at (339,598) size 167x32 clip at (340,599) size 150x15 scrollWidth 430 scrollHeight 17
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 426x13
                 text run at (0,0) width 71: "Lorem ipsum "
                 text run at (70,0) width 356: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (508,540) size 167x32 clip at (509,541) size 150x30 scrollHeight 56
+        layer at (508,598) size 167x32 clip at (509,599) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -552,108 +552,108 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,633) size 167x32 clip at (2,634) size 150x15 scrollWidth 200 scrollHeight 43
+        layer at (1,691) size 167x32 clip at (2,692) size 150x15 scrollWidth 200 scrollHeight 43
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,26) width 127: "abcdefghijklmnopqrstuv"
-        layer at (170,633) size 167x32 clip at (171,634) size 150x15 scrollWidth 200 scrollHeight 43
+        layer at (170,691) size 167x32 clip at (171,692) size 150x15 scrollWidth 200 scrollHeight 43
           RenderTextControl {TEXTAREA} at (1,57) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,26) width 127: "abcdefghijklmnopqrstuv"
-      RenderIFrame {IFRAME} at (0,681) size 785x630
-        layer at (0,0) size 770x648
-          RenderView at (0,0) size 770x630
-        layer at (0,0) size 770x648
-          RenderBlock {HTML} at (0,0) size 770x648
-            RenderBody {BODY} at (0,5) size 770x643
+      RenderIFrame {IFRAME} at (0,727) size 785x668
+        layer at (0,0) size 770x694
+          RenderView at (0,0) size 770x668
+        layer at (0,0) size 770x694
+          RenderBlock {HTML} at (0,0) size 770x694
+            RenderBody {BODY} at (0,5) size 770x689
               RenderBlock {DIV} at (0,0) size 770x18
                 RenderText {#text} at (0,0) size 194x18
                   text run at (0,0) width 194: "CompatMode: BackCompat"
-              RenderBlock (anonymous) at (0,23) size 770x620
-                RenderBlock {DIV} at (0,28) size 169x34 [border: (1px solid #0000FF)]
+              RenderBlock (anonymous) at (0,23) size 770x666
+                RenderBlock {DIV} at (0,44) size 169x34 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x0
                   RenderBR {BR} at (81,-10) size 0x14
-                RenderBlock {DIV} at (169,14) size 169x48 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,30) size 169x48 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 78x14
                       text run at (0,0) width 78: "disabled: \"true\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (338,0) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (338,0) size 179x78 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 79x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 79: "\"padding:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (507,0) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (517,20) size 159x58 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 73: "\"padding:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,62) size 189x82 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,108) size 189x82 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 74: "\"margin:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (189,82) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (189,128) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 68: "\"margin:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (358,82) size 82x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (358,128) size 82x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 68: "\"width:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (440,68) size 82x76 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (440,78) size 82x112 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 74x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 74: "padding:20px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (522,68) size 82x76 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (522,118) size 82x72 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 63x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 56: "padding:0\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (0,172) size 169x90 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,218) size 169x90 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 71x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 71: "\"height:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (169,158) size 82x104 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,204) size 82x104 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 66x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (251,200) size 154x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (251,246) size 154x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 92x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 92: "\"overflow:hidden\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (405,185) size 169x77 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (405,231) size 169x77 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 86x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 86: "\"overflow:scroll\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (574,144) size 82x118 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (574,190) size 82x118 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 87x56
                       text run at (0,0) width 26: "style:"
@@ -661,7 +661,7 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 59: "width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (656,144) size 82x118 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (656,190) size 82x118 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 81x56
                       text run at (0,0) width 26: "style:"
@@ -669,21 +669,21 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 59: "width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (0,276) size 82x104 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,322) size 82x104 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 74x42
                       text run at (0,0) width 74: "cols: \"5\", style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (82,276) size 82x104 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,322) size 82x104 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 78x42
                       text run at (0,0) width 78: "rows: \"4\", style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (164,262) size 82x118 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (164,308) size 82x118 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 75x56
                       text run at (0,0) width 75: "cols: \"5\", rows:"
@@ -691,84 +691,84 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 63: "\"width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (246,332) size 82x48 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (246,378) size 82x48 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 45x14
                       text run at (0,0) width 45: "cols: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (328,319) size 169x61 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (328,365) size 169x61 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (497,332) size 82x48 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (497,378) size 82x48 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 45x14
                       text run at (0,0) width 45: "cols: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (579,267) size 169x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (579,313) size 169x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (0,380) size 82x88 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,426) size 82x88 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 75x28
                       text run at (0,0) width 75: "cols: \"5\", rows:"
                       text run at (0,14) width 19: "\"4\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (82,420) size 169x48 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,466) size 169x48 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 57x14
                       text run at (0,0) width 57: "wrap: \"off\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (251,420) size 169x48 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (251,466) size 169x48 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 65x14
                       text run at (0,0) width 65: "wrap: \"hard\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (420,420) size 169x48 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (420,466) size 169x48 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 62x14
                       text run at (0,0) width 62: "wrap: \"soft\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (589,406) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (589,452) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 72x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 72: "space:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,468) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,514) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 65x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 54: "space:pre\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (169,468) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,514) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 78x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 78: "space:prewrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (338,468) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (338,514) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 74: "space:nowrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (507,468) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (507,514) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 76x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 76: "space:pre-line\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,558) size 169x62 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,604) size 169x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 70x28
                       text run at (0,0) width 63: "style: \"word-"
                       text run at (0,14) width 70: "wrap:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (169,530) size 169x90 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (169,576) size 169x90 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 65x56
                       text run at (0,0) width 57: "wrap: \"off\","
@@ -776,36 +776,36 @@ layer at (0,0) size 785x1311
                       text run at (0,28) width 50: "space:pre-"
                       text run at (0,42) width 32: "wrap\","
                   RenderBR {BR} at (81,43) size 0x14
-        layer at (1,57) size 167x32 clip at (2,58) size 165x30
+        layer at (1,73) size 167x32 clip at (2,74) size 165x30
           RenderTextControl {TEXTAREA} at (1,1) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
-        layer at (170,57) size 167x32 clip at (171,58) size 150x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 167x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+        layer at (170,73) size 167x32 clip at (171,74) size 150x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 167x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (339,57) size 167x32 clip at (340,58) size 150x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 140x52
+        layer at (339,57) size 177x48 clip at (340,58) size 160x46 scrollHeight 72
+          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (11,11) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (508,57) size 167x32 clip at (509,58) size 150x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 140x52
+        layer at (518,77) size 157x28 clip at (519,78) size 140x26 scrollHeight 52
+          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (1,1) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (11,129) size 167x32 clip at (12,130) size 150x30 scrollHeight 56
+        layer at (11,175) size 167x32 clip at (12,176) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (11,39) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -813,7 +813,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (190,139) size 167x32 clip at (191,140) size 150x30 scrollHeight 56
+        layer at (190,185) size 167x32 clip at (191,186) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -821,7 +821,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (359,139) size 60x32 clip at (360,140) size 43x30 scrollHeight 199
+        layer at (359,185) size 60x32 clip at (360,186) size 43x30 scrollHeight 199
           RenderTextControl {TEXTAREA} at (1,29) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 33x195
               RenderText {#text} at (0,0) size 38x195
@@ -840,45 +840,94 @@ layer at (0,0) size 785x1311
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 28: "qrstu"
                 text run at (0,182) width 7: "v"
-        layer at (441,139) size 60x32 clip at (442,140) size 43x30 scrollHeight 199
-          RenderTextControl {TEXTAREA} at (1,43) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 33x195
-              RenderText {#text} at (0,0) size 38x195
+        layer at (441,149) size 60x68 clip at (442,150) size 43x66 scrollHeight 911
+          RenderTextControl {TEXTAREA} at (1,43) size 60x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (21,21) size 3x871
+              RenderText {#text} at (0,0) size 11x871
+                text run at (0,0) width 7: "L"
+                text run at (0,13) width 7: "o"
+                text run at (0,26) width 5: "r"
+                text run at (0,39) width 7: "e"
+                text run at (0,52) width 10: "m"
+                text run at (0,65) width 4: " "
+                text run at (0,78) width 3: "i"
+                text run at (0,91) width 7: "p"
+                text run at (0,104) width 6: "s"
+                text run at (0,117) width 7: "u"
+                text run at (0,130) width 10: "m"
+                text run at (0,143) width 7: "  "
+                text run at (0,156) width 7: "d"
+                text run at (0,169) width 7: "o"
+                text run at (0,182) width 3: "l"
+                text run at (0,195) width 7: "o"
+                text run at (0,208) width 5: "r"
+                text run at (0,221) width 4: " "
+                text run at (0,234) width 8: "A"
+                text run at (0,247) width 8: "B"
+                text run at (0,260) width 8: "C"
+                text run at (0,273) width 9: "D"
+                text run at (0,286) width 7: "E"
+                text run at (0,299) width 7: "F"
+                text run at (0,312) width 9: "G"
+                text run at (0,325) width 9: "H"
+                text run at (0,338) width 4: "I"
+                text run at (0,351) width 6: "J"
+                text run at (0,364) width 8: "K"
+                text run at (0,377) width 7: "L"
+                text run at (0,390) width 10: "M"
+                text run at (0,403) width 9: "N"
+                text run at (0,416) width 9: "O"
+                text run at (0,429) width 8: "P"
+                text run at (0,442) width 9: "Q"
+                text run at (0,455) width 8: "R"
+                text run at (0,468) width 8: "S"
+                text run at (0,481) width 8: "T"
+                text run at (0,494) width 9: "U"
+                text run at (0,507) width 8: "V"
+                text run at (0,520) width 11: "W"
+                text run at (0,533) width 8: "X"
+                text run at (0,546) width 8: "Y"
+                text run at (0,559) width 8: "Z"
+                text run at (0,572) width 4: " "
+                text run at (0,585) width 7: "a"
+                text run at (0,598) width 7: "b"
+                text run at (0,611) width 7: "c"
+                text run at (0,624) width 7: "d"
+                text run at (0,637) width 7: "e"
+                text run at (0,650) width 5: "f"
+                text run at (0,663) width 7: "g"
+                text run at (0,676) width 7: "h"
+                text run at (0,689) width 3: "i"
+                text run at (0,702) width 3: "j"
+                text run at (0,715) width 7: "k"
+                text run at (0,728) width 3: "l"
+                text run at (0,741) width 10: "m"
+                text run at (0,754) width 7: "n"
+                text run at (0,767) width 7: "o"
+                text run at (0,780) width 7: "p"
+                text run at (0,793) width 7: "q"
+                text run at (0,806) width 5: "r"
+                text run at (0,819) width 6: "s"
+                text run at (0,832) width 5: "t"
+                text run at (0,845) width 7: "u"
+                text run at (0,858) width 6: "v"
+        layer at (523,189) size 60x28 clip at (524,190) size 43x26 scrollHeight 156
+          RenderTextControl {TEXTAREA} at (1,43) size 60x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+            RenderBlock {DIV} at (1,1) size 43x156
+              RenderText {#text} at (0,0) size 44x156
                 text run at (0,0) width 36: "Lorem "
                 text run at (0,13) width 38: "ipsum  "
                 text run at (0,26) width 31: "dolor "
-                text run at (0,39) width 31: "ABCD"
-                text run at (0,52) width 33: "EFGHI"
-                text run at (0,65) width 30: "JKLM"
-                text run at (0,78) width 33: "NOPQ"
-                text run at (0,91) width 30: "RSTU"
-                text run at (0,104) width 33: "VWXY"
-                text run at (0,117) width 11: "Z "
-                text run at (0,130) width 33: "abcde"
-                text run at (0,143) width 32: "fghijkl"
-                text run at (0,156) width 30: "mnop"
-                text run at (0,169) width 28: "qrstu"
-                text run at (0,182) width 7: "v"
-        layer at (523,139) size 60x32 clip at (524,140) size 43x30 scrollHeight 199
-          RenderTextControl {TEXTAREA} at (1,43) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (6,3) size 33x195
-              RenderText {#text} at (0,0) size 38x195
-                text run at (0,0) width 36: "Lorem "
-                text run at (0,13) width 38: "ipsum  "
-                text run at (0,26) width 31: "dolor "
-                text run at (0,39) width 31: "ABCD"
-                text run at (0,52) width 33: "EFGHI"
-                text run at (0,65) width 30: "JKLM"
-                text run at (0,78) width 33: "NOPQ"
-                text run at (0,91) width 30: "RSTU"
-                text run at (0,104) width 33: "VWXY"
-                text run at (0,117) width 11: "Z "
-                text run at (0,130) width 33: "abcde"
-                text run at (0,143) width 32: "fghijkl"
-                text run at (0,156) width 30: "mnop"
-                text run at (0,169) width 28: "qrstu"
-                text run at (0,182) width 7: "v"
-        layer at (1,229) size 167x60 clip at (2,230) size 165x58
+                text run at (0,39) width 38: "ABCDE"
+                text run at (0,52) width 40: "FGHIJK"
+                text run at (0,65) width 40: "LMNOP"
+                text run at (0,78) width 39: "QRSTU"
+                text run at (0,91) width 44: "VWXYZ "
+                text run at (0,104) width 43: "abcdefg"
+                text run at (0,117) width 38: "hijklmn"
+                text run at (0,130) width 41: "opqrstu"
+                text run at (0,143) width 7: "v"
+        layer at (1,275) size 167x60 clip at (2,276) size 165x58
           RenderTextControl {TEXTAREA} at (1,29) size 167x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
@@ -886,7 +935,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 155: "ABCDEFGHIJKLMNOPQRSTU"
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (170,229) size 60x60 clip at (171,230) size 43x58 scrollHeight 199
+        layer at (170,275) size 60x60 clip at (171,276) size 43x58 scrollHeight 199
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 33x195
               RenderText {#text} at (0,0) size 38x195
@@ -905,7 +954,7 @@ layer at (0,0) size 785x1311
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 28: "qrstu"
                 text run at (0,182) width 7: "v"
-        layer at (252,257) size 152x32 clip at (253,258) size 150x30 scrollHeight 56
+        layer at (252,303) size 152x32 clip at (253,304) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 152x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -913,7 +962,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (406,242) size 167x47 clip at (407,243) size 150x30 scrollHeight 56
+        layer at (406,288) size 167x47 clip at (407,289) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -921,7 +970,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (575,229) size 60x60 clip at (576,230) size 58x58 scrollHeight 147
+        layer at (575,275) size 60x60 clip at (576,276) size 58x58 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 48x143
               RenderText {#text} at (0,0) size 48x143
@@ -936,7 +985,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (657,229) size 60x60 clip at (658,230) size 43x43 scrollHeight 199
+        layer at (657,275) size 60x60 clip at (658,276) size 43x43 scrollHeight 199
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 33x195
               RenderText {#text} at (0,0) size 38x195
@@ -955,7 +1004,7 @@ layer at (0,0) size 785x1311
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 28: "qrstu"
                 text run at (0,182) width 7: "v"
-        layer at (1,347) size 60x60 clip at (2,348) size 43x58 scrollHeight 199
+        layer at (1,393) size 60x60 clip at (2,394) size 43x58 scrollHeight 199
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 33x195
               RenderText {#text} at (0,0) size 38x195
@@ -974,7 +1023,7 @@ layer at (0,0) size 785x1311
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 28: "qrstu"
                 text run at (0,182) width 7: "v"
-        layer at (83,347) size 60x60 clip at (84,348) size 43x58 scrollHeight 199
+        layer at (83,393) size 60x60 clip at (84,394) size 43x58 scrollHeight 199
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 33x195
               RenderText {#text} at (0,0) size 38x195
@@ -993,7 +1042,7 @@ layer at (0,0) size 785x1311
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 28: "qrstu"
                 text run at (0,182) width 7: "v"
-        layer at (165,347) size 60x60 clip at (166,348) size 43x58 scrollHeight 199
+        layer at (165,393) size 60x60 clip at (166,394) size 43x58 scrollHeight 199
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 33x195
               RenderText {#text} at (0,0) size 38x195
@@ -1012,7 +1061,7 @@ layer at (0,0) size 785x1311
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 28: "qrstu"
                 text run at (0,182) width 7: "v"
-        layer at (247,375) size 48x32 clip at (248,376) size 31x30 scrollHeight 329
+        layer at (247,421) size 48x32 clip at (248,422) size 31x30 scrollHeight 329
           RenderTextControl {TEXTAREA} at (1,15) size 48x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 21x325
               RenderText {#text} at (0,0) size 23x325
@@ -1041,7 +1090,7 @@ layer at (0,0) size 785x1311
                 text run at (0,286) width 20: "nop"
                 text run at (0,299) width 21: "qrst"
                 text run at (0,312) width 13: "uv"
-        layer at (329,362) size 167x45 clip at (330,363) size 150x43 scrollHeight 56
+        layer at (329,408) size 167x45 clip at (330,409) size 150x43 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,15) size 167x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -1049,7 +1098,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (498,375) size 76x32 clip at (499,376) size 59x30 scrollHeight 147
+        layer at (498,421) size 76x32 clip at (499,422) size 59x30 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,15) size 76x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 49x143
               RenderText {#text} at (0,0) size 49x143
@@ -1064,7 +1113,7 @@ layer at (0,0) size 785x1311
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (580,310) size 167x97 clip at (581,311) size 165x95
+        layer at (580,356) size 167x97 clip at (581,357) size 165x95
           RenderTextControl {TEXTAREA} at (1,15) size 167x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
@@ -1072,7 +1121,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 155: "ABCDEFGHIJKLMNOPQRSTU"
                 text run at (0,26) width 44: "VWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,437) size 62x58 clip at (2,438) size 45x56 scrollHeight 186
+        layer at (1,483) size 62x58 clip at (2,484) size 45x56 scrollHeight 186
           RenderTextControl {TEXTAREA} at (1,29) size 62x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 35x182
               RenderText {#text} at (0,0) size 38x182
@@ -1090,12 +1139,12 @@ layer at (0,0) size 785x1311
                 text run at (0,143) width 32: "fghijkl"
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 34: "qrstuv"
-        layer at (83,463) size 167x32 clip at (84,464) size 150x15 scrollWidth 433 scrollHeight 17
+        layer at (83,509) size 167x32 clip at (84,510) size 150x15 scrollWidth 433 scrollHeight 17
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (252,463) size 167x32 clip at (253,464) size 150x30 scrollHeight 56
+        layer at (252,509) size 167x32 clip at (253,510) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -1103,7 +1152,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (421,463) size 167x32 clip at (422,464) size 150x30 scrollHeight 56
+        layer at (421,509) size 167x32 clip at (422,510) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,15) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -1111,7 +1160,7 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (590,463) size 167x32 clip at (591,464) size 150x30 scrollHeight 56
+        layer at (590,509) size 167x32 clip at (591,510) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -1120,12 +1169,12 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,525) size 167x32 clip at (2,526) size 150x15 scrollWidth 433 scrollHeight 17
+        layer at (1,571) size 167x32 clip at (2,572) size 150x15 scrollWidth 433 scrollHeight 17
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (170,525) size 167x32 clip at (171,526) size 150x30 scrollHeight 56
+        layer at (170,571) size 167x32 clip at (171,572) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -1133,13 +1182,13 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 59: "TUVWXYZ "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (339,525) size 167x32 clip at (340,526) size 150x15 scrollWidth 430 scrollHeight 17
+        layer at (339,571) size 167x32 clip at (340,572) size 150x15 scrollWidth 430 scrollHeight 17
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 155x13
               RenderText {#text} at (0,0) size 426x13
                 text run at (0,0) width 71: "Lorem ipsum "
                 text run at (70,0) width 356: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (508,525) size 167x32 clip at (509,526) size 150x30 scrollHeight 56
+        layer at (508,571) size 167x32 clip at (509,572) size 150x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -1148,14 +1197,14 @@ layer at (0,0) size 785x1311
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,615) size 167x32 clip at (2,616) size 150x15 scrollWidth 200 scrollHeight 43
+        layer at (1,661) size 167x32 clip at (2,662) size 150x15 scrollWidth 200 scrollHeight 43
           RenderTextControl {TEXTAREA} at (1,29) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x39
               RenderText {#text} at (0,0) size 198x39
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
                 text run at (0,13) width 198: "ABCDEFGHIJKLMNOPQRSTUVWXYZ "
                 text run at (0,26) width 127: "abcdefghijklmnopqrstuv"
-        layer at (170,615) size 167x32 clip at (171,616) size 150x15 scrollWidth 200 scrollHeight 43
+        layer at (170,661) size 167x32 clip at (171,662) size 150x15 scrollWidth 200 scrollHeight 43
           RenderTextControl {TEXTAREA} at (1,57) size 167x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (6,3) size 140x39
               RenderText {#text} at (0,0) size 198x39

--- a/LayoutTests/platform/mac-wk2/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/basic-textareas-quirks-expected.txt
@@ -1,224 +1,224 @@
-layer at (0,0) size 785x986
+layer at (0,0) size 785x1011
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x986
-  RenderBlock {HTML} at (0,0) size 785x986
+layer at (0,0) size 785x1011
+  RenderBlock {HTML} at (0,0) size 785x1011
     RenderBody {BODY} at (8,8) size 769x584
-      RenderBlock (floating) {DIV} at (0,0) size 352x777 [border: (1px solid #FF0000)]
+      RenderBlock (floating) {DIV} at (0,0) size 352x783 [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 350x14
-          RenderText {#text} at (0,-2) size 179x17
-            text run at (0,-2) width 179: "Plain textarea with little content"
+          RenderText {#text} at (0,-1) size 179x16
+            text run at (0,-1) width 179: "Plain textarea with little content"
         RenderBlock {DIV} at (1,15) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
             text run at (181,20) width 14: " B"
-        RenderBlock (anonymous) at (1,52) size 350x14
-          RenderText {#text} at (0,-2) size 77x17
-            text run at (0,-2) width 77: "Plain textarea"
-        RenderBlock {DIV} at (1,66) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,51) size 350x15
+          RenderText {#text} at (0,-1) size 77x16
+            text run at (0,-1) width 77: "Plain textarea"
+        RenderBlock {DIV} at (1,65) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
             text run at (181,20) width 14: " B"
-        RenderBlock (anonymous) at (1,103) size 350x14
-          RenderText {#text} at (0,-2) size 98x17
-            text run at (0,-2) width 98: "Disabled textarea"
-        RenderBlock {DIV} at (1,117) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,102) size 350x14
+          RenderText {#text} at (0,-1) size 98x16
+            text run at (0,-1) width 98: "Disabled textarea"
+        RenderBlock {DIV} at (1,116) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
             text run at (181,20) width 14: " B"
-        RenderBlock (anonymous) at (1,154) size 350x14
-          RenderText {#text} at (0,-2) size 123x17
-            text run at (0,-2) width 123: "style=\"padding:10px\""
-        RenderBlock {DIV} at (1,168) size 352x37 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,20) size 14x17
-            text run at (1,20) width 14: "A "
-          RenderText {#text} at (181,20) size 14x17
-            text run at (181,20) width 14: " B"
-        RenderBlock (anonymous) at (1,205) size 350x14
-          RenderText {#text} at (0,-2) size 116x17
-            text run at (0,-2) width 116: "style=\"padding:0px\""
-        RenderBlock {DIV} at (1,219) size 352x37 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,20) size 14x17
-            text run at (1,20) width 14: "A "
-          RenderText {#text} at (181,20) size 14x17
-            text run at (181,20) width 14: " B"
-        RenderBlock (anonymous) at (1,256) size 350x14
-          RenderText {#text} at (0,-2) size 118x17
-            text run at (0,-2) width 118: "style=\"margin:10px\""
-        RenderBlock {DIV} at (1,270) size 352x57 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,152) size 350x15
+          RenderText {#text} at (0,-1) size 123x16
+            text run at (0,-1) width 123: "style=\"padding:10px\""
+        RenderBlock {DIV} at (1,166) size 352x53 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,36) size 14x17
+            text run at (1,36) width 14: "A "
+          RenderText {#text} at (191,36) size 14x17
+            text run at (191,36) width 14: " B"
+        RenderBlock (anonymous) at (1,219) size 350x14
+          RenderText {#text} at (0,-1) size 116x16
+            text run at (0,-1) width 116: "style=\"padding:0px\""
+        RenderBlock {DIV} at (1,233) size 352x33 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,16) size 14x17
+            text run at (1,16) width 14: "A "
+          RenderText {#text} at (171,16) size 14x17
+            text run at (171,16) width 14: " B"
+        RenderBlock (anonymous) at (1,265) size 350x15
+          RenderText {#text} at (0,-1) size 118x16
+            text run at (0,-1) width 118: "style=\"margin:10px\""
+        RenderBlock {DIV} at (1,279) size 352x57 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,40) size 14x17
             text run at (1,40) width 14: "A "
           RenderText {#text} at (201,40) size 14x17
             text run at (201,40) width 14: " B"
-        RenderBlock (anonymous) at (1,327) size 350x14
-          RenderText {#text} at (0,-2) size 111x17
-            text run at (0,-2) width 111: "style=\"margin:0px\""
-        RenderBlock {DIV} at (1,341) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,336) size 350x14
+          RenderText {#text} at (0,-1) size 111x16
+            text run at (0,-1) width 111: "style=\"margin:0px\""
+        RenderBlock {DIV} at (1,350) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
             text run at (181,20) width 14: " B"
-        RenderBlock (anonymous) at (1,378) size 350x14
-          RenderText {#text} at (0,-2) size 38x17
-            text run at (0,-2) width 38: "cols=3"
-        RenderBlock {DIV} at (1,392) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,386) size 350x15
+          RenderText {#text} at (0,-1) size 38x16
+            text run at (0,-1) width 38: "cols=3"
+        RenderBlock {DIV} at (1,400) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (62,20) size 14x17
             text run at (62,20) width 14: " B"
-        RenderBlock (anonymous) at (1,429) size 350x14
-          RenderText {#text} at (0,-2) size 43x17
-            text run at (0,-2) width 43: "rows=3"
-        RenderBlock {DIV} at (1,443) size 352x50 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,437) size 350x14
+          RenderText {#text} at (0,-1) size 43x16
+            text run at (0,-1) width 43: "rows=3"
+        RenderBlock {DIV} at (1,451) size 352x50 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,33) size 14x17
             text run at (1,33) width 14: "A "
           RenderText {#text} at (181,33) size 14x17
             text run at (181,33) width 14: " B"
-        RenderBlock (anonymous) at (1,493) size 350x14
-          RenderText {#text} at (0,-2) size 45x17
-            text run at (0,-2) width 45: "cols=10"
-        RenderBlock {DIV} at (1,507) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,500) size 350x15
+          RenderText {#text} at (0,-1) size 45x16
+            text run at (0,-1) width 45: "cols=10"
+        RenderBlock {DIV} at (1,514) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (111,20) size 14x17
             text run at (111,20) width 14: " B"
-        RenderBlock (anonymous) at (1,544) size 350x14
-          RenderText {#text} at (0,-2) size 50x17
-            text run at (0,-2) width 50: "rows=10"
-        RenderBlock {DIV} at (1,558) size 352x141 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,551) size 350x14
+          RenderText {#text} at (0,-1) size 50x16
+            text run at (0,-1) width 50: "rows=10"
+        RenderBlock {DIV} at (1,565) size 352x141 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,124) size 14x17
             text run at (1,124) width 14: "A "
           RenderText {#text} at (181,124) size 14x17
             text run at (181,124) width 14: " B"
-        RenderBlock (anonymous) at (1,699) size 350x14
-          RenderText {#text} at (0,-2) size 84x17
-            text run at (0,-2) width 84: "cols=5 rows=4"
-        RenderBlock {DIV} at (1,713) size 352x63 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,705) size 350x15
+          RenderText {#text} at (0,-1) size 84x16
+            text run at (0,-1) width 84: "cols=5 rows=4"
+        RenderBlock {DIV} at (1,719) size 352x63 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,46) size 14x17
             text run at (1,46) width 14: "A "
           RenderText {#text} at (76,46) size 14x17
             text run at (76,46) width 14: " B"
-      RenderBlock (floating) {DIV} at (352,0) size 352x978 [border: (1px solid #FF0000)]
+      RenderBlock (floating) {DIV} at (352,0) size 352x1003 [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 350x14
-          RenderText {#text} at (0,-2) size 110x17
-            text run at (0,-2) width 110: "style=\"width:60px\""
+          RenderText {#text} at (0,-1) size 110x16
+            text run at (0,-1) width 110: "style=\"width:60px\""
         RenderBlock {DIV} at (1,15) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (74,20) size 14x17
             text run at (74,20) width 14: " B"
-        RenderBlock (anonymous) at (1,52) size 350x14
-          RenderText {#text} at (0,-2) size 191x17
-            text run at (0,-2) width 191: "style=\"width:60px;padding:20px\""
-        RenderBlock {DIV} at (1,66) size 352x37 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,20) size 14x17
-            text run at (1,20) width 14: "A "
-          RenderText {#text} at (74,20) size 14x17
-            text run at (74,20) width 14: " B"
-        RenderBlock (anonymous) at (1,103) size 350x14
-          RenderText {#text} at (0,-2) size 170x17
-            text run at (0,-2) width 170: "style=\"width:60px;padding:0\""
-        RenderBlock {DIV} at (1,117) size 352x37 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,20) size 14x17
-            text run at (1,20) width 14: "A "
-          RenderText {#text} at (74,20) size 14x17
-            text run at (74,20) width 14: " B"
-        RenderBlock (anonymous) at (1,154) size 350x14
-          RenderText {#text} at (0,-2) size 113x17
-            text run at (0,-2) width 113: "style=\"height:60px\""
-        RenderBlock {DIV} at (1,168) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,51) size 350x15
+          RenderText {#text} at (0,-1) size 191x16
+            text run at (0,-1) width 191: "style=\"width:60px;padding:20px\""
+        RenderBlock {DIV} at (1,65) size 352x73 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,56) size 14x17
+            text run at (1,56) width 14: "A "
+          RenderText {#text} at (74,56) size 14x17
+            text run at (74,56) width 14: " B"
+        RenderBlock (anonymous) at (1,138) size 350x14
+          RenderText {#text} at (0,-1) size 170x16
+            text run at (0,-1) width 170: "style=\"width:60px;padding:0\""
+        RenderBlock {DIV} at (1,152) size 352x33 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,16) size 14x17
+            text run at (1,16) width 14: "A "
+          RenderText {#text} at (74,16) size 14x17
+            text run at (74,16) width 14: " B"
+        RenderBlock (anonymous) at (1,184) size 350x15
+          RenderText {#text} at (0,-1) size 113x16
+            text run at (0,-1) width 113: "style=\"height:60px\""
+        RenderBlock {DIV} at (1,198) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (181,48) size 14x17
             text run at (181,48) width 14: " B"
-        RenderBlock (anonymous) at (1,233) size 350x14
-          RenderText {#text} at (0,-2) size 181x17
-            text run at (0,-2) width 181: "style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,247) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,263) size 350x14
+          RenderText {#text} at (0,-1) size 181x16
+            text run at (0,-1) width 181: "style=\"width:60px;height:60px\""
+        RenderBlock {DIV} at (1,277) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,312) size 350x14
-          RenderText {#text} at (0,-2) size 138x17
-            text run at (0,-2) width 138: "style=\"overflow:hidden\""
-        RenderBlock {DIV} at (1,326) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,341) size 350x15
+          RenderText {#text} at (0,-1) size 138x16
+            text run at (0,-1) width 138: "style=\"overflow:hidden\""
+        RenderBlock {DIV} at (1,355) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (166,20) size 14x17
             text run at (166,20) width 14: " B"
-        RenderBlock (anonymous) at (1,363) size 350x14
-          RenderText {#text} at (0,-2) size 131x17
-            text run at (0,-2) width 131: "style=\"overflow:scroll\""
-        RenderBlock {DIV} at (1,377) size 352x52 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,392) size 350x14
+          RenderText {#text} at (0,-1) size 131x16
+            text run at (0,-1) width 131: "style=\"overflow:scroll\""
+        RenderBlock {DIV} at (1,406) size 352x52 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,35) size 14x17
             text run at (1,35) width 14: "A "
           RenderText {#text} at (181,35) size 14x17
             text run at (181,35) width 14: " B"
-        RenderBlock (anonymous) at (1,429) size 350x14
-          RenderText {#text} at (0,-2) size 276x17
-            text run at (0,-2) width 276: "style=\"overflow:hidden;width:60px;height:60px\""
-        RenderBlock {DIV} at (1,443) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,457) size 350x15
+          RenderText {#text} at (0,-1) size 276x16
+            text run at (0,-1) width 276: "style=\"overflow:hidden;width:60px;height:60px\""
+        RenderBlock {DIV} at (1,471) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,508) size 350x14
-          RenderText {#text} at (0,-2) size 269x17
-            text run at (0,-2) width 269: "style=\"overflow:scroll;width:60px;height:60px\""
-        RenderBlock {DIV} at (1,522) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,536) size 350x14
+          RenderText {#text} at (0,-1) size 269x16
+            text run at (0,-1) width 269: "style=\"overflow:scroll;width:60px;height:60px\""
+        RenderBlock {DIV} at (1,550) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,587) size 350x14
-          RenderText {#text} at (0,-2) size 222x17
-            text run at (0,-2) width 222: "cols=5 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,601) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,614) size 350x15
+          RenderText {#text} at (0,-1) size 222x16
+            text run at (0,-1) width 222: "cols=5 style=\"width:60px;height:60px\""
+        RenderBlock {DIV} at (1,628) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,666) size 350x14
-          RenderText {#text} at (0,-2) size 226x17
-            text run at (0,-2) width 226: "rows=4 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,680) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,693) size 350x14
+          RenderText {#text} at (0,-1) size 226x16
+            text run at (0,-1) width 226: "rows=4 style=\"width:60px;height:60px\""
+        RenderBlock {DIV} at (1,707) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,745) size 350x14
-          RenderText {#text} at (0,-2) size 267x17
-            text run at (0,-2) width 267: "cols=5 rows=4 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,759) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,771) size 350x15
+          RenderText {#text} at (0,-1) size 267x16
+            text run at (0,-1) width 267: "cols=5 rows=4 style=\"width:60px;height:60px\""
+        RenderBlock {DIV} at (1,785) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,824) size 350x14
-          RenderText {#text} at (0,-2) size 64x17
-            text run at (0,-2) width 64: "wrap=\"off\""
-        RenderBlock {DIV} at (1,838) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,850) size 350x14
+          RenderText {#text} at (0,-1) size 64x16
+            text run at (0,-1) width 64: "wrap=\"off\""
+        RenderBlock {DIV} at (1,864) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
             text run at (181,20) width 5: " "
             text run at (185,20) width 10: "B"
-        RenderBlock (anonymous) at (1,875) size 350x14
-          RenderText {#text} at (0,-2) size 73x17
-            text run at (0,-2) width 73: "wrap=\"hard\""
-        RenderBlock {DIV} at (1,889) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,900) size 350x15
+          RenderText {#text} at (0,-1) size 73x16
+            text run at (0,-1) width 73: "wrap=\"hard\""
+        RenderBlock {DIV} at (1,914) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
             text run at (181,20) width 5: " "
             text run at (185,20) width 10: "B"
-        RenderBlock (anonymous) at (1,926) size 350x14
-          RenderText {#text} at (0,-2) size 69x17
-            text run at (0,-2) width 69: "wrap=\"soft\""
-        RenderBlock {DIV} at (1,940) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock (anonymous) at (1,951) size 350x14
+          RenderText {#text} at (0,-1) size 69x16
+            text run at (0,-1) width 69: "wrap=\"soft\""
+        RenderBlock {DIV} at (1,965) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (181,20) size 14x17
@@ -237,31 +237,31 @@ layer at (24,75) size 167x32 clip at (25,76) size 150x30 scrollHeight 56
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,126) size 167x32 clip at (25,127) size 150x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 168x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+layer at (24,125) size 167x32 clip at (25,126) size 150x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (14,1) size 168x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (6,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,177) size 167x32 clip at (25,178) size 150x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (6,3) size 140x52
+layer at (24,176) size 177x48 clip at (25,177) size 160x46 scrollHeight 72
+  RenderTextControl {TEXTAREA} at (14,1) size 178x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (11,11) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,228) size 167x32 clip at (25,229) size 150x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (6,3) size 140x52
+layer at (24,242) size 157x28 clip at (25,243) size 140x26 scrollHeight 52
+  RenderTextControl {TEXTAREA} at (14,1) size 158x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (34,289) size 167x32 clip at (35,290) size 150x30 scrollHeight 56
+layer at (34,299) size 167x32 clip at (35,300) size 150x30 scrollHeight 56
   RenderTextControl {TEXTAREA} at (24,11) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
@@ -269,7 +269,7 @@ layer at (34,289) size 167x32 clip at (35,290) size 150x30 scrollHeight 56
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,350) size 167x32 clip at (25,351) size 150x30 scrollHeight 56
+layer at (24,359) size 167x32 clip at (25,360) size 150x30 scrollHeight 56
   RenderTextControl {TEXTAREA} at (14,1) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
@@ -277,7 +277,7 @@ layer at (24,350) size 167x32 clip at (25,351) size 150x30 scrollHeight 56
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,401) size 48x32 clip at (25,402) size 31x30 scrollHeight 329
+layer at (24,410) size 48x32 clip at (25,411) size 31x30 scrollHeight 329
   RenderTextControl {TEXTAREA} at (14,1) size 49x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 21x325
       RenderText {#text} at (0,0) size 21x325
@@ -306,7 +306,7 @@ layer at (24,401) size 48x32 clip at (25,402) size 31x30 scrollHeight 329
         text run at (0,286) width 20: "nop"
         text run at (0,299) width 21: "qrst"
         text run at (0,312) width 16: "uv "
-layer at (24,452) size 167x45 clip at (25,453) size 150x43 scrollHeight 56
+layer at (24,460) size 167x45 clip at (25,461) size 150x43 scrollHeight 56
   RenderTextControl {TEXTAREA} at (14,1) size 168x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
@@ -314,7 +314,7 @@ layer at (24,452) size 167x45 clip at (25,453) size 150x43 scrollHeight 56
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,516) size 97x32 clip at (25,517) size 80x30 scrollHeight 95
+layer at (24,524) size 97x32 clip at (25,525) size 80x30 scrollHeight 95
   RenderTextControl {TEXTAREA} at (14,1) size 98x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 70x91
       RenderText {#text} at (0,0) size 71x91
@@ -325,7 +325,7 @@ layer at (24,516) size 97x32 clip at (25,517) size 80x30 scrollHeight 95
         text run at (0,52) width 59: "TUVWXYZ "
         text run at (0,65) width 64: "abcdefghijkl"
         text run at (0,78) width 66: "mnopqrstuv "
-layer at (24,567) size 167x136 clip at (25,568) size 165x134
+layer at (24,574) size 167x136 clip at (25,575) size 165x134
   RenderTextControl {TEXTAREA} at (14,1) size 168x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
@@ -333,7 +333,7 @@ layer at (24,567) size 167x136 clip at (25,568) size 165x134
         text run at (0,13) width 155: "ABCDEFGHIJKLMNOPQRSTU"
         text run at (0,26) width 44: "VWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (24,722) size 62x58 clip at (25,723) size 45x56 scrollHeight 186
+layer at (24,729) size 62x58 clip at (25,730) size 45x56 scrollHeight 186
   RenderTextControl {TEXTAREA} at (14,1) size 63x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 35x182
       RenderText {#text} at (0,0) size 37x182
@@ -370,45 +370,95 @@ layer at (376,24) size 60x32 clip at (377,25) size 43x30 scrollHeight 199
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 28: "qrstu"
         text run at (0,182) width 10: "v "
-layer at (376,75) size 60x32 clip at (377,76) size 43x30 scrollHeight 199
-  RenderTextControl {TEXTAREA} at (14,1) size 61x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (6,3) size 33x195
-      RenderText {#text} at (0,0) size 36x195
+layer at (376,75) size 60x68 clip at (377,76) size 43x66 scrollHeight 924
+  RenderTextControl {TEXTAREA} at (14,1) size 61x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (21,21) size 3x884
+      RenderText {#text} at (0,0) size 11x884
+        text run at (0,0) width 7: "L"
+        text run at (0,13) width 7: "o"
+        text run at (0,26) width 5: "r"
+        text run at (0,39) width 7: "e"
+        text run at (0,52) width 10: "m"
+        text run at (0,65) width 4: " "
+        text run at (0,78) width 3: "i"
+        text run at (0,91) width 7: "p"
+        text run at (0,104) width 6: "s"
+        text run at (0,117) width 7: "u"
+        text run at (0,130) width 10: "m"
+        text run at (0,143) width 4: " "
+        text run at (0,156) width 7: "d"
+        text run at (0,169) width 7: "o"
+        text run at (0,182) width 3: "l"
+        text run at (0,195) width 7: "o"
+        text run at (0,208) width 5: "r"
+        text run at (0,221) width 4: " "
+        text run at (0,234) width 8: "A"
+        text run at (0,247) width 8: "B"
+        text run at (0,260) width 8: "C"
+        text run at (0,273) width 9: "D"
+        text run at (0,286) width 7: "E"
+        text run at (0,299) width 7: "F"
+        text run at (0,312) width 9: "G"
+        text run at (0,325) width 9: "H"
+        text run at (0,338) width 4: "I"
+        text run at (0,351) width 6: "J"
+        text run at (0,364) width 8: "K"
+        text run at (0,377) width 7: "L"
+        text run at (0,390) width 10: "M"
+        text run at (0,403) width 9: "N"
+        text run at (0,416) width 9: "O"
+        text run at (0,429) width 8: "P"
+        text run at (0,442) width 9: "Q"
+        text run at (0,455) width 8: "R"
+        text run at (0,468) width 8: "S"
+        text run at (0,481) width 8: "T"
+        text run at (0,494) width 9: "U"
+        text run at (0,507) width 8: "V"
+        text run at (0,520) width 11: "W"
+        text run at (0,533) width 8: "X"
+        text run at (0,546) width 8: "Y"
+        text run at (0,559) width 8: "Z"
+        text run at (0,572) width 4: " "
+        text run at (0,585) width 7: "a"
+        text run at (0,598) width 7: "b"
+        text run at (0,611) width 7: "c"
+        text run at (0,624) width 7: "d"
+        text run at (0,637) width 7: "e"
+        text run at (0,650) width 5: "f"
+        text run at (0,663) width 7: "g"
+        text run at (0,676) width 7: "h"
+        text run at (0,689) width 3: "i"
+        text run at (0,702) width 3: "j"
+        text run at (0,715) width 7: "k"
+        text run at (0,728) width 3: "l"
+        text run at (0,741) width 10: "m"
+        text run at (0,754) width 7: "n"
+        text run at (0,767) width 7: "o"
+        text run at (0,780) width 7: "p"
+        text run at (0,793) width 7: "q"
+        text run at (0,806) width 5: "r"
+        text run at (0,819) width 6: "s"
+        text run at (0,832) width 5: "t"
+        text run at (0,845) width 7: "u"
+        text run at (0,858) width 6: "v"
+        text run at (0,871) width 4: " "
+layer at (376,161) size 60x28 clip at (377,162) size 43x26 scrollHeight 156
+  RenderTextControl {TEXTAREA} at (14,1) size 61x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 43x156
+      RenderText {#text} at (0,0) size 44x156
         text run at (0,0) width 36: "Lorem "
         text run at (0,13) width 35: "ipsum "
         text run at (0,26) width 31: "dolor "
-        text run at (0,39) width 31: "ABCD"
-        text run at (0,52) width 33: "EFGHI"
-        text run at (0,65) width 30: "JKLM"
-        text run at (0,78) width 33: "NOPQ"
-        text run at (0,91) width 30: "RSTU"
-        text run at (0,104) width 33: "VWXY"
-        text run at (0,117) width 11: "Z "
-        text run at (0,130) width 33: "abcde"
-        text run at (0,143) width 32: "fghijkl"
-        text run at (0,156) width 30: "mnop"
-        text run at (0,169) width 28: "qrstu"
-        text run at (0,182) width 10: "v "
-layer at (376,126) size 60x32 clip at (377,127) size 43x30 scrollHeight 199
-  RenderTextControl {TEXTAREA} at (14,1) size 61x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (6,3) size 33x195
-      RenderText {#text} at (0,0) size 36x195
-        text run at (0,0) width 36: "Lorem "
-        text run at (0,13) width 35: "ipsum "
-        text run at (0,26) width 31: "dolor "
-        text run at (0,39) width 31: "ABCD"
-        text run at (0,52) width 33: "EFGHI"
-        text run at (0,65) width 30: "JKLM"
-        text run at (0,78) width 33: "NOPQ"
-        text run at (0,91) width 30: "RSTU"
-        text run at (0,104) width 33: "VWXY"
-        text run at (0,117) width 11: "Z "
-        text run at (0,130) width 33: "abcde"
-        text run at (0,143) width 32: "fghijkl"
-        text run at (0,156) width 30: "mnop"
-        text run at (0,169) width 28: "qrstu"
-        text run at (0,182) width 10: "v "
-layer at (376,177) size 167x60 clip at (377,178) size 165x58
+        text run at (0,39) width 38: "ABCDE"
+        text run at (0,52) width 40: "FGHIJK"
+        text run at (0,65) width 40: "LMNOP"
+        text run at (0,78) width 39: "QRSTU"
+        text run at (0,91) width 44: "VWXYZ "
+        text run at (0,104) width 43: "abcdefg"
+        text run at (0,117) width 38: "hijklmn"
+        text run at (0,130) width 41: "opqrstu"
+        text run at (0,143) width 10: "v "
+layer at (376,208) size 167x60 clip at (377,209) size 165x58
   RenderTextControl {TEXTAREA} at (14,1) size 168x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
@@ -416,7 +466,7 @@ layer at (376,177) size 167x60 clip at (377,178) size 165x58
         text run at (0,13) width 155: "ABCDEFGHIJKLMNOPQRSTU"
         text run at (0,26) width 44: "VWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (376,256) size 60x60 clip at (377,257) size 43x58 scrollHeight 199
+layer at (376,286) size 60x60 clip at (377,287) size 43x58 scrollHeight 199
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 33x195
       RenderText {#text} at (0,0) size 36x195
@@ -435,7 +485,7 @@ layer at (376,256) size 60x60 clip at (377,257) size 43x58 scrollHeight 199
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 28: "qrstu"
         text run at (0,182) width 10: "v "
-layer at (376,335) size 152x32 clip at (377,336) size 150x30 scrollHeight 56
+layer at (376,365) size 152x32 clip at (377,366) size 150x30 scrollHeight 56
   RenderTextControl {TEXTAREA} at (14,1) size 153x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
@@ -443,7 +493,7 @@ layer at (376,335) size 152x32 clip at (377,336) size 150x30 scrollHeight 56
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (376,386) size 167x47 clip at (377,387) size 150x30 scrollHeight 56
+layer at (376,415) size 167x47 clip at (377,416) size 150x30 scrollHeight 56
   RenderTextControl {TEXTAREA} at (14,1) size 168x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
@@ -451,7 +501,7 @@ layer at (376,386) size 167x47 clip at (377,387) size 150x30 scrollHeight 56
         text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
-layer at (376,452) size 60x60 clip at (377,453) size 58x58 scrollHeight 147
+layer at (376,481) size 60x60 clip at (377,482) size 58x58 scrollHeight 147
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 48x143
       RenderText {#text} at (0,0) size 48x143
@@ -466,7 +516,7 @@ layer at (376,452) size 60x60 clip at (377,453) size 58x58 scrollHeight 147
         text run at (0,104) width 43: "abcdefg"
         text run at (0,117) width 44: "hijklmno"
         text run at (0,130) width 44: "pqrstuv "
-layer at (376,531) size 60x60 clip at (377,532) size 43x43 scrollHeight 199
+layer at (376,559) size 60x60 clip at (377,560) size 43x43 scrollHeight 199
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 33x195
       RenderText {#text} at (0,0) size 36x195
@@ -485,7 +535,7 @@ layer at (376,531) size 60x60 clip at (377,532) size 43x43 scrollHeight 199
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 28: "qrstu"
         text run at (0,182) width 10: "v "
-layer at (376,610) size 60x60 clip at (377,611) size 43x58 scrollHeight 199
+layer at (376,638) size 60x60 clip at (377,639) size 43x58 scrollHeight 199
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 33x195
       RenderText {#text} at (0,0) size 36x195
@@ -504,7 +554,7 @@ layer at (376,610) size 60x60 clip at (377,611) size 43x58 scrollHeight 199
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 28: "qrstu"
         text run at (0,182) width 10: "v "
-layer at (376,689) size 60x60 clip at (377,690) size 43x58 scrollHeight 199
+layer at (376,716) size 60x60 clip at (377,717) size 43x58 scrollHeight 199
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 33x195
       RenderText {#text} at (0,0) size 36x195
@@ -523,7 +573,7 @@ layer at (376,689) size 60x60 clip at (377,690) size 43x58 scrollHeight 199
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 28: "qrstu"
         text run at (0,182) width 10: "v "
-layer at (376,768) size 60x60 clip at (377,769) size 43x58 scrollHeight 199
+layer at (376,795) size 60x60 clip at (377,796) size 43x58 scrollHeight 199
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 33x195
       RenderText {#text} at (0,0) size 36x195
@@ -542,7 +592,7 @@ layer at (376,768) size 60x60 clip at (377,769) size 43x58 scrollHeight 199
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 28: "qrstu"
         text run at (0,182) width 10: "v "
-layer at (376,847) size 167x32 clip at (377,848) size 150x15 scrollWidth 189 scrollHeight 212
+layer at (376,873) size 167x32 clip at (377,874) size 150x15 scrollWidth 189 scrollHeight 212
   RenderTextControl {TEXTAREA} at (14,1) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x208
       RenderText {#text} at (0,0) size 185x195
@@ -577,7 +627,7 @@ layer at (376,847) size 167x32 clip at (377,848) size 150x15 scrollWidth 189 scr
         text run at (0,182) width 185: "This is a text area with wrap=\"soft\""
         text run at (184,182) width 1: " "
       RenderBR {BR} at (0,195) size 0x13
-layer at (376,898) size 167x32 clip at (377,899) size 150x30 scrollHeight 394
+layer at (376,924) size 167x32 clip at (377,925) size 150x30 scrollHeight 394
   RenderTextControl {TEXTAREA} at (14,1) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x390
       RenderText {#text} at (0,0) size 121x377
@@ -626,7 +676,7 @@ layer at (376,898) size 167x32 clip at (377,899) size 150x30 scrollHeight 394
         text run at (0,364) width 64: "wrap=\"soft\""
         text run at (63,364) width 1: " "
       RenderBR {BR} at (0,377) size 0x13
-layer at (376,949) size 167x32 clip at (377,950) size 150x30 scrollHeight 394
+layer at (376,974) size 167x32 clip at (377,975) size 150x30 scrollHeight 394
   RenderTextControl {TEXTAREA} at (14,1) size 168x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (6,3) size 140x390
       RenderText {#text} at (0,0) size 121x377

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-disabled-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 404x18
         text run at (0,0) width 404: "This tests that text can not be inserted into a disabled text field."
       RenderBR {BR} at (403,0) size 1x18
-      RenderTextControl {INPUT} at (0,18) size 154x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 154x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
 layer at (15,30) size 140x13
   RenderBlock {DIV} at (7,4) size 140x13

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-disabled-color-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 521x18
         text run at (0,0) width 521: "This tests that the text color changes appropriately when the text field is disabled."
       RenderBR {BR} at (520,0) size 1x18
-      RenderTextControl {INPUT} at (0,18) size 154x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 154x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (153,18) size 5x19
         text run at (153,18) width 5: " "
       RenderTextControl {INPUT} at (157,18) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         text run at (153,39) width 5: " "
       RenderTextControl {INPUT} at (157,39) size 157x21 [color=#FF0000] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderBR {BR} at (313,39) size 1x19
-      RenderTextControl {INPUT} at (0,60) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#0000FF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,60) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderText {#text} at (145,60) size 5x18
         text run at (145,60) width 5: " "
       RenderTextControl {INPUT} at (149,60) size 149x20 [bgcolor=#0000FF] [border: (2px inset #808080)]
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         text run at (145,79) width 5: " "
       RenderTextControl {INPUT} at (149,79) size 149x20 [color=#FF0000] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderBR {BR} at (297,79) size 1x19
-      RenderTextControl {INPUT} at (0,99) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#000000] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,99) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderText {#text} at (145,98) size 5x19
         text run at (145,98) width 5: " "
       RenderTextControl {INPUT} at (149,99) size 149x20 [bgcolor=#000000] [border: (2px inset #808080)]
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         text run at (145,118) width 5: " "
       RenderTextControl {INPUT} at (149,118) size 149x20 [color=#FFFFFF] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderBR {BR} at (297,118) size 1x19
-      RenderTextControl {INPUT} at (0,137) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#808080] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,137) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#808080] [border: (2px inset #808080)]
       RenderText {#text} at (145,137) size 5x19
         text run at (145,137) width 5: " "
       RenderTextControl {INPUT} at (149,137) size 149x20 [bgcolor=#808080] [border: (2px inset #808080)]

--- a/LayoutTests/platform/mac-wk2/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -8,41 +8,41 @@ layer at (0,0) size 800x600
           text run at (0,0) width 762: "Test appearances of spin buttons. Disabled state and read-only state should have appearances different from the normal"
           text run at (0,18) width 34: "state."
       RenderBlock {DIV} at (0,52) size 784x37
-        RenderInline {LABEL} at (0,12) size 348x18
-          RenderTextControl {INPUT} at (0,0) size 262x37 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-            RenderFlexibleBox {DIV} at (12,7) size 243x23
-              RenderBlock {DIV} at (0,0) size 223x23
-          RenderText {#text} at (261,12) size 87x18
-            text run at (261,12) width 87: " Normal state"
+        RenderInline {LABEL} at (0,12) size 353x19
+          RenderTextControl {INPUT} at (0,0) size 267x37 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderFlexibleBox {DIV} at (12,7) size 248x23
+              RenderBlock {DIV} at (0,0) size 228x23
+          RenderText {#text} at (266,12) size 87x19
+            text run at (266,12) width 87: " Normal state"
       RenderBlock {DIV} at (0,89) size 784x37
-        RenderInline {LABEL} at (0,12) size 354x18
-          RenderTextControl {INPUT} at (0,0) size 260x37 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-            RenderFlexibleBox {DIV} at (12,7) size 241x23
-              RenderBlock {DIV} at (0,0) size 221x23
-          RenderText {#text} at (259,12) size 95x18
-            text run at (259,12) width 95: " Disabled state"
+        RenderInline {LABEL} at (0,12) size 359x19
+          RenderTextControl {INPUT} at (0,0) size 265x37 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderFlexibleBox {DIV} at (12,7) size 246x23
+              RenderBlock {DIV} at (0,0) size 226x23
+          RenderText {#text} at (264,12) size 95x19
+            text run at (264,12) width 95: " Disabled state"
       RenderBlock {DIV} at (0,126) size 784x37
-        RenderInline {LABEL} at (0,12) size 364x18
-          RenderTextControl {INPUT} at (0,0) size 260x37 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
-            RenderFlexibleBox {DIV} at (12,7) size 241x23
-              RenderBlock {DIV} at (0,0) size 221x23
-          RenderText {#text} at (259,12) size 105x18
-            text run at (259,12) width 105: " Read-only state"
-layer at (20,67) size 223x23
-  RenderBlock {DIV} at (0,0) size 223x23
-    RenderText {#text} at (0,0) size 13x23
+        RenderInline {LABEL} at (0,12) size 369x19
+          RenderTextControl {INPUT} at (0,0) size 265x37 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+            RenderFlexibleBox {DIV} at (12,7) size 246x23
+              RenderBlock {DIV} at (0,0) size 226x23
+          RenderText {#text} at (264,12) size 105x19
+            text run at (264,12) width 105: " Read-only state"
+layer at (20,67) size 228x23
+  RenderBlock {DIV} at (0,0) size 228x23
+    RenderText {#text} at (0,-1) size 13x25
       text run at (0,0) width 13: "0"
-layer at (20,104) size 221x23
-  RenderBlock {DIV} at (0,0) size 221x23
-    RenderText {#text} at (0,0) size 13x23
+layer at (20,104) size 226x23
+  RenderBlock {DIV} at (0,0) size 226x23
+    RenderText {#text} at (0,-1) size 13x25
       text run at (0,0) width 13: "0"
-layer at (20,141) size 221x23
-  RenderBlock {DIV} at (0,0) size 221x23
-    RenderText {#text} at (0,0) size 13x23
+layer at (20,141) size 226x23
+  RenderBlock {DIV} at (0,0) size 226x23
+    RenderText {#text} at (0,-1) size 13x25
       text run at (0,0) width 13: "0"
-layer at (243,67) size 20x23
-  RenderBlock (relative positioned) {DIV} at (222,0) size 21x23
-layer at (241,104) size 20x23
-  RenderBlock (relative positioned) {DIV} at (220,0) size 21x23
-layer at (241,141) size 20x23
-  RenderBlock (relative positioned) {DIV} at (220,0) size 21x23
+layer at (248,67) size 20x23
+  RenderBlock (relative positioned) {DIV} at (227,0) size 21x23
+layer at (246,104) size 20x23
+  RenderBlock (relative positioned) {DIV} at (225,0) size 21x23
+layer at (246,141) size 20x23
+  RenderBlock (relative positioned) {DIV} at (225,0) size 21x23

--- a/LayoutTests/platform/mac-wk2/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/placeholder-pseudo-style-expected.txt
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 142x13
       RenderText {#text} at (475,18) size 5x19
         text run at (475,18) width 5: " "
-      RenderTextControl {INPUT} at (479,18) size 155x21 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (479,18) size 155x21 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
       RenderTextControl {INPUT} at (0,39) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (155,39) size 5x19

--- a/LayoutTests/platform/mac-wk2/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -20,7 +20,7 @@ layer at (8,26) size 167x32 clip at (9,27) size 165x30
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "text"
 layer at (179,26) size 167x32 clip at (180,27) size 165x30
-  RenderTextControl {TEXTAREA} at (171,18) size 167x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (171,18) size 167x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (6,3) size 155x13
     RenderBlock {DIV} at (6,3) size 155x13 [color=#640000]
       RenderText {#text} at (0,0) size 68x13
@@ -32,7 +32,7 @@ layer at (350,26) size 167x32 clip at (351,27) size 165x30
       RenderText {#text} at (0,0) size 37x13
         text run at (0,0) width 37: "default"
 layer at (521,26) size 167x32 clip at (522,27) size 165x30
-  RenderTextControl {TEXTAREA} at (513,18) size 167x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (513,18) size 167x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (6,3) size 155x13
     RenderBlock {DIV} at (6,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 85x13

--- a/LayoutTests/platform/wpe/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/basic-inputs-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (8,1) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (181,4) size 27x18
           text run at (181,4) width 27: "text "
-        RenderTextControl {INPUT} at (208,1) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (208,1) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (380,4) size 19x18
           text run at (380,4) width 12: "b "
           text run at (392,4) width 7: "a"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 167x18
         RenderText {#text} at (174,28) size 64x18
           text run at (174,28) width 64: "password "
-        RenderTextControl {INPUT} at (238,25) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (238,25) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 166x18
             RenderBlock {DIV} at (0,0) size 166x18
         RenderText {#text} at (410,28) size 8x18
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 12x12
         RenderText {#text} at (24,2) size 65x17
           text run at (24,2) width 65: "checkbox "
-        RenderBlock {INPUT} at (91,4) size 12x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (91,4) size 12x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (105,2) size 8x17
           text run at (105,2) width 8: "b"
       RenderBlock {DIV} at (10,406) size 450x21 [border: (1px solid #FF0000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 12x12
         RenderText {#text} at (24,2) size 36x17
           text run at (24,2) width 36: "radio "
-        RenderBlock {INPUT} at (62,4) size 12x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (62,4) size 12x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (76,2) size 8x17
           text run at (76,2) width 8: "b"
 layer at (29,328) size 167x18 scrollWidth 190

--- a/LayoutTests/platform/wpe/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/basic-textareas-expected.txt
@@ -220,7 +220,7 @@ layer at (0,0) size 785x836
           RenderText {#text} at (0,0) size 121x18
             text run at (0,0) width 121: "Lorem ipsum dolor"
     layer at (184,75) size 181x42 clip at (185,76) size 164x40 scrollHeight 76
-      RenderTextControl {TEXTAREA} at (1,16) size 181x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+      RenderTextControl {TEXTAREA} at (1,16) size 181x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
         RenderBlock {DIV} at (3,3) size 160x72
           RenderText {#text} at (0,0) size 160x72
             text run at (0,0) width 129: "Lorem ipsum  dolor "
@@ -823,7 +823,7 @@ layer at (0,836) size 785x787
           RenderText {#text} at (0,0) size 121x18
             text run at (0,0) width 121: "Lorem ipsum dolor"
     layer at (184,75) size 181x42 clip at (185,76) size 164x40 scrollHeight 76
-      RenderTextControl {TEXTAREA} at (1,16) size 181x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+      RenderTextControl {TEXTAREA} at (1,16) size 181x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
         RenderBlock {DIV} at (3,3) size 160x72
           RenderText {#text} at (0,0) size 160x72
             text run at (0,0) width 129: "Lorem ipsum  dolor "

--- a/LayoutTests/platform/wpe/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/basic-textareas-quirks-expected.txt
@@ -238,7 +238,7 @@ layer at (24,85) size 181x42 clip at (25,86) size 164x40 scrollHeight 76
         text run at (0,36) width 128: "PQRSTUVWXYZ "
         text run at (0,54) width 157: "abcdefghijklmnopqrstuv "
 layer at (24,145) size 181x42 clip at (25,146) size 164x40 scrollHeight 76
-  RenderTextControl {TEXTAREA} at (15,1) size 181x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (15,1) size 181x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 160x72
       RenderText {#text} at (0,0) size 160x72
         text run at (0,0) width 125: "Lorem ipsum dolor "

--- a/LayoutTests/platform/wpe/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/input-appearance-disabled-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 393x18
         text run at (0,0) width 393: "This tests that text can not be inserted into a disabled text field."
       RenderBR {BR} at (393,0) size 0x18
-      RenderTextControl {INPUT} at (0,18) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 166x18
   RenderBlock {DIV} at (3,3) size 166x18

--- a/LayoutTests/platform/wpe/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/input-disabled-color-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 509x18
         text run at (0,0) width 509: "This tests that the text color changes appropriately when the text field is disabled."
       RenderBR {BR} at (509,0) size 0x18
-      RenderTextControl {INPUT} at (0,18) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (172,21) size 4x18
         text run at (172,21) width 4: " "
       RenderTextControl {INPUT} at (176,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         text run at (172,45) width 4: " "
       RenderTextControl {INPUT} at (176,42) size 173x24 [color=#FF0000] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderBR {BR} at (349,45) size 0x18
-      RenderTextControl {INPUT} at (0,66) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#0000FF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,66) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderText {#text} at (172,69) size 4x18
         text run at (172,69) width 4: " "
       RenderTextControl {INPUT} at (176,66) size 173x24 [bgcolor=#0000FF] [border: (2px inset #808080)]
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         text run at (172,93) width 4: " "
       RenderTextControl {INPUT} at (176,90) size 173x24 [color=#FF0000] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderBR {BR} at (349,93) size 0x18
-      RenderTextControl {INPUT} at (0,114) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#000000] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,114) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderText {#text} at (172,117) size 4x18
         text run at (172,117) width 4: " "
       RenderTextControl {INPUT} at (176,114) size 173x24 [bgcolor=#000000] [border: (2px inset #808080)]
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         text run at (172,141) width 4: " "
       RenderTextControl {INPUT} at (176,138) size 173x24 [color=#FFFFFF] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderBR {BR} at (349,141) size 0x18
-      RenderTextControl {INPUT} at (0,162) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#808080] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,162) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#808080] [border: (2px inset #808080)]
       RenderText {#text} at (172,165) size 4x18
         text run at (172,165) width 4: " "
       RenderTextControl {INPUT} at (176,162) size 173x24 [bgcolor=#808080] [border: (2px inset #808080)]

--- a/LayoutTests/platform/wpe/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
             text run at (215,7) width 84: " Normal state"
       RenderBlock {DIV} at (0,63) size 784x29
         RenderInline {LABEL} at (0,7) size 306x18
-          RenderTextControl {INPUT} at (0,0) size 214x29 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+          RenderTextControl {INPUT} at (0,0) size 214x29 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
             RenderFlexibleBox {DIV} at (3,3) size 208x23
               RenderBlock {DIV} at (0,0) size 192x23
           RenderText {#text} at (214,7) size 92x18

--- a/LayoutTests/platform/wpe/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/placeholder-pseudo-style-expected.txt
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 167x18
       RenderText {#text} at (527,21) size 4x18
         text run at (527,21) width 4: " "
-      RenderTextControl {INPUT} at (531,18) size 172x24 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (531,18) size 172x24 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
       RenderTextControl {INPUT} at (0,42) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (173,45) size 4x18

--- a/LayoutTests/platform/wpe/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -20,7 +20,7 @@ layer at (8,26) size 181x42 clip at (9,27) size 179x40
       RenderText {#text} at (0,0) size 23x18
         text run at (0,0) width 23: "text"
 layer at (193,26) size 181x42 clip at (194,27) size 179x40
-  RenderTextControl {TEXTAREA} at (185,18) size 181x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (185,18) size 181x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 175x18
     RenderBlock {DIV} at (3,3) size 175x18 [color=#640000]
       RenderText {#text} at (0,0) size 79x18
@@ -32,7 +32,7 @@ layer at (378,26) size 181x42 clip at (379,27) size 179x40
       RenderText {#text} at (0,0) size 43x18
         text run at (0,0) width 43: "default"
 layer at (563,26) size 181x42 clip at (564,27) size 179x40
-  RenderTextControl {TEXTAREA} at (555,18) size 181x42 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (555,18) size 181x42 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 175x18
     RenderBlock {DIV} at (3,3) size 175x18 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 99x18

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -381,7 +381,7 @@ button {
 }
 
 ::-internal-writing-suggestions {
-    color: color-mix(in srgb, currentColor 50%, transparent);
+    color: color-mix(currentColor 50%, transparent);
 }
 
 input, textarea, select, button {
@@ -754,7 +754,7 @@ input::placeholder {
 }
 
 input:disabled, textarea:disabled {
-    color: color-mix(in hsl, CanvasText 66%, Canvas);
+    color: color-mix(CanvasText 66%, Canvas);
 }
 
 input:is([type="hidden"], [type="image"], [type="file"]) {
@@ -1076,33 +1076,33 @@ select:-internal-uses-menulist {
 select:-internal-uses-menulist:enabled:hover {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
 #if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
-    background-color: -internal-auto-base(rgba(0, 0, 0, 0.04), color-mix(in lab, currentColor 10%, transparent));
+    background-color: -internal-auto-base(rgba(0, 0, 0, 0.04), color-mix(currentColor 10%, transparent));
 #else
-    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill, color-mix(in lab, currentColor 10%, transparent));
+    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill, color-mix(currentColor 10%, transparent));
 #endif /* defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
 #else
-    background-color: -internal-auto-base(Canvas, color-mix(in lab, currentColor 10%, transparent));
+    background-color: -internal-auto-base(Canvas, color-mix(currentColor 10%, transparent));
 #endif /* defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY */
 }
 
 select:-internal-uses-menulist:enabled:active {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
 #if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
-    background-color: -internal-auto-base(rgba(0, 0, 0, 0.04), color-mix(in lab, currentColor 20%, transparent));
+    background-color: -internal-auto-base(rgba(0, 0, 0, 0.04), color-mix(currentColor 20%, transparent));
 #else
-    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill, color-mix(in lab, currentColor 20%, transparent));
+    background-color: -internal-auto-base(-apple-system-opaque-secondary-fill, color-mix(currentColor 20%, transparent));
 #endif /* defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
 #else
-    background-color: -internal-auto-base(Canvas, color-mix(in lab, currentColor 20%, transparent));
+    background-color: -internal-auto-base(Canvas, color-mix(currentColor 20%, transparent));
 #endif /* defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY */
 }
 
 select:-internal-uses-menulist:disabled {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     background-color: -internal-auto-base(-apple-system-opaque-secondary-fill-disabled, transparent);
-    color: -internal-auto-base(-apple-system-tertiary-label, color-mix(in lab, currentColor 50%, transparent));
+    color: -internal-auto-base(-apple-system-tertiary-label, color-mix(currentColor 50%, transparent));
 #else
-    color: -internal-auto-base(GrayText, color-mix(in lab, currentColor 50%, transparent));
+    color: -internal-auto-base(GrayText, color-mix(currentColor 50%, transparent));
 #endif
 }
 
@@ -1175,15 +1175,15 @@ select option {
 }
 
 select option:enabled:hover {
-    background-color: color-mix(in lab, currentColor 10%, transparent);
+    background-color: color-mix(currentColor 10%, transparent);
 }
 
 select option:enabled:active {
-    background-color: color-mix(in lab, currentColor 20%, transparent);
+    background-color: color-mix(currentColor 20%, transparent);
 }
 
 select option:disabled {
-    color: color-mix(in lab, currentColor 50%, transparent);
+    color: color-mix(currentColor 50%, transparent);
 }
 
 select option::checkmark {


### PR DESCRIPTION
#### c21896a3dab7c37f023def475d7c06ebc093548a
<pre>
Drop color-mix() color space in UA styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=308555">https://bugs.webkit.org/show_bug.cgi?id=308555</a>
<a href="https://rdar.apple.com/171083769">rdar://171083769</a>

Reviewed by Anne van Kesteren and Sam Weinig.

It was resolved in <a href="https://github.com/w3c/csswg-drafts/issues/13496">https://github.com/w3c/csswg-drafts/issues/13496</a> to use the default color-mix() color space.

Also change some non-standardized usages to use the default color-mix() color space as well.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/resources/customizable-select-in-page.css:
(.customizable-select-in-page.disabled):
(.customizable-select-in-page:not(.disabled) .customizable-select-legend.disabled):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/resources/customizable-select-styles.css:
(.customizable-select-option.disabled):
(.customizable-select-button.disabled):
(.customizable-select-button.hover):
(.customizable-select-button.active):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles.html:
* LayoutTests/platform/gtk/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/gtk/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/gtk/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/gtk/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/gtk/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/gtk/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/ios/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/ios/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/ios/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/ios/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/wpe/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/wpe/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/wpe/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/wpe/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/wpe/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/wpe/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/wpe/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/wpe/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* Source/WebCore/css/html.css:
(::-internal-writing-suggestions):
(input:disabled, textarea:disabled):
(select:-internal-uses-menulist:enabled:hover):
(select:-internal-uses-menulist:enabled:active):
(select:-internal-uses-menulist:disabled):
(select option:enabled:hover):
(select option:enabled:active):
(select option:disabled):

Canonical link: <a href="https://commits.webkit.org/308186@main">https://commits.webkit.org/308186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b486cd6f241742d61e6874f5e0d6564409f26acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146732 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/19408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148607 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19867 "Failed to checkout and rebase branch from PR 59334") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/155396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149695 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/19867 "Failed to checkout and rebase branch from PR 59334") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/19867 "Failed to checkout and rebase branch from PR 59334") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/2840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/19867 "Failed to checkout and rebase branch from PR 59334") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/157727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/157727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/157727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22638 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/18827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->