### PR TITLE
Script element should keep the wrapper object alive until the load or error event are dispatched

### DIFF
--- a/LayoutTests/http/tests/dom/script-error-event-gc-expected.txt
+++ b/LayoutTests/http/tests/dom/script-error-event-gc-expected.txt
@@ -1,0 +1,19 @@
+garbage collect HTML script elements before the error events are dispatched
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/dom/script-error-event-gc.html
+++ b/LayoutTests/http/tests/dom/script-error-event-gc.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src='/js-test-resources/js-test.js'></script>
+<script>
+  description('garbage collect HTML script elements before the error events are dispatched');
+  jsTestIsAsync = true;
+  onload = async () => {
+      let promises = Array(10).fill().map(() => 
+          new Promise(resolve => {
+              var s = document.createElement('script');
+              s.src = '/resources/network-simulator.py?test=dom-script-error-event-gc&initialdelay=1000&path=non-existent-file';
+              s.onerror = () => resolve('onerror');
+              document.body.appendChild(s);
+          }));
+      await new Promise(resolve => setTimeout(resolve, 100));
+      document.querySelectorAll('script').forEach(i => i.remove());
+      gc();
+      for (const promise of promises)
+          debug(await promise);
+      finishJSTest();
+  }
+</script>

--- a/LayoutTests/http/tests/dom/script-load-event-gc-expected.txt
+++ b/LayoutTests/http/tests/dom/script-load-event-gc-expected.txt
@@ -1,0 +1,19 @@
+garbage collect HTML script elements before the load events are dispatched
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/dom/script-load-event-gc.html
+++ b/LayoutTests/http/tests/dom/script-load-event-gc.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src='/js-test-resources/js-test.js'></script>
+<script>
+  description('garbage collect HTML script elements before the load events are dispatched');
+  jsTestIsAsync = true;
+  onload = async () => {
+      let promises = Array(10).fill().map(() => 
+          new Promise(resolve => {
+              var s = document.createElement('script');
+              s.src = '/resources/slow-script.pl?delay=1000';
+              s.onload = () => resolve('onload');
+              document.body.appendChild(s);
+          }));
+      await new Promise(resolve => setTimeout(resolve, 100));
+      document.querySelectorAll('script').forEach(i => i.remove());
+      gc();
+      for (const promise of promises)
+          debug(await promise);
+      finishJSTest();
+  }
+</script>

--- a/LayoutTests/http/tests/svg/script-error-event-gc-expected.txt
+++ b/LayoutTests/http/tests/svg/script-error-event-gc-expected.txt
@@ -1,0 +1,19 @@
+garbage collect SVG script elements before the error events are dispatched
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+onerror
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/svg/script-error-event-gc.html
+++ b/LayoutTests/http/tests/svg/script-error-event-gc.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src='/js-test-resources/js-test.js'></script>
+<script>
+  description('garbage collect SVG script elements before the error events are dispatched');
+  jsTestIsAsync = true;
+  onload = async () => {
+      let promises = Array(10).fill().map(() => 
+          new Promise(resolve => {
+              var s = document.createElementNS('http://www.w3.org/2000/svg', 'script');
+              s.setAttribute('href', '/resources/network-simulator.py?test=svg-script-load-event-gc&initialdelay=1000&path=non-existent-file');
+              s.onerror = () => resolve('onerror');
+              document.body.appendChild(s);
+          }));
+      await new Promise(resolve => setTimeout(resolve, 100));
+      document.querySelectorAll('script').forEach(i => i.remove());
+      gc();
+      for (const promise of promises)
+          debug(await promise);
+      finishJSTest();
+  }
+</script>

--- a/LayoutTests/http/tests/svg/script-load-event-gc-expected.txt
+++ b/LayoutTests/http/tests/svg/script-load-event-gc-expected.txt
@@ -1,0 +1,19 @@
+garbage collect SVG script elements before the load events are dispatched
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+onload
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/svg/script-load-event-gc.html
+++ b/LayoutTests/http/tests/svg/script-load-event-gc.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src='/js-test-resources/js-test.js'></script>
+<script>
+  description('garbage collect SVG script elements before the load events are dispatched');
+  jsTestIsAsync = true;
+  onload = async () => {
+      let promises = Array(10).fill().map(() => 
+          new Promise(resolve => {
+              var s = document.createElementNS('http://www.w3.org/2000/svg', 'script');
+              s.setAttribute('href', '/resources/slow-script.pl?delay=1000');
+              s.onload = () => resolve('onload');
+              document.body.appendChild(s);
+          }));
+      await new Promise(resolve => setTimeout(resolve, 100));
+      document.querySelectorAll('script').forEach(i => i.remove());
+      gc();
+      for (const promise of promises)
+          debug(await promise);
+      finishJSTest();
+  }
+</script>

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -82,7 +82,8 @@ namespace WebCore {
 static const auto maxUserGesturePropagationTime = 1_s;
 
 ScriptElement::ScriptElement(Element& element, bool parserInserted, bool alreadyStarted)
-    : m_element(element)
+    : ActiveDOMObject(element.document())
+    , m_element(element)
     , m_parserInserted(parserInserted ? ParserInserted::Yes : ParserInserted::No)
     , m_alreadyStarted(alreadyStarted)
     , m_forceAsync(!parserInserted)
@@ -134,6 +135,9 @@ void ScriptElement::handleAsyncAttribute()
 
 void ScriptElement::dispatchErrorEvent()
 {
+    // Keep the JS wrapper alive until the end of this method.
+    Ref wrapperProtector = makePendingActivity(*this);
+
     protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
@@ -638,16 +642,6 @@ void ScriptElement::setTrustedScriptText(const String& text)
     m_trustedScriptText = text;
 }
 
-void ScriptElement::ref() const
-{
-    element().ref();
-}
-
-void ScriptElement::deref() const
-{
-    element().deref();
-}
-
 bool isScriptElement(Node& node)
 {
     return is<HTMLScriptElement>(node) || is<SVGScriptElement>(node);
@@ -726,6 +720,15 @@ void ScriptElement::unregisterSpeculationRules()
     }
 
     document->considerSpeculationRules();
+}
+
+bool ScriptElement::virtualHasPendingActivity() const
+{
+    if (!m_hasRelevantLoadEventsListener)
+        return false;
+    if (!loadableScript())
+        return false;
+    return !haveFiredLoadEvent();
 }
 
 }

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <JavaScriptCore/Forward.h>
+#include <WebCore/ActiveDOMObject.h>
 #include <WebCore/ContainerNode.h>
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/LoadableScript.h>
@@ -43,7 +44,7 @@ class Node;
 class PendingScript;
 class ScriptSourceCode;
 
-class ScriptElement {
+class ScriptElement : public ActiveDOMObject {
 public:
     virtual ~ScriptElement() = default;
 
@@ -77,16 +78,16 @@ public:
     bool readyToBeParserExecuted() const { return m_readyToBeParserExecuted; }
     bool willExecuteWhenDocumentFinishedParsing() const { return m_willExecuteWhenDocumentFinishedParsing; }
     bool willExecuteInOrder() const { return m_willExecuteInOrder; }
-    LoadableScript* loadableScript() { return m_loadableScript.get(); }
+    LoadableScript* loadableScript() const { return m_loadableScript.get(); }
 
     ScriptType scriptType() const { return m_scriptType; }
 
     JSC::SourceTaintedOrigin sourceTaintedOrigin() const { return m_taintedOrigin; }
 
-    void NODELETE ref() const;
-    void deref() const;
-
     static std::optional<ScriptType> determineScriptType(const String& typeAttribute, const String& languageAttribute, bool isHTMLDocument = true, bool speculationRulesPrefetchEnabled = false);
+
+    // ActiveDOMObject
+    bool virtualHasPendingActivity() const final;
 
 protected:
     ScriptElement(Element&, bool createdByParser, bool isEvaluated);
@@ -96,6 +97,8 @@ protected:
     ParserInserted isParserInserted() const { return m_parserInserted; }
     bool alreadyStarted() const { return m_alreadyStarted; }
     bool forceAsync() const { return m_forceAsync; }
+
+    void setHasRelevantLoadEventsListener(bool hasListener) { m_hasRelevantLoadEventsListener = hasListener; }
 
     // Helper functions used by our parent classes.
     Node::InsertedIntoAncestorResult insertedIntoAncestor(Node::InsertionType insertionType, ContainerNode&) const
@@ -151,6 +154,7 @@ private:
     bool m_forceAsync : 1;
     bool m_willExecuteInOrder : 1 { false };
     bool m_childrenChangedByAPI : 1 { false };
+    bool m_hasRelevantLoadEventsListener : 1 { false };
     ScriptType m_scriptType : bitWidthOfScriptType { ScriptType::Classic };
     AtomString m_characterEncoding;
     AtomString m_fallbackCharacterEncoding;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLScriptElement);
 using namespace HTMLNames;
 
 inline HTMLScriptElement::HTMLScriptElement(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
-    : HTMLElement(tagName, document)
+    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
     , ScriptElement(*this, wasInsertedByParser, alreadyStarted)
 {
     ASSERT(hasTagName(scriptTag));
@@ -54,7 +54,9 @@ inline HTMLScriptElement::HTMLScriptElement(const QualifiedName& tagName, Docume
 
 Ref<HTMLScriptElement> HTMLScriptElement::create(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
 {
-    return adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser, alreadyStarted));
+    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser, alreadyStarted));
+    scriptElement->suspendIfNeeded();
+    return scriptElement;
 }
 
 bool HTMLScriptElement::isURLAttribute(const Attribute& attribute) const
@@ -264,6 +266,9 @@ bool HTMLScriptElement::hasSourceAttribute() const
 
 void HTMLScriptElement::dispatchLoadEvent()
 {
+    // Keep the JS wrapper alive until the end of this method.
+    Ref wrapperProtector = makePendingActivity(*this);
+
     ASSERT(!haveFiredLoadEvent());
     setHaveFiredLoadEvent(true);
 
@@ -287,7 +292,7 @@ bool HTMLScriptElement::isScriptPreventedByAttributes() const
 
 Ref<Element> HTMLScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {
-    return adoptRef(*new HTMLScriptElement(tagQName(), document, false, alreadyStarted()));
+    return HTMLScriptElement::create(tagQName(), document, false, alreadyStarted());
 }
 
 String HTMLScriptElement::referrerPolicyForBindings() const
@@ -308,6 +313,17 @@ String HTMLScriptElement::fetchPriorityForBindings() const
 RequestPriority HTMLScriptElement::fetchPriority() const
 {
     return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto);
+}
+
+void HTMLScriptElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
+{
+    HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
+    ScriptElement::didMoveToNewDocument(newDocument);
+}
+
+void HTMLScriptElement::eventListenersDidChange()
+{
+    setHasRelevantLoadEventsListener(hasEventListeners(eventNames().errorEvent) || hasEventListeners(eventNames().loadEvent));
 }
 
 }

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -61,8 +61,9 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 
-    using HTMLElement::ref;
-    using HTMLElement::deref;
+    // ActiveDOMObject
+    void ref() const final { HTMLElement::ref(); }
+    void deref() const final { HTMLElement::deref(); }
 
     static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s || type == "speculationrules"_s; }
 
@@ -80,6 +81,7 @@ private:
     void childrenChanged(const ChildChange&) final;
     void finishParsingChildren() final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     void potentiallyBlockRendering() final;
     void unblockRendering() final;
@@ -105,6 +107,11 @@ private:
     bool isScriptPreventedByAttributes() const final;
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const final;
+
+    // EventTarget
+    void eventListenersDidChange() final;
+
+    using HTMLElement::scriptExecutionContext;
 
     const std::unique_ptr<DOMTokenList> m_blockingList;
     bool m_isRenderBlocking { false };

--- a/Source/WebCore/html/HTMLScriptElement.idl
+++ b/Source/WebCore/html/HTMLScriptElement.idl
@@ -18,6 +18,7 @@
  */
 
 [
+    ActiveDOMObject,
     Exposed=Window
 ] interface HTMLScriptElement : HTMLElement {
     [CEReactions=NotNeeded] attribute (TrustedScript or DOMString) text;

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -25,6 +25,7 @@
 #include "Document.h"
 #include "ElementInlines.h"
 #include "Event.h"
+#include "EventTargetInlines.h"
 #include "NodeInlines.h"
 #include "ScriptElement.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -41,9 +42,11 @@ inline SVGScriptElement::SVGScriptElement(const QualifiedName& tagName, Document
     ASSERT(hasTagName(SVGNames::scriptTag));
 }
 
-Ref<SVGScriptElement> SVGScriptElement::create(const QualifiedName& tagName, Document& document, bool insertedByParser)
+Ref<SVGScriptElement> SVGScriptElement::create(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
 {
-    return adoptRef(*new SVGScriptElement(tagName, document, insertedByParser, false));
+    Ref scriptElement = adoptRef(*new SVGScriptElement(tagName, document, wasInsertedByParser, alreadyStarted));
+    scriptElement->suspendIfNeeded();
+    return scriptElement;
 }
 
 void SVGScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -114,13 +117,32 @@ void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 }
 Ref<Element> SVGScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {
-    return adoptRef(*new SVGScriptElement(tagQName(), document, false, alreadyStarted()));
+    return SVGScriptElement::create(tagQName(), document, false, alreadyStarted());
+}
+
+void SVGScriptElement::dispatchLoadEvent()
+{
+    // Keep the JS wrapper alive until the end of this method.
+    Ref wrapperProtector = makePendingActivity(*this);
+
+    SVGURIReference::dispatchLoadEvent();
 }
 
 void SVGScriptElement::dispatchErrorEvent()
 {
     setErrorOccurred(true);
     ScriptElement::dispatchErrorEvent();
+}
+
+void SVGScriptElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
+{
+    SVGElement::didMoveToNewDocument(oldDocument, newDocument);
+    ScriptElement::didMoveToNewDocument(newDocument);
+}
+
+void SVGScriptElement::eventListenersDidChange()
+{
+    setHasRelevantLoadEventsListener(hasEventListeners(eventNames().errorEvent) || hasEventListeners(eventNames().loadEvent));
 }
 
 }

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -33,11 +33,13 @@ class SVGScriptElement final : public SVGElement, public SVGURIReference, public
     WTF_MAKE_TZONE_ALLOCATED(SVGScriptElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGScriptElement);
 public:
-    static Ref<SVGScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser);
+    static Ref<SVGScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted = false);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
-    using SVGElement::ref;
-    using SVGElement::deref;
+
+    // ActiveDOMObject
+    void ref() const final { SVGElement::ref(); }
+    void deref() const final { SVGElement::deref(); }
 
     bool async() const;
 
@@ -51,6 +53,7 @@ private:
     void didFinishInsertingNode() final;
     void childrenChanged(const ChildChange&) final;
     void finishParsingChildren() final;
+    void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     bool NODELETE isURLAttribute(const Attribute&) const final;
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
@@ -69,7 +72,7 @@ private:
     bool hasNoModuleAttribute() const final { return false; }
     ReferrerPolicy referrerPolicy() const final { return ReferrerPolicy::EmptyString; }
     bool hasSourceAttribute() const final { return hasAttribute(SVGNames::hrefAttr) || hasAttribute(XLinkNames::hrefAttr); }
-    void dispatchLoadEvent() final { SVGURIReference::dispatchLoadEvent(); }
+    void dispatchLoadEvent() final;
     void dispatchErrorEvent() final;
 
     // SVGElement
@@ -80,6 +83,9 @@ private:
     void setHaveFiredLoadEvent(bool haveFiredLoadEvent) final { ScriptElement::setHaveFiredLoadEvent(haveFiredLoadEvent); }
     bool errorOccurred() const final { return ScriptElement::errorOccurred(); }
     void setErrorOccurred(bool errorOccurred) final { ScriptElement::setErrorOccurred(errorOccurred); }
+
+    // EventTarget
+    void eventListenersDidChange() final;
 
 #ifndef NDEBUG
     bool filterOutAnimatableAttribute(const QualifiedName& name) const final { return name == SVGNames::typeAttr; }

--- a/Source/WebCore/svg/SVGScriptElement.idl
+++ b/Source/WebCore/svg/SVGScriptElement.idl
@@ -26,6 +26,7 @@
 // https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement
 
 [
+    ActiveDOMObject,
     Exposed=Window
 ] interface SVGScriptElement : SVGElement {
     [Reflect] attribute DOMString type;


### PR DESCRIPTION
#### afe50b886de1c7e2ccfad6ea004b994d1a94a1aa
<pre>
Script element should keep the wrapper object alive until the load or error event are dispatched
<a href="https://bugs.webkit.org/show_bug.cgi?id=305566">https://bugs.webkit.org/show_bug.cgi?id=305566</a>

Reviewed by Ryosuke Niwa.

An assertion failed in JSEventListener::ensureJSFunction since a wrapper object
of a script element was already reclaimed when the load event was dispatched.

Made ScriptElement an ActiveDOMObject subclass, and implemented
virtualHasPendingActivity() method that returns true if it has a relevant event
listener and the script is loading in order to keep the wrapper object alive.

Tests: http/tests/dom/script-error-event-gc.html
       http/tests/dom/script-load-event-gc.html
       http/tests/svg/script-error-event-gc.html
       http/tests/svg/script-load-event-gc.html

* LayoutTests/http/tests/dom/script-error-event-gc-expected.txt: Added.
* LayoutTests/http/tests/dom/script-error-event-gc.html: Added.
* LayoutTests/http/tests/dom/script-load-event-gc-expected.txt: Added.
* LayoutTests/http/tests/dom/script-load-event-gc.html: Added.
* LayoutTests/http/tests/svg/script-error-event-gc-expected.txt: Added.
* LayoutTests/http/tests/svg/script-error-event-gc.html: Added.
* LayoutTests/http/tests/svg/script-load-event-gc-expected.txt: Added.
* LayoutTests/http/tests/svg/script-load-event-gc.html: Added.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::ScriptElement):
(WebCore::ScriptElement::dispatchErrorEvent):
(WebCore::ScriptElement::virtualHasPendingActivity const):
(WebCore::ScriptElement::ref const): Deleted.
(WebCore::ScriptElement::deref const): Deleted.
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::loadableScript const):
(WebCore::ScriptElement::setHasRelevantLoadEventsListener):
(WebCore::ScriptElement::loadableScript): Deleted.
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::HTMLScriptElement):
(WebCore::HTMLScriptElement::create):
(WebCore::HTMLScriptElement::dispatchLoadEvent):
(WebCore::HTMLScriptElement::cloneElementWithoutAttributesAndChildren const):
(WebCore::HTMLScriptElement::didMoveToNewDocument):
(WebCore::HTMLScriptElement::eventListenersDidChange):
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLScriptElement.idl:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::create):
(WebCore::SVGScriptElement::cloneElementWithoutAttributesAndChildren const):
(WebCore::SVGScriptElement::dispatchLoadEvent):
(WebCore::SVGScriptElement::didMoveToNewDocument):
(WebCore::SVGScriptElement::eventListenersDidChange):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGScriptElement.idl:

Canonical link: <a href="https://commits.webkit.org/308535@main">https://commits.webkit.org/308535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f3034e4d2b7e4de146efad2536a704603684408

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156501 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113958 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94719 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158836 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121987 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122188 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76432 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9233 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->