### PR TITLE
Scroll rubberbanding may fail to reveal banner view overlay

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -259,6 +259,7 @@ public:
 #endif
 
     virtual void triggerMainFrameRubberBandSnapBack() { }
+    virtual void mainFrameRubberBandTargetOffsetDidChange() { }
 
     WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -50,6 +50,7 @@ public:
     RetainPtr<CALayer> rootContentsLayer() const { return m_rootContentsLayer; }
 
     void startRubberBandSnapBack();
+    void rubberBandTargetOffsetDidChange();
 
 protected:
     ScrollingTreeFrameScrollingNodeMac(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -73,6 +73,11 @@ void ScrollingTreeFrameScrollingNodeMac::startRubberBandSnapBack()
     delegate().startRubberBandSnapBack();
 }
 
+void ScrollingTreeFrameScrollingNodeMac::rubberBandTargetOffsetDidChange()
+{
+    delegate().rubberBandTargetOffsetDidChange();
+}
+
 void ScrollingTreeFrameScrollingNodeMac::willBeDestroyed()
 {
     delegate().nodeWillBeDestroyed();

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -60,6 +60,7 @@ public:
 
     bool isRubberBandInProgress() const;
     void startRubberBandSnapBack();
+    void rubberBandTargetOffsetDidChange();
 
 #if HAVE(RUBBER_BANDING)
     std::optional<RubberbandingState> captureRubberbandingState() const final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -224,6 +224,11 @@ void ScrollingTreeScrollingNodeDelegateMac::startRubberBandSnapBack()
     m_scrollController.startRubberBandSnapBack();
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::rubberBandTargetOffsetDidChange()
+{
+    m_scrollController.rubberBandTargetOffsetDidChange();
+}
+
 #if HAVE(RUBBER_BANDING)
 std::optional<RubberbandingState> ScrollingTreeScrollingNodeDelegateMac::captureRubberbandingState() const
 {

--- a/Source/WebCore/platform/RubberbandingState.h
+++ b/Source/WebCore/platform/RubberbandingState.h
@@ -36,6 +36,7 @@ namespace WebCore {
 struct RubberbandingState {
     FloatSize initialVelocity;
     FloatSize initialOverscroll;
+    FloatSize targetOverscroll;
 
     MonotonicTime animationStartTime;
     MonotonicTime captureTime;

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -199,6 +199,7 @@ public:
 
     void stopRubberBanding();
     void startRubberBandSnapBack();
+    void rubberBandTargetOffsetDidChange();
     bool isRubberBandInProgress() const;
     RectEdges<bool> rubberBandingEdges() const { return m_rubberBandingEdges; }
 
@@ -231,7 +232,7 @@ private:
     void startRubberBandAnimationIfNecessary();
 
     bool startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll);
-    bool startRubberBandAnimationWithElapsedTime(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, Seconds alreadyElapsed);
+    bool startRubberBandAnimationWithElapsedTime(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, Seconds alreadyElapsed, std::optional<FloatSize> targetOverscroll = std::nullopt);
     void stopRubberBandAnimation();
 
     void willStartRubberBandAnimation();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -352,6 +352,8 @@ void RemoteScrollingCoordinatorProxy::setBannerViewHeight(float offset)
 
     if (offset < previousOffset)
         m_scrollingTree->triggerMainFrameRubberBandSnapBack();
+    else if (offset > previousOffset)
+        m_scrollingTree->mainFrameRubberBandTargetOffsetDidChange();
 }
 
 void RemoteScrollingCoordinatorProxy::setBannerViewMaximumHeight(float offset)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -52,6 +52,7 @@ public:
     void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, int) override;
 
     void triggerMainFrameRubberBandSnapBack() override;
+    void mainFrameRubberBandTargetOffsetDidChange() override;
 
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -573,6 +573,15 @@ void RemoteScrollingTreeMac::triggerMainFrameRubberBandSnapBack()
     rootScrollingNode->startRubberBandSnapBack();
 }
 
+void RemoteScrollingTreeMac::mainFrameRubberBandTargetOffsetDidChange()
+{
+    RefPtr rootScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeMac>(rootNode());
+    if (!rootScrollingNode)
+        return;
+
+    rootScrollingNode->rubberBandTargetOffsetDidChange();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)


### PR DESCRIPTION
#### 696fd484d40fb67e77715d29e01e431c51f5ffe7
<pre>
Scroll rubberbanding may fail to reveal banner view overlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=308358">https://bugs.webkit.org/show_bug.cgi?id=308358</a>
<a href="https://rdar.apple.com/170860262">rdar://170860262</a>

Reviewed by Abrar Rahman Protyasha.

When a banner view overlay is present and increases in height,
we should rubberband to the new offset, not back to 0. Doing this
universally can lead to unexpected scrolling behavior, so for now,
gate this behavior so that it only works if a rubberband animation
is already occuring.

* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::mainFrameRubberBandTargetOffsetDidChange):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::rubberBandTargetOffsetDidChange):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::rubberBandTargetOffsetDidChange):
* Source/WebCore/platform/RubberbandingState.h:
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::startRubberBandAnimationWithElapsedTime):
(WebCore::ScrollingEffectsController::rubberBandTargetOffsetDidChange):
(WebCore::ScrollingEffectsController::captureRubberbandingState const):
(WebCore::ScrollingEffectsController::restoreRubberbandingState):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::setBannerViewHeight):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::mainFrameRubberBandTargetOffsetDidChange):

Canonical link: <a href="https://commits.webkit.org/308223@main">https://commits.webkit.org/308223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6389738030d531c0dac66cbe1f483257549665f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/152ca2af-84d2-4f68-b46f-271d67dfd8a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113056 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80717 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93801 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/594baa2d-1436-47f8-a525-6e75b11f0c9a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12308 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2838 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157725 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/865 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121063 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121276 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31086 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75019 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8347 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82572 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->