### PR TITLE
Shrink RenderBlockFlowRareData from 40 to 32 bytes

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -98,9 +98,18 @@ struct SameSizeAsMarginInfo {
 static_assert(sizeof(MarginValues) == sizeof(LayoutUnit[4]), "MarginValues should stay small");
 static_assert(sizeof(RenderBlockFlow::MarginInfo) == sizeof(SameSizeAsMarginInfo), "MarginInfo should stay small");
 
+struct SameSizeAsRenderBlockFlowRareData {
+    LayoutUnit margins[4];
+    uint32_t bitfields;
+    LayoutUnit alignContentShift;
+    void* multiColumnFlow;
+};
+
+static_assert(sizeof(RenderBlockFlowRareData) == sizeof(SameSizeAsRenderBlockFlowRareData), "RenderBlockFlowRareData should stay small");
+
 RenderBlockFlowRareData::RenderBlockFlowRareData(const RenderBlockFlow& block)
     : m_margins(positiveMarginBeforeDefault(block), negativeMarginBeforeDefault(block), positiveMarginAfterDefault(block), negativeMarginAfterDefault(block))
-    , m_lineBreakToAvoidWidow(-1)
+    , m_lineBreakToAvoidWidow(0)
     , m_didBreakAtLineToAvoidWidow(false)
 {
 }
@@ -2168,7 +2177,7 @@ void RenderBlockFlow::setBreakAtLineToAvoidWidow(int lineToBreak)
 {
     ASSERT(lineToBreak >= 0);
     ASSERT(!ensureRareBlockFlowData().m_didBreakAtLineToAvoidWidow);
-    ensureRareBlockFlowData().m_lineBreakToAvoidWidow = lineToBreak;
+    ensureRareBlockFlowData().m_lineBreakToAvoidWidow = lineToBreak + 1;
 }
 
 void RenderBlockFlow::setDidBreakAtLineToAvoidWidow()
@@ -2194,7 +2203,7 @@ void RenderBlockFlow::clearShouldBreakAtLineToAvoidWidow() const
     if (!hasRareBlockFlowData())
         return;
 
-    rareBlockFlowData()->m_lineBreakToAvoidWidow = -1;
+    rareBlockFlowData()->m_lineBreakToAvoidWidow = 0;
 }
 
 bool RenderBlockFlow::hasNextPage(LayoutUnit logicalOffset, PageBoundaryRule pageBoundaryRule) const

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -102,12 +102,11 @@ public:
     }
 
     MarginValues m_margins;
-    int m_lineBreakToAvoidWidow;
+    unsigned m_lineBreakToAvoidWidow : 31;
+    unsigned m_didBreakAtLineToAvoidWidow : 1;
     LayoutUnit m_alignContentShift; // Caches negative shifts for overflow calculation.
 
     SingleThreadWeakPtr<RenderMultiColumnFlow> m_multiColumnFlow;
-
-    bool m_didBreakAtLineToAvoidWidow : 1;
 };
 
 class RenderBlockFlow : public RenderBlock {
@@ -264,9 +263,9 @@ public:
 
     bool childrenPreventSelfCollapsing() const final;
 
-    bool shouldBreakAtLineToAvoidWidow() const { return hasRareBlockFlowData() && rareBlockFlowData()->m_lineBreakToAvoidWidow >= 0; }
+    bool shouldBreakAtLineToAvoidWidow() const { return hasRareBlockFlowData() && rareBlockFlowData()->m_lineBreakToAvoidWidow > 0; }
     void NODELETE clearShouldBreakAtLineToAvoidWidow() const;
-    int lineBreakToAvoidWidow() const { return hasRareBlockFlowData() ? rareBlockFlowData()->m_lineBreakToAvoidWidow : -1; }
+    int lineBreakToAvoidWidow() const { return hasRareBlockFlowData() ? static_cast<int>(rareBlockFlowData()->m_lineBreakToAvoidWidow) - 1 : -1; }
     void setBreakAtLineToAvoidWidow(int);
     void NODELETE clearDidBreakAtLineToAvoidWidow();
     void NODELETE setDidBreakAtLineToAvoidWidow();


### PR DESCRIPTION
#### d7a89eb2ecde5fc7a900547346a9a03cdbccc557
<pre>
Shrink RenderBlockFlowRareData from 40 to 32 bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308587">https://bugs.webkit.org/show_bug.cgi?id=308587</a>
<a href="https://rdar.apple.com/171113221">rdar://171113221</a>

Reviewed by NOBODY (OOPS!).

Pack m_lineBreakToAvoidWidow (31 bits) and m_didBreakAtLineToAvoidWidow
(1 bit) into adjacent bitfields sharing a single 32-bit word, and move
m_didBreakAtLineToAvoidWidow earlier in the struct to eliminate 8 bytes
of tail padding after the pointer-aligned m_multiColumnFlow.

Since the field is now unsigned, the sentinel encoding changes from -1
to 0 (with stored values offset by 1). The external API seen by callers
is unchanged: lineBreakToAvoidWidow() still returns -1 when unset and
the original line number otherwise.

Added a static_assert to prevent future regressions.

BEFORE (40 bytes):                      AFTER (32 bytes):
0: m_margins          (16)              0: m_margins          (16)
16: m_lineBreakTo...   (4)              16: m_lineBreak...:31 +
20: m_alignContent     (4)                  m_didBreak...:1    (4)
24: m_multiColumnFlow  (8)              20: m_alignContent     (4)
32: m_didBreak...:1    (1)              24: m_multiColumnFlow  (8)
33: padding            (7)              ────────────────────────
────────────────────────                32 bytes
40 bytes

No new tests, as no change in functionality.

Influenced by this Chromium patch: &lt;<a href="https://chromium.googlesource.com/chromium/blink/+/04f5c29ed654ba4f1fdd6c5343c237e1cb15e9e2">https://chromium.googlesource.com/chromium/blink/+/04f5c29ed654ba4f1fdd6c5343c237e1cb15e9e2</a>&gt;
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlowRareData::RenderBlockFlowRareData):
(WebCore::RenderBlockFlow::setBreakAtLineToAvoidWidow):
(WebCore::RenderBlockFlow::clearShouldBreakAtLineToAvoidWidow const):
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::shouldBreakAtLineToAvoidWidow const):
(WebCore::RenderBlockFlow::lineBreakToAvoidWidow const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a89eb2ecde5fc7a900547346a9a03cdbccc557

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12843 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155309 "Hash d7a89eb2 for PR 59366 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100032 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e96e573a-e013-4f60-8dc7-c5c3fa76a077) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19780 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19223 "Hash d7a89eb2 for PR 59366 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/155309 "Hash d7a89eb2 for PR 59366 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80684 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16224164-2ca2-4798-8b2a-703243ce2d70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131761 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/155309 "Hash d7a89eb2 for PR 59366 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ea5d28c-5f63-4879-aecf-2014c936587f) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2753 "Hash d7a89eb2 for PR 59366 does not build (failure)") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9625 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157637 "Hash d7a89eb2 for PR 59366 does not build (failure)") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11059 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/157637 "Hash d7a89eb2 for PR 59366 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19124 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/19223 "Hash d7a89eb2 for PR 59366 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/157637 "Hash d7a89eb2 for PR 59366 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74933 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8285 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82487 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18529 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->