### PR TITLE
Revert TestIPC Swift change

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -416,18 +416,6 @@ GENERATE_SINGLE_SWIFT_INTEROP_FILE = $(GENERATE_SINGLE_SWIFT_INTEROP_FILE_$(WK_G
 GENERATE_SINGLE_SWIFT_INTEROP_FILE_ = ;
 GENERATE_SINGLE_SWIFT_INTEROP_FILE_YES = GENERATE_SINGLE_SWIFT_INTEROP_FILE;
 
-// If (and only if) we've enabled IPC testing (on ASAN and debug builds, typically)
-// also enable testing of a Swift IPC receiver - but only if we're using a sufficiently
-// recent SDK.
-ENABLE_IPC_TESTING_SWIFT = ;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx*] = ENABLE_IPC_TESTING_SWIFT;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx14*] = ;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx15*] = ;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.0*] = ;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.1*] = ;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.2*] = ;
-ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.3*] = ;
-
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
 OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)) $(OTHER_SWIFT_FLAGS_MARK_FOUNDATION_AS_OBJC_$(WK_GENERATE_SINGLE_SWIFT_INTEROP_FILE);


### PR DESCRIPTION
#### 025460e0fccc6e0c4e20c23c29c4b432d7a97db2
<pre>
Revert TestIPC Swift change
<a href="https://bugs.webkit.org/show_bug.cgi?id=308638">https://bugs.webkit.org/show_bug.cgi?id=308638</a>
<a href="https://rdar.apple.com/171164743">rdar://171164743</a>

Unreviewed build revert.

Revert 308195@main, cf19c3da18f8d4eef13ba02a77d80643a6e0b778.
This is causing build failures for some combinations of SDK, for reasons yet to
be determined.

Canonical link: <a href="https://commits.webkit.org/308201@main">https://commits.webkit.org/308201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/825779f8595581f13614bd79c45165e3d01ed12b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155427 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6e0dea0-a565-4bc2-9415-bf197e6620c5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/967fc244-340b-418f-8534-ff3e3a454d81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93828 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c78daee8-2810-41c8-b0f2-44b1e9dffd78) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14563 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2871 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124148 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157758 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121090 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121303 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31064 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131488 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8374 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18858 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82605 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->