### PR TITLE
XML Document Viewer should respect dark mode

### DIFF
--- a/Source/WebCore/xml/XMLViewer.css
+++ b/Source/WebCore/xml/XMLViewer.css
@@ -26,12 +26,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+:root {
+    color-scheme: light dark;
+}
+
 body {
     margin: 0
 }
 
 div.header {
-    border-bottom: 2px solid black;
+    border-bottom: 2px solid light-dark(black, white);
     padding-bottom: 5px;
     margin: 10px;
 }
@@ -53,23 +57,23 @@ div.collapsible > div.hidden {
 
 .comment {
     /* Keep this in sync with inspector.css (.webkit-html-comment) */
-    color: rgb(35, 110, 37);
+    color: light-dark(rgb(35, 110, 37), hsl(119, 40%, 72%));
     white-space: pre;
 }
 
 .tag {
     /* Keep this in sync with inspector.css (.tag-name) */
-    color: rgb(136, 18, 128);
+    color: light-dark(rgb(136, 18, 128), hsl(299, 71%, 80%));
 }
 
 .attribute-name {
     /* Keep this in sync with inspector.css (.webkit-html-attribute-name) */
-    color: rgb(153, 69, 0);
+    color: light-dark(rgb(153, 69, 0), hsl(27, 100%, 80%));
 }
 
 .attribute-value {
     /* Keep this in sync with inspector.css (.webkit-html-attribute-value) */
-    color: rgb(26, 26, 166);
+    color: light-dark(rgb(26, 26, 166), hsl(28, 84%, 63%));
 }
 
 .button {


### PR DESCRIPTION
#### b019fc2aabbed888a10facd7a123124068bebecf
<pre>
XML Document Viewer should respect dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=268223">https://bugs.webkit.org/show_bug.cgi?id=268223</a>
<a href="https://rdar.apple.com/122234600">rdar://122234600</a>

Reviewed by Tim Nguyen.

Add dark mode support to the XML Document Viewer by declaring
color-scheme: light dark on :root and using the light-dark() CSS
function to provide adjusted colors for syntax highlighting. Dark
mode colors are copied from the Web Inspector&apos;s dark theme to stay
consistent with existing syntax highlighting.

* Source/WebCore/xml/XMLViewer.css:
(:root):
(div.header):
(.comment):
(.tag):
(.attribute-name):
(.attribute-value):

Canonical link: <a href="https://commits.webkit.org/316832@main">https://commits.webkit.org/316832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd199622f26cadec38c37387885dd6072fb57593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183001 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131141 "Failed to checkout and rebase branch from PR 59345") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59f711af-6748-4eb8-9a24-cc76c6393811) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134844 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/131141 "Failed to checkout and rebase branch from PR 59345") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d066663-6d96-4c17-8e76-f0881fcce87a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3fc07eff-8b84-4d51-969b-f30351b71fb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31486 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185426 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143712 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47028 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47707 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112811 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38520 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119458 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46213 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9960 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45672 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->