### PR TITLE
ImageDocument should support dark mode

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -206,6 +206,7 @@ inspector/css/overrideUserPreferenceMatchedStyles.html [ Skip ]
 editing/pasteboard/paste-dark-mode-color-filtered.html [ Skip ]
 fast/forms/number/number-dark-appearance.html [ Skip ]
 fast/loader/plain-text-document-dark-mode.html [ Skip ]
+fast/loader/image-document-dark-mode.html [ Skip ]
 
 # Only Mac supports force tests.
 fast/events/cancelled-force-click-link-navigation.html [ Skip ]

--- a/LayoutTests/fast/loader/image-document-dark-mode-expected.html
+++ b/LayoutTests/fast/loader/image-document-dark-mode-expected.html
@@ -1,0 +1,5 @@
+<script>
+    if (window.internals)
+        internals.settings.setUseDarkAppearance(true);
+</script>
+<iframe src="resources/image-document-dark-mode-expected.html">

--- a/LayoutTests/fast/loader/image-document-dark-mode-expected.html
+++ b/LayoutTests/fast/loader/image-document-dark-mode-expected.html
@@ -1,0 +1,5 @@
+<script>
+    if (window.internals)
+        internals.settings.setUseDarkAppearance(true);
+</script>
+<iframe src="resources/image-document-dark-mode-subframe.html">

--- a/LayoutTests/fast/loader/image-document-dark-mode.html
+++ b/LayoutTests/fast/loader/image-document-dark-mode.html
@@ -1,0 +1,5 @@
+<script>
+    if (window.internals)
+        internals.settings.setUseDarkAppearance(true);
+</script>
+<iframe src="resources/image@test.png">

--- a/LayoutTests/fast/loader/resources/image-document-dark-mode-expected.html
+++ b/LayoutTests/fast/loader/resources/image-document-dark-mode-expected.html
@@ -1,0 +1,6 @@
+<html style="color-scheme: light dark; height: 100%">
+<head></head>
+<body style="margin: 0px; height: 100%">
+<img src="image@test.png">
+</body>
+</html>

--- a/LayoutTests/fast/loader/resources/image-document-dark-mode-subframe.html
+++ b/LayoutTests/fast/loader/resources/image-document-dark-mode-subframe.html
@@ -1,0 +1,6 @@
+<html style="color-scheme: light dark; height: 100%">
+<head></head>
+<body style="margin: 0px; height: 100%">
+<img src="image@test.png">
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3225,6 +3225,7 @@ css-dark-mode [ Pass ]
 css-dark-mode/older-systems [ Skip ]
 editing/pasteboard/paste-dark-mode-color-filtered.html [ Pass ]
 fast/loader/plain-text-document-dark-mode.html [ Pass ]
+fast/loader/image-document-dark-mode.html [ Pass ]
 
 fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html [ Pass ]
 fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1273,6 +1273,7 @@ inspector/css/overrideUserPreferenceMatchedStyles.html [ Pass ]
 editing/pasteboard/paste-dark-mode-color-filtered.html [ Pass ]
 fast/forms/number/number-dark-appearance.html [ Pass ]
 fast/loader/plain-text-document-dark-mode.html [ Pass ]
+fast/loader/image-document-dark-mode.html [ Pass ]
 
 webkit.org/b/189686 webgl/2.0.y/conformance/textures/misc/tex-image-and-sub-image-2d-with-array-buffer-view.html [ Slow ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -292,6 +292,7 @@ fast/forms/drag-out-of-textarea.html [ Skip ]
 http/tests/local/drag-over-remote-content.html [ Skip ]
 
 fast/loader/plain-text-document-dark-mode.html [ Pass ]
+fast/loader/image-document-dark-mode.html [ Pass ]
 
 # Tests below are copied from wk2 expectations, because we've marked
 #  as passing the whole fast/events directory.

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -243,6 +243,7 @@ Ref<DocumentParser> ImageDocument::createParser()
 void ImageDocument::createDocumentStructure()
 {
     Ref rootElement = HTMLHtmlElement::create(*this);
+    rootElement->setAttribute(styleAttr, "color-scheme: light dark"_s);
     appendChild(rootElement);
     rootElement->setInlineStyleProperty(CSSPropertyHeight, 100, CSSUnitType::CSS_PERCENTAGE);
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -245,8 +245,8 @@ Ref<DocumentParser> ImageDocument::createParser()
 void ImageDocument::createDocumentStructure()
 {
     Ref rootElement = HTMLHtmlElement::create(*this);
+    rootElement->setAttribute(styleAttr, "color-scheme: light dark; height: 100%"_s);
     appendChild(rootElement);
-    rootElement->setInlineStyleProperty(CSSPropertyHeight, 100, CSSUnitType::Percentage);
 
     if (RefPtr localFrame = frame())
         localFrame->injectUserScripts(UserScriptInjectionTime::DocumentStart);


### PR DESCRIPTION
#### beffe1e5b6d1b9cfdaff8dc0257fe2d9968931a5
<pre>
ImageDocument should support dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=243204">https://bugs.webkit.org/show_bug.cgi?id=243204</a>
<a href="https://rdar.apple.com/97965029">rdar://97965029</a>

Reviewed by NOBODY (OOPS!).

Add color-scheme: light dark to the root element of ImageDocument
so the background adapts to the user&apos;s system appearance instead of
always rendering white.

* LayoutTests/fast/loader/image-document-dark-mode-expected.html: Added.
* LayoutTests/fast/loader/image-document-dark-mode.html: Added.
* LayoutTests/fast/loader/resources/image-document-dark-mode-subframe.html: Added.
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::createDocumentStructure):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beffe1e5b6d1b9cfdaff8dc0257fe2d9968931a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150275 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/852e903e-bfc6-4baf-b31a-3b2dfdf510a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59158 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144978 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100515 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba431164-fbae-4d48-afc5-0659a27d4339) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125270 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b471186-5b3c-46fa-86cb-937b47d83687) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47379 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45447 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45130 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6894 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197792 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154505 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154152 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48621 "Found 1 new test failure: pdf/fullscreen.html (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132257 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129055 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58280 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20152 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->