### PR TITLE
[JSC] add GC object validation to the two-arg Heap::writeBarrier(from, to) when GC_VALIDATION is enabled

### DIFF
--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -106,19 +106,22 @@ inline void Heap::writeBarrier(const JSCell* from, JSCell* to)
 #if ENABLE(WRITE_BARRIER_PROFILING)
     WriteBarrierCounters::countWriteBarrier();
 #endif
-    if (!from)
+    ASSERT_GC_OBJECT_LOOKS_VALID(const_cast<JSCell*>(from));
+    // FIXME: above assert verifies from is never nullptr so should be unnecessary
+    if (!from) [[unlikely]]
         return;
-    if (!to) [[likely]]
+    if (!to) [[unlikely]]
         return;
-    if (!isWithinThreshold(from->cellState(), barrierThreshold()))
-        return;
-    writeBarrierSlowPath(from);
+    ASSERT_GC_OBJECT_LOOKS_VALID(to);
+    if (isWithinThreshold(from->cellState(), barrierThreshold())) [[unlikely]]
+        writeBarrierSlowPath(from);
 }
 
 inline void Heap::writeBarrier(const JSCell* from)
 {
     ASSERT_GC_OBJECT_LOOKS_VALID(const_cast<JSCell*>(from));
-    if (!from)
+    // FIXME: above assert verifies from is never nullptr so should be unnecessary
+    if (!from) [[unlikely]]
         return;
     if (isWithinThreshold(from->cellState(), barrierThreshold())) [[unlikely]]
         writeBarrierSlowPath(from);

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -179,8 +179,12 @@ MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(
     , m_cells(cells.size())
     , m_callLinkInfos(WTF::move(callLinkInfos))
 {
-    for (unsigned i = cells.size(); i--;)
-        m_cells[i].set(vm, owner, cells[i]);
+    for (unsigned i = cells.size(); i--;) {
+        if (owner)
+            m_cells[i].set(vm, owner, cells[i]);
+        else
+            m_cells[i].setWithoutWriteBarrier(cells[i]);
+    }
 }
 
 template<typename Visitor>


### PR DESCRIPTION
#### 682cd16441c4418b042cfc842585da9fe7fefd70
<pre>
[JSC] add GC object validation to the two-arg Heap::writeBarrier(from, to) when GC_VALIDATION is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=308556">https://bugs.webkit.org/show_bug.cgi?id=308556</a>
<a href="https://rdar.apple.com/171085355">rdar://171085355</a>

Reviewed by Yusuke Suzuki.

When called directly (i.e. not via WriteBarrier class), there is no
GC_VALIDATION for the Heap::writeBarrier(to, from) case. This function
is often used by WebCore, both directly and via JSValueInWrappedObject,
so it seems useful to have this validation.

So, add validation that to and from both look like valid GC objects.
GC_VALIDATION is enabled in !NDEBUG builds already.

Fix the static prediction hint on the if (!to). It should usually
be non-nullptr.

Write the two-arg and one-arg Heap::WriteBarrier isWithinThreshold guard
using the same (positive check) pattern for better readability.

The guards &apos;!from&apos; in both the two-arg and one-arg Heap::writeBarrier()
seem unnecessary since Debug builds verify they look like valid GC
objects which disallow nullptr. But let&apos;s change this in a future
commit to be careful.

There was only one place that was calling Heap::writeBarrier(to, from)
with an nullptr owner: MarkingGCAwareJITStubRoutine. Avoid doing that
so that we can always check from is a valid GC object.

Testing: Covered by existing tests with Debug builds. I also ran an EWS
tests with ENABLE_GC_VALIDATION=1 in Release builds and this change.

* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::writeBarrier):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine):

Canonical link: <a href="https://commits.webkit.org/308160@main">https://commits.webkit.org/308160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c88bd3aca3a540a50e8de8d7d8ae0341a96c4ca9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155246 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112942 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8536470a-9826-4992-8c06-a59d1b0b4e25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a1cf3ad-9aec-4f81-adb1-5e538a6b9366) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14431 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12203 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2688 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138556 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157573 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7376 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120956 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121164 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31044 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74868 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8238 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177869 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18675 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45608 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18405 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->