### PR TITLE
[WPEPlatform] Ignore touch-up and cancel events for previously unseen touch points

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -405,19 +405,19 @@ gboolean ViewPlatform::handleEvent(WPEEvent* event)
 #endif
         return TRUE;
     case WPE_EVENT_TOUCH_UP:
-    case WPE_EVENT_TOUCH_CANCEL: {
+    case WPE_EVENT_TOUCH_CANCEL:
 #if ENABLE(TOUCH_EVENTS)
-        m_touchEvents.set(wpe_event_touch_get_sequence_id(event), event);
-        auto points = touchPointsForEvent(event);
-        m_touchEvents.remove(wpe_event_touch_get_sequence_id(event));
-        page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, WTF::move(points)));
+        if (m_touchEvents.contains(wpe_event_touch_get_sequence_id(event))) {
+            auto points = touchPointsForEvent(event);
+            m_touchEvents.remove(wpe_event_touch_get_sequence_id(event));
+            page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, WTF::move(points)));
+        }
 #endif
         return TRUE;
-    }
     case WPE_EVENT_TOUCH_MOVE:
 #if ENABLE(TOUCH_EVENTS)
-        m_touchEvents.set(wpe_event_touch_get_sequence_id(event), event);
-        page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, touchPointsForEvent(event)));
+        if (m_touchEvents.contains(wpe_event_touch_get_sequence_id(event)))
+            page().handleTouchEvent(nullptr, NativeWebTouchEvent(event, touchPointsForEvent(event)));
 #endif
         return TRUE;
     };


### PR DESCRIPTION
#### 08657ba55498504a4f3cc6d33a7f18878fe479f3
<pre>
[WPEPlatform] Ignore touch-up and cancel events for previously unseen touch points
<a href="https://bugs.webkit.org/show_bug.cgi?id=308628">https://bugs.webkit.org/show_bug.cgi?id=308628</a>

Reviewed by NOBODY (OOPS!).

Skip calling handleTouchEvent() for WPE_EVENT_TOUCH_{UP,CANCEL,MOVE}
events with a sequence identifier (that is: a touch point) that has not
previously been registered as a _DOWN event. This filters out potentially
bogus events that have been provided without the touch-down event needed
to start a correct processing sequence (either by API misuse, or by oddly
functioning hardware), and avoids tripping the logic in WebTouchEvent
that checks whether all in-flight touch point events have been cancelled.

To some extend, the Wayland platform (in WPEWaylandSeat) has similar
checks; but it is better to do this internally so it applies to all
platform implementations. Unfortunately, the checks cannot be removed
from WPEWaylandSeat because it still needs to track the active touch
points in order to provide cancellation for all in-flight touch points
because the list of the active ones is not provided by the compositor.

It may be reasonable to repurpose WPE_EVENT_TOUCH_CANCEL to cancel all
in-flight touch events, without needing to provide one event per touch
point event. This would allow simplifying platform implementations; but
that is left for future consideration.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::handleEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08657ba55498504a4f3cc6d33a7f18878fe479f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100140 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19331 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113073 "Found 4 new test failures: fast/events/touch/basic-single-touch-events.html fast/events/touch/multi-touch-inside-iframes.html fast/events/touch/touch-slider-no-js-touch-listener.html fast/events/touch/touch-slider.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80725 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12327 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2861 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124138 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157748 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/888 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121080 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75043 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16900 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8362 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->