### PR TITLE
[macOS release] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html
@@ -80,6 +80,7 @@ function mediaTest(file, mime) {
                                     'Check the sequence of fired events.');
             }));
             var video = document.createElement('video');
+            document.body.appendChild(video);
             video.src = window.URL.createObjectURL(mediaSource);
         });
     }, 'SourceBuffer#abort() (' + mime + ') : Check the algorithm when the updating attribute is true.');

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2501,5 +2501,3 @@ webkit.org/b/308494 media/remote-control-command-is-user-gesture.html [ Timeout 
 webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
 
 webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure ]
-
-webkit.org/b/308601 [ Release ] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html [ Failure Pass ]


### PR DESCRIPTION
#### 4e267e85a5af73b7148631b46ea30ddbbe0199f4
<pre>
[macOS release] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html is a flaky text failure
<a href="https://rdar.apple.com/171125061">rdar://171125061</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308601">https://bugs.webkit.org/show_bug.cgi?id=308601</a>

Reviewed by NOBODY (OOPS!).

The test is flaky because the video element isn&apos;t being kept alive throughout the test. Since nothing holds a reference to
it after the GET callback returns, GC may collect the video element before the test completes. When this happens, the MediaSource
is detached and closes, causing endOfStream() to throw InvalidStateError and the test to timeout (since sourceended never fires).

This fix adds document.body.appendChild(video) at line 83, which keeps the element alive until explicitly removed. This pattern
is already used by other MSE tests via mediasource-util.js.

* LayoutTests/imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e267e85a5af73b7148631b46ea30ddbbe0199f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100078 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113023 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157685 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121029 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74979 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16859 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8327 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18786 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18516 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->