### PR TITLE
[GFC] Fix crash in auto-placement when grid has no explicit rows

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -328,8 +328,10 @@ void ImplicitGrid::placeAutoPositionedItemWithAutoColumnAndRow(const UnplacedGri
             // Advance to next row, reset column to 0.
             ++m_autoPlacementCursorRow;
             m_autoPlacementCursorColumn = 0;
-            growRowsToFit(m_autoPlacementCursorRow + rowSpan - 1);
         }
+
+        // Ensure the grid has enough rows before checking if the range is empty.
+        growRowsToFit(m_autoPlacementCursorRow + rowSpan - 1);
 
         // Try to place at current cursor position.
         if (isCellRangeEmpty(m_autoPlacementCursorColumn, m_autoPlacementCursorColumn + columnSpan, m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan)) {


### PR DESCRIPTION
#### 6c08f4a9a68070ba40b75379506e2c0108a72eeb
<pre>
[GFC] Fix crash in auto-placement when grid has no explicit rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=308569">https://bugs.webkit.org/show_bug.cgi?id=308569</a>
&lt;<a href="https://rdar.apple.com/171098357">rdar://171098357</a>&gt;

Reviewed by Sammy Gill.

When a grid does not have grid-template-rows, explicitly placed items, or
items locked to a given row, the implicit grid starts with 0 rows.
This causes a crash when in the auto placement algorithm when placing the
first auto placed item because it checks if the cell the cursor is pointing
to is empty before it exists.

This is because we previously only called growRowsToFit() when wrapping to a new row,
but this never happens on the first iteration. moving this out of the wrapping condidtional
so rows are created before accessing the grid.

* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::placeAutoPositionedItemWithAutoColumnAndRow):

Canonical link: <a href="https://commits.webkit.org/308217@main">https://commits.webkit.org/308217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b6a0de05c812f4a827f4292700699ea6e224997

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100004 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4925709-92bc-4829-a516-8a088ebe1a33) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112965 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80673 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93712 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e1df8ec-158f-430a-8d97-4fbb793d4e5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14452 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12229 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2725 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157608 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120973 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121185 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31081 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74905 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8267 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82459 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18592 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->