### PR TITLE
Remove `deprecatedIsLeftToRightDirection()` usage from `TextFieldInputType::elementDidBlur()`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-scroll-on-blur-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-scroll-on-blur-expected.txt
@@ -1,0 +1,13 @@
+
+
+PASS input in writing-mode: horizontal-tb; direction: ltr scrolls back to beginning on blur
+PASS input in writing-mode: horizontal-tb; direction: rtl scrolls back to beginning on blur
+PASS input in writing-mode: vertical-lr; direction: ltr scrolls back to beginning on blur
+PASS input in writing-mode: vertical-lr; direction: rtl scrolls back to beginning on blur
+PASS input in writing-mode: vertical-rl; direction: ltr scrolls back to beginning on blur
+PASS input in writing-mode: vertical-rl; direction: rtl scrolls back to beginning on blur
+PASS input in writing-mode: sideways-lr; direction: ltr scrolls back to beginning on blur
+PASS input in writing-mode: sideways-lr; direction: rtl scrolls back to beginning on blur
+PASS input in writing-mode: sideways-rl; direction: ltr scrolls back to beginning on blur
+PASS input in writing-mode: sideways-rl; direction: rtl scrolls back to beginning on blur
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-scroll-on-blur.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-scroll-on-blur.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<link rel="author" title="WebKit Contributors">
+<link rel="help" href="https://html.spec.whatwg.org/#the-input-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test that text inputs scroll back to the beginning on blur for all writing-mode and direction combinations</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+    input {
+        font-family: monospace;
+        font-size: 13px;
+        inline-size: 100px;
+    }
+</style>
+
+<input id="testInput">
+
+<script>
+const longValue = "veryveryveryveryveryveryveryveryverylongvalue";
+
+for (const writingMode of ["horizontal-tb", "vertical-lr", "vertical-rl", "sideways-lr", "sideways-rl"]) {
+    for (const direction of ["ltr", "rtl"]) {
+        promise_test(async t => {
+            const input = document.getElementById("testInput");
+            const isHorizontal = writingMode === "horizontal-tb";
+
+            input.style.writingMode = writingMode;
+            input.style.direction = direction;
+            input.value = longValue;
+            t.add_cleanup(() => {
+                input.removeAttribute("style");
+                input.value = "";
+                input.blur();
+            });
+
+            const scrollProp = isHorizontal ? "scrollLeft" : "scrollTop";
+            const orthogonalScrollProp = isHorizontal ? "scrollTop" : "scrollLeft";
+
+            input.focus();
+            input.setSelectionRange(input.value.length, input.value.length);
+            await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+            assert_not_equals(
+                input[scrollProp], 0,
+                `${scrollProp} should be non-zero after scrolling to end`
+            );
+
+            input.blur();
+            await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+            assert_equals(
+                input[scrollProp], 0,
+                `${scrollProp} should be 0 after blur (scrolled back to beginning)`
+            );
+
+            assert_equals(
+                input[orthogonalScrollProp], 0,
+                `${orthogonalScrollProp} should be 0 after blur (orthogonal scroll position unchanged)`
+            );
+        }, `input in writing-mode: ${writingMode}; direction: ${direction} scrolls back to beginning on blur`);
+    }
+}
+</script>

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -269,9 +269,16 @@ void TextFieldInputType::elementDidBlur()
 
     CheckedPtr innerLayerScrollable = innerLayer->ensureLayerScrollableArea();
 
-    bool isLeftToRightDirection = downcast<RenderTextControlSingleLine>(*renderer).style().writingMode().deprecatedIsLeftToRightDirection();
-    ScrollOffset scrollOffset(isLeftToRightDirection ? 0 : innerLayerScrollable->scrollWidth(), 0);
-    innerLayerScrollable->scrollToOffset(scrollOffset);
+    auto writingMode = downcast<RenderTextControlSingleLine>(*renderer).style().writingMode();
+    int xOffset = 0;
+    int yOffset = 0;
+    if (writingMode.isInlineFlipped()) {
+        if (writingMode.isHorizontal())
+            xOffset = innerLayerScrollable->scrollWidth();
+        else
+            yOffset = innerLayerScrollable->scrollHeight();
+    }
+    innerLayerScrollable->scrollToOffset(ScrollOffset(xOffset, yOffset));
 
     closeSuggestions();
 }


### PR DESCRIPTION
#### f6f3246e1825207acddb27f4fd3d180ea39aad49
<pre>
Remove `deprecatedIsLeftToRightDirection()` usage from `TextFieldInputType::elementDidBlur()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308576">https://bugs.webkit.org/show_bug.cgi?id=308576</a>
<a href="https://rdar.apple.com/171109624">rdar://171109624</a>

Reviewed by Elika Etemad.

Fix text input blur scroll for vertical writing modes

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-scroll-on-blur-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-scroll-on-blur.html: Added.
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::elementDidBlur):

Canonical link: <a href="https://commits.webkit.org/309776@main">https://commits.webkit.org/309776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b976888f7bfe3ed81e2da5bc21b2296d7c6cda9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104615 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18c5929c-6a8a-4d1e-ac62-b98ca4016701) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116714 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82853 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11ee1c6c-55b1-40fe-825a-cf1c824c4b24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17931 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15882 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7753 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162380 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5505 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124723 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34018 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80182 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12124 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23207 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->