### PR TITLE
[AppKit Gestures] Propagate the input source from an event when presenting a context menu

### DIFF
--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -142,6 +142,7 @@ DragEvent::DragEvent(
         syntheticClickType,
         { },
         { },
+        std::nullopt,
         isSimulated,
         isTrusted
     )

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -92,7 +92,8 @@ Ref<MouseEvent> MouseEvent::create(
         event.force(),
         event.syntheticClickType(),
         coalescedEvents,
-        predictedEvents
+        predictedEvents,
+        event.inputSource()
     );
 }
 
@@ -116,6 +117,7 @@ Ref<MouseEvent> MouseEvent::create(
     SyntheticClickType syntheticClickType,
     const Vector<Ref<MouseEvent>>& coalescedEvents,
     const Vector<Ref<MouseEvent>>& predictedEvents,
+    const std::optional<MouseEventInputSource>& inputSource,
     IsSimulated isSimulated,
     IsTrusted isTrusted
 )
@@ -142,6 +144,7 @@ Ref<MouseEvent> MouseEvent::create(
             syntheticClickType,
             coalescedEvents,
             predictedEvents,
+            inputSource,
             isSimulated,
             isTrusted
         )
@@ -230,6 +233,7 @@ MouseEvent::MouseEvent(
     SyntheticClickType syntheticClickType,
     const Vector<Ref<MouseEvent>>& coalescedEvents,
     const Vector<Ref<MouseEvent>>& predictedEvents,
+    const std::optional<MouseEventInputSource>& inputSource,
     IsSimulated isSimulated,
     IsTrusted isTrusted
 )
@@ -258,6 +262,7 @@ MouseEvent::MouseEvent(
     , m_force(force)
     , m_coalescedEvents(coalescedEvents)
     , m_predictedEvents(predictedEvents)
+    , m_inputSource(inputSource)
 {
 }
 

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -28,6 +28,7 @@
 #include <WebCore/MouseEventInit.h>
 #include <WebCore/MouseEventTypes.h>
 #include <WebCore/MouseRelatedEvent.h>
+#include <WebCore/PlatformMouseEvent.h>
 
 #include <wtf/Platform.h>
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
@@ -46,7 +47,6 @@ class JSValue;
 namespace WebCore {
 
 class Node;
-class PlatformMouseEvent;
 
 enum class SyntheticClickType : uint8_t;
 
@@ -76,6 +76,7 @@ public:
         SyntheticClickType,
         const Vector<Ref<MouseEvent>>& coalescedEvents,
         const Vector<Ref<MouseEvent>>& predictedEvents,
+        const std::optional<MouseEventInputSource>& inputSource = { },
         IsSimulated = IsSimulated::No,
         IsTrusted = IsTrusted::Yes
     );
@@ -137,6 +138,8 @@ public:
         EventTarget* relatedTarget
     );
 
+    const std::optional<MouseEventInputSource>& inputSource() const { return m_inputSource; }
+
     MouseButton button() const;
     int16_t buttonAsShort() const { return m_button; }
     unsigned short buttons() const { return m_buttons; }
@@ -179,6 +182,7 @@ protected:
         SyntheticClickType,
         const Vector<Ref<MouseEvent>>& coalescedEvents,
         const Vector<Ref<MouseEvent>>& predictedEvents,
+        const std::optional<MouseEventInputSource>& inputSource,
         IsSimulated,
         IsTrusted
     );
@@ -220,6 +224,7 @@ private:
     double m_force { 0 };
     Vector<Ref<MouseEvent>> m_coalescedEvents;
     Vector<Ref<MouseEvent>> m_predictedEvents;
+    std::optional<MouseEventInputSource> m_inputSource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -228,6 +228,7 @@ PointerEvent::PointerEvent(
         mouseEvent.syntheticClickType(),
         { },
         { },
+        mouseEvent.inputSource(),
         mouseEvent.isSimulated() ? IsSimulated::Yes : IsSimulated::No,
         mouseEvent.isTrusted() ? IsTrusted::Yes : IsTrusted::No
     )

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -78,6 +78,7 @@ private:
             SyntheticClickType::NoTap,
             { },
             { },
+            std::nullopt,
             IsSimulated::Yes,
             source == SimulatedClickSource::UserAgent ? IsTrusted::Yes : IsTrusted::No
         )

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -86,6 +86,7 @@ inline WheelEvent::WheelEvent(const PlatformWheelEvent& event, RefPtr<WindowProx
         SyntheticClickType::NoTap,
         { },
         { },
+        std::nullopt,
         IsSimulated::No,
         IsTrusted::Yes
     )

--- a/Source/WebCore/dom/glib/PointerEventGLib.cpp
+++ b/Source/WebCore/dom/glib/PointerEventGLib.cpp
@@ -78,7 +78,7 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 static constexpr unsigned touchMinimumPointerId = WebCore::mousePointerID + 1;
 
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const DoublePoint& touchDelta)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp(), WTF::move(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp(), WTF::move(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, std::nullopt, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(touchMinimumPointerId + event.touchPoints().at(index).id())
     , m_width(2 * event.touchPoints().at(index).radius().width())
     , m_height(2 * event.touchPoints().at(index).radius().height())

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -72,6 +72,7 @@ Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned ind
             SyntheticClickType::NoTap,
             { },
             { },
+            std::nullopt,
             IsSimulated::No,
             IsTrusted::Yes
         )

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -106,6 +106,7 @@ PointerEvent::PointerEvent(
         SyntheticClickType::NoTap,
         { },
         { },
+        std::nullopt,
         IsSimulated::No,
         IsTrusted::Yes
     )

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -44,6 +44,8 @@ class Encoder;
 
 namespace WebKit {
 
+enum class WebMouseEventInputSource : uint8_t;
+
 class ContextMenuContextData {
 public:
     using Type = WebCore::ContextMenuContext::Type;
@@ -76,6 +78,7 @@ public:
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
         , std::optional<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier
 #endif
+        , std::optional<WebMouseEventInputSource> inputSource
     );
 
     Type type() const { return m_type; }
@@ -143,6 +146,8 @@ public:
     std::optional<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier() const { return m_mediaElementIdentifier; }
 #endif
 
+    std::optional<WebMouseEventInputSource> inputSource() const { return m_inputSource; }
+
 private:
     Type m_type;
 
@@ -181,6 +186,8 @@ private:
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     Markable<WebCore::HTMLMediaElementIdentifier> m_mediaElementIdentifier;
 #endif
+
+    std::optional<WebMouseEventInputSource> m_inputSource;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -48,7 +48,7 @@ class WebKit::ContextMenuContextData {
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     std::optional<WebCore::MediaPlayerClientIdentifier> mediaElementIdentifier();
 #endif
-
+    std::optional<WebKit::WebMouseEventInputSource> inputSource();
 };
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -90,6 +90,18 @@ WebCore::MouseEventInputSource platform(WebMouseEventInputSource source)
     }
 }
 
+WebMouseEventInputSource kit(WebCore::MouseEventInputSource source)
+{
+    switch (source) {
+    case WebCore::MouseEventInputSource::UserDriven:
+        return WebMouseEventInputSource::UserDriven;
+    case WebCore::MouseEventInputSource::Automation:
+        return WebMouseEventInputSource::Automation;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
 WebCore::PlatformEvent::Type platform(WebEventType type)
 {
     switch (type) {

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -75,6 +75,7 @@ WebCore::PlatformGestureEvent platform(const WebGestureEvent&);
 #endif
 
 WebCore::MouseEventInputSource platform(WebMouseEventInputSource);
+WebMouseEventInputSource kit(WebCore::MouseEventInputSource);
 
 WebCore::MouseButton platform(WebMouseEventButton);
 WebMouseEventButton NODELETE kit(WebCore::MouseButton);

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -484,6 +484,7 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
         SyntheticClickType::NoTap,
         { },
         { },
+        std::nullopt,
         MouseEvent::IsSimulated::Yes
     );
 

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -981,6 +981,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
             WebCore::SyntheticClickType::NoTap,
             { },
             { },
+            std::nullopt,
             WebCore::MouseEvent::IsSimulated::Yes
         );
     }


### PR DESCRIPTION
#### fe4dd1d95f8cdda17bfc2152e3e2228f11e9a358
<pre>
[AppKit Gestures] Propagate the input source from an event when presenting a context menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=308621">https://bugs.webkit.org/show_bug.cgi?id=308621</a>
<a href="https://rdar.apple.com/171142968">rdar://171142968</a>

Reviewed by Aditya Keerthi.

When presenting a context menu, include the event&apos;s input source when needed.

Since the flow of context menus are somewhat confusing, here is the path of information travel:

1. An NSEvent is created inside `WKTextSelectionController`, which is then sent to WebViewImpl
2. A `WebKit::WebMouseEvent` event is created from that NSEvent
3. `WebFrame::handleMouseEvent` is invoked with that WebMouseEvent
4. A `WebCore::PlatformMouseEvent` event is created from the `WebKit::WebMouseEvent` event.
5. The PlatformMouseEvent then goes through `WebFrame::handleContextMenuEvent` to `EventHandler::sendContextMenuEvent`
6. `EventHandler::dispatchMouseEvent` is invoked with the an event name of `contextmenuEvent`, which then invokes `Element::dispatchMouseEvent`
7. In `Element::dispatchMouseEvent`, a `WebCore::MouseEvent` is created from the PlatformMouseEvent, and stores the platform event within itself, so that it then can still access the input source.
8. `dispatchPointerEventIfNeeded` is then called, which creates a PointerEvent from the MouseEvent, discards the MouseEvent, and the pointer event is then dispatched. The input source is still propogated to the pointer event now.
9. In `Node::defaultEventHandler`, the `ContextMenuController::handleContextMenuEvent` method is called, which sets `m_contextMenu` using the event passed into it.
10. A `ContextMenuContextData` is created from the `WebCore::ContextMenuContext`
11. In `WebContextMenuProxyMac::showContextMenuWithItems`, the input source of `m_context` (which is a `WebKit::ContextMenuContextData`) is accessed.
12. An NSMenu is then presented using AppKit.

* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::create):
(WebCore::DragEvent::DragEvent):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::MouseEvent):
* Source/WebCore/dom/MouseEvent.h:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::underlyingPlatformEvent const):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::SimulatedMouseEvent::SimulatedMouseEvent):
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::WheelEvent):
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::m_selectionIsEditable):
(WebKit::ContextMenuContextData::ContextMenuContextData):
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::inputSource const):
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::kit):
* Source/WebKit/Shared/WebEventConversion.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::showContextMenuWithItems):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView PDFViewWillClickOnLink:withURL:]):

Canonical link: <a href="https://commits.webkit.org/308229@main">https://commits.webkit.org/308229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62b5c453b4515da979b34628d6bd68614d1624b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146831 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155499 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0563e71-3483-40de-b660-e58201625e4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113134 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e8a6405-a41d-42b2-9df4-9aea5fd5dfd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15388 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/546f4dd5-36f0-466f-88c6-0a482ca3f2c1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2943 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157831 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11232 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121144 "17 flakes 6 failures") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31091 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131548 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18929 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18659 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18810 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->