### PR TITLE
Re-import css/css-animations WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/Document-getAnimations.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/Document-getAnimations.tentative.html
@@ -182,8 +182,18 @@ test(t => {
   assert_equals(animLeft.animationName, 'animLeft',
                 'Originally, animLeft animation comes first');
 
+  // Pause: now we are ignoring animation-play-state.
+  animLeft.pause();
+
   // Disassociate animLeft from markup and restart
   div.style.animation = 'animTop 100s';
+
+  // The animation should be cancelled regardless of whether we are ignoring
+  // animation-play-state.
+  assert_equals(document.getAnimations().length, 1,
+      'one animation (animLeft) cancelled');
+  assert_equals(document.getAnimations()[0].animationName, 'animTop',
+      'only animTop remains');
   animLeft.play();
 
   const animations = document.getAnimations();
@@ -191,7 +201,8 @@ test(t => {
                 'getAnimations returns markup-bound and free animations');
   assert_equals(animations[0].animationName, 'animTop',
                 'Markup-bound animations come first');
-  assert_equals(animations[1], animLeft, 'Free animations come last');
+  assert_equals(animations[1].animationName, 'animLeft',
+      'Free animations come last');
 }, 'Order of CSS Animations - markup-bound vs free animations');
 
 test(t => {
@@ -200,6 +211,7 @@ test(t => {
   const animLeft = document.getAnimations()[0];
   // Disassociate animLeft from markup and restart
   div.style.animation = '';
+  assert_equals(document.getAnimations().length, 0, "css animation cancelled");
   animLeft.play();
 
   div.style.top = '0px';
@@ -214,7 +226,8 @@ test(t => {
   assert_equals(animations.length, 2,
                 'Both CSS animations and transitions are returned');
   assert_class_string(animations[0], 'CSSTransition', 'Transition comes first');
-  assert_equals(animations[1], animLeft, 'Free animations come last');
+  assert_equals(animations[1].animationName,
+      "animLeft", 'Free animations come last');
 }, 'Order of CSS Animations - free animation vs CSS Transitions');
 
 test(t => {
@@ -224,15 +237,16 @@ test(t => {
 
   // Disassociate both animations from markup and restart in opposite order
   div.style.animation = '';
+  assert_equals(document.getAnimations().length, 0, "animations are removed");
   animTop.play();
   animLeft.play();
 
   const animations = document.getAnimations();
   assert_equals(animations.length, 2,
                 'getAnimations returns free animations');
-  assert_equals(animations[0], animTop,
+  assert_equals(animations[0].animationName, "animTop",
                 'Free animations are returned in the order they are started');
-  assert_equals(animations[1], animLeft,
+  assert_equals(animations[1].animationName, "animLeft",
                 'Animations started later are returned later');
 
   // Restarting an animation should have no effect

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative-expected.txt
@@ -4,6 +4,7 @@ PASS KeyframeEffect.getKeyframes() returns expected frames for a simple animatio
 PASS KeyframeEffect.getKeyframes() returns frames with expected easing values, when the easing comes from animation-timing-function on the element
 PASS KeyframeEffect.getKeyframes() returns frames with expected easing values, when the easing is specified on each keyframe
 PASS KeyframeEffect.getKeyframes() returns frames with expected easing values, when the easing is specified on some keyframes
+PASS KeyframeEffect.getKeyframes() returns animation-wide easing for var() keyframe easing
 PASS KeyframeEffect.getKeyframes() returns frames with expected composite values, when the composite is set on the effect using animation-composition on the element
 PASS KeyframeEffect.getKeyframes() returns frames with expected composite values, when the composite is specified on each keyframe
 PASS KeyframeEffect.getKeyframes() returns frames with expected composite values, when the composite is specified on some keyframes

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
@@ -19,6 +19,11 @@
   to   { }
 }
 
+@keyframes anim-keyframe-timing-var {
+  from { color: rgb(0, 0, 0); animation-timing-function: var(--kf_ease); }
+  to   { color: rgb(255, 255, 255); }
+}
+
 @keyframes anim-only-non-animatable {
   from { animation-duration: 3s; }
   to   { animation-duration: 5s; }
@@ -316,6 +321,26 @@ test(t => {
                 "value of 'easing' on ComputedKeyframe #2");
 }, 'KeyframeEffect.getKeyframes() returns frames with expected easing'
    + ' values, when the easing is specified on some keyframes');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.setProperty('--kf_ease', 'steps(2, start)');
+
+  // Note: This test matches current interop behavior (Firefox/Safari/Chromium),
+  // not necessarily the spec-intended behavior for var() in keyframe easing.
+  div.style.animation = 'anim-keyframe-timing-var 100s linear';
+
+  const animation = div.getAnimations()[0];
+  assert_equals(animation.effect.getTiming().easing, 'linear',
+                "value of 'easing' on effect.getTiming()");
+
+  const frames = getKeyframes(div);
+  assert_equals(frames.length, 2, "number of frames");
+  assert_equals(frames[0].easing, "linear",
+                "value of 'easing' on ComputedKeyframe #0");
+  assert_equals(frames[1].easing, "linear",
+                "value of 'easing' on ComputedKeyframe #1");
+}, 'KeyframeEffect.getKeyframes() returns animation-wide easing for var() keyframe easing');
 
 test(t => {
   for (const composite of kCompositeValues) {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html
@@ -4,7 +4,7 @@
 <title>Matching animation-name with nested shadow roots</title>
 <link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
 <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
-<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-1/#shadow-names">
 <link rel="match" href="animation-name-in-nested-shadow-ref.html">
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html
@@ -4,7 +4,7 @@
 <title>Matching animation-name from within a shadow root with multiple @keyframes rules</title>
 <link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
 <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
-<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-1/#shadow-names">
 <link rel="match" href="animation-name-in-shadow-part-ref.html">
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html
@@ -4,7 +4,7 @@
 <title>Matching animation-name from within a shadow root with multiple @keyframes rules</title>
 <link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
 <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
-<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-1/#shadow-names">
 <link rel="match" href="animation-name-in-shadow-part-ref.html">
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html
@@ -4,7 +4,7 @@
 <title>Matching animation-name from within a shadow root with a single @keyframes rule in the outer scope</title>
 <link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
 <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296048">
-<link rel="help" href="https://drafts.csswg.org/css-scoping-1/#shadow-names">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-1/#shadow-names">
 <link rel="match" href="animation-name-in-shadow-part-ref.html">
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/keyframe-easing-var-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/keyframe-easing-var-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Animations: keyframe easing var() should not crash</title>
+<meta name="assert" content="This should not crash.">
+<style>
+@keyframes kf {
+  0% {
+    transform: translateX(0px);
+    animation-timing-function: var(--kf_ease);
+  }
+  100% {
+    transform: translateX(100px);
+  }
+}
+
+#target {
+  width: 40px;
+  height: 40px;
+  background: #4a90e2;
+  animation: kf 1s linear 1;
+  will-change: transform;
+}
+</style>
+<div id="target"></div>
+<script>
+  const target = document.getElementById("target");
+  target.getAnimations();
+  document.documentElement.style.setProperty("--kf_ease", "steps(2, start)");
+  const animation = target.getAnimations()[0];
+  animation.effect.getTiming();
+  animation.effect.getKeyframes();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/w3c-import.log
@@ -20,5 +20,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/chrome-bug-404743651.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/chrome-bug-405795970.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/chrome-bug-415627003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/keyframe-easing-var-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/pseudo-element-animation-with-marker.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/replace-keyframes-animating-filter-001.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL revert-rule in keyframes, reverted-to value changing (standard property) assert_true: expected true got false
+FAIL revert-rule in keyframes, reverted-to value changing (custom property) assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>CSS Animations: revert-rule in keyframes, dynamic</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">
+<link rel="help" href="https://drafts.csswg.org/css-animations/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @property --x {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+  }
+  @keyframes anim {
+    from { width: revert-rule; }
+    to { width: 200px; }
+  }
+  @keyframes anim-custom {
+    from { --x: revert-rule; }
+    to { --x: 200px; }
+  }
+  #target {
+    width: 100px;
+    --x: 100px;
+    animation: anim 3600s steps(2, start),
+               anim-custom 3600s steps(2, start);
+  }
+</style>
+  <div id=target></div>
+<script>
+  test((t) => {
+    t.add_cleanup(() => { target.style = ''; });
+    assert_true(CSS.supports('color', 'revert-rule'));
+    assert_equals(getComputedStyle(target).width, '150px');
+    target.style.setProperty('width', '120px');
+    assert_equals(getComputedStyle(target).width, '160px');
+  }, 'revert-rule in keyframes, reverted-to value changing (standard property)');
+
+  test((t) => {
+    t.add_cleanup(() => { target.style = ''; });
+    assert_true(CSS.supports('color', 'revert-rule'));
+    assert_equals(getComputedStyle(target).getPropertyValue('--x'), '150px');
+    target.style.setProperty('--x', '120px');
+    assert_equals(getComputedStyle(target).getPropertyValue('--x'), '160px');
+  }, 'revert-rule in keyframes, reverted-to value changing (custom property)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL revert-rule in keyframes (width) assert_true: expected true got false
+FAIL revert-rule in keyframes (--x) assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>CSS Animations: revert-rule in keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">
+<link rel="help" href="https://drafts.csswg.org/css-animations/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @property --x {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+  }
+  @keyframes anim {
+    from {
+      width: revert-rule;
+      --x: revert-rule;
+    }
+    to {
+      width: 200px;
+      --x: 200px;
+    }
+  }
+  #target {
+    width: 100px;
+    --x: 100px;
+    animation: anim 3600s steps(2, start);
+  }
+</style>
+<div id="target"></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color', 'revert-rule'));
+    assert_equals(getComputedStyle(target).width, '150px');
+  }, 'revert-rule in keyframes (width)');
+
+  test(() => {
+    assert_true(CSS.supports('color', 'revert-rule'));
+    assert_equals(getComputedStyle(target).getPropertyValue('--x'), '150px');
+  }, 'revert-rule in keyframes (--x)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/w3c-import.log
@@ -151,6 +151,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/pending-style-changes-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/sample-on-last-keyframe.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/simultaneous-animations-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/style-animation-parsing.html


### PR DESCRIPTION
#### cd790b1edad8405e4c724b4859d22e622dfb2927
<pre>
Re-import css/css-animations WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=308609">https://bugs.webkit.org/show_bug.cgi?id=308609</a>
<a href="https://rdar.apple.com/171134980">rdar://171134980</a>

Reviewed by Simon Fraser.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/6fb07d00b6334b27d0db5b6f9f152699d0baae93">https://github.com/web-platform-tests/wpt/commit/6fb07d00b6334b27d0db5b6f9f152699d0baae93</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/Document-getAnimations.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-nested-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-inner-match.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part-outer-match.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-name-in-shadow-part.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/keyframe-easing-var-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/308180@main">https://commits.webkit.org/308180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a0e8846ba97a079f7defeacba0b78e21f0b1c16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155369 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87e3396b-01d1-4b4d-867d-c366659f5a71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113037 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/818ebd5c-2121-4e1e-a3ae-c53b113dfd07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fbd330e-8a49-4b0c-b423-1bf631c344a4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2813 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157699 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121044 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121257 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131430 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22634 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18800 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18530 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->