### PR TITLE
[Site Isolation] Route same-site child frame back/forward navigations through UIProcess when UseUIProcessForBackForwardItemLoading is enabled.

### DIFF
--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,8 +13,5 @@ window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persist
 </head>
 <body>
 <h1>Iframe Page</h1>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
@@ -12,7 +12,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
-        'navigate-to-cross-site': () => navigateIframeTo(`http://${crossSiteHostname}:8000/navigation/resources/cross-site-iframe-nav-page.html`),
+        'navigate-to-cross-site': () => navigateIframeTo(crossSiteUrl('cross-site-iframe-nav-page.html')),
         'navigate-to-other': () => navigateTo("cross-site-iframe-nav-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,9 +13,5 @@ window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persis
 </head>
 <body>
 <h1>Iframe Page</h1>
-<p id="host"></p>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/navigation-utils.js
+++ b/LayoutTests/http/tests/navigation/resources/navigation-utils.js
@@ -1,5 +1,10 @@
-const sameSiteHostname = "127.0.0.1";
-const crossSiteHostname = "localhost";
+const hostname = location.hostname;
+
+const localhost = "localhost";
+const loopbackAddress = "127.0.0.1";
+
+const sameSiteHostname = hostname;
+const crossSiteHostname = hostname === localhost ? loopbackAddress : localhost;
 
 /* `page` must be defined in embedding HTML files */
 function makeMessage(action, arg = "") {
@@ -90,4 +95,10 @@ function navigateTo(url) {
 
 function navigateIframeTo(url) {
     iframeContentWindow().location.href = url;
+}
+
+function crossSiteUrl(path) {
+    const url = new URL(path, location.href);
+    url.hostname = crossSiteHostname;
+    return url.href;
 }

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with same-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.
+Navigate iframe to page2.
+Navigate main frame to other.
+Go back. (back-iframe-popup.html with iframe showing page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false UseUIProcessForBackForwardItemLoading=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/navigation/resources/navigation-utils.js"></script>
+<script>
+
+description("Nested iframe history navigation works correctly with same-site iframe when back/forward cache is disabled.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("/navigation/resources/back-iframe-popup.html");
+}
+
+var page1ShowCount = 0;
+var page2ShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+        },
+    },
+    page1: {
+        load: () => debug("Page1 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page1 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page1ShowCount++;
+            if (page1ShowCount == 1) {
+                debug("Page1 displayed first time.");
+                sendMessageToPopup("navigate-to-page2");
+            } else if (page1ShowCount == 2) {
+                testFailed("Page1 should be displayed only once.");
+                finishJSTest();
+            }
+        }
+    },
+    page2: {
+        load: () => debug("Page2 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page2 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page2ShowCount++;
+            if (page2ShowCount == 1) {
+                debug("Page2 displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (page2ShowCount == 2) {
+                testPassed("Page2 displayed twice.");
+                finishJSTest();
+            } else {
+                testFailed("Page2 should be displayed only twice.");
+                finishJSTest();
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            debug("Other page displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to page2.</li>
+    <li>Navigate main frame to other.</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing page2)</li>
+</ul>
+<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/AdvancedPrivacyProtections.h>
+#include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/Element.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/ReferrerPolicy.h>
@@ -79,6 +80,9 @@ public:
     bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
     void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
+    const std::optional<BackForwardItemIdentifier>& targetBackForwardItemIdentifier() const { return m_targetBackForwardItemIdentifier; }
+    void setTargetBackForwardItemIdentifier(BackForwardItemIdentifier itemID) { m_targetBackForwardItemIdentifier = itemID; }
+
 protected:
     FrameLoadRequestBase() = default;
     FrameLoadRequestBase(const FrameLoadRequestBase&) = default;
@@ -99,6 +103,7 @@ private:
     AtomString m_downloadAttribute;
     RefPtr<Element> m_sourceElement;
     InitiatedByMainFrame m_initiatedByMainFrame { InitiatedByMainFrame::Unknown };
+    std::optional<BackForwardItemIdentifier> m_targetBackForwardItemIdentifier;
     bool m_isRequestFromClientOrUserInput { false };
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -497,6 +497,15 @@ void FrameLoader::checkContentPolicy(const ResourceResponse& response, ContentPo
     protect(client())->dispatchDecidePolicyForResponse(response, activeDocumentLoader()->request(), activeDocumentLoader()->downloadAttribute(), WTF::move(function));
 }
 
+FrameLoadRequest FrameLoader::createFrameLoadRequest(URL&& url)
+{
+    RefPtr frame = lexicalFrameFromCommonVM();
+    auto initiatedByMainFrame = frame && frame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
+
+    Ref document = *m_frame->document();
+    return FrameLoadRequest(document.copyRef(), document->securityOrigin(), { WTF::move(url) }, selfTargetFrameName(), initiatedByMainFrame, { });
+}
+
 void FrameLoader::changeLocation(const URL& url, const AtomString& passedTarget, Event* triggeringEvent, const ReferrerPolicy& referrerPolicy, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> openerPolicy, const AtomString& downloadAttribute, std::optional<PrivateClickMeasurement>&& privateClickMeasurement, NavigationHistoryBehavior historyBehavior, Element* sourceElement)
 {
     RefPtr frame = lexicalFrameFromCommonVM();
@@ -1076,17 +1085,41 @@ void FrameLoader::loadURLIntoChildFrame(const URL& url, const String& referer, L
 
     // If we're moving in the back/forward list, we might want to replace the content
     // of this child frame with whatever was there at that point.
-    RefPtr parentItem = history().currentItem();
-    if (parentItem && parentItem->children().size() && isBackForwardLoadType(loadType()) && !m_frame->document()->loadEventFinished()) {
-        if (RefPtr childItem = parentItem->childItemWithTarget(childFrame.tree().uniqueName())) {
-            Ref childLoader = childFrame.loader();
-            childItem->setFrameID(childFrame.frameID());
-            childLoader->m_requestedHistoryItem = childItem;
-            childLoader->loadDifferentDocumentItem(*childItem, nullptr, loadType(), MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No);
+    if (isBackForwardLoadType(loadType()) && !m_frame->document()->loadEventFinished()) {
+        if (m_frame->page() && m_frame->page()->settings().useUIProcessForBackForwardItemLoading()) {
+            m_client->dispatchBackForwardItemLoading(url, referer, childFrame);
             return;
         }
+
+        if (loadChildHistoryItemIntoFrame(childFrame))
+            return;
     }
 
+    continueLoadURLIntoChildFrame(url, referer, childFrame);
+}
+
+bool FrameLoader::loadChildHistoryItemIntoFrame(LocalFrame& childFrame)
+{
+    ASSERT(isBackForwardLoadType(loadType()));
+    ASSERT(!m_frame->document()->loadEventFinished());
+
+    RefPtr parentItem = history().currentItem();
+    if (!parentItem || !parentItem->children().size())
+        return false;
+
+    RefPtr childItem = parentItem->childItemWithTarget(childFrame.tree().uniqueName());
+    if (!childItem)
+        return false;
+
+    Ref childLoader = childFrame.loader();
+    childItem->setFrameID(childFrame.frameID());
+    childLoader->m_requestedHistoryItem = childItem;
+    childLoader->loadDifferentDocumentItem(*childItem, nullptr, loadType(), MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No);
+    return true;
+}
+
+void FrameLoader::continueLoadURLIntoChildFrame(const URL& url, const String& referer, LocalFrame& childFrame)
+{
     RefPtr lexicalFrame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
@@ -4456,7 +4489,7 @@ void FrameLoader::loadSameDocumentItem(HistoryItem& item)
 // FIXME: This function should really be split into a couple pieces, some of
 // which should be methods of HistoryController and some of which should be
 // methods of FrameLoader.
-void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType loadType, FormSubmissionCacheLoadPolicy cacheLoadPolicy, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
+void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType loadType, FormSubmissionCacheLoadPolicy cacheLoadPolicy, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, PolicyAlreadyDecided policyAlreadyDecided)
 {
     FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadDifferentDocumentItem: frame load started");
 
@@ -4477,9 +4510,10 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
         m_client->updateCachedDocumentLoader(*documentLoader);
 
         auto action = NavigationAction { protect(frame->document()).releaseNonNull(), documentLoader->request(), initiatedByMainFrame, documentLoader->isRequestFromClientOrUserInput(), loadType, false };
-        action.setTargetBackForwardItem(item);
+        action.setTargetBackForwardItemIdentifier(item.itemID());
         action.setSourceBackForwardItem(fromItem);
         action.setNavigationAPIType(determineNavigationType(loadType, NavigationHistoryBehavior::Auto));
+        action.setPolicyAlreadyDecided(policyAlreadyDecided);
         documentLoader->setTriggeringAction(WTF::move(action));
 
         documentLoader->setLastCheckedRequest(ResourceRequest());
@@ -4570,9 +4604,10 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
         action = { protect(frame->document()).releaseNonNull(), requestForOriginalURL, initiatedByMainFrame, request.isAppInitiated(), loadType, isFormSubmission, nullptr, shouldOpenExternalURLsPolicy };
     }
 
-    action.setTargetBackForwardItem(item);
+    action.setTargetBackForwardItemIdentifier(item.itemID());
     action.setSourceBackForwardItem(fromItem);
     action.setNavigationAPIType(determineNavigationType(loadType, NavigationHistoryBehavior::Auto));
+    action.setPolicyAlreadyDecided(policyAlreadyDecided);
 
     loadWithNavigationAction(WTF::move(request), WTF::move(action), loadType, { }, AllowNavigationToInvalidURL::Yes, shouldTreatAsContinuingLoad);
 }
@@ -4623,6 +4658,20 @@ void FrameLoader::loadItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadTy
         loadSameDocumentItem(item);
     } else
         loadDifferentDocumentItem(item, fromItem, loadType, MayAttemptCacheOnlyLoadForFormSubmissionItem, shouldTreatAsContinuingLoad);
+}
+
+void FrameLoader::setRequestedHistoryItem(HistoryItem& item)
+{
+    Ref frame = m_frame.get();
+
+    item.setFrameID(frame->frameID());
+    m_requestedHistoryItem = item;
+}
+
+void FrameLoader::loadRequestedHistoryItem(FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)
+{
+    ASSERT(m_requestedHistoryItem);
+    loadDifferentDocumentItem(protect(*m_requestedHistoryItem), nullptr, loadType, MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No, policyAlreadyDecided);
 }
 
 void FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad()

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -36,6 +36,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/LoaderMalloc.h>
+#include <WebCore/NavigationAction.h>
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PrivateClickMeasurement.h>
@@ -79,7 +80,6 @@ class HistoryController;
 class HistoryItem;
 class LocalDOMWindow;
 class LocalFrameLoaderClient;
-class NavigationAction;
 class NetworkingContext;
 class Node;
 class Page;
@@ -355,6 +355,8 @@ public:
     // HistoryController specific.
     void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad);
     HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
+    WEBCORE_EXPORT void setRequestedHistoryItem(HistoryItem&);
+    WEBCORE_EXPORT void loadRequestedHistoryItem(FrameLoadType, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
 
     void updateURLAndHistory(const URL&, RefPtr<SerializedScriptValue>&& stateObject, NavigationHistoryBehavior = NavigationHistoryBehavior::Replace);
 
@@ -365,6 +367,10 @@ public:
 
     void prefetch(const URL&, const Vector<String>&, std::optional<ReferrerPolicy>, bool lowPriority = false);
     DocumentPrefetcher& documentPrefetcher() { return m_documentPrefetcher.get(); }
+
+    bool loadChildHistoryItemIntoFrame(LocalFrame&);
+    WEBCORE_EXPORT void continueLoadURLIntoChildFrame(const URL&, const String& referer, LocalFrame&);
+    WEBCORE_EXPORT FrameLoadRequest createFrameLoadRequest(URL&&);
 
 private:
     enum FormSubmissionCacheLoadPolicy {
@@ -383,7 +389,7 @@ private:
     void checkCompletenessNow();
 
     void loadSameDocumentItem(HistoryItem&);
-    void loadDifferentDocumentItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, FormSubmissionCacheLoadPolicy, ShouldTreatAsContinuingLoad);
+    void loadDifferentDocumentItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, FormSubmissionCacheLoadPolicy, ShouldTreatAsContinuingLoad, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
 
     void loadProvisionalItemFromCachedPage();
 

--- a/Source/WebCore/loader/LocalFrameLoaderClient.cpp
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.cpp
@@ -27,6 +27,7 @@
 #include "LocalFrameLoaderClient.h"
 
 #include "FrameLoader.h"
+#include "LocalFrame.h"
 
 namespace WebCore {
 
@@ -55,6 +56,18 @@ void LocalFrameLoaderClient::didExceedNetworkUsageThreshold()
 RefPtr<Frame> LocalFrameLoaderClient::provisionalParentFrame() const
 {
     return nullptr;
+}
+
+void LocalFrameLoaderClient::dispatchBackForwardItemLoading(const URL& url, const String& referer, LocalFrame& childFrame)
+{
+    Ref loader = m_loader;
+    ASSERT(isBackForwardLoadType(loader->loadType()));
+    ASSERT(!loader->frame().document()->loadEventFinished());
+
+    if (loader->loadChildHistoryItemIntoFrame(childFrame))
+        return;
+
+    loader->continueLoadURLIntoChildFrame(url, referer, childFrame);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -206,6 +206,8 @@ public:
     virtual void dispatchWillSendSubmitEvent(Ref<FormState>&&) = 0;
     virtual void dispatchWillSubmitForm(FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) = 0;
 
+    virtual void dispatchBackForwardItemLoading(const URL&, const String& referer, LocalFrame& childFrame);
+
     virtual void revertToProvisionalState(DocumentLoader*) = 0;
     virtual void setMainDocumentError(DocumentLoader*, const ResourceError&) = 0;
 

--- a/Source/WebCore/loader/NavigationAction.cpp
+++ b/Source/WebCore/loader/NavigationAction.cpp
@@ -158,11 +158,6 @@ NavigationAction NavigationAction::copyWithShouldOpenExternalURLsPolicy(ShouldOp
     return result;
 }
 
-void NavigationAction::setTargetBackForwardItem(HistoryItem& item)
-{
-    m_targetBackForwardItemIdentifier = item.itemID();
-}
-
 void NavigationAction::setSourceBackForwardItem(HistoryItem* item)
 {
     m_sourceBackForwardItemIdentifier = item ? std::make_optional(item->itemID()) : std::nullopt;

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
 #include <WebCore/FrameLoadRequest.h>
@@ -52,6 +53,7 @@ class UIEventWithKeyState;
 enum class SyntheticClickType : uint8_t;
 enum class MouseButton : int8_t;
 enum class NavigationNavigationType : uint8_t;
+enum class PolicyAlreadyDecided : bool { No, Yes };
 
 // NavigationAction should never hold a strong reference to the originating document either directly
 // or indirectly as doing so prevents its destruction even after navigating away from it because
@@ -115,12 +117,8 @@ public:
     bool openedByDOMWithOpener() const { return m_openedByDOMWithOpener; }
     void setOpenedByDOMWithOpener() { m_openedByDOMWithOpener = true; }
 
-    void NODELETE setTargetBackForwardItem(HistoryItem&);
-    const std::optional<BackForwardItemIdentifier>& targetBackForwardItemIdentifier() const { return m_targetBackForwardItemIdentifier; }
-
     void NODELETE setSourceBackForwardItem(HistoryItem*);
     const std::optional<BackForwardItemIdentifier>& sourceBackForwardItemIdentifier() const { return m_sourceBackForwardItemIdentifier; }
-
 
     const std::optional<PrivateClickMeasurement>& privateClickMeasurement() const { return m_privateClickMeasurement; };
     void setPrivateClickMeasurement(PrivateClickMeasurement&& privateClickMeasurement) { m_privateClickMeasurement = privateClickMeasurement; };
@@ -132,6 +130,10 @@ public:
     void setPendingDispatchNavigateEvent(std::function<bool()>&& function) { m_pendingDispatchNavigateEvent = WTF::move(function); }
     std::function<bool()> takePendingDispatchNavigateEvent() { return std::exchange(m_pendingDispatchNavigateEvent, nullptr); }
 
+    // Whether UIProcess has already made the policy decision for this navigation.
+    PolicyAlreadyDecided policyAlreadyDecided() const { return m_policyAlreadyDecided; }
+    void setPolicyAlreadyDecided(PolicyAlreadyDecided value) { m_policyAlreadyDecided = value; }
+
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
     // originating document. See comment above the class for more details.
@@ -140,7 +142,6 @@ private:
     std::optional<UIEventWithKeyStateData> m_keyStateEventData;
     std::optional<MouseEventData> m_mouseEventData;
     RefPtr<UserGestureToken> m_userGestureToken { UserGestureIndicator::currentUserGesture() };
-    std::optional<BackForwardItemIdentifier> m_targetBackForwardItemIdentifier;
     std::optional<BackForwardItemIdentifier> m_sourceBackForwardItemIdentifier;
     std::optional<PrivateClickMeasurement> m_privateClickMeasurement;
     std::function<bool()> m_pendingDispatchNavigateEvent;
@@ -151,6 +152,7 @@ private:
     bool m_treatAsSameOriginNavigation { false };
     bool m_hasOpenedFrames { false };
     bool m_openedByDOMWithOpener { false };
+    PolicyAlreadyDecided m_policyAlreadyDecided { PolicyAlreadyDecided::No };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -335,6 +335,11 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
         // We ignore the response from the client for initial empty document loads and proceed with the load synchronously.
         frameLoader->client().dispatchDecidePolicyForNavigationAction(action, request, redirectResponse, formState.get(), clientRedirectSourceForHistory, navigationID, hitTestResult(action), hasOpener, frameLoader->navigationUpgradeToHTTPSBehavior(), sandboxFlags, policyDecisionMode, [](PolicyAction) { });
         decisionHandler(PolicyAction::Use);
+    } else if (action.policyAlreadyDecided() == PolicyAlreadyDecided::Yes) {
+        // UIProcess already made the policy decision, skip IPC.
+        // We still run local security checks (CSP, etc.) above, but skip the IPC roundtrip.
+        POLICYCHECKER_RELEASE_LOG("checkNavigationPolicy: skipping UIProcess IPC (already decided)");
+        decisionHandler(PolicyAction::Use);
     } else
         frameLoader->client().dispatchDecidePolicyForNavigationAction(action, request, redirectResponse, formState.get(), clientRedirectSourceForHistory, navigationID, hitTestResult(action), hasOpener, frameLoader->navigationUpgradeToHTTPSBehavior(), sandboxFlags, policyDecisionMode, WTF::move(decisionHandler));
 }

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -30,6 +30,7 @@
 #include "WebMouseEvent.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/AdvancedPrivacyProtections.h>
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FrameLoaderTypes.h>

--- a/Source/WebKit/Shared/PolicyDecision.h
+++ b/Source/WebKit/Shared/PolicyDecision.h
@@ -29,6 +29,7 @@
 #include "NavigatingToAppBoundDomain.h"
 #include "SafeBrowsingCheckOngoing.h"
 #include "SandboxExtension.h"
+#include "SessionState.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/NavigationIdentifier.h>
 
@@ -54,6 +55,7 @@ struct PolicyDecision {
     std::optional<SandboxExtension::Handle> sandboxExtensionHandle { std::nullopt };
     std::optional<PolicyDecisionConsoleMessage> consoleMessage { std::nullopt };
     SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing { SafeBrowsingCheckOngoing::No };
+    RefPtr<FrameState> backForwardFrameState { nullptr };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/PolicyDecision.serialization.in
+++ b/Source/WebKit/Shared/PolicyDecision.serialization.in
@@ -31,6 +31,7 @@ enum class WebKit::SafeBrowsingCheckOngoing : bool;
     std::optional<WebKit::SandboxExtensionHandle> sandboxExtensionHandle;
     std::optional<WebKit::PolicyDecisionConsoleMessage> consoleMessage;
     WebKit::SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing;
+    RefPtr<WebKit::FrameState> backForwardFrameState;
 }
 
 [CustomHeader] struct WebKit::PolicyDecisionConsoleMessage {

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -91,6 +91,13 @@ WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemForFrameID(Fr
     return nullptr;
 }
 
+WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemAtIndex(uint64_t index)
+{
+    if (index >= m_children.size())
+        return nullptr;
+    return m_children[index].ptr();
+}
+
 WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
 {
     return m_backForwardListItem.get();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -59,6 +59,7 @@ public:
     Ref<WebBackForwardListFrameItem> rootFrame();
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
+    WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
 
     WebBackForwardListItem* backForwardListItem() const;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -757,6 +757,23 @@ void WebBackForwardList::backForwardListCounts(CompletionHandler<void(WebBackFor
     completionHandler(counts());
 }
 
+FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, uint64_t childFrameIndex)
+{
+    RefPtr targetItem = itemForID(itemID);
+    if (!targetItem)
+        return nullptr;
+
+    RefPtr parentFrameItem = protect(targetItem->mainFrameItem())->childItemForFrameID(parentFrameID);
+    if (!parentFrameItem)
+        return nullptr;
+
+    RefPtr childFrameItem = parentFrameItem->childItemAtIndex(childFrameIndex);
+    if (!childFrameItem)
+        return nullptr;
+
+    return &childFrameItem->frameState();
+}
+
 String WebBackForwardList::loggingString()
 {
     StringBuilder builder;

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -97,6 +97,8 @@ public:
     void backForwardAddItemShared(IPC::Connection&, Ref<FrameState>&&, LoadedWebArchive);
     void backForwardGoToItemShared(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
 
+    FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
+
     String loggingString();
 
 private:

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -847,6 +847,21 @@ RefPtr<WebFrameProxy> WebFrameProxy::childFrame(uint64_t index) const
     return child;
 }
 
+std::optional<uint64_t> WebFrameProxy::indexInFrameTreeSiblings() const
+{
+    RefPtr parent = m_parentFrame.get();
+    if (!parent)
+        return std::nullopt;
+    uint64_t index = 0;
+    for (auto& child : parent->m_childFrames) {
+        if (child.ptr() == this)
+            return index;
+        index++;
+    }
+    ASSERT_NOT_REACHED("This frame should be in its parent's child frames");
+    return std::nullopt;
+}
+
 void WebFrameProxy::updateOpener(std::optional<WebCore::FrameIdentifier> newOpener)
 {
     RefPtr previousOpener = m_opener.get();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -227,6 +227,7 @@ public:
     WebFrameProxy* parentFrame() const { return m_parentFrame; }
     Ref<WebFrameProxy> rootFrame();
     RefPtr<WebFrameProxy> childFrame(uint64_t index) const;
+    std::optional<uint64_t> indexInFrameTreeSiblings() const;
 
     WebProcessProxy& NODELETE process() const;
     void setProcess(FrameProcess&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8491,8 +8491,37 @@ static bool NODELETE frameSandboxAllowsOpeningExternalCustomProtocols(SandboxFla
 }
 #endif
 
-void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& process, WebFrameProxy& frame, NavigationActionData&& navigationActionData, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
+RefPtr<FrameState> WebPageProxy::frameStateForBackForwardChildFrame(WebFrameProxy& frame, WebCore::BackForwardItemIdentifier targetBackForwardItemIdentifier)
 {
+    auto index = frame.indexInFrameTreeSiblings();
+    if (!index)
+        return nullptr;
+
+    return backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), *index);
+}
+
+void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& process, WebFrameProxy& frame, NavigationActionData&& navigationActionData, CompletionHandler<void(PolicyDecision&&)>&& originalCompletionHandler)
+{
+    RefPtr<FrameState> frameStateForBackForwardNavigation;
+    if (protect(preferences())->useUIProcessForBackForwardItemLoading() && navigationActionData.navigationType == WebCore::NavigationType::BackForward && navigationActionData.targetBackForwardItemIdentifier) {
+        if (RefPtr frameState = frameStateForBackForwardChildFrame(frame, *navigationActionData.targetBackForwardItemIdentifier)) {
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "frameStateForBackForwardChildFrame: Back/Forward child frame, rewriting URL to %" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
+            navigationActionData.request.setURL(URL { frameState->urlString });
+
+            frameStateForBackForwardNavigation = WTF::move(frameState);
+        }
+    }
+
+    // Wrap completionHandler to include FrameState in response.
+    auto completionHandler = [
+        originalCompletionHandler = WTF::move(originalCompletionHandler),
+        frameStateForBackForwardNavigation = WTF::move(frameStateForBackForwardNavigation)
+    ](PolicyDecision&& policyDecision) mutable {
+        if (frameStateForBackForwardNavigation && (policyDecision.policyAction == PolicyAction::Use))
+            policyDecision.backForwardFrameState = WTF::move(frameStateForBackForwardNavigation);
+        originalCompletionHandler(WTF::move(policyDecision));
+    };
+
     auto frameInfo = navigationActionData.frameInfo;
     auto navigationID = navigationActionData.navigationID;
     auto originatingFrameInfoData = navigationActionData.originatingFrameInfoData;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3073,6 +3073,7 @@ private:
     void didDestroyNavigation(IPC::Connection&, WebCore::NavigationIdentifier);
 
     void decidePolicyForNavigationAction(Ref<WebProcessProxy>&&, WebFrameProxy&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
+    RefPtr<FrameState> frameStateForBackForwardChildFrame(WebFrameProxy&, WebCore::BackForwardItemIdentifier);
     void decidePolicyForNewWindowAction(IPC::Connection&, NavigationActionData&&, const String& frameName, CompletionHandler<void(PolicyDecision&&)>&&);
     void decidePolicyForResponse(IPC::Connection&, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
     void beginSafeBrowsingCheck(const URL&, API::Navigation&, bool forMainFrameNavigation);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -32,6 +32,7 @@
 #include "MessageSenderInlines.h"
 #include "NavigationActionData.h"
 #include "WebFrame.h"
+#include "WebLocalFrameLoaderClient.h"
 #include "WebMouseEvent.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -44,6 +44,8 @@
 #include "NetworkProcessConnection.h"
 #include "NetworkResourceLoadParameters.h"
 #include "PluginView.h"
+#include "SessionState.h"
+#include "SessionStateConversion.h"
 #include "UserData.h"
 #include "WKBundleAPICast.h"
 #include "WebAutomationSessionProxy.h"
@@ -76,6 +78,7 @@
 #include <WebCore/EventHandler.h>
 #include <WebCore/FormState.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
+#include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTMLFormControlElement.h>
 #include <WebCore/HTMLFormElement.h>
@@ -87,6 +90,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/MediaDocument.h>
 #include <WebCore/MouseEvent.h>
+#include <WebCore/NavigationAction.h>
 #include <WebCore/NodeDocument.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PluginData.h>
@@ -1141,6 +1145,73 @@ void WebLocalFrameLoaderClient::dispatchWillSubmitForm(FormState& formState, URL
     }
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::WillSubmitForm { m_frame->info(), sourceFrame->info(), values, UserData { WebProcess::singleton().transformObjectsToHandles(userData.get()).get() }, requestURL, method }, WTF::move(completionHandler));
+}
+
+void WebLocalFrameLoaderClient::dispatchBackForwardItemLoading(const URL& url, const String& referer, LocalFrame& childFrame)
+{
+    auto* childClient = dynamicDowncast<WebLocalFrameLoaderClient>(childFrame.loader().client());
+    ASSERT(childClient);
+
+    Ref localFrame = m_localFrame.get();
+    ASSERT(!localFrame->document()->loadEventFinished());
+
+    Ref loader = localFrame->loader();
+    ASSERT(isBackForwardLoadType(loader->loadType()));
+
+    RefPtr item = loader->history().currentItem();
+    if (!item) {
+        loader->continueLoadURLIntoChildFrame(url, referer, childFrame);
+        return;
+    }
+
+    auto frameLoadRequest = loader->createFrameLoadRequest(URL { url });
+    frameLoadRequest.setTargetBackForwardItemIdentifier(item->itemID());
+    childClient->dispatchDecidePolicyForBackForwardNavigationAction(WTF::move(frameLoadRequest), referer, loader->loadType());
+}
+
+void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&& frameLoadRequest, const String& referer, WebCore::FrameLoadType loadType)
+{
+    Ref localFrame = m_localFrame.get();
+
+    NavigationAction navigationAction { frameLoadRequest, NavigationType::BackForward, nullptr };
+
+    auto request = frameLoadRequest.resourceRequest();
+
+    // Call dispatchDecidePolicyForNavigationAction on this (child) frame's client
+    // Response will be handled in the callback below
+    dispatchDecidePolicyForNavigationAction(
+        navigationAction,
+        request,
+        ResourceResponse { },
+        nullptr, // formState
+        { }, // clientRedirectSourceForHistory
+        std::nullopt, // navigationID
+        std::nullopt, // hitTestResult
+        false, // hasOpener
+        NavigationUpgradeToHTTPSBehavior::BasedOnPolicy,
+        localFrame->effectiveSandboxFlags(),
+        PolicyDecisionMode::Asynchronous,
+        [weakLocalFrame = WeakPtr { localFrame.ptr() }, url = request.url(), referer, loadType](PolicyAction action) {
+            if (action != PolicyAction::Use)
+                return;
+
+            RefPtr localFrame = weakLocalFrame.get();
+            if (!localFrame)
+                return;
+
+            RefPtr historyItem = localFrame->loader().requestedHistoryItem();
+            if (!historyItem) {
+                // Fallback: FrameState not found, use normal load path
+                RELEASE_LOG(Loading, "dispatchDecidePolicyForBackForwardNavigationAction: FrameState not found, using fallback normal load path");
+
+                if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
+                    parent->loader().continueLoadURLIntoChildFrame(URL { url }, referer, *localFrame);
+                return;
+            }
+
+            localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
+        }
+    );
 }
 
 void WebLocalFrameLoaderClient::revertToProvisionalState(DocumentLoader*)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -34,6 +34,7 @@
 #include <pal/SessionID.h>
 
 namespace WebCore {
+class FrameLoadRequest;
 struct BackForwardItemIdentifierType;
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 }
@@ -151,6 +152,8 @@ private:
     void dispatchWillSendSubmitEvent(Ref<WebCore::FormState>&&) final;
     void dispatchWillSubmitForm(WebCore::FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) final;
     
+    void dispatchBackForwardItemLoading(const URL&, const String& referer, WebCore::LocalFrame& childFrame) final;
+
     void revertToProvisionalState(WebCore::DocumentLoader*) final;
     void setMainDocumentError(WebCore::DocumentLoader*, const WebCore::ResourceError&) final;
     
@@ -285,6 +288,8 @@ private:
 
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&) final;
     void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&) final;
+
+    void dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&&, const String& referer, WebCore::FrameLoadType);
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void didExceedNetworkUsageThreshold();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -45,6 +45,7 @@
 #include "NetworkProcessConnection.h"
 #include "PluginView.h"
 #include "ProvisionalFrameCreationParameters.h"
+#include "SessionStateConversion.h"
 #include "WKAPICast.h"
 #include "WKBundleAPICast.h"
 #include "WebChromeClient.h"
@@ -52,8 +53,10 @@
 #include "WebEventConversion.h"
 #include "WebEventFactory.h"
 #include "WebFrameProxyMessages.h"
+#include "WebHistoryItemClient.h"
 #include "WebImage.h"
 #include "WebKeyboardEvent.h"
+#include "WebLocalFrameLoaderClient.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
@@ -616,6 +619,11 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
             documentLoader->setNavigationID(*policyDecision.navigationID);
     }
 
+    if (policyDecision.backForwardFrameState) {
+        RELEASE_LOG(Loading, "didReceivePolicyDecision: Received FrameState for child frame, URL=%" SENSITIVE_LOG_STRING, policyDecision.backForwardFrameState->urlString.utf8().data());
+        setHistoryItemForBackForwardNavigation(protect(*policyDecision.backForwardFrameState));
+    }
+
     if (policyDecision.policyAction == PolicyAction::Use && policyDecision.sandboxExtensionHandle) {
         if (RefPtr page = this->page()) {
             Ref mainWebFrame = page->mainWebFrame();
@@ -624,6 +632,22 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     }
 
     function(policyDecision.policyAction);
+}
+
+void WebFrame::setHistoryItemForBackForwardNavigation(const FrameState& frameState)
+{
+    RefPtr page = m_page.get();
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    if (!localFrame || !page)
+        return;
+
+    // Build HistoryItem from FrameState
+    Ref historyItemClient = page->historyItemClient();
+    auto ignoreHistoryItemChangesForScope = historyItemClient->ignoreChangesForScope();
+    Ref historyItem = toHistoryItem(historyItemClient, protect(frameState));
+
+    Ref frameLoader = localFrame->loader();
+    frameLoader->setRequestedHistoryItem(historyItem);
 }
 
 void WebFrame::startDownload(const WebCore::ResourceRequest& request, const String& suggestedName, FromDownloadAttribute fromDownloadAttribute)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -314,6 +314,8 @@ private:
 
     CheckedRef<FrameInspectorTarget> ensureInspectorTarget();
 
+    void setHistoryItemForBackForwardNavigation(const FrameState&);
+
     WeakPtr<WebCore::Frame> m_coreFrame;
     WeakPtr<WebPage> m_page;
     RefPtr<WebCore::LocalFrame> m_provisionalFrame;


### PR DESCRIPTION
#### 212c74a1c63a57108f00e04d75e5478ee375a73f
<pre>
[Site Isolation] Route same-site child frame back/forward navigations through UIProcess when UseUIProcessForBackForwardItemLoading is enabled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308562">https://bugs.webkit.org/show_bug.cgi?id=308562</a>
<a href="https://rdar.apple.com/170106309">rdar://170106309</a>

Reviewed by Charlie Wolfe and Sihui Liu.

When UseUIProcessForBackForwardItemLoading is enabled and a parent frame performs a back/forward
navigation, child frame URL loads were falling through to the legacy loadURLIntoChildFrame path
instead of being intercepted by the UIProcess.

This patch routes same-site child frame back/forward loads through the existing
decidePolicyForNavigationAction IPC, letting the UIProcess make the decision about what URL to
load. The WebProcess simply dispatches the navigation; the UIProcess looks up the correct
FrameState from the BackForwardList, rewrites the request URL, and sends the FrameState back in
the PolicyDecision so the WebProcess can reconstruct a HistoryItem and load it.

WebProcess side:
- In FrameLoader::loadURLIntoChildFrame, when UseUIProcessForBackForwardItemLoading is enabled,
  call dispatchBackForwardItemLoading on the client instead of the legacy child item lookup path.
  Extract the remaining legacy logic into loadChildHistoryItemIntoFrame and continueLoadURLIntoChildFrame
  for fallback use.
- In WebLocalFrameLoaderClient::dispatchBackForwardItemLoading, build a FrameLoadRequest with the
  parent&apos;s BackForwardItemIdentifier and dispatch it through
  dispatchDecidePolicyForBackForwardNavigationAction on the child frame&apos;s client.
- In WebFrame::didReceivePolicyDecision, when the response includes a backForwardFrameState,
  reconstruct a HistoryItem and stash it via FrameLoader::setRequestedHistoryItem.
- In the policy callback, call FrameLoader::loadRequestedHistoryItem with PolicyAlreadyDecided::Yes
  to load the historical content without a redundant UIProcess round-trip.

UIProcess side:
- In WebPageProxy::decidePolicyForNavigationAction, detect back/forward navigations with a
  targetBackForwardItemIdentifier. Look up the child frame&apos;s FrameState by finding the frame&apos;s
  sibling index (WebFrameProxy::indexInFrameTreeSiblings) and looking up the corresponding child
  in the BackForwardList (WebBackForwardList::frameStateForIndexedChild). Rewrite the request URL
  to the historical URL and attach the FrameState to the PolicyDecision response.

Other changes:
- Add PolicyAlreadyDecided enum to skip the UIProcess IPC in PolicyChecker when the decision has
  already been made.
- Add WebBackForwardListFrameItem::childItemAtIndex, WebFrameProxy::indexInFrameTreeSiblings,
  and FrameLoader::createFrameLoadRequest helpers.
- Remove NavigationAction::setTargetBackForwardItem(HistoryItem&amp;) and
  targetBackForwardItemIdentifier(); the identifier is now carried on FrameLoadRequest instead.

Test: http/tests/site-isolation/history/back-iframe-no-bf-cache.html
* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html:
* LayoutTests/http/tests/navigation/resources/navigation-utils.js:
(crossSiteUrl):
* LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html: Added.
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::targetBackForwardItemIdentifier const):
(WebCore::FrameLoadRequestBase::setTargetBackForwardItemIdentifier):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::createFrameLoadRequest):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::loadChildHistoryItemIntoFrame):
(WebCore::FrameLoader::continueLoadURLIntoChildFrame):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::setRequestedHistoryItem):
(WebCore::FrameLoader::loadRequestedHistoryItem):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/LocalFrameLoaderClient.cpp:
(WebCore::LocalFrameLoaderClient::dispatchBackForwardItemLoading):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/NavigationAction.cpp:
(WebCore::NavigationAction::setTargetBackForwardItem): Deleted.
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::policyAlreadyDecided const):
(WebCore::NavigationAction::setPolicyAlreadyDecided):
(WebCore::NavigationAction::targetBackForwardItemIdentifier const): Deleted.
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/PolicyDecision.h:
* Source/WebKit/Shared/PolicyDecision.serialization.in:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::childItemAtIndex):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::findFrameStateInItem):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::indexInFrameTreeSiblings const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::frameStateForBackForwardChildFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchBackForwardItemLoading):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didReceivePolicyDecision):
(WebKit::WebFrame::setHistoryItemForBackForwardNavigation):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:

Canonical link: <a href="https://commits.webkit.org/308613@main">https://commits.webkit.org/308613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1597449be34367a763c47da72b899acc8555b046

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101359 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114057 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81335 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bca639da-0dfd-48e7-841b-140906aa7407) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94820 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cad3c391-666b-4a53-a130-756aa63966bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15458 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13242 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158961 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122090 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31354 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76581 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9339 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83806 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19776 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->