### PR TITLE
[GFC][Cleanup] Store used gap values inside GridLayoutState

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -149,6 +149,22 @@ public:
 
     const WritingMode writingMode() const { return m_gridBox->style().writingMode(); }
 
+    // FIXME: This is only here because the integration code needs to know the
+    // row gap to update RenderGrid. We should figure out a way to do that and remove
+    // this from the public API.
+    static LayoutUnit usedGapValue(const Style::GapGutter& gap)
+    {
+        if (gap.isNormal())
+            return { };
+
+        // Only handle fixed length gaps for now
+        if (auto fixedGap = gap.tryFixed())
+            return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, Style::ZoomNeeded { });
+
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -72,8 +72,7 @@ private:
     static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes);
     static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes);
 
-    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&, const GridLayoutConstraints&,
-        const StyleContentAlignmentData& usedJustifyContent, const StyleContentAlignmentData& usedAlignContent) const;
+    UsedTrackSizes performGridSizingAlgorithm(const GridLayoutState&, const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const GridAreaSizes&,
         const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutState.h
@@ -35,6 +35,8 @@ struct GridLayoutState {
     const GridDefinition gridDefinition;
     const StyleContentAlignmentData usedJustifyContent;
     const StyleContentAlignmentData usedAlignContent;
+    const LayoutUnit usedColumnGap;
+    const LayoutUnit usedRowGap;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -30,18 +30,7 @@ namespace WebCore {
 namespace Layout {
 namespace GridLayoutUtils {
 
-LayoutUnit computeGapValue(const Style::GapGutter& gap)
-{
-    if (gap.isNormal())
-        return { };
 
-    // Only handle fixed length gaps for now
-    if (auto fixedGap = gap.tryFixed())
-        return Style::evaluate<LayoutUnit>(*fixedGap, 0_lu, Style::ZoomNeeded { });
-
-    ASSERT_NOT_REACHED();
-    return { };
-}
 
 LayoutUnit totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize)
 {

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -36,7 +36,6 @@ struct GridItemSizingFunctions;
 
 namespace GridLayoutUtils {
 
-LayoutUnit computeGapValue(const Style::GapGutter&);
 LayoutUnit totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize);
 
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, LayoutUnit columnsSize, const IntegrationUtils&);

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -417,7 +417,7 @@ static void maximizeTracks(UnsizedTracks& unsizedTracks, std::optional<LayoutUni
 TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const ComputedSizesList& gridItemComputedSizesList,
     const UsedBorderAndPaddingList& borderAndPaddingList, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions,
     std::optional<LayoutUnit> availableGridSpace, const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions& gridItemSizingFunctions,
-    const FreeSpaceScenario& freeSpaceScenario, const LayoutUnit& gapSize, const StyleContentAlignmentData& usedContentAlignment)
+    const FreeSpaceScenario& freeSpaceScenario, const LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment)
 {
     ASSERT(gridItems.size() == gridItemSpanList.size());
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -54,7 +54,7 @@ public:
     static TrackSizes sizeTracks(const PlacedGridItems&, const ComputedSizesList&, const UsedBorderAndPaddingList&,
         const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableGridSpace,
         const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions&,
-        const FreeSpaceScenario&, const LayoutUnit& gapSize, const StyleContentAlignmentData& usedContentAlignment);
+        const FreeSpaceScenario&, const LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment);
 
 private:
 

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -168,7 +168,7 @@ void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutCon
 
     if (layoutConstraints.blockAxis.scenario() != Layout::FreeSpaceScenario::Definite) {
         auto& rowSizes = usedTrackSizes.rowSizes;
-        auto usedRowGutter = Layout::GridLayoutUtils::computeGapValue(renderGrid->style().rowGap());
+        auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap());
         auto blockContentSize = std::reduce(rowSizes.begin(), rowSizes.end()) + Layout::GridLayoutUtils::totalGuttersSize(rowSizes.size(), usedRowGutter);
         renderGrid->setHeight(blockContentSize);
     }


### PR DESCRIPTION
#### e35185a9fcc2f1df83d2c9e02b48698456f1eb6e
<pre>
[GFC][Cleanup] Store used gap values inside GridLayoutState
<a href="https://bugs.webkit.org/show_bug.cgi?id=308595">https://bugs.webkit.org/show_bug.cgi?id=308595</a>
<a href="https://rdar.apple.com/171122153">rdar://171122153</a>

Reviewed by Elika Etemad.

We currently have a helper function on GridLayoutUtils that is used to
compute the used gap values and is called multiple times during layout.
However, the used gap values never change so this piece of information
can be computed just once. This can be done inside of
GridFormattingContext and passed around as an additional piece of
information that lives on GridLayoutState.

Any places that were previously calling the GridLayoutUtils function
will now just have the used gap value plumbed to them.

(WebCore::Layout::GridLayout::layout):
We were unpacking each field inside GridLayoutState but let&apos;s just get
the values when we need them.

(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
This function was taking in many of the things from GridLayoutState as
an argument. Just to make the code a bit more compact we can have it
take in GridLayoutState. In most cases it would be nice if the function
took in only what it needed but since it uses quite a few different
pieces from GridLayoutState I think it is ok here.

Canonical link: <a href="https://commits.webkit.org/308340@main">https://commits.webkit.org/308340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8edd80d83aff2bce7df65b48ceb0934c099070

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100482 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa324465-31b4-4c4c-a640-60f90e87bcde) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113332 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80858 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94088 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fee115e-28b3-45f1-b68d-db3c758a3862) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12547 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158081 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1212 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121355 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31163 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75518 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8612 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82920 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18895 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->