### PR TITLE
[WPEPlatform] Page scrolls at double speed when scrolling with two fingers

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -430,7 +430,8 @@ void ViewPlatform::handleGesture(WPEEvent* event)
     if (!gestureController)
         return;
 
-    wpe_gesture_controller_handle_event(gestureController, event);
+    if (!wpe_gesture_controller_handle_event(gestureController, event))
+        return;
 
     if (wpe_event_get_event_type(event) == WPE_EVENT_TOUCH_DOWN)
         return;

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp
@@ -49,14 +49,17 @@ static void wpe_gesture_controller_default_init(WPEGestureControllerInterface*)
  * @event: a #WPEEvent
  *
  * Get the gesture detected by @controller if any was detected during processing of @event.
+ * 
+ * Returns: %TRUE if @event was handled by @controller and gesture information is updated,
+ *    or %FALSE otherwise.
  */
-void wpe_gesture_controller_handle_event(WPEGestureController* controller, WPEEvent* event)
+gboolean wpe_gesture_controller_handle_event(WPEGestureController* controller, WPEEvent* event)
 {
-    g_return_if_fail(controller);
-    g_return_if_fail(event);
+    g_return_val_if_fail(controller, FALSE);
+    g_return_val_if_fail(event, FALSE);
 
     auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
-    controllerInterface->handle_event(controller, event);
+    return controllerInterface->handle_event(controller, event);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureController.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureController.h
@@ -57,7 +57,7 @@ struct _WPEGestureControllerInterface
 {
     GTypeInterface parent_interface;
 
-    void        (* handle_event)         (WPEGestureController *controller,
+    gboolean    (* handle_event)         (WPEGestureController *controller,
                                           WPEEvent             *event );
     void        (* cancel)               (WPEGestureController *controller);
     WPEGesture  (* get_gesture)          (WPEGestureController *controller);
@@ -70,7 +70,7 @@ struct _WPEGestureControllerInterface
     gboolean    (* is_drag_begin)        (WPEGestureController *controller);
 };
 
-WPE_API void        wpe_gesture_controller_handle_event         (WPEGestureController *controller,
+WPE_API gboolean    wpe_gesture_controller_handle_event         (WPEGestureController *controller,
                                                                  WPEEvent             *event);
 WPE_API void        wpe_gesture_controller_cancel               (WPEGestureController *controller);
 WPE_API WPEGesture  wpe_gesture_controller_get_gesture          (WPEGestureController *controller);

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.cpp
@@ -39,9 +39,9 @@ WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
     WPEGestureControllerImpl, wpe_gesture_controller_impl, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WPE_TYPE_GESTURE_CONTROLLER, wpe_gesture_controller_interface_init))
 
-static void wpeHandleEvent(WPEGestureController* controller, WPEEvent* event)
+static gboolean wpeHandleEvent(WPEGestureController* controller, WPEEvent* event)
 {
-    WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.handleEvent(event);
+    return WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.handleEvent(event);
 }
 
 static void wpeCancel(WPEGestureController* controller)

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp
@@ -32,10 +32,10 @@
 
 namespace WPE {
 
-void GestureDetector::handleEvent(WPEEvent* event)
+bool GestureDetector::handleEvent(WPEEvent* event)
 {
     if (m_sequenceId && *m_sequenceId != wpe_event_touch_get_sequence_id(event))
-        return;
+        return false;
 
     switch (wpe_event_get_event_type(event)) {
     case WPE_EVENT_TOUCH_DOWN:
@@ -50,6 +50,8 @@ void GestureDetector::handleEvent(WPEEvent* event)
         reset();
         break;
     case WPE_EVENT_TOUCH_MOVE:
+        if (!m_sequenceId)
+            return false;
         if (double x, y; wpe_event_get_position(event, &x, &y) && m_position) {
             auto* settings = wpe_display_get_settings(wpe_view_get_display(wpe_event_get_view(event)));
             auto dragActivationThresholdPx = wpe_settings_get_uint32(settings, WPE_SETTING_DRAG_THRESHOLD, nullptr);
@@ -67,6 +69,8 @@ void GestureDetector::handleEvent(WPEEvent* event)
             reset();
         break;
     case WPE_EVENT_TOUCH_UP:
+        if (!m_sequenceId)
+            return false;
         if (double x, y; wpe_event_get_position(event, &x, &y) && m_position) {
             if (m_gesture == WPE_GESTURE_DRAG)
                 m_delta = { x - m_nextDeltaReferencePosition->x, y - m_nextDeltaReferencePosition->y };
@@ -77,6 +81,8 @@ void GestureDetector::handleEvent(WPEEvent* event)
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
+
+    return true;
 }
 
 void GestureDetector::reset()

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h
@@ -32,7 +32,7 @@ namespace WPE {
 
 class GestureDetector final {
 public:
-    void handleEvent(WPEEvent*);
+    bool handleEvent(WPEEvent*);
     WPEGesture gesture() const { return m_gesture; }
     void reset();
 


### PR DESCRIPTION
#### f0af1daa9de5f0fd5f83815a89c5c585478c68b0
<pre>
[WPEPlatform] Page scrolls at double speed when scrolling with two fingers
<a href="https://bugs.webkit.org/show_bug.cgi?id=308643">https://bugs.webkit.org/show_bug.cgi?id=308643</a>

Reviewed by Carlos Garcia Campos.

When scrolling begins with one finger and a second finger is placed on
the screen and both fingers move together, the page scrolls at twice the
expected speed.

`WPEGestureDetector` only tracks the first touch sequence and ignores
events from other sequences. However, `handleGesture()` did not check
whether the event was actually processed and always proceeded to emit a
scroll event based on the current gesture state. As a result, touch move
events from the second finger triggered a second scroll event, doubling
the scroll speed.

Fixed by making `wpe_gesture_controller_handle_event()` return a boolean
indicating whether the event was consumed.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::handleGesture):
* Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp:
(wpe_gesture_controller_handle_event):
* Source/WebKit/WPEPlatform/wpe/WPEGestureController.h:
* Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.cpp:
(wpeHandleEvent):
* Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp:
(WPE::GestureDetector::handleEvent):
* Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h:

Canonical link: <a href="https://commits.webkit.org/308271@main">https://commits.webkit.org/308271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b81705a615e986ab9808785912410fd7e3d24f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100172 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12353 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2891 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124176 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157778 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121107 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31120 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75119 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8396 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82637 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18608 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->