### PR TITLE
[css-cascade] Implement revert-rule CSS keyword

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL revert-rule in keyframes, reverted-to value changing (standard property) assert_true: expected true got false
-FAIL revert-rule in keyframes, reverted-to value changing (custom property) assert_true: expected true got false
+FAIL revert-rule in keyframes, reverted-to value changing (standard property) assert_equals: expected "160px" but got "150px"
+FAIL revert-rule in keyframes, reverted-to value changing (custom property) assert_equals: expected "160px" but got "150px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL revert-rule in keyframes (width) assert_true: expected true got false
-FAIL revert-rule in keyframes (--x) assert_true: expected true got false
+PASS revert-rule in keyframes (width)
+PASS revert-rule in keyframes (--x)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL The revert-rule keyword rolls back to the previous rule assert_true: expected true got false
-FAIL Cascade order determines the previous rule, not order of appearance assert_true: expected true got false
-FAIL Reverting from style attribute reverts to regular rules assert_true: expected true got false
-FAIL A chain of revert-rule works assert_true: expected true got false
+PASS The revert-rule keyword rolls back to the previous rule
+PASS Cascade order determines the previous rule, not order of appearance
+PASS Reverting from style attribute reverts to regular rules
+PASS A chain of revert-rule works
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL revert-rule in !important declaration reverts to later normal rule if the !important rule comes first assert_true: expected true got false
+PASS revert-rule in !important declaration reverts to later normal rule if the !important rule comes first
 PASS revert-rule in !important declaration reverts across layers
 PASS revert-rule in !important declaration reverts to earlier normal rule if the !important rule comes later
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL The revert-rule keyword can cross layers assert_true: expected true got false
-FAIL The revert-rule does not unconditionally cross layers assert_true: expected true got false
+PASS The revert-rule keyword can cross layers
+PASS The revert-rule does not unconditionally cross layers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-shadow-expected.txt
@@ -1,0 +1,14 @@
+
+PASS revert-rule in document rule falls back to :host rule
+PASS revert-rule in document rule falls back to ::slotted rule
+PASS revert-rule in :host rule has no effect when a document rule already wins
+PASS revert-rule with no shadow fallback falls through to unset (inherited)
+PASS revert-rule in document rule falls back to the winning :host rule
+PASS revert-rule chain across document rule and :host rule
+PASS revert-rule in ::part() rule falls back to earlier ::part() rule
+PASS revert-rule in ::part() rule falls back to shadow-internal rule
+PASS revert-rule in shadow-internal rule has no effect when ::part() rule wins
+PASS revert-rule in third ::part() rule falls back to second ::part() rule
+PASS revert-rule on host and ::part() rule on part are independent
+PASS revert-rule in higher-specificity ::part() rule falls back to lower-specificity ::part() rule
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-shadow.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<title>The revert-rule keyword: interaction with shadow DOM scopes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- Test 1: revert-rule in document rule falls back to :host rule -->
+<div id="host1"></div>
+<script>
+host1.attachShadow({mode: 'open'}).innerHTML = `
+<style>
+  :host { color: green; }
+</style>
+`;
+</script>
+<style>
+  #host1 {
+    color: red;
+    color: revert-rule;
+  }
+</style>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(host1).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in document rule falls back to :host rule');
+</script>
+
+<!-- Test 2: revert-rule in document rule falls back to ::slotted rule -->
+<div id="host2"><div id="slotted2"></div></div>
+<script>
+host2.attachShadow({mode: 'open'}).innerHTML = `
+<style>
+  ::slotted(*) { color: green; }
+</style>
+<slot></slot>
+`;
+</script>
+<style>
+  #slotted2 {
+    color: red;
+    color: revert-rule;
+  }
+</style>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(slotted2).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in document rule falls back to ::slotted rule');
+</script>
+
+<!-- Test 3: revert-rule in :host rule has no effect when a document rule wins -->
+<div id="host3"></div>
+<script>
+host3.attachShadow({mode: 'open'}).innerHTML = `
+<style>
+  :host { color: revert-rule; }
+</style>
+`;
+</script>
+<style>
+  #host3 { color: green; }
+</style>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(host3).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in :host rule has no effect when a document rule already wins');
+</script>
+
+<!-- Test 4: revert-rule in document rule with no fallback falls through to unset -->
+<div id="host4"></div>
+<script>
+host4.attachShadow({mode: 'open'}).innerHTML = `<slot></slot>`;
+</script>
+<style>
+  #host4 {
+    color: red;
+    color: revert-rule;
+  }
+</style>
+<script>
+  test(() => {
+    // No :host rule exists; color is inherited from the document body (rgb(0,0,0)).
+    assert_equals(getComputedStyle(host4).color, 'rgb(0, 0, 0)');
+  }, 'revert-rule with no shadow fallback falls through to unset (inherited)');
+</script>
+
+<!-- Test 5: revert-rule in document rule, multiple competing :host rules -->
+<div id="host5"></div>
+<script>
+host5.attachShadow({mode: 'open'}).innerHTML = `
+<style>
+  :host { color: green; }
+  :host { color: red; }
+</style>
+`;
+</script>
+<style>
+  #host5 {
+    color: blue;
+    color: revert-rule;
+  }
+</style>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(host5).color, 'rgb(255, 0, 0)');
+  }, 'revert-rule in document rule falls back to the winning :host rule');
+</script>
+
+<!-- Test 6: revert-rule in document rule, :host rule also reverts -->
+<div id="host6"></div>
+<script>
+host6.attachShadow({mode: 'open'}).innerHTML = `
+<style>
+  :host { color: green; }
+  :host { color: revert-rule; }
+</style>
+`;
+</script>
+<style>
+  #host6 {
+    color: blue;
+    color: revert-rule;
+  }
+</style>
+<script>
+  test(() => {
+    // The document revert-rule falls back to the :host block. Within the :host
+    // block, the second :host rule says revert-rule, which falls back to the
+    // first :host rule's green.
+    assert_equals(getComputedStyle(host6).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule chain across document rule and :host rule');
+</script>
+
+<!-- Test 7: revert-rule in ::part() rule falls back to earlier ::part() rule -->
+<div id="host7"></div>
+<script>
+{
+  const shadow = host7.attachShadow({mode: 'open'});
+  shadow.innerHTML = `<span id="p7" part="mypart">text</span>`;
+}
+</script>
+<style>
+  #host7::part(mypart) { color: green; }
+  #host7::part(mypart) { color: revert-rule; }
+</style>
+<script>
+  test(() => {
+    const part = host7.shadowRoot.getElementById('p7');
+    assert_equals(getComputedStyle(part).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in ::part() rule falls back to earlier ::part() rule');
+</script>
+
+<!-- Test 8: revert-rule in ::part() rule falls back to shadow-internal rule -->
+<div id="host8"></div>
+<script>
+{
+  const shadow = host8.attachShadow({mode: 'open'});
+  shadow.innerHTML = `
+    <style>span { color: green; }</style>
+    <span id="p8" part="mypart">text</span>
+  `;
+}
+</script>
+<style>
+  #host8::part(mypart) { color: revert-rule; }
+</style>
+<script>
+  test(() => {
+    // The ::part() rule reverts, falling back to the shadow-internal span rule (green).
+    const part = host8.shadowRoot.getElementById('p8');
+    assert_equals(getComputedStyle(part).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in ::part() rule falls back to shadow-internal rule');
+</script>
+
+<!-- Test 9: revert-rule in shadow-internal rule, ::part() rule wins -->
+<div id="host9"></div>
+<script>
+{
+  const shadow = host9.attachShadow({mode: 'open'});
+  shadow.innerHTML = `
+    <style>
+      span { color: blue; }
+      span { color: revert-rule; }
+    </style>
+    <span id="p9" part="mypart">text</span>
+  `;
+}
+</script>
+<style>
+  #host9::part(mypart) { color: green; }
+</style>
+<script>
+  test(() => {
+    // The ::part() rule in the document wins. revert-rule inside the shadow
+    // does not affect the winning ::part() declaration.
+    const part = host9.shadowRoot.getElementById('p9');
+    assert_equals(getComputedStyle(part).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in shadow-internal rule has no effect when ::part() rule wins');
+</script>
+
+<!-- Test 10: revert-rule chain across two ::part() rules -->
+<div id="host10"></div>
+<script>
+{
+  const shadow = host10.attachShadow({mode: 'open'});
+  shadow.innerHTML = `<span id="p10" part="mypart">text</span>`;
+}
+</script>
+<style>
+  #host10::part(mypart) { color: red; }
+  #host10::part(mypart) { color: green; }
+  #host10::part(mypart) { color: revert-rule; }
+</style>
+<script>
+  test(() => {
+    // Third rule reverts to what would exist without it → second rule (green).
+    const part = host10.shadowRoot.getElementById('p10');
+    assert_equals(getComputedStyle(part).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in third ::part() rule falls back to second ::part() rule');
+</script>
+
+<!-- Test 11: revert-rule in ::part() and :host on same host element -->
+<div id="host11"></div>
+<script>
+{
+  const shadow = host11.attachShadow({mode: 'open'});
+  shadow.innerHTML = `
+    <style>:host { color: blue; }</style>
+    <span id="p11" part="mypart">text</span>
+  `;
+}
+</script>
+<style>
+  #host11 { color: red; color: revert-rule; }
+  #host11::part(mypart) { color: green; }
+</style>
+<script>
+  test(() => {
+    // Host color reverts to :host rule (blue).
+    assert_equals(getComputedStyle(host11).color, 'rgb(0, 0, 255)');
+    // Part color is set by ::part() rule (green), independent of host revert.
+    const part = host11.shadowRoot.getElementById('p11');
+    assert_equals(getComputedStyle(part).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule on host and ::part() rule on part are independent');
+</script>
+
+<!-- Test 12: revert-rule in ::part() rule falls back across selector specificity -->
+<div id="host12" class="host12cls"></div>
+<script>
+{
+  const shadow = host12.attachShadow({mode: 'open'});
+  shadow.innerHTML = `<span id="p12" part="mypart">text</span>`;
+}
+</script>
+<style>
+  #host12::part(mypart) { color: green; }
+  #host12.host12cls::part(mypart) { color: revert-rule; }
+</style>
+<script>
+  test(() => {
+    // Higher specificity rule reverts, so falls back to the lower-specificity green.
+    const part = host12.shadowRoot.getElementById('p12');
+    assert_equals(getComputedStyle(part).color, 'rgb(0, 128, 0)');
+  }, 'revert-rule in higher-specificity ::part() rule falls back to lower-specificity ::part() rule');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt
@@ -55,6 +55,7 @@ PASS Query custom property including unknown var() reference with matching fallb
 PASS Query custom property matching guaranteed-invalid values
 PASS Style query with revert keyword is false
 PASS Style query with revert-layer keyword is false
+PASS Style query with revert-rule keyword is false
 PASS Style query 'initial' matching
 PASS Style query matching negated value-less query against initial value
 PASS Style query 'initial' not matching

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The revert-rule works in an env() fallback assert_true: expected true got false
+PASS The revert-rule works in an env() fallback
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL The revert-rule keyword can revert to a nested rule assert_true: expected true got false
-FAIL The revert-rule keyword can revert to a CSSNestedDeclarationsRule assert_true: expected true got false
-FAIL The revert-rule keyword can revert from a CSSNestedDeclarationsRule assert_true: expected true got false
-FAIL The revert-rule keyword can revert to scoped declarations assert_true: expected true got false
+PASS The revert-rule keyword can revert to a nested rule
+PASS The revert-rule keyword can revert to a CSSNestedDeclarationsRule
+PASS The revert-rule keyword can revert from a CSSNestedDeclarationsRule
+PASS The revert-rule keyword can revert to scoped declarations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL The revert-rule works as a branch in if() assert_true: expected true got false
-FAIL The revert-rule works as a branch in if(), earlier return assert_true: expected true got false
+FAIL The revert-rule works as a branch in if() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL The revert-rule works as a branch in if(), earlier return assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL var(--unknown, revert-rule) in custom property assert_equals: expected "PASS" but got "revert-rule"
-FAIL var(--unknown, revert-rule) in shorthand assert_true: expected true got false
-FAIL var(--unknown, revert-rule) in shorthand observed via longhand assert_true: expected true got false
-FAIL var(--unknown, revert-rule) in longhand assert_true: expected true got false
+PASS var(--unknown, revert-rule) in custom property
+PASS var(--unknown, revert-rule) in shorthand
+PASS var(--unknown, revert-rule) in shorthand observed via longhand
+PASS var(--unknown, revert-rule) in longhand
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Using revert-rule to revert to a value containing var() assert_true: expected true got false
+PASS Using revert-rule to revert to a value containing var()
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -6,6 +6,7 @@ initial
 unset
 revert
 revert-layer
+revert-rule
 
 //
 // CSS_PROP_OUTLINE_STYLE

--- a/Source/WebCore/css/CSSWideKeyword.h
+++ b/Source/WebCore/css/CSSWideKeyword.h
@@ -38,7 +38,8 @@ enum class CSSWideKeyword : uint8_t {
     Inherit,
     Unset,
     Revert,
-    RevertLayer
+    RevertLayer,
+    RevertRule
 };
 
 inline bool isCSSWideKeyword(CSSValueID valueID)
@@ -49,6 +50,7 @@ inline bool isCSSWideKeyword(CSSValueID valueID)
     case CSSValueUnset:
     case CSSValueRevert:
     case CSSValueRevertLayer:
+    case CSSValueRevertRule:
         return true;
     default:
         return false;
@@ -68,6 +70,8 @@ inline std::optional<CSSWideKeyword> parseCSSWideKeyword(CSSValueID valueID)
         return CSSWideKeyword::Revert;
     case CSSValueRevertLayer:
         return CSSWideKeyword::RevertLayer;
+    case CSSValueRevertRule:
+        return CSSWideKeyword::RevertRule;
     default:
         return { };
     }
@@ -86,6 +90,8 @@ inline CSSValueID toValueID(CSSWideKeyword keyword)
         return CSSValueRevert;
     case CSSWideKeyword::RevertLayer:
         return CSSValueRevertLayer;
+    case CSSWideKeyword::RevertRule:
+        return CSSValueRevertRule;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -738,7 +738,8 @@ static bool isUniversalKeyword(StringView string)
         || equalLettersIgnoringASCIICase(string, "inherit"_s)
         || equalLettersIgnoringASCIICase(string, "unset"_s)
         || equalLettersIgnoringASCIICase(string, "revert"_s)
-        || equalLettersIgnoringASCIICase(string, "revert-layer"_s);
+        || equalLettersIgnoringASCIICase(string, "revert-layer"_s)
+        || equalLettersIgnoringASCIICase(string, "revert-rule"_s);
 }
 
 static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID property, StringView string, CSS::PropertyParserState& state)

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -69,6 +69,17 @@ PropertyCascade::PropertyCascade(const PropertyCascade& parent, Origin maximumOr
     buildCascade();
 }
 
+PropertyCascade::PropertyCascade(const PropertyCascade& parent, Vector<unsigned>&& revertRuleExclusions)
+    : m_matchResult(parent.m_matchResult)
+    , m_includedProperties(normalProperties())
+    , m_maximumOrigin(Origin::Author)
+    , m_revertRuleExclusions(WTF::move(revertRuleExclusions))
+    , m_animationLayer(parent.m_animationLayer)
+    , m_positionTryFallbackProperties(parent.m_positionTryFallbackProperties)
+{
+    buildCascade();
+}
+
 PropertyCascade::~PropertyCascade() = default;
 
 PropertyCascade::AnimationLayer::AnimationLayer(const HashSet<AnimatableCSSProperty>& properties)
@@ -106,7 +117,7 @@ void PropertyCascade::buildCascade()
     sortLogicalGroupPropertyIDs();
 }
 
-void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin)
+void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin, unsigned authorDeclarationsIndex)
 {
     ASSERT(matchedProperties.linkMatchType <= SelectorChecker::MatchAll);
     property.id = id;
@@ -114,6 +125,7 @@ void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, 
     property.styleScopeOrdinal = matchedProperties.styleScopeOrdinal;
     property.cascadeLayerPriority = matchedProperties.cascadeLayerPriority;
     property.fromStyleAttribute = matchedProperties.fromStyleAttribute;
+    property.authorDeclarationsIndex = authorDeclarationsIndex;
 
     if (matchedProperties.linkMatchType == SelectorChecker::MatchAll) {
         property.origins[SelectorChecker::MatchDefault] = origin;
@@ -130,7 +142,7 @@ void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, 
     }
 }
 
-void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin)
+void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin, unsigned authorDeclarationsIndex)
 {
     ASSERT(!CSSProperty::isInLogicalPropertyGroup(id));
     ASSERT(id < firstLogicalGroupProperty);
@@ -142,21 +154,21 @@ void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedPro
         auto result = m_customProperties.ensure(customValue.name(), [&]() {
             Property property;
             property.cssValue = { };
-            setPropertyInternal(property, id, cssValue, matchedProperties, origin);
+            setPropertyInternal(property, id, cssValue, matchedProperties, origin, authorDeclarationsIndex);
             return property;
         });
         if (!result.isNewEntry)
-            setPropertyInternal(result.iterator->value, id, cssValue, matchedProperties, origin);
+            setPropertyInternal(result.iterator->value, id, cssValue, matchedProperties, origin, authorDeclarationsIndex);
         return;
     }
 
     auto& property = m_properties[id];
     if (!m_propertyIsPresent.testAndSet(id))
         property.cssValue = { };
-    setPropertyInternal(property, id, cssValue, matchedProperties, origin);
+    setPropertyInternal(property, id, cssValue, matchedProperties, origin, authorDeclarationsIndex);
 }
 
-void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin)
+void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin, unsigned authorDeclarationsIndex)
 {
     ASSERT(id >= firstLogicalGroupProperty);
     ASSERT(id <= lastLogicalGroupProperty);
@@ -168,7 +180,7 @@ void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssVal
         m_highestSeenLogicalGroupProperty = std::max(m_highestSeenLogicalGroupProperty, id);
     }
     setLogicalGroupPropertyIndex(id, ++m_lastIndexForLogicalGroup);
-    setPropertyInternal(property, id, cssValue, matchedProperties, origin);
+    setPropertyInternal(property, id, cssValue, matchedProperties, origin, authorDeclarationsIndex);
 }
 
 bool PropertyCascade::hasProperty(CSSPropertyID propertyID, const CSSValue& value)
@@ -212,7 +224,7 @@ const PropertyCascade::Property* PropertyCascade::lastPropertyResolvingLogicalPr
     return nullptr;
 }
 
-bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origin origin, IsImportant important)
+bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origin origin, IsImportant important, unsigned authorDeclarationsIndex)
 {
     auto includePropertiesForRollback = [&] {
         if (m_rollbackScope && matchedProperties.styleScopeOrdinal > *m_rollbackScope)
@@ -288,9 +300,9 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
             continue;
 
         if (propertyID < firstLogicalGroupProperty)
-            set(propertyID, *current.value(), matchedProperties, origin);
+            set(propertyID, *current.value(), matchedProperties, origin, authorDeclarationsIndex);
         else
-            setLogicalGroupProperty(propertyID, *current.value(), matchedProperties, origin);
+            setLogicalGroupProperty(propertyID, *current.value(), matchedProperties, origin, authorDeclarationsIndex);
     }
 
     return hasImportantProperties;
@@ -364,9 +376,12 @@ static auto& declarationsForOrigin(const MatchResult& matchResult, PropertyCasca
 bool PropertyCascade::addNormalMatches(Origin origin)
 {
     bool hasImportant = false;
-    for (auto& matchedDeclarations : declarationsForOrigin(m_matchResult, origin))
-        hasImportant |= addMatch(matchedDeclarations, origin, IsImportant::No);
-
+    auto& declarations = declarationsForOrigin(m_matchResult, origin);
+    for (unsigned i = 0; i < declarations.size(); ++i) {
+        if (origin == Origin::Author && m_revertRuleExclusions.contains(i))
+            continue;
+        hasImportant |= addMatch(declarations[i], origin, IsImportant::No, i);
+    }
     return hasImportant;
 }
 
@@ -393,6 +408,9 @@ void PropertyCascade::addImportantMatches(Origin origin)
     auto& matchedDeclarations = declarationsForOrigin(m_matchResult, origin);
 
     for (unsigned i = 0; i < matchedDeclarations.size(); ++i) {
+        if (origin == Origin::Author && m_revertRuleExclusions.contains(i))
+            continue;
+
         const MatchedProperties& matchedProperties = matchedDeclarations[i];
 
         if (!hasImportantProperties(matchedProperties.properties))
@@ -421,7 +439,7 @@ void PropertyCascade::addImportantMatches(Origin origin)
     }
 
     for (auto& match : importantMatches)
-        addMatch(matchedDeclarations[match.index], origin, IsImportant::Yes);
+        addMatch(matchedDeclarations[match.index], origin, IsImportant::Yes, match.index);
 }
 
 void PropertyCascade::sortLogicalGroupPropertyIDs()

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -73,6 +73,8 @@ public:
 
     PropertyCascade(const MatchResult&, IncludedProperties&&, const HashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
     PropertyCascade(const PropertyCascade&, Origin, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
+    // Constructor for revert-rule: rebuilds from scratch excluding the given set of author declaration indices.
+    PropertyCascade(const PropertyCascade&, Vector<unsigned>&& revertRuleExclusions);
 
     ~PropertyCascade();
 
@@ -84,6 +86,8 @@ public:
         FromStyleAttribute fromStyleAttribute;
         std::array<CSSValue*, 3> cssValue; // Values for link match states MatchDefault, MatchLink and MatchVisited
         std::array<Origin, 3> origins;
+        // Index into MatchResult::authorDeclarations for this property's winning declaration (used by revert-rule).
+        unsigned authorDeclarationsIndex { 0 };
     };
 
     bool isEmpty() const { return m_propertyIsPresent.isEmpty() && !m_seenLogicalGroupPropertyCount; }
@@ -107,18 +111,19 @@ public:
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
 
     bool applyLowPriorityOnly() const { return !m_includedProperties.ids.isEmpty(); }
+    const Vector<unsigned>& revertRuleExclusions() const { return m_revertRuleExclusions; }
 
 private:
     void buildCascade();
     bool addNormalMatches(Origin);
     void addImportantMatches(Origin);
-    bool addMatch(const MatchedProperties&, Origin, IsImportant);
+    bool addMatch(const MatchedProperties&, Origin, IsImportant, unsigned authorDeclarationsIndex = 0);
     bool shouldApplyAfterAnimation(const StyleProperties::PropertyReference&);
     void addPositionTryFallbackProperties();
 
-    void set(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
-    void setLogicalGroupProperty(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
-    static void setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
+    void set(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin, unsigned authorDeclarationsIndex);
+    void setLogicalGroupProperty(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin, unsigned authorDeclarationsIndex);
+    static void setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, Origin, unsigned authorDeclarationsIndex);
 
     bool hasProperty(CSSPropertyID, const CSSValue&);
     bool mayOverrideExistingProperty(CSSPropertyID, const CSSValue&);
@@ -132,6 +137,8 @@ private:
     const Origin m_maximumOrigin;
     const std::optional<ScopeOrdinal> m_rollbackScope;
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;
+    // For revert-rule rollback cascades: author declaration indices to skip, accumulated across chain levels.
+    const Vector<unsigned> m_revertRuleExclusions;
 
     struct AnimationLayer {
         AnimationLayer(const HashSet<AnimatableCSSProperty>&);

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -369,19 +369,27 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     bool isUnset = valueID == CSSValueUnset;
     bool isRevert = valueID == CSSValueRevert;
     bool isRevertLayer = valueID == CSSValueRevertLayer;
-    bool isRevertOrRevertLayer = isRevert || isRevertLayer;
+    bool isRevertRule = valueID == CSSValueRevertRule;
+    bool isRevertOrRevertLayerOrRevertRule = isRevert || isRevertLayer || isRevertRule;
 
-    if (isRevertOrRevertLayer) {
-        // In @keyframes, 'revert-layer' rolls back the cascaded value to the author level.
+    if (isRevertOrRevertLayerOrRevertRule) {
+        // In @keyframes, 'revert-layer' and 'revert-rule' roll back the cascaded value to the author level.
         // We can just not apply the property in order to keep the value from the base style.
-        if (isRevertLayer && m_state->m_isBuildingKeyframeStyle)
+        if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle)
             return;
 
-        auto* rollbackCascade = isRevert ? ensureRollbackCascadeForRevert() : ensureRollbackCascadeForRevertLayer();
+        auto* rollbackCascade = [&]() -> const PropertyCascade* {
+            if (isRevert)
+                return ensureRollbackCascadeForRevert();
+            if (isRevertLayer)
+                return ensureRollbackCascadeForRevertLayer();
+            return ensureRollbackCascadeForRevertRule();
+        }();
 
         if (rollbackCascade) {
             // With the rollback cascade built, we need to obtain the property and apply it. If the property is
             // not present, then we behave like "unset." Otherwise we apply the property instead of our own.
+            SetForScope revertRuleScope(m_currentRevertRuleCascade, isRevertRule ? rollbackCascade : m_currentRevertRuleCascade);
             if (applyRollbackCascadeProperty(*rollbackCascade, id, linkMatchMask))
                 return;
         }
@@ -397,7 +405,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return isInheritedProperty() ? ApplyValueType::Inherit : ApplyValueType::Initial;
     };
 
-    if (isUnset || isRevertOrRevertLayer)
+    if (isUnset || isRevertOrRevertLayerOrRevertRule)
         valueType = unsetValueType();
 
     if (!m_state->applyPropertyToRegularStyle() && !isValidVisitedLinkProperty(id)) {
@@ -426,10 +434,10 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
 
     BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), valueType);
 
-    if (!isRevertOrRevertLayer)
+    if (!isRevertOrRevertLayerOrRevertRule)
         m_state->disableNativeAppearanceIfNeeded(id, cascadeOrigin);
 
-    if (!isUnset && !isRevertOrRevertLayer && m_state->isCurrentPropertyInvalidAtComputedValueTime()) {
+    if (!isUnset && !isRevertOrRevertLayerOrRevertRule && m_state->isCurrentPropertyInvalidAtComputedValueTime()) {
         // https://drafts.csswg.org/css-variables-2/#invalid-variables
         // A declaration can be invalid at computed-value time if...
         // When this happens, the computed value is one of the following...
@@ -476,6 +484,7 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
             ApplyValueType valueType = ApplyValueType::Value;
             bool isRevert = false;
             bool isRevertLayer = false;
+            bool isRevertRule = false;
 
             auto isInheritedProperty = [&] {
                 return registeredCustomProperty ? registeredCustomProperty->inherits : true;
@@ -505,19 +514,31 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
                 isRevertLayer = true;
                 valueType = unsetValueType();
                 break;
+            case CSSWideKeyword::RevertRule:
+                isRevertRule = true;
+                valueType = unsetValueType();
+                break;
             }
 
-            if (isRevert || isRevertLayer) {
-                // In @keyframes, 'revert-layer' rolls back the cascaded value to the author level.
+            bool isRevertOrRevertLayerOrRevertRule = isRevert || isRevertLayer || isRevertRule;
+            if (isRevertOrRevertLayerOrRevertRule) {
+                // In @keyframes, 'revert-layer' and 'revert-rule' roll back the cascaded value to the author level.
                 // We can just not apply the property in order to keep the value from the base style.
-                if (isRevertLayer && m_state->m_isBuildingKeyframeStyle)
+                if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle)
                     return;
 
-                auto* rollbackCascade = isRevert ? ensureRollbackCascadeForRevert() : ensureRollbackCascadeForRevertLayer();
+                auto* rollbackCascade = [&]() -> const PropertyCascade* {
+                    if (isRevert)
+                        return ensureRollbackCascadeForRevert();
+                    if (isRevertLayer)
+                        return ensureRollbackCascadeForRevertLayer();
+                    return ensureRollbackCascadeForRevertRule();
+                }();
 
                 if (rollbackCascade) {
                     // With the rollback cascade built, we need to obtain the property and apply it. If the property is
                     // not present, then we behave like "unset." Otherwise we apply the property instead of our own.
+                    SetForScope revertRuleScope(m_currentRevertRuleCascade, isRevertRule ? rollbackCascade : m_currentRevertRuleCascade);
                     if (applyRollbackCascadeCustomProperty(*rollbackCascade, name))
                         return;
                 }
@@ -636,6 +657,7 @@ RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(c
                 return isInherited ? inherit() : initial();
             case CSSWideKeyword::Revert:
             case CSSWideKeyword::RevertLayer:
+            case CSSWideKeyword::RevertRule:
                 // https://drafts.csswg.org/css-contain-3/#style-container
                 // "Cascade-dependent keywords, such as revert and revert-layer, are invalid as values in a style feature,
                 // and cause the container style query to be false."
@@ -790,6 +812,17 @@ auto Builder::makeRollbackCascadeKey(PropertyCascade::Origin cascadeOrigin, Scop
 {
     static constexpr auto isNonEmptyValue = true;
     return { static_cast<unsigned>(cascadeOrigin), static_cast<unsigned>(scopeOrdinal), static_cast<unsigned>(cascadeLayerPriority), isNonEmptyValue };
+}
+
+const PropertyCascade* Builder::ensureRollbackCascadeForRevertRule()
+{
+    auto excludedIndex = m_state->m_currentProperty->authorDeclarationsIndex;
+    auto* parentCascade = m_currentRevertRuleCascade ? m_currentRevertRuleCascade : &m_cascade;
+    return m_revertRuleRollbackCascades.ensure({ parentCascade, excludedIndex }, [&] {
+        auto exclusions = parentCascade->revertRuleExclusions();
+        exclusions.append(excludedIndex);
+        return makeUnique<const PropertyCascade>(m_cascade, WTF::move(exclusions));
+    }).iterator->value.get();
 }
 
 }

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -83,6 +83,7 @@ private:
 
     const PropertyCascade* ensureRollbackCascadeForRevert();
     const PropertyCascade* ensureRollbackCascadeForRevertLayer();
+    const PropertyCascade* ensureRollbackCascadeForRevertRule();
 
     using RollbackCascadeKey = std::tuple<unsigned, unsigned, unsigned, bool>;
     RollbackCascadeKey makeRollbackCascadeKey(PropertyCascade::Origin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
@@ -90,6 +91,10 @@ private:
     const PropertyCascade m_cascade;
     // Rollback cascades are build on demand to resolve 'revert' and 'revert-layer' keywords.
     HashMap<RollbackCascadeKey, std::unique_ptr<const PropertyCascade>> m_rollbackCascades;
+    // Rollback cascades for 'revert-rule', keyed by (parent cascade, excluded declaration index).
+    HashMap<std::pair<const PropertyCascade*, unsigned>, std::unique_ptr<const PropertyCascade>> m_revertRuleRollbackCascades;
+    // The revert-rule rollback cascade currently being applied (nullptr = root cascade).
+    const PropertyCascade* m_currentRevertRuleCascade { nullptr };
 
     const UniqueRef<BuilderState> m_state;
 };


### PR DESCRIPTION
#### 0d8bd06800aabfac7d0f0681bbcfa4901b917ae1
<pre>
[css-cascade] Implement revert-rule CSS keyword
<a href="https://bugs.webkit.org/show_bug.cgi?id=308604">https://bugs.webkit.org/show_bug.cgi?id=308604</a>
<a href="https://rdar.apple.com/171132753">rdar://171132753</a>

Reviewed by NOBODY (OOPS!).

<a href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword</a>

The revert-rule CSS-wide keyword rolls back the cascade similar to revert and revert-layer, except it works by style rule rather than cascade origin or cascade layer.

If the cascaded value of a property is the revert-rule keyword, the cascaded value is rolled back such that the specified value is calculated as if the current style rule had not been present at all.

The revert-rule keyword behaves like revert-layer in the animation origin.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-shadow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-shadow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/CSSWideKeyword.h:
(WebCore::isCSSWideKeyword):
(WebCore::parseCSSWideKeyword):
(WebCore::toValueID):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::isUniversalKeyword):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::setPropertyInternal):
(WebCore::Style::PropertyCascade::set):
(WebCore::Style::PropertyCascade::setLogicalGroupProperty):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::addNormalMatches):
(WebCore::Style::PropertyCascade::addImportantMatches):
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::revertRuleExclusions const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::applyCustomProperty):
(WebCore::Style::Builder::resolveCustomPropertyForContainerQueries):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertRule):
* Source/WebCore/style/StyleBuilder.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d8bd06800aabfac7d0f0681bbcfa4901b917ae1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100531 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a88e68d9-6ba8-4e9f-99df-428d14651f06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113380 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80881 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/650d3fd3-0c31-4777-b169-e61489318cd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94138 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2755b8c0-ea89-4c85-a669-d0386df889db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14799 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12582 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158130 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121404 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121605 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131850 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75567 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8658 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18945 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19095 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->