### PR TITLE
Use C++17 if constexpr with initializers for std::optional constexpr variables

### DIFF
--- a/Source/WebCore/platform/graphics/ColorConversion.h
+++ b/Source/WebCore/platform/graphics/ColorConversion.h
@@ -82,11 +82,8 @@ constexpr std::optional<unsigned> analogousComponentIndex()
 {
     if constexpr (IndexInInput == 3)
         return 3; // Special case alpha, it always should carry forward.
-    else {
-        constexpr auto inputCategory = Input::Model::componentInfo[IndexInInput].category;
-        if constexpr (!inputCategory)
-            return std::nullopt;
-        else if constexpr (*inputCategory == Output::Model::componentInfo[0].category)
+    else if constexpr (constexpr auto inputCategory = Input::Model::componentInfo[IndexInInput].category) {
+        if constexpr (*inputCategory == Output::Model::componentInfo[0].category)
             return 0;
         else if constexpr (*inputCategory == Output::Model::componentInfo[1].category)
             return 1;
@@ -94,7 +91,8 @@ constexpr std::optional<unsigned> analogousComponentIndex()
             return 2;
         else
             return std::nullopt;
-    }
+    } else
+        return std::nullopt;
 }
 
 // Utility to update appropriate component in `output` if an analogous component
@@ -102,8 +100,7 @@ constexpr std::optional<unsigned> analogousComponentIndex()
 template<typename Output, typename Input, unsigned IndexInInput>
 constexpr void tryToCarryForwardComponentIfMissing(const ColorComponents<float, 4>& input, ColorComponents<float, 4>& output)
 {
-    constexpr auto analogousComponentIndexInOutput = analogousComponentIndex<Output, Input, IndexInInput>();
-    if constexpr (analogousComponentIndexInOutput) {
+    if constexpr (constexpr auto analogousComponentIndexInOutput = analogousComponentIndex<Output, Input, IndexInInput>()) {
         if (std::isnan(input[IndexInInput]))
             output[*analogousComponentIndexInOutput] = std::numeric_limits<float>::quiet_NaN();
     }


### PR DESCRIPTION
#### 70550d7bfe2205e0ec835630c8b58084923ceceb
<pre>
Use C++17 if constexpr with initializers for std::optional constexpr variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=308602">https://bugs.webkit.org/show_bug.cgi?id=308602</a>
<a href="https://rdar.apple.com/171128213">rdar://171128213</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/WebCore/platform/graphics/ColorConversion.h:
(WebCore::analogousComponentIndex):
(WebCore::tryToCarryForwardComponentIfMissing):

Canonical link: <a href="https://commits.webkit.org/308206@main">https://commits.webkit.org/308206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c47282c6fa5d0c5656514a4c22b0be5949ca4dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113027 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80705 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12287 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157684 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/825 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121034 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31069 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74978 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8323 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18785 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82532 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->