### PR TITLE
[AutoFill Debugging] Suppress text extraction if either screen time shield or safe browsing warning is present

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -183,6 +183,8 @@ RefPtr<WebKit::BrowsingWarning> Navigation::safeBrowsingWarning()
 
 void Navigation::setSafeBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBrowsingWarning)
 {
+    if (safeBrowsingWarning)
+        m_hadSafeBrowsingWarning = true;
     m_safeBrowsingWarning = WTF::move(safeBrowsingWarning);
 }
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -189,6 +189,7 @@ public:
     RefPtr<WebKit::BrowsingWarning> NODELETE safeBrowsingWarning();
     void setSafeBrowsingCheckTimedOut() { m_safeBrowsingCheckTimedOut = true; }
     bool safeBrowsingCheckTimedOut() { return m_safeBrowsingCheckTimedOut; }
+    bool hadSafeBrowsingWarning() const { return m_hadSafeBrowsingWarning; }
     MonotonicTime requestStart() const { return m_requestStart; }
     void resetRequestStart();
 
@@ -233,6 +234,7 @@ private:
     bool m_requestIsFromClientInput : 1 { false };
     bool m_isFromLoadData : 1 { false };
     bool m_safeBrowsingCheckTimedOut : 1 { false };
+    bool m_hadSafeBrowsingWarning : 1 { false };
     bool m_hasStorageForCurrentSite : 1 { false };
     bool m_isEnhancedSecurityLinkForCurrentSite : 1 { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -663,14 +663,6 @@ struct PerWebProcessState {
 #if PLATFORM(MAC)
 - (nullable WebKit::WebViewImpl *)_impl;
 #endif
-#if ENABLE(SCREEN_TIME)
-- (nullable STWebpageController *)_screenTimeWebpageController;
-#if PLATFORM(MAC)
-- (nullable NSVisualEffectView *)_screenTimeBlurredSnapshot;
-#else
-- (nullable UIVisualEffectView *)_screenTimeBlurredSnapshot;
-#endif
-#endif
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -47,6 +47,14 @@ struct WKAppPrivacyReportTestingData {
     BOOL didPerformSoftUpdate;
 };
 
+@class STWebpageController;
+
+#if TARGET_OS_IPHONE
+typedef UIVisualEffectView _WKPlatformVisualEffectView;
+#else
+typedef NSVisualEffectView _WKPlatformVisualEffectView;
+#endif
+
 @class _WKNowPlayingMetadata;
 @protocol _WKMediaSessionCoordinator;
 
@@ -100,6 +108,9 @@ struct WKAppPrivacyReportTestingData {
 - (void)_didPresentContactPicker;
 - (void)_didDismissContactPicker;
 - (void)_dismissContactPickerWithContacts:(NSArray *)contacts;
+
+- (STWebpageController *)_screenTimeWebpageController;
+- (_WKPlatformVisualEffectView *)_screenTimeBlurredSnapshot;
 
 - (void)_getRenderTreeAsStringWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSString * NS_NULLABLE_RESULT, NSError * _Nullable error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1270,6 +1270,24 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(protect(_page->drawingArea()))->displayLinkWantsHighFrameRateForTesting();
 }
 
+- (STWebpageController *)_screenTimeWebpageController
+{
+#if ENABLE(SCREEN_TIME)
+    return _screenTimeWebpageController.get();
+#else
+    return nil;
+#endif
+}
+
+- (_WKPlatformVisualEffectView *)_screenTimeBlurredSnapshot
+{
+#if ENABLE(SCREEN_TIME)
+    return _screenTimeBlurredSnapshot.get();
+#else
+    return nil;
+#endif
+}
+
 @end
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -325,9 +325,10 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
                 }
             }
 
-            if (!navigation->safeBrowsingCheckOngoing() && navigation->safeBrowsingWarning() && navigation->safeBrowsingCheckTimedOut())
+            if (!navigation->safeBrowsingCheckOngoing() && navigation->safeBrowsingWarning() && navigation->safeBrowsingCheckTimedOut()) {
+                protectedThis->setHasShownSafeBrowsingWarningAfterLastLoadCommit();
                 protectedThis->showBrowsingWarning(navigation->safeBrowsingWarning());
-            else if (!navigation->safeBrowsingWarning())
+            } else if (!navigation->safeBrowsingWarning())
                 protectedThis->completeSafeBrowsingCheckForModals(true);
         });
     };

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -263,6 +263,12 @@ void PageLoadState::clearPendingAPIRequest(const Transaction::Token& token)
     m_uncommittedState.pendingAPIRequest = { };
 }
 
+void PageLoadState::setHadSafeBrowsingWarning(const Transaction::Token& token)
+{
+    ASSERT_UNUSED(token, &token.m_pageLoadState == this);
+    m_uncommittedState.hadSafeBrowsingWarning = true;
+}
+
 void PageLoadState::didExplicitOpen(const Transaction::Token& token, const String& url)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -206,6 +206,9 @@ public:
 
     bool committedHasInsecureContent() const { return m_committedState.hasInsecureContent; }
 
+    void setHadSafeBrowsingWarning(const Transaction::Token&);
+    bool committedHadSafeBrowsingWarning() const { return m_committedState.hadSafeBrowsingWarning; }
+
     // FIXME: We piggy-back off PageLoadState::Observer so that both WKWebView and WKObservablePageState
     // can listen for changes. Once we get rid of WKObservablePageState these could just be part of API::NavigationClient.
     void willChangeProcessIsResponsive();
@@ -241,6 +244,7 @@ private:
         bool canGoBack { false };
         bool canGoForward { false };
         bool isHTTPFallbackInProgress { false };
+        bool hadSafeBrowsingWarning { false };
 
         double estimatedProgress { 0 };
         bool networkRequestsInProgress { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2957,6 +2957,11 @@ public:
 
     void updateRemoteIntersectionObserversInOtherWebProcesses(IPC::Connection&);
 
+#if HAVE(SAFE_BROWSING)
+    void setHasShownSafeBrowsingWarningAfterLastLoadCommit() { m_hasShownSafeBrowsingWarningAfterLastLoadCommit = true; }
+    bool hasShownSafeBrowsingWarningAfterLastLoadCommit() const { return m_hasShownSafeBrowsingWarningAfterLastLoadCommit; }
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -4130,6 +4135,7 @@ private:
 #if HAVE(SAFE_BROWSING)
     Vector<CompletionHandler<void(bool)>> m_deferredModalHandlers;
     bool m_isSafeBrowsingCheckInProgress { false };
+    bool m_hasShownSafeBrowsingWarningAfterLastLoadCommit { false };
 #endif
     bool m_isLockdownModeExplicitlySet { false };
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6152,7 +6152,7 @@ void WebViewImpl::nativeMouseEventHandlerInternal(NSEvent *event, WebMouseEventI
     if (m_warningView)
         return;
 #if ENABLE(SCREEN_TIME)
-    if ([[m_view _screenTimeWebpageController] URLIsBlocked])
+    if (RetainPtr view = m_view.get(); view && [view->_screenTimeWebpageController URLIsBlocked])
         return;
 #endif
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -35,6 +35,7 @@ cocoa/ImageAnalysisTestingUtilities.mm @nonARC
 cocoa/ModelLoadingMessageHandler.mm @nonARC
 cocoa/NSItemProviderAdditions.mm @nonARC
 cocoa/PlatformUtilitiesCocoa.mm @nonARC
+cocoa/SafeBrowsingTestUtilities.mm @nonARC
 cocoa/TestCocoa.mm @nonARC
 cocoa/TestDownloadDelegate.mm @nonARC
 cocoa/TestInspectorURLSchemeHandler.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1512,10 +1512,10 @@
 		F6B7BE9517469212008A3445 /* DidAssociateFormControls_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6B7BE92174691EF008A3445 /* DidAssociateFormControls_Bundle.cpp */; };
 		F6D67D3826F90206006E0349 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3626F90206006E0349 /* Int128.cpp */; };
 		F6F49C6B15545CA70007F39D /* DOMWindowExtensionNoCache_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6F49C6615545C8D0007F39D /* DOMWindowExtensionNoCache_Bundle.cpp */; };
-		FC0A4AEE2F0E76EE0053173D /* MessageLogTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0A4AED2F0E76EE0053173D /* MessageLogTests.cpp */; };
-		FC0A4AEF2F0E76EE0053173D /* MessageLogEndToEndTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0A4AF02F0E76EE0053173D /* MessageLogEndToEndTests.cpp */; };
 		FAC1FE462F19C3EB0030C30E /* open-in-new-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = FAC1FE452F19C3EB0030C30E /* open-in-new-tab.html */; };
 		FAC1FE572F21AD890030C30E /* JSHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC1FE4F2F2152270030C30E /* JSHandlePlugIn.mm */; };
+		FC0A4AEE2F0E76EE0053173D /* MessageLogTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0A4AED2F0E76EE0053173D /* MessageLogTests.cpp */; };
+		FC0A4AEF2F0E76EE0053173D /* MessageLogEndToEndTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0A4AF02F0E76EE0053173D /* MessageLogEndToEndTests.cpp */; };
 		FE2BCDC72470FDA300DEC33B /* StdLibExtrasTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2BCDC62470FC7000DEC33B /* StdLibExtrasTests.cpp */; };
 		FE2D9474245EB2F400E48135 /* BitSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2D9473245EB2DF00E48135 /* BitSet.cpp */; };
 		FE9CD7E42D10CE7500266FDD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
@@ -4402,6 +4402,8 @@
 		F4C3F29A2C447EB50029A47D /* SimulateClickOverText.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SimulateClickOverText.mm; sourceTree = "<group>"; };
 		F4C3F2A32C44832B0029A47D /* click-targets.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "click-targets.html"; sourceTree = "<group>"; };
 		F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollViewInsetTests.mm; sourceTree = "<group>"; };
+		F4CA0F032F4E700500081F3D /* SafeBrowsingTestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SafeBrowsingTestUtilities.h; path = cocoa/SafeBrowsingTestUtilities.h; sourceTree = "<group>"; };
+		F4CA0F042F4E700500081F3D /* SafeBrowsingTestUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = SafeBrowsingTestUtilities.mm; path = cocoa/SafeBrowsingTestUtilities.mm; sourceTree = "<group>"; };
 		F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-9.html"; sourceTree = "<group>"; };
 		F4CD74C520FDACF500DE3794 /* text-with-async-script.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "text-with-async-script.html"; sourceTree = "<group>"; };
 		F4CD74C720FDB49600DE3794 /* TestURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestURLSchemeHandler.h; sourceTree = "<group>"; };
@@ -4728,6 +4730,8 @@
 				0F139E721A423A2B00F590F5 /* PlatformUtilitiesCocoa.mm */,
 				F4010B8224DA267F00A876E2 /* PoseAsClass.h */,
 				F4010B8124DA267F00A876E2 /* PoseAsClass.mm */,
+				F4CA0F032F4E700500081F3D /* SafeBrowsingTestUtilities.h */,
+				F4CA0F042F4E700500081F3D /* SafeBrowsingTestUtilities.mm */,
 				A17C58432C9BE200009DD0B5 /* TestBundleLoader.h */,
 				CE640CA52370A4F300C5CAA4 /* TestCocoa.h */,
 				CE640CA62370A4F300C5CAA4 /* TestCocoa.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
@@ -115,15 +115,6 @@ static void testSuppressUsageRecordingWithDataStore(RetainPtr<WKWebsiteDataStore
 @property (readonly, copy) STWebHistoryProfileIdentifier profileIdentifier;
 @end
 
-@interface WKWebView (Internal)
-- (STWebpageController *)_screenTimeWebpageController;
-#if PLATFORM(MAC)
-- (NSVisualEffectView *) _screenTimeBlurredSnapshot;
-#else
-- (UIVisualEffectView *) _screenTimeBlurredSnapshot;
-#endif
-@end
-
 @interface BlockedStateObserver : NSObject
 - (instancetype)initWithWebView:(TestWKWebView *)webView;
 @end

--- a/Tools/TestWebKitAPI/cocoa/SafeBrowsingTestUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/SafeBrowsingTestUtilities.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <wtf/Seconds.h>
+
+@interface TestServiceLookupResult : NSObject
++ (instancetype)resultWithProvider:(NSString *)provider phishing:(BOOL)phishing malware:(BOOL)malware unwantedSoftware:(BOOL)unwantedSoftware;
+@end
+
+@interface TestLookupResult : NSObject
++ (instancetype)resultWithResults:(NSArray<TestServiceLookupResult *> *)results;
+@end
+
+@interface TestLookupContext : NSObject
++ (TestLookupContext *)sharedLookupContext;
+@end
+
+@interface DelayedLookupContext : NSObject
+@property (nonatomic, class) Seconds delayDuration;
+@end

--- a/Tools/TestWebKitAPI/cocoa/SafeBrowsingTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/SafeBrowsingTestUtilities.mm
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SafeBrowsingTestUtilities.h"
+
+#import "TestNSBundleExtras.h"
+#import <wtf/BlockPtr.h>
+#import <wtf/CompletionHandler.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/RunLoop.h>
+
+@implementation TestServiceLookupResult {
+    RetainPtr<NSString> _provider;
+    BOOL _isPhishing;
+    BOOL _isMalware;
+    BOOL _isUnwantedSoftware;
+}
+
++ (instancetype)resultWithProvider:(NSString *)provider phishing:(BOOL)phishing malware:(BOOL)malware unwantedSoftware:(BOOL)unwantedSoftware
+{
+    RetainPtr result = adoptNS([TestServiceLookupResult new]);
+    if (!result)
+        return nil;
+
+    result->_provider = adoptNS([provider copy]);
+    result->_isPhishing = phishing;
+    result->_isMalware = malware;
+    result->_isUnwantedSoftware = unwantedSoftware;
+
+    return result.autorelease();
+}
+
+- (NSString *)provider
+{
+    return _provider.get();
+}
+
+- (BOOL)isPhishing
+{
+    return _isPhishing;
+}
+
+- (BOOL)isMalware
+{
+    return _isMalware;
+}
+
+- (BOOL)isUnwantedSoftware
+{
+    return _isUnwantedSoftware;
+}
+
+- (NSString *)malwareDetailsBaseURLString
+{
+    return @"test://";
+}
+
+- (NSURL *)learnMoreURL
+{
+    return [NSURL URLWithString:@"test://"];
+}
+
+- (NSString *)reportAnErrorBaseURLString
+{
+    return @"test://";
+}
+
+- (NSString *)localizedProviderDisplayName
+{
+    return @"test display name";
+}
+
+@end
+
+@implementation TestLookupResult {
+    RetainPtr<NSArray> _results;
+}
+
++ (instancetype)resultWithResults:(NSArray<TestServiceLookupResult *> *)results
+{
+    RetainPtr result = adoptNS([TestLookupResult new]);
+    if (!result)
+        return nil;
+
+    result->_results = adoptNS([results copy]);
+    return result.autorelease();
+}
+
+- (NSArray<TestServiceLookupResult *> *)serviceLookupResults
+{
+    return _results.get();
+}
+
+@end
+
+@implementation TestLookupContext
+
++ (TestLookupContext *)sharedLookupContext
+{
+    static NeverDestroyed<RetainPtr<TestLookupContext>> context = adoptNS([TestLookupContext new]);
+    return context.get().get();
+}
+
+- (void)lookUpURL:(NSURL *)URL completionHandler:(void (^)(TestLookupResult *, NSError *))completionHandler
+{
+    completionHandler([TestLookupResult resultWithResults:@[[TestServiceLookupResult resultWithProvider:@"SSBProviderApple" phishing:YES malware:NO unwantedSoftware:NO]]], nil);
+}
+
+@end
+
+static Seconds globalDelayDuration;
+
+@implementation DelayedLookupContext
+
++ (Seconds)delayDuration
+{
+    return globalDelayDuration;
+}
+
++ (void)setDelayDuration:(Seconds)duration
+{
+    globalDelayDuration = duration;
+}
+
++ (DelayedLookupContext *)sharedLookupContext
+{
+    static NeverDestroyed<RetainPtr<DelayedLookupContext>> context = adoptNS([DelayedLookupContext new]);
+    return context.get().get();
+}
+
+- (void)lookUpURL:(NSURL *)url completionHandler:(void (^)(TestLookupResult *, NSError *))completionHandler
+{
+    RetainPtr resourceURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    BOOL phishing = ![url isEqual:resourceURL.get()] && ![url.path isEqual:@"/safe"];
+    RunLoop::mainSingleton().dispatchAfter(globalDelayDuration, [completionHandler = makeBlockPtr(completionHandler), phishing] {
+        completionHandler.get()([TestLookupResult resultWithResults:@[[TestServiceLookupResult resultWithProvider:@"SSBProviderApple" phishing:phishing malware:NO unwantedSoftware:NO]]], nil);
+    });
+}
+
+@end

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -157,6 +157,7 @@ class Color;
 - (CGRect)elementRectFromSelector:(NSString *)selector;
 - (CGPoint)elementMidpointFromSelector:(NSString *)selector;
 - (_WKJSHandle *)querySelector:(NSString *)selector frame:(WKFrameInfo *)frame world:(WKContentWorld *)world;
+- (void)visitUnsafeSite;
 @end
 
 #endif // __cplusplus

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -841,6 +841,11 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
     return dynamic_objc_cast<_WKJSHandle>([self objectByEvaluatingJavaScript:script.get() inFrame:frame inContentWorld:world]);
 }
 
+- (void)visitUnsafeSite
+{
+    [[self _safeBrowsingWarning] performSelector:NSSelectorFromString(@"clickedOnLink:") withObject:[NSURL URLWithString:@"WKVisitUnsafeWebsiteSentinel"]];
+}
+
 @end
 
 #endif // __cplusplus


### PR DESCRIPTION
#### bac61d2b1bab1f4a66c981e0d9fd96db91072252
<pre>
[AutoFill Debugging] Suppress text extraction if either screen time shield or safe browsing warning is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=308589">https://bugs.webkit.org/show_bug.cgi?id=308589</a>
<a href="https://rdar.apple.com/171117238">rdar://171117238</a>

Reviewed by Aditya Keerthi, Pascoe, and Abrar Rahman Protyasha.

Suppress text extraction when the Screen Time shield is up, when the safe browsing warning is shown,
or if the user has navigated to an unsafe website (manually bypassing the safe browsing warning).

See below for more details.

Tests: TextExtractionTests.ScreenTimeBlocksTextExtraction
       TextExtractionTests.SafeBrowsingWarningBlocksTextExtraction
       TextExtractionTests.DelayedSafeBrowsingWarningBlocksTextExtraction

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setSafeBrowsingWarning):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::hadSafeBrowsingWarning const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfiguration:completionHandler:]):

Early return with a blank result in the above scenarios.

(-[WKWebView _screenTimeWebpageController]): Deleted.
(-[WKWebView _screenTimeBlurredSnapshot]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _screenTimeWebpageController]):
(-[WKWebView _screenTimeBlurredSnapshot]):

Move these testing hooks out into the `WKTesting` category (as testing-only SPI), so that they can
be accessed from `TextExtractionTests.mm`. This also lets us delete the extra forward declarations
in `ScreenTime.mm`.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::setHadSafeBrowsingWarning):
* Source/WebKit/UIProcess/PageLoadState.h:
(WebKit::PageLoadState::committedHadSafeBrowsingWarning const):

Add plumbing to keep track of whether we ever showed a safe browsing warning for the current
(committed) page load. To do this, we add a new flag on the `API::Navigation` that&apos;s set if a
safe browsing warning is ever set on the navigation, and then consult this flag when committing a
navigation to update a new (similar) flag on the page load state.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):

Additionally take care of the case where the safe browsing check initially times out, but then
completes after the load commits. To do this, add a new flag on `WebPageProxy` that&apos;s set when we
show the safe browsing warning after the fact, which isn&apos;t cleared until the next load is committed.

This ensures that in both cases where the safe browsing warning is shown before load commit or after
load commit, we will correctly block text extractions.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::resetState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::nativeMouseEventHandlerInternal):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm:
(TEST(SafeBrowsing, VisitUnsafeWebsite)):
(TEST(SafeBrowsing, ShowWarningSPI)):
(TEST(SafeBrowsing, URLObservation)):
(TEST(SafeBrowsing, HangTimeout)):
(TEST(SafeBrowsing, PostResponse)):
(TEST(SafeBrowsing, PostResponseIframe)):
(TEST(SafeBrowsing, PostResponseServerSideRedirect)):
(TEST(SafeBrowsing, PostResponseInjectedBundleSkipsDecidePolicyForResponse)):
(TEST(SafeBrowsing, PostTimeout)):
(TEST(SafeBrowsing, ModalDeferredDuringCheck)):
(TEST(SafeBrowsing, DeferredModalShownWhenProceedingThroughWarning)):
(TEST(SafeBrowsing, DeferredModalSuppressedWhenGoingBack)):
(TEST(SafeBrowsing, MultipleDeferredModalsShownInOrder)):
(TEST(SafeBrowsing, DeferredModalsClearedOnNavigation)):
(TEST(SafeBrowsing, AllModalTypesProperlyDeferred)):
(+[TestServiceLookupResult resultWithProvider:phishing:malware:unwantedSoftware:]): Deleted.
(-[TestServiceLookupResult provider]): Deleted.
(-[TestServiceLookupResult isPhishing]): Deleted.
(-[TestServiceLookupResult isMalware]): Deleted.
(-[TestServiceLookupResult isUnwantedSoftware]): Deleted.
(-[TestServiceLookupResult malwareDetailsBaseURLString]): Deleted.
(-[TestServiceLookupResult learnMoreURL]): Deleted.
(-[TestServiceLookupResult reportAnErrorBaseURLString]): Deleted.
(-[TestServiceLookupResult localizedProviderDisplayName]): Deleted.
(+[TestLookupResult resultWithResults:]): Deleted.
(-[TestLookupResult serviceLookupResults]): Deleted.
(+[TestLookupContext sharedLookupContext]): Deleted.
(-[TestLookupContext lookUpURL:completionHandler:]): Deleted.
(visitUnsafeSite): Deleted.
(+[DelayedLookupContext sharedLookupContext]): Deleted.
(-[DelayedLookupContext lookUpURL:completionHandler:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::ScreenTimeBlocksTextExtraction)):
(TestWebKitAPI::SafeBrowsingWarningBlocksTextExtraction)):

Add text extraction API tests to cover these new cases.

(TestWebKitAPI::DelayedSafeBrowsingWarningBlocksTextExtraction)):
* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::makeRequestMap):
(TestWebKitAPI::HTTPServer::RequestData::RequestData):
(): Deleted.
* Tools/TestWebKitAPI/cocoa/SafeBrowsingTestUtilities.h: Added.
* Tools/TestWebKitAPI/cocoa/SafeBrowsingTestUtilities.mm: Added.
(+[TestServiceLookupResult resultWithProvider:phishing:malware:unwantedSoftware:]):
(-[TestServiceLookupResult provider]):
(-[TestServiceLookupResult isPhishing]):
(-[TestServiceLookupResult isMalware]):
(-[TestServiceLookupResult isUnwantedSoftware]):
(-[TestServiceLookupResult malwareDetailsBaseURLString]):
(-[TestServiceLookupResult learnMoreURL]):
(-[TestServiceLookupResult reportAnErrorBaseURLString]):
(-[TestServiceLookupResult localizedProviderDisplayName]):

Move all of these existing safe-browsing-related testing helpers out into a new shared utility file,
`SafeBrowsingTestUtilities`, so that they can be used across API tests in multiple suites.

(+[TestLookupResult resultWithResults:]):
(-[TestLookupResult serviceLookupResults]):
(+[TestLookupContext sharedLookupContext]):
(-[TestLookupContext lookUpURL:completionHandler:]):
(+[DelayedLookupContext delayDuration]):
(+[DelayedLookupContext setDelayDuration:]):
(+[DelayedLookupContext sharedLookupContext]):
(-[DelayedLookupContext lookUpURL:completionHandler:]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView visitUnsafeSite]):

Add a new helper method that simulates dismissing a safe browsing warning and visiting the unsafe
destination. Deploy it in various places that simulate this behavior (including my new API test).

Canonical link: <a href="https://commits.webkit.org/308262@main">https://commits.webkit.org/308262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24995b8583ec0a8bf468a83cec9f549bd326fe19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100259 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c513f77b-ab5b-4a0f-a8f1-5181c9809874) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80780 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4cf4435-61ba-43ee-9e3c-80315db18087) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15418 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93928 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7183a6a9-b6cd-4e2d-b4ba-f1e0578f0e59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14649 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12423 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2995 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157884 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1015 "Found 2 new failures in UIProcess/API/ios/WKWebViewIOS.mm, UIProcess/ios/WKContentViewInteraction.mm") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121195 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31113 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131659 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16982 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82723 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18757 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->