### PR TITLE
[Site Isolation] Fix storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html

### DIFF
--- a/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers-expected.txt
+++ b/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers-expected.txt
@@ -1,2 +1,3 @@
 CONSOLE MESSAGE: Error: One unhandled exception
+CONSOLE MESSAGE: Error: Two unhandled exceptions.
 This test passes if it doesn't crash.

--- a/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html
+++ b/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html
@@ -11,8 +11,10 @@
                throw new Error("One unhandled exception");
            });
            countRequest.addEventListener('success', ev => {
-               testRunner?.notifyDone();
                throw new Error("Two unhandled exceptions.");
+           });
+           countRequest.addEventListener('success', ev => {
+               testRunner?.notifyDone();
            });
        }
        await (async () => {


### PR DESCRIPTION
#### 63b172404c9a56f54de64b85bfba5882fa94c03a
<pre>
[Site Isolation] Fix storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=308616">https://bugs.webkit.org/show_bug.cgi?id=308616</a>
<a href="https://rdar.apple.com/171138106">rdar://171138106</a>

Reviewed by Per Arne Vollan.

TestRunner::notifyDone() dumps result synchronously without Site Isolation and dumps result asynchronously under Site
Isolation. This difference has caused the test to generate different outputs in different configurations: under Site
Isolation, there&apos;ll be console log error about the second unhandled exception. To ensure the test could generate the
same output in both configurations and also keep the test validate the behavior of exceptions thrown in different event
handlers, create a third event handler and move notifyDone() there.

* LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html:

Canonical link: <a href="https://commits.webkit.org/308219@main">https://commits.webkit.org/308219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb153514a6a22af477f3ed711876510b5e574067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100102 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f63ae473-6e84-474a-8e44-e648dbcb0c5d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113045 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80710 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8263006-9915-4080-b099-489ea41e5682) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93791 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edffb510-743e-4bc7-b2c2-8f7ed051e1c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14529 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2823 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157709 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121052 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31083 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75004 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16872 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18810 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->