### PR TITLE
[JSC] Handle jettison during compilation finalization for DFG quick tier up

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2845,8 +2845,11 @@ void CodeBlock::didDFGJettison(Profiler::JettisonReason reason)
     if (!Profiler::isSpeculationFailure(reason))
         return;
 
-    ASSERT(unlinkedCodeBlock()->hasQuickDFGTierUpUpdated());
-    unlinkedCodeBlock()->setQuickDFGTierUp(TriState::False);
+    // Only mark as failed if code was already installed and ran (flag = True).
+    // If jettison happens during compilation (flag = Indeterminate), leave it
+    // unchanged - this was environmental (OOM, GC pressure), not a code quality issue.
+    if (unlinkedCodeBlock()->hasQuickDFGTierUpUpdated())
+        unlinkedCodeBlock()->setQuickDFGTierUp(TriState::False);
 }
 
 void CodeBlock::didFailDFGCompilation()


### PR DESCRIPTION
#### 66f509e2dccd7bdd2eb177f16d3ed87383143aba
<pre>
[JSC] Handle jettison during compilation finalization for DFG quick tier up
<a href="https://rdar.apple.com/171122738">rdar://171122738</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308598">https://bugs.webkit.org/show_bug.cgi?id=308598</a>

Reviewed by Mark Lam.

Remove incorrect assertion and handle the case where watchpoints fire
during DFG compilation finalization, before code installation completes.

Under memory pressure, ArrayBufferViewWatchpointAdaptor::add() can fail
to allocate an ArrayBuffer (via slowDownAndWasteMemory()) and immediately
fire the watchpoint. This triggers jettison while the quick tier-up flag
is still Indeterminate, before didInstallDFGCode() is called.

The sequence:
operationOptimize() -&gt; Plan::finalize() -&gt; reallyAdd()
-&gt; ArrayBuffer::tryCreate() fails (OOM)
-&gt; watchpoint.fire(JettisonDueToUnprofiledWatchpoint)
-&gt; didDFGJettison() called with flag = Indeterminate

The fix only updates the flag if it was already set (True -&gt; False),
which represents real speculation failure after code execution. If the
flag is Indeterminate, leave it unchanged - the jettison was due to
environmental factors (OOM, GC pressure) during compilation, not code
quality issues. The function deserves a fair retry without penalty.

State transitions:
Indeterminate -&gt; True:          didInstallDFGCode() (successful install)
Indeterminate -&gt; False:         didFailDFGCompilation() (compilation failed)
True -&gt; False:                  didDFGJettison() (post-install speculation failure)
Indeterminate -&gt; Indeterminate: didDFGJettison() (environmental issue)

This issue is exposed by the stress test [1] under memory pressure.

Test:
[1] stress/array-buffer-view-watchpoint-can-be-fired-in-really-add-in-dfg.js

Canonical link: <a href="https://commits.webkit.org/308249@main">https://commits.webkit.org/308249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b18e72a225ccba1f816198d99c983fbac283b8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155568 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a66b889-062d-45e2-bbf5-ea8da743520b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5d6561b-1b13-4512-846a-d79bb0460e7a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15430 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60f238c0-2fbe-4d4c-929e-bb21a2769502) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3010 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138854 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157899 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7674 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31104 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131619 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178174 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18983 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45640 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->