### PR TITLE
[Grid] Move rawGridTrackSize to GridLayoutFunctions

### DIFF
--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -34,11 +34,13 @@ namespace Style {
 enum class GridTrackSizingDirection : bool;
 class GridTrackBreadth;
 struct GridTrackFitContentLength;
+struct GridTrackSize;
 }
 
 class GridSpan;
 class RenderElement;
 class RenderGrid;
+class RenderStyle;
 
 enum class ItemPosition : uint8_t;
 
@@ -95,6 +97,8 @@ void updateAutoMarginsInColumnAxisIfNeeded(RenderBox&, WritingMode);
 
 bool NODELETE isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength&, std::optional<LayoutUnit> availableSpace);
 bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth&, std::optional<LayoutUnit> availableSpace);
+
+const Style::GridTrackSize& rawGridTrackSize(const RenderStyle&, Style::GridTrackSizingDirection, unsigned translatedIndex, unsigned autoRepeatTracksCount, unsigned explicitGridStart);
 
 } // namespace GridLayoutFunctions
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -178,7 +178,6 @@ private:
 
     std::optional<LayoutUnit> NODELETE availableSpace() const;
     Style::GridTrackSize calculateGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
-    const Style::GridTrackSize& rawGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
 
     // Helper methods for step 1. initializeTrackSizes().
     LayoutUnit initialBaseSize(const Style::GridTrackSize&) const;


### PR DESCRIPTION
#### 7a10d165b2bbdda66eb59c83b50268626226c6d3
<pre>
[Grid] Move rawGridTrackSize to GridLayoutFunctions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308566">https://bugs.webkit.org/show_bug.cgi?id=308566</a>
<a href="https://rdar.apple.com/171098221">rdar://171098221</a>

Reviewed by Vitor Roriz and Tim Nguyen.

I plan to use this outside of GridTrackSizingAlgorithm so we can move it
into GridLayoutFunctions where it can be accessed. This concept is
independent of track sizing so moving it outside makes this notion a bit
more clear as well. Any callers of the GridTrackSizingAlgorithm version
will now call into the GridLayoutFunctions version instead. We will need
to pass in the RenderGrid&apos;s style along with a couple of other pieces of
information from the Grid that are used by this function.

Canonical link: <a href="https://commits.webkit.org/308157@main">https://commits.webkit.org/308157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8102cf0b4ba0c3af830d521c0a5056f9309a0278

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/245e2cf6-7383-4474-b09c-617506c73446) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112960 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a6799a5-9a5b-499b-a74c-d72fb725c304) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2719 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157602 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/746 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16032 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/121179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31042 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74899 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8259 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18706 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18436 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->