### PR TITLE
[macOS] imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html
@@ -17,8 +17,7 @@
     const inner = outer.firstChild;
 
     // First request fullscreen for the outer element.
-    await trusted_request(outer);
-    await fullScreenChange();
+    await Promise.all([fullScreenChange(), trusted_request(outer)]);
     assert_equals(document.fullscreenElement, outer);
     assert_true(
       outer.matches(":fullscreen"),

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2490,8 +2490,6 @@ webkit.org/b/308334 [ Tahoe Debug ] http/tests/webgpu/webgpu/api/validation/gpu_
 
 webkit.org/b/308494 media/remote-control-command-is-user-gesture.html [ Timeout Pass ]
 
-webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
-
 webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure ]
 
 webkit.org/b/308601 [ Release ] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html [ Failure Pass ]


### PR DESCRIPTION
#### 9dbb511485aa820314629ec7475abfa1373abd1a
<pre>
[macOS] imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html is a flaky text failure
<a href="https://rdar.apple.com/171112681">rdar://171112681</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308586">https://bugs.webkit.org/show_bug.cgi?id=308586</a>

Reviewed by Tim Nguyen.

The test was intermittently timing out because the fullscreenchange
event listener was registered after the event had already fired.

The sequential awaits:
    await trusted_request(outer);
    await fullScreenChange();
caused the fullscreenchange event to fire while waiting for
requestFullscreen() to resolve, before the listener in
fullScreenChange() was registered.

Using Promise.all() ensures the listener is registered synchronously
before the fullscreen transition completes:
await Promise.all([trusted_request(outer), fullScreenChange()]);

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308351@main">https://commits.webkit.org/308351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d9c49e4488d1fa06576e6d196a57ca9e24a2a6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113196 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80792 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14663 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3025 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157914 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121218 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121420 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31175 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75351 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8489 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->