### PR TITLE
[JSC] DFGDriver should use mode-specific compilation options for FTL

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCommon.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DFGCommon.h"
 
+#include "FunctionAllowlist.h"
 #include <wtf/Lock.h>
 #include <wtf/PrintStream.h>
 
@@ -34,6 +35,30 @@
 namespace JSC { namespace DFG {
 
 const char* const tierName = "DFG ";
+
+FunctionAllowlist& ensureGlobalDFGAllowlist()
+{
+    static LazyNeverDestroyed<FunctionAllowlist> dfgAllowlist;
+    static std::once_flag initializeAllowlistFlag;
+    std::call_once(initializeAllowlistFlag, [] {
+        const char* functionAllowlistFile = Options::dfgAllowlist();
+        dfgAllowlist.construct(functionAllowlistFile);
+    });
+    return dfgAllowlist;
+}
+
+#if ENABLE(FTL_JIT)
+FunctionAllowlist& ensureGlobalFTLAllowlist()
+{
+    static LazyNeverDestroyed<FunctionAllowlist> ftlAllowlist;
+    static std::once_flag initializeAllowlistFlag;
+    std::call_once(initializeAllowlistFlag, [] {
+        const char* functionAllowlistFile = Options::ftlAllowlist();
+        ftlAllowlist.construct(functionAllowlistFile);
+    });
+    return ftlAllowlist;
+}
+#endif
 
 static Lock crashLock;
 

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -34,6 +34,10 @@
 #include <limits.h>
 #include <wtf/text/StringImpl.h>
 
+namespace JSC {
+class FunctionAllowlist;
+}
+
 namespace JSC { namespace DFG {
 
 struct Node;
@@ -291,6 +295,14 @@ struct NodeAndIndex {
 // A less-than operator for strings that is useful for generating string switches. Sorts by <
 // relation on characters. Ensures that if a is a prefix of b, then a < b.
 bool stringLessThan(StringImpl& a, StringImpl& b);
+
+// Get the global DFG allowlist for filtering which functions can be DFG-compiled
+JSC::FunctionAllowlist& ensureGlobalDFGAllowlist();
+
+#if ENABLE(FTL_JIT)
+// Get the global FTL allowlist for filtering which functions can be FTL-compiled
+JSC::FunctionAllowlist& ensureGlobalFTLAllowlist();
+#endif
 
 } } // namespace JSC::DFG
 


### PR DESCRIPTION
#### d7f3c7ee2d70ea57700b309d4ab38b74e73880e6
<pre>
[JSC] DFGDriver should use mode-specific compilation options for FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=308563">https://bugs.webkit.org/show_bug.cgi?id=308563</a>
<a href="https://rdar.apple.com/171094227">rdar://171094227</a>

Reviewed by Yusuke Suzuki.

DFGDriver::compileImpl() is used for both DFG and FTL compilation, but it
was always checking DFG-specific options (bytecodeRangeToDFGCompile and
ensureGlobalDFGAllowlist) regardless of the compilation mode. This meant
FTL compilation ignored its own filtering options (bytecodeRangeToFTLCompile
and ensureGlobalFTLAllowlist), making debugging tools ineffective.

This patch fixes the issue by using a switch statement to dispatch on the
JITCompilationMode parameter and check the appropriate options for each tier:
- FTL/FTLForOSREntry modes use FTL-specific options
- DFG/UnlinkedDFG modes use DFG-specific options
- Baseline/InvalidCompilation modes assert (should never reach this function)

Additionally, this patch eliminates code duplication by moving
ensureGlobalDFGAllowlist() and ensureGlobalFTLAllowlist() from DFGDriver.cpp
and DFGTierUpCheckInjectionPhase.cpp into DFGCommon.cpp. Having these shared
accessor functions in a common location ensures consistent behavior and makes
the code easier to maintain.

No new tests since these options are debug-only infrastructure that defaults to
disabled. The bug only affects developers who manually set --ftlAllowlist or
--bytecodeRangeToFTLCompile for debugging purposes. The fix is mechanically
correct and verified by inspection.

Canonical link: <a href="https://commits.webkit.org/308185@main">https://commits.webkit.org/308185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2b9d533a462f4b3a5ea6d20ccfdf63d33268337

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100011 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f17516ec-66be-41de-ab75-071bc4a009c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80676 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a89f793a-2364-4a79-92c1-4881925aa911) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/226af694-896b-483d-891f-ad64e060522a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14460 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12235 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2732 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138593 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157615 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7413 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/759 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120981 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31054 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74912 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16825 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8273 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177913 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82466 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->