### PR TITLE
com.apple.WebKit.WebContent at WebKit:  WebKit::AudioVideoRendererRemote::addTrack

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1587,8 +1587,14 @@ WTFLogChannel& MediaSource::logChannel() const
 
 void MediaSource::failedToCreateRenderer(RendererType type)
 {
+    ERROR_LOG(LOGIDENTIFIER, type == RendererType::Video ? "video"_s : "audio"_s);
+
     if (RefPtr context = scriptExecutionContext())
         context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource "_s, type == RendererType::Video ? "video"_s : "audio"_s, " renderer creation failed."_s));
+
+    ensureWeakOnHTMLMediaElementContext([](auto& mediaElement) {
+        mediaElement.mediaLoadingFailedFatally(MediaPlayer::NetworkState::DecodeError);
+    });
 }
 
 void MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged()

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -142,7 +142,7 @@ public:
     virtual void setPreferences(VideoRendererPreferences) { }
     virtual void setHasProtectedVideoContent(bool) { }
 
-    virtual TrackIdentifier addTrack(TrackType) = 0;
+    virtual std::optional<TrackIdentifier> addTrack(TrackType) = 0;
     virtual void removeTrack(TrackIdentifier) = 0;
 
     virtual void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime> = std::nullopt) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -71,7 +71,7 @@ public:
     void setHasProtectedVideoContent(bool) final;
 
     // TracksRendererInterface
-    TrackIdentifier addTrack(TrackType) final;
+    std::optional<TrackIdentifier> addTrack(TrackType) final;
     void removeTrack(TrackIdentifier) final;
 
     void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime>) final;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -155,7 +155,7 @@ void AudioVideoRendererAVFObjC::setHasProtectedVideoContent(bool protectedConten
         updateDisplayLayerIfNeeded();
 }
 
-TracksRendererManager::TrackIdentifier AudioVideoRendererAVFObjC::addTrack(TrackType type)
+std::optional<TracksRendererManager::TrackIdentifier> AudioVideoRendererAVFObjC::addTrack(TrackType type)
 {
     auto identifier = TrackIdentifier::generate();
     m_trackTypes.add(identifier, type);
@@ -174,8 +174,7 @@ TracksRendererManager::TrackIdentifier AudioVideoRendererAVFObjC::addTrack(Track
         addAudioRenderer(identifier);
         break;
     default:
-        ASSERT_NOT_REACHED();
-        break;
+        return std::nullopt;
     }
     return identifier;
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -183,6 +183,7 @@ private:
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
     void characteristicsChanged();
+    void errorOccurred();
 
     void setPreservesPitch(bool) final;
     void setPresentationSize(const IntSize&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -223,8 +223,11 @@ void RemoteAudioVideoRendererProxyManager::addTrack(RemoteAudioVideoRendererIden
         completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
         return;
     }
-    auto trackIdentifier = renderer->addTrack(type);
-    completionHandler(trackIdentifier);
+    if (auto trackIdentifier = renderer->addTrack(type)) {
+        completionHandler(*trackIdentifier);
+        return;
+    }
+    completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
 }
 
 void RemoteAudioVideoRendererProxyManager::removeTrack(RemoteAudioVideoRendererIdentifier identifier, TrackIdentifier trackIdentifier)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -154,7 +154,7 @@ private:
     void setPreferences(WebCore::VideoRendererPreferences) final;
     void setHasProtectedVideoContent(bool) final;
 
-    TrackIdentifier addTrack(TrackType) final;
+    std::optional<TrackIdentifier> addTrack(TrackType) final;
     void removeTrack(TrackIdentifier) final;
 
     void enqueueSample(TrackIdentifier, Ref<WebCore::MediaSample>&&, std::optional<MediaTime>) final;


### PR DESCRIPTION
#### 6f26fc7aee48b630a04ccd18bbf26571471cdcd2
<pre>
com.apple.WebKit.WebContent at WebKit:  WebKit::AudioVideoRendererRemote::addTrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=308557">https://bugs.webkit.org/show_bug.cgi?id=308557</a>
<a href="https://rdar.apple.com/170648732">rdar://170648732</a>

Reviewed by Jer Noble.

AudioVideoRenderer::addTrack was assumed to be infallible, which is correct
when the AudioVideoRenderer lives in the same process as its caller.
However, should the GPUP crash, we would have caused a release assertion.

We change AudioVideoRenderer::addTrack API to return a std::optional&lt;TrackIdentifier&gt;
instead.
We now handle all addTrack error (such as when the GPUP has crashed) as a
decoding error which will be reported back to the HTMLMediaElement.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::failedToCreateRenderer):
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::addTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::videoTrackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::audioTrackDidChangeEnabled):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::load):
(WebCore::MediaPlayerPrivateWebM::errorOccurred):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::addTrack):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::addTrack):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/308199@main">https://commits.webkit.org/308199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/443040100556ee73491c69c6d8686fa4f24f962d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fd97b75-3520-4c8d-a6e6-b0625a394c5d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113048 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80712 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebad0b27-e022-41cb-b5b1-7ddad0e06f0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93793 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c5efe32-a1cf-4651-9494-7536eb6b3964) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14532 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2825 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157711 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121055 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31065 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75006 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16877 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8340 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18812 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82559 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18542 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->