### PR TITLE
Regression (294225@main): `Width` value in result pane does not go away and clicking leave repaint smear (jsfiddle.net).

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -894,6 +894,7 @@ void RenderLayer::setWasOmittedFromZOrderTree()
 
     ASSERT(!isNormalFlowOnly());
     removeSelfFromCompositor();
+    setSelfAndDescendantsNeedPositionUpdate();
 
     // Omitting a stacking context removes the whole subtree, otherwise collectLayers will
     // visit and omit/include descendants separately.
@@ -904,6 +905,15 @@ void RenderLayer::setWasOmittedFromZOrderTree()
         parent()->setDescendantsNeedCompositingRequirementsTraversal();
 
     m_wasOmittedFromZOrderTree = true;
+}
+
+void RenderLayer::setWasIncludedInZOrderTree()
+{
+    if (!m_wasOmittedFromZOrderTree)
+        return;
+
+    m_wasOmittedFromZOrderTree = false;
+    setSelfAndDescendantsNeedPositionUpdate();
 }
 
 void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZOrderList, std::unique_ptr<Vector<RenderLayer*>>& negativeZOrderList, OptionSet<Compositing>& accumulatedDirtyFlags)
@@ -1253,7 +1263,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
     }
 
     if (mode == Write)
-        updateDescendantDependentFlags();
+        updateLayerListsIfNeeded();
     else {
         LAYER_POSITIONS_ASSERT(!m_visibleDescendantStatusDirty);
         LAYER_POSITIONS_ASSERT(!m_hasSelfPaintingLayerDescendantDirty);
@@ -1292,10 +1302,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
         if (mode == Verify) {
             WeakPtr repaintContainer = renderer().containerForRepaint().renderer.get();
             LAYER_POSITIONS_ASSERT(repaintRects() || (isSubtreeVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer()));
-            if (isSubtreeVisibilityHiddenOrOpacityZero())
-                LAYER_POSITIONS_ASSERT(!m_repaintContainer);
-            else
-                LAYER_POSITIONS_ASSERT(m_repaintContainer == repaintContainer);
+            LAYER_POSITIONS_ASSERT(m_repaintContainer == repaintContainer);
             LAYER_POSITIONS_ASSERT_IMPLIES(repaintRects(), *repaintRects() == renderer().rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes));
             return;
         }
@@ -1489,10 +1496,7 @@ void RenderLayer::computeRepaintRects(const RenderLayerModelObject* repaintConta
     else
         setRepaintRects(renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes));
 
-    if (isSubtreeVisibilityHiddenOrOpacityZero())
-        m_repaintContainer = nullptr;
-    else
-        m_repaintContainer = repaintContainer;
+    m_repaintContainer = repaintContainer;
 }
 
 void RenderLayer::computeRepaintRectsIncludingDescendants()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -889,7 +889,6 @@ public:
     RenderLayer* backingProviderLayerAtEndOfCompositingUpdate() const LIFETIME_BOUND { return m_backingProviderLayerAtEndOfCompositingUpdate.get(); }
     void setBackingProviderLayerAtEndOfCompositingUpdate(RenderLayer* provider) { m_backingProviderLayerAtEndOfCompositingUpdate = provider; }
     RenderLayerModelObject* repaintContainer() const { return m_repaintContainer.get(); }
-    void clearRepaintContainer() { m_repaintContainer = nullptr; }
 
     RenderLayerBacking* backing() const LIFETIME_BOUND { return m_backing.get(); }
     RenderLayerBacking* ensureBacking() LIFETIME_BOUND;
@@ -1303,7 +1302,7 @@ private:
     void updatePagination();
 
     void setWasOmittedFromZOrderTree();
-    void setWasIncludedInZOrderTree() { m_wasOmittedFromZOrderTree = false; }
+    void setWasIncludedInZOrderTree();
     void removeSelfFromCompositor();
     void removeDescendantsFromCompositor();
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2566,7 +2566,6 @@ void RenderLayerCompositor::layerWillBeRemoved(RenderLayer& parent, RenderLayer&
     } else
         return;
 
-    child.clearRepaintContainer();
     child.setNeedsCompositingLayerConnection();
 }
 


### PR DESCRIPTION
#### 6e7e05f90dc1849df753bf990bc230be85348461
<pre>
Regression (294225@main): `Width` value in result pane does not go away and clicking leave repaint smear (jsfiddle.net).
<a href="https://bugs.webkit.org/show_bug.cgi?id=308600">https://bugs.webkit.org/show_bug.cgi?id=308600</a>
&lt;<a href="https://rdar.apple.com/169112402">rdar://169112402</a>&gt;

Reviewed by Simon Fraser.

The regressing change made it so we always keep a repaint container for non-self
painting layers (despite not storing repaint rects).

It had the side effect of also never keeping a repaint container for opacity:0
layers, which previously was inconsistent, depending on which update path was
taken.

The fix is to make opacity:0 layers the same as non-self painting layers, always
hold the repaint container.

Unfortunately I haven&apos;t been able to make a test that captures this, and it only
reproduces very inconsistenty on the original site.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::computeRepaintRects):

Canonical link: <a href="https://commits.webkit.org/309861@main">https://commits.webkit.org/309861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0bbb8d1ab4d5bfe1d53e7cc3ddde79ae647297d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105260 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e4349f8-9a72-41a5-aece-5d5c8699fb17) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117252 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83204 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68a4e945-6fef-46f7-b4fb-96da48b98494) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97967 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4086064d-af68-4306-b6bf-6a9152f3d9fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18502 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16439 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8380 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163009 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6158 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125272 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125453 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34072 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80959 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20482 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12696 "Found 4 new test failures: accessibility/accessibility-crash-focused-element-change.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/mac/live-regions/atomic-region-node-added.html animations/CSSKeyframesRule-name-null.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88286 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23852 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->