### PR TITLE
REGRESSION (302097@main): pinch to zoom makes content jump or disappear

### DIFF
--- a/LayoutTests/fast/events/resize-event-not-fired-during-page-scale-expected.txt
+++ b/LayoutTests/fast/events/resize-event-not-fired-during-page-scale-expected.txt
@@ -1,0 +1,10 @@
+Tests that changing page scale factor does not fire a spurious resize event.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS resizeCount is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/resize-event-not-fired-during-page-scale.html
+++ b/LayoutTests/fast/events/resize-event-not-fired-during-page-scale.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that changing page scale factor does not fire a spurious resize event.");
+jsTestIsAsync = true;
+
+var resizeCount = 0;
+
+window.addEventListener("resize", function() {
+    resizeCount++;
+});
+
+window.onload = function() {
+    if (window.testRunner)
+        testRunner.setPageScaleFactor(2, 0, 0);
+
+    requestAnimationFrame(function() {
+        setTimeout(function() {
+            shouldBe("resizeCount", "0");
+            finishJSTest();
+        }, 0);
+    });
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4806,14 +4806,12 @@ void LocalFrameView::scheduleResizeEventIfNeeded()
 
     IntSize currentSize = sizeForResizeEvent();
     float currentZoomFactor = renderView->style().usedZoom();
-    float currentFrameScaleFactor = m_frame->frameScaleFactor();
 
-    if (currentSize == m_lastViewportSize && currentZoomFactor == m_lastUsedZoomFactor && currentFrameScaleFactor == m_lastFrameScaleFactor)
+    if (currentSize == m_lastViewportSize && currentZoomFactor == m_lastUsedZoomFactor)
         return;
 
     m_lastViewportSize = currentSize;
     m_lastUsedZoomFactor = currentZoomFactor;
-    m_lastFrameScaleFactor = currentFrameScaleFactor;
 
     if (!layoutContext().didFirstLayout())
         return;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -1043,7 +1043,6 @@ private:
     OptionSet<PaintBehavior> m_paintBehavior;
 
     float m_lastUsedZoomFactor { 1 };
-    float m_lastFrameScaleFactor { 1 };
     unsigned m_visuallyNonEmptyCharacterCount { 0 };
     unsigned m_visuallyNonEmptyPixelCount { 0 };
     unsigned m_textRendererCountForVisuallyNonEmptyCharacters { 0 };


### PR DESCRIPTION
#### d359a18a7a212d1820e28fa1543d356253fa1394
<pre>
REGRESSION (302097@main): pinch to zoom makes content jump or disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=308156">https://bugs.webkit.org/show_bug.cgi?id=308156</a>
<a href="https://rdar.apple.com/169593089">rdar://169593089</a>

Reviewed by Simon Fraser.

302097@main added frameScaleFactor as a trigger for firing resize events
in scheduleResizeEventIfNeeded(). On macOS, the main frame&apos;s
frameScaleFactor() returns pageScaleFactor(), which changes when
pinch-to-zoom commits. This caused resize event to fire even though
the viewport didn&apos;t actually resize.

innerWidth/innerHeight have always taken frameScaleFactor into account
(in mapFromLayoutToCSSUnits), so they report smaller values at higher
zoom levels. When the spurious resize event fires, sites that use
JS-driven responsive breakpoints read the smaller innerWidth and
switch to a mobile layout. This mismatch causes content to
jump or disappear (e.g., roadburn.com/nightbus collapses from
two-column to single-column layout on pinch zoom).

Note: innerWidth/innerHeight changing during pinch-to-zoom may itself
be a bug worth investigating separately. Chrome does not change these
values on pinch zoom nor fire a resize event.

This fix simply undoes the  frameScaleFactor addition from 302097@main
to recover from the regression. Cmd+/- (page zoom) and CSS zoom changes
still correctly fire resize events. only pinch-to-zoom no longer does.

* LayoutTests/fast/events/resize-event-not-fired-during-page-scale-expected.txt: Added.
* LayoutTests/fast/events/resize-event-not-fired-during-page-scale.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scheduleResizeEventIfNeeded):
* Source/WebCore/page/LocalFrameView.h:

Canonical link: <a href="https://commits.webkit.org/308244@main">https://commits.webkit.org/308244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1acebb341f0ddcf039cec463cefa21eb596969c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100187 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b80148c9-c11b-46a1-be40-7aaaa57bb380) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113112 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80751 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eeb553da-8833-49b5-a576-95a3f023c3dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93857 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4812c5c1-cad8-4220-86b2-70ee3a755b7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12373 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2910 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157798 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121125 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121337 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31100 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131518 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8408 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82651 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18626 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18777 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->