### PR TITLE
Reduce RefPtr operations in ComposedTreeAncestorIterator to improve performance

### DIFF
--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -76,17 +76,17 @@ inline ComposedTreeAncestorIterator::ComposedTreeAncestorIterator(Element& curre
 
 inline CheckedPtr<Element> ComposedTreeAncestorIterator::traverseParent(Node* current)
 {
-    RefPtr parent = current->parentNode();
+    auto* parent = current->parentNode();
     if (!parent)
         return nullptr;
     if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*parent))
         return shadowRoot->host();
-    RefPtr parentElement = dynamicDowncast<Element>(*parent);
+    auto* parentElement = dynamicDowncast<Element>(*parent);
     if (!parentElement)
         return nullptr;
     if (RefPtr shadowRoot = parentElement->shadowRoot())
         return shadowRoot->findAssignedSlot(*current);
-    return parentElement.get();
+    return parentElement;
 }
 
 class ComposedTreeAncestorAdapter {


### PR DESCRIPTION
#### 5fd533ccf7e102c13ed46d0e9e923e226847dd5a
<pre>
Reduce RefPtr operations in ComposedTreeAncestorIterator to improve performance
<a href="https://rdar.apple.com/171145037">rdar://171145037</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308623">https://bugs.webkit.org/show_bug.cgi?id=308623</a>

Reviewed by NOBODY (OOPS!).

WIP.

Convert ComposedTreeAncestorIterator to use a raw pointer instead of a
RefPtr when holding the parent Node on each call to traverseParent(),
which gets called on every iteration.
A/B testing shows this is a small performance win.

This is safe because between when the local raw pointer variable
is instantiated to the end of traverseParent(), we do not call any function
that can free the memory of parent inside traverseParent(),
then try to use parentElement which would cause a use after free.
None of the functions called can potentially mutate the DOM.

This local pointer to the parent does not persist on the ComposedTreeAncestorIterator
object across multiple iterations. It is scoped to
traverseParent(), which is called from operator++.
By the time operator++ returns and the loop body runs,
parent has been destroyed.

* Source/WebCore/dom/ComposedTreeAncestorIterator.h:
(WebCore::ComposedTreeAncestorIterator::traverseParent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fd533ccf7e102c13ed46d0e9e923e226847dd5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100753 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee277b13-414c-4ffc-8701-917a38b7d8c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113559 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80987 "Exiting early after 60 failures. 15371 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89fafe03-a709-4003-9260-f2dbb59fd777) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/903ab404-097e-4c6e-a1fd-d5fd0796f7be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14956 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12740 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158352 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1490 "Found 4 new failures in dom/ComposedTreeAncestorIterator.h") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121586 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121785 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75811 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19437 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83199 "Found 4 new failures in dom/ComposedTreeAncestorIterator.h") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19167 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19318 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->