### PR TITLE
pdf/pdf-plugin-printing.html is flakily crashing, ASSERTION FAILED: m_plugInStreamLoaders.contains(&loader)

### DIFF
--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -197,6 +197,12 @@ void NetscapePlugInStreamLoader::notifyDone()
 
     if (RefPtr documentLoader = this->documentLoader())
         documentLoader->removePlugInStreamLoader(*this);
+
+    // Prevent double removal from DocumentLoader::m_plugInStreamLoaders.
+    // This can happen when re-entrant IPC during a sync print operation
+    // triggers layout that destroys the PluginView, causing stream
+    // cancellation while didFinishLoading is still on the stack.
+    m_isInitialized = false;
 }
 
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -186,26 +186,26 @@ void PluginView::Stream::didFail(NetscapePlugInStreamLoader&, const ResourceErro
 {
     // Calling streamDidFail could cause us to be deleted, so we hold on to a reference here.
     Ref protectedThis { *this };
+    RefPtr pluginView = std::exchange(m_pluginView, nullptr);
 
     // We only want to call streamDidFail if the stream was not explicitly cancelled by the plug-in.
     if (!m_streamWasCancelled)
-        m_pluginView->m_plugin->streamDidFail();
+        pluginView->m_plugin->streamDidFail();
 
-    ASSERT(m_pluginView->m_stream == this);
-    m_pluginView->m_stream = nullptr;
-    m_pluginView = nullptr;
+    ASSERT(pluginView->m_stream == this);
+    pluginView->m_stream = nullptr;
 }
 
 void PluginView::Stream::didFinishLoading(NetscapePlugInStreamLoader&)
 {
     // Calling streamDidFinishLoading could cause us to be deleted, so we hold on to a reference here.
     Ref protectedThis { *this };
+    RefPtr pluginView = std::exchange(m_pluginView, nullptr);
 
-    m_pluginView->m_plugin->streamDidFinishLoading();
+    pluginView->m_plugin->streamDidFinishLoading();
 
-    ASSERT(m_pluginView->m_stream == this);
-    m_pluginView->m_stream = nullptr;
-    m_pluginView = nullptr;
+    ASSERT(pluginView->m_stream == this);
+    pluginView->m_stream = nullptr;
 }
 
 RefPtr<PluginView> PluginView::create(HTMLPlugInElement& element, const URL& mainResourceURL, const String& contentType, bool shouldUseManualLoader)


### PR DESCRIPTION
#### 8f4821e1ffd59699e422945d202686753d57ea37
<pre>
pdf/pdf-plugin-printing.html is flakily crashing, ASSERTION FAILED: m_plugInStreamLoaders.contains(&amp;loader)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308583">https://bugs.webkit.org/show_bug.cgi?id=308583</a>
<a href="https://rdar.apple.com/171111801">rdar://171111801</a>

Reviewed by Wenson Hsieh.

When PDFPluginBase::tryRunScriptsInPDFDocument() triggers window.print(),
WebChromeClient::print() sends a sync PrintFrame message to the UI process.
The UI process responds with BeginPrintingDuringDOMPrintOperation, which is
dispatched re-entrantly during waitForSyncReply. This re-entrant message
triggers layout via updateLayout(), which can destroy the PluginView through
WidgetHierarchyUpdatesSuspensionScope::moveWidgets().

When the PluginView is destroyed, its stream is cancelled, which calls
NetscapePlugInStreamLoader::notifyDone() to remove the loader from
DocumentLoader::m_plugInStreamLoaders. But when the re-entrant unwind
completes and control returns to Stream::didFinishLoading (still on the
stack), it calls notifyDone() again, hitting the assertion that the loader
is still in m_plugInStreamLoaders. It also dereferences m_pluginView, which
is a WeakPtr that has been nulled by the PluginView&apos;s destruction.

In this patch, we fix both issues:

1. In NetscapePlugInStreamLoader::notifyDone(), reset m_isInitialized
   before removing from m_plugInStreamLoaders, so a next call is a no-op.

2. In PluginView::Stream::didFail() and didFinishLoading(), hold on to
   the PluginView object in a local RefPtr and clear out m_pluginView.
   This serves two purposes: nulling m_pluginView early ensures that if
   the callback triggers re-entrant destruction of the Stream, the
   ASSERT(!m_pluginView) in ~Stream() holds; and capturing the result
   into a RefPtr keeps the PluginView alive across the callback, so the
   cleanup afterward operates on a valid object.

* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::notifyDone):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::Stream::didFail):
(WebKit::PluginView::Stream::didFinishLoading):

Canonical link: <a href="https://commits.webkit.org/308242@main">https://commits.webkit.org/308242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec3f27c634385eb9054cee0ab02e60c35c951ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100147 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e5bae2b-5412-47f1-9838-f1ed98f5c1a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80731 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1953937e-a94c-4425-abaf-9446fa90a534) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93826 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6faaaf7-619a-405d-baf4-6174dd6b1e2d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14559 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12331 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2868 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157755 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121088 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121301 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31099 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75056 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8372 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82602 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18644 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->