### PR TITLE
Web Inspector: Network: Follow-up for Bug 308310 Request / Response menu ignores user’s previous setting

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -118,7 +118,7 @@ WI.Setting = class Setting extends WI.Object
         if (!window.InspectorTest && window.localStorage) {
             let key = WI.Setting._localStorageKeyPrefix + this._name;
             try {
-                if (Object.shallowEqual(this._value, this._defaultValue))
+                if (this._value === this._defaultValue || Object.shallowEqual(this._value, this._defaultValue))
                     window.localStorage.removeItem(key);
                 else
                     window.localStorage.setItem(key, JSON.stringify(this._value));


### PR DESCRIPTION
#### db14f805f786480be3828341eefdc7823cea91de
<pre>
Web Inspector: Network: Follow-up for Bug 308310 Request / Response menu ignores user’s previous setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=308642">https://bugs.webkit.org/show_bug.cgi?id=308642</a>
<a href="https://rdar.apple.com/171168680">rdar://171168680</a>

Reviewed by Devin Rousso.

Replace the singular &quot;resource-content-view-identifier-for-mime-type&quot; setting
with individual settings per mime type.

Remove `WI.ResourceClusterContentView.prototype.attached()` with its logic to show
a prefered or default content view because `WI.ResourceClusterContentView.prototype.restoreFromCookie()`,
which already handles this, is always called.

This view is always shown via the call chain `WI.ContentViewContainer.showBackForwardEntryForIndex()` -&gt; `_showEntry()`
which creates the view, attaches it, then calls `restoreFromCookie()` on it.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
(WI.Setting.prototype.save):

Drive-by: check for equality between primitives (string, number, boolean),
not just shallow equal objects, when determining if the new value and default value
are identical in order to remove the entry from local storage.

* Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js:
(WI.ResourceClusterContentView.prototype._showContentViewForIdentifier):
(WI.ResourceClusterContentView.prototype._pathComponentSelected):
(WI.ResourceClusterContentView.prototype._getPreferredContentViewIdentifier):
(WI.ResourceClusterContentView.prototype._getPreferredContentViewSetting):
(WI.ResourceClusterContentView.prototype._setPreferredContentViewIdentifier):
(WI.ResourceClusterContentView.prototype.async _tryEnableCustomResponseContentViews):
(WI.ResourceClusterContentView):
(WI.ResourceClusterContentView.prototype.attached): Deleted.
(WI.ResourceClusterContentView.prototype.closed): Deleted.
(WI.ResourceClusterContentView.prototype._tryEnableCustomResponseContentViews): Deleted.

Canonical link: <a href="https://commits.webkit.org/308344@main">https://commits.webkit.org/308344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/927b5af78366a07133f3a6b7468bf63c5908d91e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100411 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113271 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80830 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf132114-f9f2-4319-866e-e40bda1c0187) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94027 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8004150-7d72-49c5-b84b-3ecaecf0a817) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14728 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12505 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3121 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158010 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121294 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31165 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75447 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8570 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->