### PR TITLE
Reduce unsafeness in WebCore/html/shadow

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -38,7 +38,6 @@ dom/Node.h
 editing/Editor.h
 html/HTMLMediaElement.cpp
 html/canvas/PlaceholderRenderingContext.cpp
-html/shadow/DateTimeEditElement.h
 inspector/InspectorStyleSheet.h
 inspector/InstrumentingAgents.h
 inspector/PageInspectorController.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -198,10 +198,6 @@ html/parser/HTMLDocumentParser.cpp
 html/parser/HTMLParserScheduler.cpp
 html/parser/HTMLScriptRunner.cpp
 html/parser/HTMLTreeBuilder.cpp
-html/shadow/DateTimeNumericFieldElement.cpp
-html/shadow/DateTimeSymbolicFieldElement.cpp
-html/shadow/SliderThumbElement.cpp
-[ Mac ] html/shadow/TextControlInnerElements.cpp
 inspector/DOMEditor.cpp
 inspector/InspectorAuditAccessibilityObject.cpp
 inspector/InspectorCanvas.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -373,8 +373,6 @@ html/parser/HTMLConstructionSite.cpp
 html/parser/HTMLParserScheduler.cpp
 html/parser/HTMLScriptRunner.cpp
 html/parser/HTMLTreeBuilder.cpp
-html/shadow/MediaControlTextTrackContainerElement.cpp
-[ Mac ] html/shadow/TextControlInnerElements.cpp
 [ Mac ] html/track/VTTCue.cpp
 inspector/DOMEditor.cpp
 inspector/InspectorAuditAccessibilityObject.cpp

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -254,7 +254,7 @@ String BaseDateAndTimeInputType::localizeValue(const String& proposedValue) cons
         return proposedValue;
 
     ASSERT(element());
-    String localized = protect(element())->locale().formatDateTime(*date);
+    String localized = protect(protect(element())->locale())->formatDateTime(*date);
     return localized.isEmpty() ? proposedValue : localized;
 }
 

--- a/Source/WebCore/html/DateInputType.cpp
+++ b/Source/WebCore/html/DateInputType.cpp
@@ -104,7 +104,7 @@ String DateInputType::formatDateTimeFieldsState(const DateTimeFieldsState& state
 
 void DateInputType::setupLayoutParameters(DateTimeEditElement::LayoutParameters& layoutParameters, const DateComponents&) const
 {
-    layoutParameters.dateTimeFormat = layoutParameters.locale.dateFormat();
+    layoutParameters.dateTimeFormat = layoutParameters.locale->dateFormat();
     layoutParameters.fallbackDateTimeFormat = "yyyy-MM-dd"_s;
 }
 

--- a/Source/WebCore/html/DateTimeLocalInputType.cpp
+++ b/Source/WebCore/html/DateTimeLocalInputType.cpp
@@ -135,10 +135,10 @@ void DateTimeLocalInputType::setupLayoutParameters(DateTimeEditElement::LayoutPa
     layoutParameters.shouldHaveMillisecondField = shouldHaveMillisecondField(date);
 
     if (layoutParameters.shouldHaveMillisecondField || shouldHaveSecondField(date)) {
-        layoutParameters.dateTimeFormat = layoutParameters.locale.dateTimeFormatWithSeconds();
+        layoutParameters.dateTimeFormat = layoutParameters.locale->dateTimeFormatWithSeconds();
         layoutParameters.fallbackDateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss"_s;
     } else {
-        layoutParameters.dateTimeFormat = layoutParameters.locale.dateTimeFormatWithoutSeconds();
+        layoutParameters.dateTimeFormat = layoutParameters.locale->dateTimeFormatWithoutSeconds();
         layoutParameters.fallbackDateTimeFormat = "yyyy-MM-dd'T'HH:mm"_s;
     }
 }

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -155,7 +155,7 @@ String MonthInputType::formatDateTimeFieldsState(const DateTimeFieldsState& stat
 
 void MonthInputType::setupLayoutParameters(DateTimeEditElement::LayoutParameters& layoutParameters, const DateComponents&) const
 {
-    layoutParameters.dateTimeFormat = layoutParameters.locale.shortMonthFormat();
+    layoutParameters.dateTimeFormat = layoutParameters.locale->shortMonthFormat();
     layoutParameters.fallbackDateTimeFormat = "yyyy-MM"_s;
 }
 

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -399,7 +399,7 @@ void NumberInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& eve
     auto normalizedText = normalizeFullWidthNumberChars(event.text()).get();
     LOG(Editing, "normalizeFullWidthNumberChars() -> [%s]", normalizedText.utf8().data());
 
-    auto localizedText = protect(element())->locale().convertFromLocalizedNumber(normalizedText);
+    auto localizedText = protect(protect(element())->locale())->convertFromLocalizedNumber(normalizedText);
 
     // If the cleaned up text doesn't match input text, don't insert partial input
     // since it could be an incorrect paste.
@@ -541,7 +541,7 @@ String NumberInputType::localizeValue(const String& proposedValue) const
     if (proposedValue.find(isE) != notFound)
         return proposedValue;
     ASSERT(element());
-    return protect(element())->locale().convertToLocalizedNumber(proposedValue);
+    return protect(protect(element())->locale())->convertToLocalizedNumber(proposedValue);
 }
 
 String NumberInputType::visibleValue() const
@@ -558,7 +558,7 @@ String NumberInputType::convertFromVisibleValue(const String& visibleValue) cons
     if (visibleValue.find(isE) != notFound)
         return visibleValue;
     ASSERT(element());
-    return protect(element())->locale().convertFromLocalizedNumber(visibleValue);
+    return protect(protect(element())->locale())->convertFromLocalizedNumber(visibleValue);
 }
 
 ValueOrReference<String> NumberInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -141,10 +141,10 @@ void TimeInputType::setupLayoutParameters(DateTimeEditElement::LayoutParameters&
     layoutParameters.shouldHaveMillisecondField = shouldHaveMillisecondField(date);
 
     if (layoutParameters.shouldHaveMillisecondField || shouldHaveSecondField(date)) {
-        layoutParameters.dateTimeFormat = layoutParameters.locale.timeFormat();
+        layoutParameters.dateTimeFormat = layoutParameters.locale->timeFormat();
         layoutParameters.fallbackDateTimeFormat = "HH:mm:ss"_s;
     } else {
-        layoutParameters.dateTimeFormat = layoutParameters.locale.shortTimeFormat();
+        layoutParameters.dateTimeFormat = layoutParameters.locale->shortTimeFormat();
         layoutParameters.fallbackDateTimeFormat = "HH:mm"_s;
     }
 }

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -55,6 +55,13 @@ using namespace HTMLNames;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DateTimeEditElement);
 
+DateTimeEditElement::LayoutParameters::LayoutParameters(Locale& locale)
+    : locale(locale)
+{
+}
+
+DateTimeEditElement::LayoutParameters::~LayoutParameters() = default;
+
 class DateTimeEditBuilder final : private DateTimeFormat::TokenHandler {
     WTF_MAKE_NONCOPYABLE(DateTimeEditBuilder);
 
@@ -133,12 +140,12 @@ void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int co
         switch (count) {
         case countForNarrowMonth:
         case countForAbbreviatedMonth: {
-            Ref field = DateTimeSymbolicMonthFieldElement::create(document.get(), m_editElement, fieldType == DateTimeFormat::FieldTypeMonth ? m_parameters.locale.shortMonthLabels() : m_parameters.locale.shortStandAloneMonthLabels());
+            Ref field = DateTimeSymbolicMonthFieldElement::create(document.get(), m_editElement, fieldType == DateTimeFormat::FieldTypeMonth ? m_parameters.locale->shortMonthLabels() : m_parameters.locale->shortStandAloneMonthLabels());
             m_editElement->addField(field);
             return;
         }
         case countForFullMonth: {
-            Ref field = DateTimeSymbolicMonthFieldElement::create(document.get(), m_editElement, fieldType == DateTimeFormat::FieldTypeMonth ? m_parameters.locale.monthLabels() : m_parameters.locale.standAloneMonthLabels());
+            Ref field = DateTimeSymbolicMonthFieldElement::create(document.get(), m_editElement, fieldType == DateTimeFormat::FieldTypeMonth ? m_parameters.locale->monthLabels() : m_parameters.locale->standAloneMonthLabels());
             m_editElement->addField(field);
             return;
         }
@@ -149,7 +156,7 @@ void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int co
     }
 
     case DateTimeFormat::FieldTypePeriod: {
-        m_editElement->addField(DateTimeMeridiemFieldElement::create(document.get(), m_editElement, m_parameters.locale.timeAMPMLabels()));
+        m_editElement->addField(DateTimeMeridiemFieldElement::create(document.get(), m_editElement, m_parameters.locale->timeAMPMLabels()));
         return;
     }
 
@@ -157,7 +164,7 @@ void DateTimeEditBuilder::visitField(DateTimeFormat::FieldType fieldType, int co
         m_editElement->addField(DateTimeSecondFieldElement::create(document.get(), m_editElement));
 
         if (m_parameters.shouldHaveMillisecondField) {
-            visitLiteral(m_parameters.locale.localizedDecimalSeparator());
+            visitLiteral(m_parameters.locale->localizedDecimalSeparator());
             visitField(DateTimeFormat::FieldTypeFractionalSecond, 3);
         }
         return;

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -29,6 +29,7 @@
 #include "DateComponents.h"
 #include "DateTimeFieldElement.h"
 
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -65,13 +66,11 @@ public:
     struct LayoutParameters {
         String dateTimeFormat;
         String fallbackDateTimeFormat;
-        Locale& locale;
+        const CheckedRef<Locale> locale;
         bool shouldHaveMillisecondField { false };
 
-        LayoutParameters(Locale& locale)
-            : locale(locale)
-        {
-        }
+        explicit LayoutParameters(Locale&);
+        ~LayoutParameters();
     };
 
     static Ref<DateTimeEditElement> create(Document&, DateTimeEditElementEditControlOwner&);

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -73,12 +73,13 @@ void DateTimeNumericFieldElement::adjustMinInlineSize(RenderStyle& style) const
     else if (m_range.maximum > 99)
         length = 3;
 
-    auto& locale = localeForOwner();
+    CheckedRef locale = localeForOwner();
 
     float inlineSize = 0;
     for (char c = '0'; c <= '9'; ++c) {
-        auto numberString = locale.convertToLocalizedNumber(makeString(pad(c, length, makeString(c))));
-        inlineSize = std::max(inlineSize, font->width(RenderBlock::constructTextRun(numberString, style)));
+        auto numberString = locale->convertToLocalizedNumber(makeString(pad(c, length, makeString(c))));
+        auto textRun = RenderBlock::constructTextRun(numberString, style);
+        inlineSize = std::max(inlineSize, font->width(protect(textRun)));
     }
 
     style.setLogicalMinWidth(Style::MinimumSize::Fixed { inlineSize / style.usedZoomForLength().value });
@@ -91,13 +92,13 @@ int DateTimeNumericFieldElement::maximum() const
 
 String DateTimeNumericFieldElement::formatValue(int value) const
 {
-    Locale& locale = localeForOwner();
+    CheckedRef locale = localeForOwner();
 
     if (m_range.maximum > 999)
-        return locale.convertToLocalizedNumber(makeString(pad('0', 4, value)));
+        return locale->convertToLocalizedNumber(makeString(pad('0', 4, value)));
     if (m_range.maximum > 99)
-        return locale.convertToLocalizedNumber(makeString(pad('0', 3, value)));
-    return locale.convertToLocalizedNumber(makeString(pad('0', 2, value)));
+        return locale->convertToLocalizedNumber(makeString(pad('0', 3, value)));
+    return locale->convertToLocalizedNumber(makeString(pad('0', 2, value)));
 }
 
 bool DateTimeNumericFieldElement::hasValue() const
@@ -169,7 +170,7 @@ void DateTimeNumericFieldElement::handleKeyboardEvent(KeyboardEvent& keyboardEve
         return;
 
     auto charCode = static_cast<char16_t>(keyboardEvent.charCode());
-    String number = localeForOwner().convertFromLocalizedNumber(span(charCode));
+    String number = protect(localeForOwner())->convertFromLocalizedNumber(span(charCode));
     int digit = number[0] - '0';
     if (digit < 0 || digit > 9)
         return;

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -55,9 +55,10 @@ void DateTimeSymbolicFieldElement::adjustMinInlineSize(RenderStyle& style) const
     CheckedRef font = style.fontCascade();
 
     float inlineSize = 0;
-    for (auto& symbol : m_symbols)
-        inlineSize = std::max(inlineSize, font->width(RenderBlock::constructTextRun(symbol, style)));
-
+    for (auto& symbol : m_symbols) {
+        auto textRun = RenderBlock::constructTextRun(symbol, style);
+        inlineSize = std::max(inlineSize, font->width(protect(textRun)));
+    }
     style.setLogicalMinWidth(Style::MinimumSize::Fixed { inlineSize / style.usedZoomForLength().value });
 }
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -122,8 +122,8 @@ private:
     bool m_needsToGenerateTextTrackRepresentation { false };
     bool m_shouldShowCaptionPreviewCue { false };
 
-    mutable RefPtr<TextTrack> m_previewTrack;
-    mutable RefPtr<VTTCue> m_previewCue;
+    const RefPtr<TextTrack> m_previewTrack;
+    const RefPtr<VTTCue> m_previewCue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -580,10 +580,10 @@ std::optional<Style::UnadjustedStyle> SliderThumbElement::resolveCustomStyle(con
     auto elementStyle = resolveStyle(resolutionContext);
     switch (hostStyle->usedAppearance()) {
     case StyleAppearance::SliderVertical:
-        elementStyle.style->setUsedAppearance(StyleAppearance::SliderThumbVertical);
+        protect(elementStyle.style)->setUsedAppearance(StyleAppearance::SliderThumbVertical);
         break;
     case StyleAppearance::SliderHorizontal:
-        elementStyle.style->setUsedAppearance(StyleAppearance::SliderThumbHorizontal);
+        protect(elementStyle.style)->setUsedAppearance(StyleAppearance::SliderThumbHorizontal);
         break;
     default:
         break;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -140,7 +140,7 @@ std::optional<Style::UnadjustedStyle> TextControlInnerElement::resolveCustomStyl
     // We don't want the shadow DOM to be editable, so we set this block to read-only in case the input itself is editable.
     newStyle->setUserModify(UserModify::ReadOnly);
 
-    if (isStrongPasswordTextField(shadowHost())) {
+    if (isStrongPasswordTextField(protect(shadowHost()))) {
         newStyle->setFlexShrink(0);
         newStyle->setTextOverflow(TextOverflow::Clip);
         newStyle->setOverflowX(Overflow::Hidden);

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -47,8 +47,10 @@
 #include <hb.h>
 #endif
 
-
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LocaleICU);
+
 using namespace icu;
 
 std::unique_ptr<Locale> Locale::create(const AtomString& locale)

--- a/Source/WebCore/platform/text/LocaleICU.h
+++ b/Source/WebCore/platform/text/LocaleICU.h
@@ -34,6 +34,7 @@
 #include <unicode/udat.h>
 #include <unicode/unum.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,31 +43,33 @@ namespace WebCore {
 // We should use this class only for LocalizedNumberICU.cpp, LocalizedDateICU.cpp,
 // and LocalizedNumberICUTest.cpp.
 class LocaleICU final : public Locale {
+    WTF_MAKE_TZONE_ALLOCATED(LocaleICU);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocaleICU);
 public:
     explicit LocaleICU(const char*);
     virtual ~LocaleICU();
 
-    Locale::WritingDirection defaultWritingDirection() const override;
+    Locale::WritingDirection defaultWritingDirection() const final;
 
-    String dateFormat() override;
-    String monthFormat() override;
-    String shortMonthFormat() override;
-    String timeFormat() override;
-    String shortTimeFormat() override;
-    String dateTimeFormatWithSeconds() override;
-    String dateTimeFormatWithoutSeconds() override;
-    const Vector<String>& NODELETE monthLabels() override;
-    const Vector<String>& shortMonthLabels() override;
-    const Vector<String>& standAloneMonthLabels() override;
-    const Vector<String>& shortStandAloneMonthLabels() override;
-    const Vector<String>& timeAMPMLabels() override;
+    String dateFormat() final;
+    String monthFormat() final;
+    String shortMonthFormat() final;
+    String timeFormat() final;
+    String shortTimeFormat() final;
+    String dateTimeFormatWithSeconds() final;
+    String dateTimeFormatWithoutSeconds() final;
+    const Vector<String>& NODELETE monthLabels() final;
+    const Vector<String>& shortMonthLabels() final;
+    const Vector<String>& standAloneMonthLabels() final;
+    const Vector<String>& shortStandAloneMonthLabels() final;
+    const Vector<String>& timeAMPMLabels() final;
 
 private:
 #if !UCONFIG_NO_FORMATTING
     String decimalSymbol(UNumberFormatSymbol);
     String decimalTextAttribute(UNumberFormatTextAttribute);
 #endif
-    void initializeLocaleData() override;
+    void initializeLocaleData() final;
 
     bool initializeShortDateFormat();
     UDateFormat* openDateFormat(UDateFormatStyle timeStyle, UDateFormatStyle dateStyle) const;

--- a/Source/WebCore/platform/text/LocaleNone.cpp
+++ b/Source/WebCore/platform/text/LocaleNone.cpp
@@ -29,24 +29,25 @@
 
 namespace WebCore {
 
-class LocaleNone : public Locale {
+class LocaleNone final : public Locale {
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocaleNone);
 public:
     virtual ~LocaleNone();
 
 private:
     void initializeLocaleData() final;
-    String dateFormat() override;
-    String monthFormat() override;
-    String shortMonthFormat() override;
-    String timeFormat() override;
-    String shortTimeFormat() override;
-    String dateTimeFormatWithSeconds() override;
-    String dateTimeFormatWithoutSeconds() override;
-    const Vector<String>& monthLabels() override;
-    const Vector<String>& shortMonthLabels() override;
-    const Vector<String>& standAloneMonthLabels() override;
-    const Vector<String>& shortStandAloneMonthLabels() override;
-    const Vector<String>& timeAMPMLabels() override;
+    String dateFormat() final;
+    String monthFormat() final;
+    String shortMonthFormat() final;
+    String timeFormat() final;
+    String shortTimeFormat() final;
+    String dateTimeFormatWithSeconds() final;
+    String dateTimeFormatWithoutSeconds() final;
+    const Vector<String>& monthLabels() final;
+    const Vector<String>& shortMonthLabels() final;
+    const Vector<String>& standAloneMonthLabels() final;
+    const Vector<String>& shortStandAloneMonthLabels() final;
+    const Vector<String>& timeAMPMLabels() final;
 
     Vector<String> m_timeAMPMLabels;
     Vector<String> m_shortMonthLabels;

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -60,7 +60,7 @@ private:
     void appendNumber(int number, size_t width);
 
     StringBuilder m_builder;
-    Locale& m_localizer;
+    const CheckedRef<Locale> m_localizer;
     const DateComponents& m_date;
 };
 
@@ -91,7 +91,7 @@ String DateTimeStringBuilder::zeroPadString(const String& string, size_t width)
 void DateTimeStringBuilder::appendNumber(int number, size_t width)
 {
     String zeroPaddedNumberString = zeroPadString(String::number(number), width);
-    m_builder.append(m_localizer.convertToLocalizedNumber(zeroPaddedNumberString));
+    m_builder.append(m_localizer->convertToLocalizedNumber(zeroPaddedNumberString));
 }
 
 void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int numberOfPatternCharacters)
@@ -103,9 +103,9 @@ void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int 
         return;
     case DateTimeFormat::FieldTypeMonth:
         if (numberOfPatternCharacters == 3)
-            m_builder.append(m_localizer.shortMonthLabels()[m_date.month()]);
+            m_builder.append(m_localizer->shortMonthLabels()[m_date.month()]);
         else if (numberOfPatternCharacters == 4)
-            m_builder.append(m_localizer.monthLabels()[m_date.month()]);
+            m_builder.append(m_localizer->monthLabels()[m_date.month()]);
         else {
             // Always use padding width of 2 so it matches DateTimeEditElement.
             appendNumber(m_date.month() + 1, 2);
@@ -113,9 +113,9 @@ void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int 
         return;
     case DateTimeFormat::FieldTypeMonthStandAlone:
         if (numberOfPatternCharacters == 3)
-            m_builder.append(m_localizer.shortStandAloneMonthLabels()[m_date.month()]);
+            m_builder.append(m_localizer->shortStandAloneMonthLabels()[m_date.month()]);
         else if (numberOfPatternCharacters == 4)
-            m_builder.append(m_localizer.standAloneMonthLabels()[m_date.month()]);
+            m_builder.append(m_localizer->standAloneMonthLabels()[m_date.month()]);
         else {
             // Always use padding width of 2 so it matches DateTimeEditElement.
             appendNumber(m_date.month() + 1, 2);
@@ -130,7 +130,7 @@ void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int 
         appendNumber(m_date.week(), 2);
         return;
     case DateTimeFormat::FieldTypePeriod:
-        m_builder.append(m_localizer.timeAMPMLabels()[(m_date.hour() >= 12 ? 1 : 0)]);
+        m_builder.append(m_localizer->timeAMPMLabels()[(m_date.hour() >= 12 ? 1 : 0)]);
         return;
     case DateTimeFormat::FieldTypeHour12: {
         int hour12 = m_date.hour() % 12;
@@ -161,7 +161,7 @@ void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int 
         else {
             double second = m_date.second() + m_date.millisecond() / 1000.0;
             String zeroPaddedSecondString = zeroPadString(String::numberToStringFixedWidth(second, 3), numberOfPatternCharacters + 4);
-            m_builder.append(m_localizer.convertToLocalizedNumber(zeroPaddedSecondString));
+            m_builder.append(m_localizer->convertToLocalizedNumber(zeroPaddedSecondString));
         }
         return;
     default:

--- a/Source/WebCore/platform/text/PlatformLocale.h
+++ b/Source/WebCore/platform/text/PlatformLocale.h
@@ -23,9 +23,9 @@
  * DAMAGE.
  */
 
-#ifndef PlatformLocale_h
-#define PlatformLocale_h
+#pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Language.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
@@ -39,9 +39,10 @@ class DateComponents;
 class FontCascade;
 #endif
 
-class Locale {
+class Locale : public CanMakeCheckedPtr<Locale> {
     WTF_MAKE_TZONE_ALLOCATED(Locale);
     WTF_MAKE_NONCOPYABLE(Locale);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Locale);
 
 public:
     WEBCORE_EXPORT static std::unique_ptr<Locale> create(const AtomString& localeIdentifier);
@@ -161,5 +162,4 @@ inline std::unique_ptr<Locale> Locale::createDefault()
     return Locale::create(AtomString { defaultLanguage() });
 }
 
-}
-#endif
+} // namespace WebCore

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
@@ -54,33 +54,34 @@ class DateComponents;
 
 class LocaleCocoa final : public Locale {
     WTF_MAKE_TZONE_ALLOCATED(LocaleCocoa);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocaleCocoa);
 public:
     explicit LocaleCocoa(const AtomString&);
     ~LocaleCocoa();
 
-    Locale::WritingDirection defaultWritingDirection() const override;
+    Locale::WritingDirection defaultWritingDirection() const final;
 
-    String formatDateTime(const DateComponents&, FormatType = FormatTypeUnspecified) override;
+    String formatDateTime(const DateComponents&, FormatType = FormatTypeUnspecified) final;
 
-    String dateFormat() override;
-    String monthFormat() override;
-    String shortMonthFormat() override;
-    String timeFormat() override;
-    String shortTimeFormat() override;
-    String dateTimeFormatWithSeconds() override;
-    String dateTimeFormatWithoutSeconds() override;
-    const Vector<String>& monthLabels() override;
-    const Vector<String>& shortMonthLabels() override;
-    const Vector<String>& standAloneMonthLabels() override;
-    const Vector<String>& shortStandAloneMonthLabels() override;
-    const Vector<String>& timeAMPMLabels() override;
+    String dateFormat() final;
+    String monthFormat() final;
+    String shortMonthFormat() final;
+    String timeFormat() final;
+    String shortTimeFormat() final;
+    String dateTimeFormatWithSeconds() final;
+    String dateTimeFormatWithoutSeconds() final;
+    const Vector<String>& monthLabels() final;
+    const Vector<String>& shortMonthLabels() final;
+    const Vector<String>& standAloneMonthLabels() final;
+    const Vector<String>& shortStandAloneMonthLabels() final;
+    const Vector<String>& timeAMPMLabels() final;
 
     static RetainPtr<CFStringRef> canonicalLanguageIdentifierFromString(const AtomString&);
     static void releaseMemory();
 
 private:
     RetainPtr<NSDateFormatter> shortDateFormatter();
-    void initializeLocaleData() override;
+    void initializeLocaleData() final;
 
     RetainPtr<NSLocale> m_locale;
     RetainPtr<NSCalendar> m_gregorianCalendar;

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -266,8 +266,8 @@ Ref<JSON::Object> WebExtensionLocalization::predefinedMessages()
         return object;
     };
 
-    if (m_locale && !m_localeString.isEmpty()) {
-        if (m_locale->defaultWritingDirection() == WebCore::Locale::WritingDirection::LeftToRight) {
+    if (CheckedPtr locale = m_locale.get(); locale && !m_localeString.isEmpty()) {
+        if (locale->defaultWritingDirection() == WebCore::Locale::WritingDirection::LeftToRight) {
             predefinedMessages->setObject(predefinedMessageLanguageDirection, createMessageKey(predefinedMessageValueLeftToRight));
             predefinedMessages->setObject(predefinedMessageLanguageDirectionReversed, createMessageKey(predefinedMessageValueRightToLeft));
             predefinedMessages->setObject(predefinedMessageTextLeadingEdge, createMessageKey(predefinedMessageValueTextEdgeLeft));


### PR DESCRIPTION
#### 89ea283a564e0e8b018b51bc52948d252531914d
<pre>
Reduce unsafeness in WebCore/html/shadow
<a href="https://bugs.webkit.org/show_bug.cgi?id=308644">https://bugs.webkit.org/show_bug.cgi?id=308644</a>

Reviewed by Ryosuke Niwa.

As per <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/308275@main">https://commits.webkit.org/308275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b31fd6f7082963168c146cd297d08c1e89c8ebc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155647 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113241 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93998 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14699 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3089 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157978 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121264 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121466 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131710 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17038 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82817 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18792 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->