### PR TITLE
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/css/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -71,7 +71,6 @@ bindings/js/ScriptModuleLoader.cpp
 bridge/objc/WebScriptObject.mm
 bridge/runtime_method.cpp
 contentextensions/ContentExtensionsBackend.cpp
-css/CSSImageValue.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleSheet.cpp
 css/CSSStyleSheetObservableArray.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -170,7 +170,6 @@ contentextensions/ContentExtension.cpp
 contentextensions/ContentExtensionStyleSheet.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
-css/CSSCounterStyle.cpp
 css/CSSCounterStyleDescriptors.cpp
 css/CSSCounterStyleRule.h
 css/CSSCounterValue.cpp
@@ -181,10 +180,7 @@ css/CSSFontValue.cpp
 css/CSSGridLineValue.cpp
 css/CSSGroupingRule.cpp
 css/CSSImageSetOptionValue.cpp
-css/CSSImageSetValue.cpp
-css/CSSImageValue.cpp
 css/CSSImageValue.h
-css/CSSImportRule.cpp
 css/CSSKeyframeRule.cpp
 css/CSSKeyframesRule.cpp
 css/CSSNestedDeclarations.cpp

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -398,7 +398,7 @@ String CSSCounterStyle::fallbackText(int value, WritingMode writingMode)
         return CSSCounterStyleRegistry::decimalCounter()->text(value, writingMode);
     }
     m_isFallingBack = true;
-    auto fallbackText = fallback()->text(value, writingMode);
+    auto fallbackText = protect(fallback())->text(value, writingMode);
     m_isFallingBack = false;
     return fallbackText;
 }

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -54,7 +54,7 @@ String CSSImageSetValue::customCSSText(const CSS::SerializationContext& context)
         if (i > 0)
             result.append(", "_s);
         ASSERT(is<CSSImageSetOptionValue>(item(i)));
-        result.append(item(i)->cssText(context));
+        result.append(protect(item(i))->cssText(context));
     }
     result.append(')');
     return result.toString();

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -133,7 +133,7 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
         else
             request.setInitiatorType(m_initiatorType);
         if (options.mode == FetchOptions::Mode::Cors)
-            request.updateForAccessControl(*loader.document());
+            request.updateForAccessControl(*protect(loader.document()));
         m_cachedImage = loader.requestImage(WTF::move(request)).value_or(nullptr);
         for (RefPtr<CSSImageValue> imageValue = this; (imageValue = imageValue->m_unresolvedValue.get()); )
             imageValue->m_cachedImage = m_cachedImage;

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -44,9 +44,9 @@ CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CSSStyleSheet* parent)
 CSSImportRule::~CSSImportRule()
 {
     if (m_styleSheetCSSOMWrapper)
-        m_styleSheetCSSOMWrapper->clearOwnerRule();
+        protect(m_styleSheetCSSOMWrapper)->clearOwnerRule();
     if (m_mediaCSSOMWrapper)
-        m_mediaCSSOMWrapper->detachFromParent();
+        protect(m_mediaCSSOMWrapper)->detachFromParent();
 }
 
 String CSSImportRule::href() const


### PR DESCRIPTION
#### d06a1cca9a668224daa287cc0462a9373ee18daf
<pre>
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/css/
<a href="https://bugs.webkit.org/show_bug.cgi?id=308585">https://bugs.webkit.org/show_bug.cgi?id=308585</a>
<a href="https://rdar.apple.com/171112783">rdar://171112783</a>

Reviewed by Ryosuke Niwa.

As dictated by the SaferCPP bot.

No new tests since no change in behavior.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::fallbackText):
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::customCSSText const):
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::loadImage):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::~CSSImportRule):

Canonical link: <a href="https://commits.webkit.org/308294@main">https://commits.webkit.org/308294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc1b243080017174e38bda264fda82e9eee8db19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100254 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a6b8e9a-e7b0-48f3-b496-4aefb0d16343) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113173 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80775 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66e4a96d-ff8f-479c-bc95-01bf3323be46) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93926 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51899385-e98b-4c2a-9404-bfc77e1432df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14643 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2990 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157879 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121192 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31132 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75208 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8499 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82718 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->