### PR TITLE
[GStreamer][MediaStream] setSinkId breaks WEBKIT_GST_ENABLE_AUDIO_MIXER=1

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -44,50 +44,99 @@ GStreamerAudioMixer& GStreamerAudioMixer::singleton()
 GStreamerAudioMixer::GStreamerAudioMixer()
 {
     GST_DEBUG_CATEGORY_INIT(webkit_media_gst_audio_mixer_debug, "webkitaudiomixer", 0, "WebKit GStreamer audio mixer");
-    m_pipeline = gst_element_factory_make("pipeline", "webkitaudiomixer");
-    registerActivePipeline(m_pipeline);
-    connectSimpleBusMessageCallback(m_pipeline.get());
-
-    m_mixer = makeGStreamerElement("audiomixer"_s);
-    auto* audioSink = createAutoAudioSink({ });
-
-    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_mixer.get(), audioSink, nullptr);
-    gst_element_link(m_mixer.get(), audioSink);
-    gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
 }
 
-void GStreamerAudioMixer::ensureState(GstStateChange stateChange)
+GStreamerAudioMixer::MixerPipeline& GStreamerAudioMixer::ensureMixerPipeline(DataMutexLocker<StreamingMembers>& locker, const String& deviceId, const GRefPtr<GstDevice>& device)
 {
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Handling %s transition (%u mixer pads)", gst_state_change_get_name(stateChange), m_mixer->numsinkpads);
+    auto result = locker->m_pipelines.find(deviceId);
+    if (result != locker->m_pipelines.end()) {
+        // Cancel any pending teardown since a new producer is registering.
+        result->value->teardownTimer.stop();
+        return *result->value;
+    }
+
+    auto pipelineName = makeString("webkitaudiomixer-"_s, deviceId);
+    GRefPtr<GstElement> pipeline = gst_element_factory_make("pipeline", pipelineName.utf8().data());
+    registerActivePipeline(pipeline);
+    connectSimpleBusMessageCallback(pipeline.get());
+
+    auto* mixer = makeGStreamerElement("audiomixer"_s);
+
+    // Use a device-specific sink if a GstDevice is provided, otherwise fall back to autoaudiosink.
+    GstElement* audioSink;
+    if (device)
+        audioSink = gst_device_create_element(device.get(), "audio-output-sink");
+    else
+        audioSink = createAutoAudioSink({ });
+
+    gst_bin_add_many(GST_BIN_CAST(pipeline.get()), mixer, audioSink, nullptr);
+    gst_element_link(mixer, audioSink);
+    gst_element_set_state(pipeline.get(), GST_STATE_READY);
+
+    GST_DEBUG_OBJECT(pipeline.get(), "Created mixer pipeline for device '%s'.", deviceId.utf8().data());
+    auto mp = std::unique_ptr<MixerPipeline>(new MixerPipeline {
+        WTF::move(pipeline),
+        GRefPtr<GstElement>(mixer),
+        RunLoop::Timer(RunLoop::mainSingleton(), "GStreamerAudioMixer::TeardownTimer"_s, [deviceId] { GStreamerAudioMixer::singleton().teardownPipeline(deviceId); })
+    });
+    auto addResult = locker->m_pipelines.set(deviceId, WTF::move(mp));
+    return *addResult.iterator->value;
+}
+
+void GStreamerAudioMixer::teardownPipeline(const String& deviceId)
+{
+    DataMutexLocker locker { m_streamingMembers };
+    auto it = locker->m_pipelines.find(deviceId);
+    RELEASE_ASSERT(it != locker->m_pipelines.end());
+
+    auto& mp = *it->value;
+    ASSERT(!mp.mixer->numsinkpads);
+    GST_DEBUG_OBJECT(mp.pipeline.get(), "Teardown timeout reached, destroying idle pipeline for device '%s'.", deviceId.utf8().data());
+    unregisterPipeline(mp.pipeline);
+    gst_element_set_state(mp.pipeline.get(), GST_STATE_NULL);
+    locker->m_pipelines.remove(deviceId);
+}
+
+void GStreamerAudioMixer::ensureState(GstStateChange stateChange, const String& deviceId)
+{
+    auto resolvedDeviceId = deviceId.isEmpty() ? "default"_s : deviceId;
+    DataMutexLocker locker { m_streamingMembers };
+    auto it = locker->m_pipelines.find(resolvedDeviceId);
+    RELEASE_ASSERT(it != locker->m_pipelines.end());
+    auto& mp = *it->value;
+
+    GST_DEBUG_OBJECT(mp.pipeline.get(), "Handling %s transition (%u mixer pads).", gst_state_change_get_name(stateChange), mp.mixer->numsinkpads);
 
     switch (stateChange) {
     case GST_STATE_CHANGE_READY_TO_PAUSED:
-        gst_element_set_state(m_pipeline.get(), GST_STATE_PAUSED);
+        gst_element_set_state(mp.pipeline.get(), GST_STATE_PAUSED);
         break;
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
-        gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
+        gst_element_set_state(mp.pipeline.get(), GST_STATE_PLAYING);
         break;
     case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-        if (m_mixer->numsinkpads == 1)
-            gst_element_set_state(m_pipeline.get(), GST_STATE_PAUSED);
+        if (mp.mixer->numsinkpads == 1)
+            gst_element_set_state(mp.pipeline.get(), GST_STATE_PAUSED);
         break;
     case GST_STATE_CHANGE_PAUSED_TO_READY:
-        if (m_mixer->numsinkpads == 1)
-            gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
+        if (mp.mixer->numsinkpads == 1)
+            gst_element_set_state(mp.pipeline.get(), GST_STATE_READY);
         break;
     case GST_STATE_CHANGE_READY_TO_NULL:
-        if (m_mixer->numsinkpads == 1) {
-            unregisterPipeline(m_pipeline);
-            gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
-        }
+        if (mp.mixer->numsinkpads == 1)
+            mp.teardownTimer.startOneShot(s_teardownTimeout);
         break;
     default:
         break;
     }
 }
 
-GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink, std::optional<int> forcedSampleRate)
+GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink, std::optional<int> forcedSampleRate, const String& deviceId, const GRefPtr<GstDevice>& device)
 {
+    auto resolvedDeviceId = deviceId.isEmpty() ? "default"_s : deviceId;
+    DataMutexLocker locker { m_streamingMembers };
+    auto& mp = ensureMixerPipeline(locker, resolvedDeviceId, device);
+
     GstElement* src = makeGStreamerElement("interaudiosrc"_s, unsafeSpan(GST_ELEMENT_NAME(interaudioSink)));
 
     g_object_set(src, "channel", GST_ELEMENT_NAME(interaudioSink), nullptr);
@@ -112,58 +161,78 @@ GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink
     if (auto pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SINK)))
         gst_element_add_pad(GST_ELEMENT_CAST(bin), gst_ghost_pad_new("sink", pad.get()));
 
-    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), src, bin, nullptr);
+    gst_bin_add_many(GST_BIN_CAST(mp.pipeline.get()), src, bin, nullptr);
     gst_element_link(src, bin);
 
-    bool shouldStart = !m_mixer->numsinkpads;
+    bool shouldStart = !mp.mixer->numsinkpads;
 
-    auto mixerPad = adoptGRef(gst_element_request_pad_simple(m_mixer.get(), "sink_%u"));
+    auto mixerPad = adoptGRef(gst_element_request_pad_simple(mp.mixer.get(), "sink_%u"));
     auto srcPad = adoptGRef(gst_element_get_static_pad(bin, "src"));
     gst_pad_link(srcPad.get(), mixerPad.get());
 
     if (shouldStart)
-        gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
+        gst_element_set_state(mp.pipeline.get(), GST_STATE_READY);
     else
-        gst_bin_sync_children_states(GST_BIN_CAST(m_pipeline.get()));
+        gst_bin_sync_children_states(GST_BIN_CAST(mp.pipeline.get()));
 
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Registered audio producer %" GST_PTR_FORMAT, mixerPad.get());
-    dumpBinToDotFile(m_pipeline, "audio-mixer-after-producer-registration"_s);
+    locker->m_padToDeviceId.set(mixerPad.get(), resolvedDeviceId);
+
+    GST_DEBUG_OBJECT(mp.pipeline.get(), "Registered audio producer %" GST_PTR_FORMAT, mixerPad.get());
+    dumpBinToDotFile(mp.pipeline.get(), "audio-mixer-after-producer-registration"_s);
     return mixerPad;
 }
 
 void GStreamerAudioMixer::unregisterProducer(const GRefPtr<GstPad>& mixerPad)
 {
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Unregistering audio producer %" GST_PTR_FORMAT, mixerPad.get());
+    DataMutexLocker locker { m_streamingMembers };
+    auto it = locker->m_padToDeviceId.find(mixerPad.get());
+    RELEASE_ASSERT(it != locker->m_padToDeviceId.end());
+    auto deviceId = it->value;
+
+    auto pipelineIt = locker->m_pipelines.find(deviceId);
+    RELEASE_ASSERT(pipelineIt != locker->m_pipelines.end());
+    auto& mp = *pipelineIt->value;
+
+    GST_DEBUG_OBJECT(mp.pipeline.get(), "Unregistering audio producer %" GST_PTR_FORMAT " from device '%s'.", mixerPad.get(), deviceId.utf8().data());
 
     auto peer = adoptGRef(gst_pad_get_peer(mixerPad.get()));
     auto bin = adoptGRef(gst_pad_get_parent_element(peer.get()));
     auto sinkPad = adoptGRef(gst_element_get_static_pad(bin.get(), "sink"));
     auto srcPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
     auto interaudioSrc = adoptGRef(gst_pad_get_parent_element(srcPad.get()));
-    GST_LOG_OBJECT(m_pipeline.get(), "interaudiosrc: %" GST_PTR_FORMAT, interaudioSrc.get());
+    GST_LOG_OBJECT(mp.pipeline.get(), "interaudiosrc: %" GST_PTR_FORMAT, interaudioSrc.get());
 
     gstElementLockAndSetState(interaudioSrc.get(), GST_STATE_NULL);
     gstElementLockAndSetState(bin.get(), GST_STATE_NULL);
     gst_pad_unlink(peer.get(), mixerPad.get());
     gst_element_unlink(interaudioSrc.get(), bin.get());
 
-    gst_element_release_request_pad(m_mixer.get(), mixerPad.get());
+    gst_element_release_request_pad(mp.mixer.get(), mixerPad.get());
 
-    gst_bin_remove_many(GST_BIN_CAST(m_pipeline.get()), interaudioSrc.get(), bin.get(), nullptr);
+    gst_bin_remove_many(GST_BIN_CAST(mp.pipeline.get()), interaudioSrc.get(), bin.get(), nullptr);
 
-    if (!m_mixer->numsinkpads)
-        gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+    locker->m_padToDeviceId.remove(mixerPad.get());
 
-    dumpBinToDotFile(m_pipeline, "audio-mixer-after-producer-unregistration"_s);
+    // When no more producers remain, move to PAUSED and schedule deferred teardown.
+    if (!mp.mixer->numsinkpads) {
+        gst_element_set_state(mp.pipeline.get(), GST_STATE_PAUSED);
+        mp.teardownTimer.startOneShot(s_teardownTimeout);
+        GST_DEBUG_OBJECT(mp.pipeline.get(), "No producers left for device '%s', paused pipeline; teardown in %.0f seconds.", deviceId.utf8().data(), s_teardownTimeout.seconds());
+        dumpBinToDotFile(mp.pipeline.get(), "audio-mixer-after-producer-unregistration"_s);
+    }
 }
 
 void GStreamerAudioMixer::configureSourcePeriodTime(CStringView sourceName, uint64_t periodTime)
 {
-    auto src = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), sourceName.utf8()));
-    if (!src) [[unlikely]]
-        return;
+    DataMutexLocker locker { m_streamingMembers };
+    for (auto& [deviceId, mp] : locker->m_pipelines) {
+        auto src = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(mp->pipeline.get()), sourceName.utf8()));
+        if (!src)
+            continue;
 
-    g_object_set(src.get(), "period-time", periodTime, nullptr);
+        g_object_set(src.get(), "period-time", periodTime, nullptr);
+        return;
+    }
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h
@@ -22,8 +22,13 @@
 #if USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
+#include <wtf/DataMutex.h>
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/RunLoop.h>
+#include <wtf/Seconds.h>
 #include <wtf/text/CStringView.h>
+#include <wtf/text/StringHash.h>
 
 namespace WebCore {
 
@@ -33,8 +38,8 @@ public:
     static bool isAvailable();
     static GStreamerAudioMixer& singleton();
 
-    void ensureState(GstStateChange);
-    GRefPtr<GstPad> registerProducer(GstElement*, std::optional<int> forcedSampleRate);
+    void ensureState(GstStateChange, const String& deviceId = { });
+    GRefPtr<GstPad> registerProducer(GstElement*, std::optional<int> forcedSampleRate, const String& deviceId = { }, const GRefPtr<GstDevice>& = nullptr);
     void unregisterProducer(const GRefPtr<GstPad>&);
 
     void configureSourcePeriodTime(CStringView sourceName, uint64_t periodTime);
@@ -42,8 +47,22 @@ public:
 private:
     GStreamerAudioMixer();
 
-    GRefPtr<GstElement> m_pipeline;
-    GRefPtr<GstElement> m_mixer;
+    struct MixerPipeline {
+        GRefPtr<GstElement> pipeline;
+        GRefPtr<GstElement> mixer;
+        RunLoop::Timer teardownTimer;
+    };
+
+    struct StreamingMembers {
+        HashMap<String, std::unique_ptr<MixerPipeline>> m_pipelines;
+        HashMap<GstPad*, String> m_padToDeviceId; // Reverse lookup: pad → deviceId.
+    };
+
+    MixerPipeline& ensureMixerPipeline(DataMutexLocker<StreamingMembers>&, const String& deviceId, const GRefPtr<GstDevice>&);
+    void teardownPipeline(const String& deviceId);
+
+    static constexpr Seconds s_teardownTimeout = 60_s;
+    DataMutex<StreamingMembers> m_streamingMembers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1160,21 +1160,25 @@ IGNORE_WARNINGS_END
             g_object_set(object, "client-name", clientName.ascii().data(), nullptr);
         }
     }), role.isolatedCopy().releaseImpl().leakRef(), static_cast<GClosureNotify>([](gpointer userData, GClosure*) {
-        reinterpret_cast<StringImpl*>(userData)->deref();
+        if (auto* roleImpl = reinterpret_cast<StringImpl*>(userData))
+            roleImpl->deref();
     }), static_cast<GConnectFlags>(0));
     ASSERT(g_object_is_floating(audioSink));
     return audioSink;
 }
 
-GstElement* /* (transfer floating) */ createPlatformAudioSink(const String& role)
+GstElement* /* (transfer floating) */ createPlatformAudioSink(const String& role, const String& deviceId, const GRefPtr<GstDevice>& device)
 {
-    GstElement* audioSink = webkitAudioSinkNew(role);
+    GstElement* audioSink = webkitAudioSinkNew(role, deviceId, device);
     if (!audioSink) {
         // This means the WebKit audio sink configuration failed. It can happen for the following reasons:
         // - audio mixing was not requested using the WEBKIT_GST_ENABLE_AUDIO_MIXER
         // - audio mixing was requested using the WEBKIT_GST_ENABLE_AUDIO_MIXER but the audio mixer
         //   runtime requirements are not fullfilled.
-        audioSink = createAutoAudioSink(role);
+        if (device)
+            audioSink = gst_device_create_element(device.get(), "audio-output-sink");
+        else
+            audioSink = createAutoAudioSink(role);
     }
 
     return audioSink;
@@ -2259,7 +2263,8 @@ void dumpBinToDotFile(GstBin* bin, const String& filename, GstDebugGraphDetails 
     if (!bin) [[unlikely]]
         return;
 
-    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(bin, details, filename.utf8().data());
+    auto sanitizedFilename = makeStringByReplacingAll(filename, '/', '-');
+    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(bin, details, sanitizedFilename.utf8().data());
 }
 
 void dumpBinToDotFile(const GRefPtr<GstElement>& element, const String& filename, GstDebugGraphDetails details)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -289,7 +289,7 @@ bool isGStreamerPluginAvailable(ASCIILiteral name);
 bool gstElementFactoryEquals(GstElement*, ASCIILiteral name);
 
 GstElement* createAutoAudioSink(const String& role);
-GstElement* createPlatformAudioSink(const String& role);
+GstElement* createPlatformAudioSink(const String& role, const String& deviceId = { }, const GRefPtr<GstDevice>& = { });
 
 bool webkitGstSetElementStateSynchronously(GstElement*, GstState, Function<bool(GstMessage*)>&& = [](GstMessage*) -> bool {
     return true;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1561,40 +1561,20 @@ GstElement* MediaPlayerPrivateGStreamer::createAudioSink()
     if (!player)
         return nullptr;
 
-    // For platform specific audio sinks, they need to be properly upranked so that they get properly autoplugged.
-
+    auto role = player->isVideoPlayer() ? "video"_s : "music"_s;
     GstElement* audioSink = nullptr;
 
 #if ENABLE(MEDIA_STREAM)
     auto deviceId = player->audioOutputDeviceId();
     if (!deviceId.isEmpty()) {
-        GST_DEBUG("createAudioSink: audioOutputDeviceId='%s', attempting device-specific sink", deviceId.utf8().data());
-        if (deviceId == "default"_s) {
-            const auto& devices = GStreamerAudioCaptureDeviceManager::singleton().speakerDevices();
-            if (!devices.isEmpty()) [[likely]] {
-                const auto defaultDeviceIndex = devices.findIf([](const CaptureDevice& device) {
-                    return device.isDefault();
-                });
-                deviceId = defaultDeviceIndex == notFound ? devices.first().persistentId() : devices[defaultDeviceIndex].persistentId();
-                GST_DEBUG("createAudioSink: default device is '%s'", deviceId.utf8().data());
-            }
-        }
-        if (auto captureDevice = GStreamerAudioCaptureDeviceManager::singleton().gstreamerDeviceWithUID(deviceId)) {
-            auto* device = captureDevice->device();
-            audioSink = gst_device_create_element(device, "audio-output-sink");
-            if (audioSink)
-                GST_DEBUG("createAudioSink: created '%s' (type=%s)", GST_ELEMENT_NAME(audioSink), G_OBJECT_TYPE_NAME(audioSink));
-            else
-                GST_WARNING("createAudioSink: gst_device_create_element failed, falling back to platform sink");
-        } else
-            GST_WARNING("createAudioSink: could not find GstDevice for '%s', falling back to platform sink", deviceId.utf8().data());
+        auto [resolvedId, device] = resolveAudioOutputDevice(deviceId);
+        if (device)
+            audioSink = createPlatformAudioSink(role, resolvedId, device);
     }
 #endif
 
-    if (!audioSink) {
-        auto role = player->isVideoPlayer() ? "video"_s : "music"_s;
+    if (!audioSink)
         audioSink = createPlatformAudioSink(role);
-    }
     RELEASE_ASSERT(audioSink);
     if (!audioSink)
         return nullptr;
@@ -4758,13 +4738,37 @@ void MediaPlayerPrivateGStreamer::checkPlayingConsistency()
     }
 }
 
-bool MediaPlayerPrivateGStreamer::applyAudioSinkDevice(GstElement* audioSink, GstDevice* device)
+#if ENABLE(MEDIA_STREAM)
+std::pair<String, GRefPtr<GstDevice>> MediaPlayerPrivateGStreamer::resolveAudioOutputDevice(const String& deviceId)
+{
+    auto resolvedId = deviceId;
+    if (resolvedId == "default"_s) {
+        const auto& devices = GStreamerAudioCaptureDeviceManager::singleton().speakerDevices();
+        if (!devices.isEmpty()) [[likely]] {
+            const auto idx = devices.findIf([](const CaptureDevice& device) {
+                return device.isDefault();
+            });
+            resolvedId = idx == notFound ? devices.first().persistentId() : devices[idx].persistentId();
+        }
+    }
+    GRefPtr<GstDevice> device;
+    if (auto captureDevice = GStreamerAudioCaptureDeviceManager::singleton().gstreamerDeviceWithUID(resolvedId))
+        device = captureDevice->device();
+    return { resolvedId, device };
+}
+#endif
+
+bool MediaPlayerPrivateGStreamer::applyAudioSinkDevice(GstElement* audioSink, const GRefPtr<GstDevice>& device, const String& deviceId)
 {
     bool changed = false;
 
+    // Handle mixer-based audio sink: switch the mixer pipeline.
+    if (WEBKIT_IS_AUDIO_SINK(audioSink))
+        return webkitAudioSinkSetDevice(audioSink, deviceId, device);
+
     if (GST_IS_BIN(audioSink)) {
         for (auto* element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_sinks(GST_BIN_CAST(audioSink)))) {
-            if (applyAudioSinkDevice(element, device))
+            if (applyAudioSinkDevice(element, device, deviceId))
                 changed = true;
         }
         return changed;
@@ -4781,8 +4785,8 @@ bool MediaPlayerPrivateGStreamer::applyAudioSinkDevice(GstElement* audioSink, Gs
 #endif
     }
 
-    changed = !!gst_device_reconfigure_element(device, audioSink);
-    GST_DEBUG_OBJECT(pipeline(), "%s element '%s' with device %s<%p>", changed ? "Reconfigured" : "Skipped", GST_ELEMENT_NAME(audioSink), GST_OBJECT_NAME(device), device);
+    changed = !!gst_device_reconfigure_element(device.get(), audioSink);
+    GST_DEBUG_OBJECT(pipeline(), "%s element '%s' with device %s<%p>.", changed ? "Reconfigured" : "Skipped", GST_ELEMENT_NAME(audioSink), GST_OBJECT_NAME(device.get()), device.get());
     return changed;
 }
 
@@ -4795,31 +4799,27 @@ void MediaPlayerPrivateGStreamer::audioOutputDeviceChanged()
 
     auto* sink = audioSink();
     if (!sink) {
-        GST_DEBUG_OBJECT(pipeline(), "No audio sink, skipping audio output device change");
+        GST_DEBUG_OBJECT(pipeline(), "No audio sink, skipping audio output device change.");
         return;
     }
 
     auto deviceId = player->audioOutputDeviceId();
-    if (deviceId == "default"_s) {
-        const auto& devices = GStreamerAudioCaptureDeviceManager::singleton().speakerDevices();
-        if (!devices.isEmpty()) [[likely]] {
-            const auto defaultDeviceIndex = devices.findIf([](const CaptureDevice& device) {
-                return device.isDefault();
-            });
-            deviceId = (defaultDeviceIndex == notFound) ? devices.first().persistentId() : devices[defaultDeviceIndex].persistentId();
-        }
+    bool changed = false;
+
+    if (deviceId.isEmpty()) {
+        // No device set, route back to default pipeline.
+        changed = applyAudioSinkDevice(sink, { }, { });
+    } else {
+        auto [resolvedId, device] = resolveAudioOutputDevice(deviceId);
+        if (device) {
+            auto deviceName = GMallocString::unsafeAdoptFromUTF8(gst_device_get_display_name(device.get()));
+            GST_DEBUG_OBJECT(pipeline(), "Switching to %s<%p>, output '%s'.", GST_OBJECT_NAME(device.get()), device.get(), deviceName.utf8());
+            changed = applyAudioSinkDevice(sink, device, resolvedId);
+        } else
+            GST_WARNING_OBJECT(pipeline(), "Could not obtain GstDevice for '%s'.", resolvedId.utf8().data());
     }
 
-    bool changed = false;
-    if (auto captureDevice = GStreamerAudioCaptureDeviceManager::singleton().gstreamerDeviceWithUID(deviceId)) {
-        auto* device = captureDevice->device();
-        auto deviceName = GMallocString::unsafeAdoptFromUTF8(gst_device_get_display_name(device));
-        GST_DEBUG_OBJECT(pipeline(), "Switching to %s<%p>, output '%s'", GST_OBJECT_NAME(device), device, deviceName.utf8());
-        changed = applyAudioSinkDevice(sink, device);
-    } else
-        GST_WARNING_OBJECT(pipeline(), "Could not obtain GstDevice for identifier '%s'", deviceId.utf8().data());
-
-    GST_DEBUG_OBJECT(pipeline(), "%s to audio output device '%s'", changed ? "Changed" : "Could not change", deviceId.utf8().data());
+    GST_DEBUG_OBJECT(pipeline(), "%s to audio output device '%s'.", changed ? "Changed" : "Could not change", deviceId.utf8().data());
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -662,7 +662,10 @@ private:
 
 private:
     std::optional<VideoFrameMetadata> videoFrameMetadata() final;
-    bool applyAudioSinkDevice(GstElement* audioSink, GstDevice*);
+#if ENABLE(MEDIA_STREAM)
+    std::pair<String, GRefPtr<GstDevice>> resolveAudioOutputDevice(const String& deviceId);
+#endif
+    bool applyAudioSinkDevice(GstElement* audioSink, const GRefPtr<GstDevice>&, const String& deviceId);
 
     uint64_t m_sampleCount { 0 };
     uint64_t m_lastVideoFrameMetadataSampleCount { 0 };

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -37,6 +37,8 @@ struct _WebKitAudioSinkPrivate {
     GRefPtr<GstElement> interAudioSink;
     GRefPtr<GstPad> mixerPad;
     String role;
+    String deviceId;
+    GRefPtr<GstDevice> device;
 };
 
 enum {
@@ -158,11 +160,11 @@ static GstStateChangeReturn webKitAudioSinkChangeState(GstElement* element, GstS
         if (priv->role == "webaudio"_s)
             forcedSampleRate = AudioDestination::hardwareSampleRate();
 #endif
-        priv->mixerPad = mixer.registerProducer(priv->interAudioSink.get(), forcedSampleRate);
+        priv->mixerPad = mixer.registerProducer(priv->interAudioSink.get(), forcedSampleRate, priv->deviceId, priv->device);
     }
 
     if (priv->mixerPad)
-        mixer.ensureState(stateChange);
+        mixer.ensureState(stateChange, priv->deviceId);
 
     GstStateChangeReturn result = GST_ELEMENT_CLASS(webkit_audio_sink_parent_class)->change_state(element, stateChange);
 
@@ -206,18 +208,63 @@ static void webkit_audio_sink_class_init(WebKitAudioSinkClass* klass)
     eklass->change_state = GST_DEBUG_FUNCPTR(webKitAudioSinkChangeState);
 }
 
-GstElement* /* (transfer floating) */ webkitAudioSinkNew(const String& role)
+GstElement* /* (transfer floating) */ webkitAudioSinkNew(const String& role, const String& deviceId, const GRefPtr<GstDevice>& device)
 {
     auto element = GST_ELEMENT_CAST(g_object_new(WEBKIT_TYPE_AUDIO_SINK, nullptr));
     auto audioSink = WEBKIT_AUDIO_SINK(element);
 
     audioSink->priv->role = role;
+    audioSink->priv->deviceId = deviceId;
+    if (device)
+        audioSink->priv->device = device;
     if (!webKitAudioSinkConfigure(audioSink)) {
         gst_object_unref(element);
         return nullptr;
     }
     ASSERT(g_object_is_floating(element));
     return element;
+}
+
+bool webkitAudioSinkSetDevice(GstElement* element, const String& deviceId, const GRefPtr<GstDevice>& device)
+{
+    if (!WEBKIT_IS_AUDIO_SINK(element))
+        return false;
+
+    auto* sink = WEBKIT_AUDIO_SINK(element);
+    auto* priv = sink->priv;
+
+    // No-op if already on the requested device.
+    if (priv->deviceId == deviceId)
+        return true;
+
+    auto& mixer = GStreamerAudioMixer::singleton();
+
+    if (priv->mixerPad) {
+        mixer.unregisterProducer(priv->mixerPad);
+        priv->mixerPad = nullptr;
+    }
+
+    priv->deviceId = deviceId;
+    priv->device = device;
+
+    if (priv->interAudioSink) {
+        std::optional<int> forcedSampleRate;
+#if ENABLE(WEB_AUDIO)
+        if (priv->role == "webaudio"_s)
+            forcedSampleRate = AudioDestination::hardwareSampleRate();
+#endif
+        priv->mixerPad = mixer.registerProducer(priv->interAudioSink.get(), forcedSampleRate, priv->deviceId, priv->device);
+
+        // Bring the new pipeline to the current element state.
+        GstState currentState;
+        gst_element_get_state(element, &currentState, nullptr, 0);
+        if (currentState >= GST_STATE_PAUSED) {
+            mixer.ensureState(GST_STATE_CHANGE_READY_TO_PAUSED, priv->deviceId);
+            if (currentState >= GST_STATE_PLAYING)
+                mixer.ensureState(GST_STATE_CHANGE_PAUSED_TO_PLAYING, priv->deviceId);
+        }
+    }
+    return true;
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h
@@ -20,7 +20,9 @@
 
 #if USE(GSTREAMER)
 
+#include "GRefPtrGStreamer.h"
 #include <gst/gst.h>
+#include <wtf/text/WTFString.h>
 
 G_BEGIN_DECLS
 
@@ -48,6 +50,7 @@ GType webkit_audio_sink_get_type(void);
 
 G_END_DECLS
 
-GstElement* webkitAudioSinkNew(const String&);
+GstElement* webkitAudioSinkNew(const String& role, const String& deviceId = { }, const GRefPtr<GstDevice>& = { });
+bool webkitAudioSinkSetDevice(GstElement*, const String& deviceId = { }, const GRefPtr<GstDevice>& = { });
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -89,7 +89,10 @@ void GStreamerCapturer::tearDown(bool disconnectSignals)
         return;
 
     m_valve = nullptr;
-    m_src = nullptr;
+    {
+        Locker locker { m_lock };
+        m_src = nullptr;
+    }
     m_capsfilter = nullptr;
     m_sink = nullptr;
     m_pipeline = nullptr;
@@ -148,7 +151,7 @@ struct CapturerProbeData {
 };
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(CapturerProbeData);
 
-GstElement* GStreamerCapturer::createSource()
+GstElement* GStreamerCapturer::createSource() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     if (m_pipewireDevice) {
         m_src = makeElement("pipewiresrc");

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -28,6 +28,7 @@
 #include "GStreamerCommon.h"
 #include "PipeWireCaptureDevice.h"
 
+#include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakHashSet.h>
 
@@ -71,7 +72,11 @@ public:
 
     GstElement* makeElement(ASCIILiteral factoryName);
     virtual GstElement* createSource();
-    GstElement* source() { return m_src.get();  }
+    GRefPtr<GstElement> source()
+    {
+        Locker locker { m_lock };
+        return m_src;
+    }
     virtual ASCIILiteral name() = 0;
 
     GstElement* sink() const { return m_sink.get(); }
@@ -94,7 +99,7 @@ public:
 
 protected:
     GRefPtr<GstElement> m_sink;
-    GRefPtr<GstElement> m_src;
+    GRefPtr<GstElement> m_src WTF_GUARDED_BY_LOCK(m_lock);
     GRefPtr<GstElement> m_valve;
     GRefPtr<GstElement> m_capsfilter;
     std::optional<GStreamerCaptureDevice> m_device { };
@@ -103,6 +108,7 @@ protected:
     GRefPtr<GstElement> m_pipeline;
 
 private:
+    Lock m_lock;
     CaptureDevice::DeviceType m_deviceType;
     WeakHashSet<GStreamerCapturerObserver> m_observers;
 };

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -203,8 +203,12 @@ void MockRealtimeAudioSourceGStreamer::render(Seconds delta)
 
         auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
         // Mock GstDevice is an appsrc, see webkitMockDeviceCreateElement().
-        ASSERT(GST_IS_APP_SRC(m_capturer->source()));
-        gst_app_src_push_sample(GST_APP_SRC_CAST(m_capturer->source()), sample.get());
+        auto appSrc = m_capturer->source();
+        if (!appSrc || !GST_IS_APP_SRC(appSrc.get())) {
+            GST_WARNING("AppSrc not available, capture source may have changed");
+            break;
+        }
+        gst_app_src_push_sample(GST_APP_SRC_CAST(appSrc.get()), sample.get());
     }
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -138,8 +138,12 @@ void MockRealtimeVideoSourceGStreamer::updateSampleBuffer()
         return;
 
     // Mock GstDevice is an appsrc, see webkitMockDeviceCreateElement().
-    ASSERT(GST_IS_APP_SRC(m_capturer->source()));
-    gst_app_src_push_sample(GST_APP_SRC_CAST(m_capturer->source()), videoFrame->sample());
+    auto appSrc = m_capturer->source();
+    if (!appSrc || !GST_IS_APP_SRC(appSrc.get())) {
+        GST_WARNING("AppSrc not available, capture source may have changed");
+        return;
+    }
+    gst_app_src_push_sample(GST_APP_SRC_CAST(appSrc.get()), videoFrame->sample());
 }
 
 void MockRealtimeVideoSourceGStreamer::setSizeFrameRateAndZoom(const VideoPresetConstraints& constraints)


### PR DESCRIPTION
#### b1791af759fa494bf45a37a256c562721577207c
<pre>
[GStreamer][MediaStream] setSinkId breaks WEBKIT_GST_ENABLE_AUDIO_MIXER=1
<a href="https://bugs.webkit.org/show_bug.cgi?id=308311">https://bugs.webkit.org/show_bug.cgi?id=308311</a>

Reviewed by Philippe Normand.

GStreamerAudioMixer now manages one mixer pipeline per output device
(keyed by device ID) instead of a single shared pipeline. When the last
producer leaves a pipeline, teardown is deferred via a timer (default
60 s, configurable via GSTREAMER_AUDIO_MIXER_TEARDOWN_TIMEOUT) so that
rapid device switches do not destroy and recreate the pipeline
unnecessarily.

WebKitAudioSink stores the target device ID and GstDevice, passes them
to GStreamerAudioMixer::registerProducer(), and supports runtime device
switching through the new webkitAudioSinkSetDevice() helper, which
moves the producer from the old pipeline to the new one and brings the
new pipeline to the current element state.

createPlatformAudioSink() and applyAudioSinkDevice() are extended with
optional deviceId/GstDevice parameters. applyAudioSinkDevice() now
handles WebKitAudioSink directly by delegating to
webkitAudioSinkSetDevice(). A resolveAudioOutputDevice() helper is
extracted from createAudioSink() and audioOutputDeviceChanged() to
deduplicate device-ID resolution logic.

Fly-by fixes:
* Guard against a null roleImpl in the createAutoAudioSink()
GClosure notify callback
* Sanitize slashes in filenames passed to
dumpBinToDotFile() to avoid failures during pipeline dumping.
* Fix pre-existing race condition between GStreamerCapturer::setDevice() and
mock source render threads that surfaced now

* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
(WebCore::GStreamerAudioMixer::GStreamerAudioMixer):
(WebCore::GStreamerAudioMixer::ensureMixerPipeline):
(WebCore::GStreamerAudioMixer::teardownPipeline):
(WebCore::GStreamerAudioMixer::ensureState):
(WebCore::GStreamerAudioMixer::registerProducer):
(WebCore::GStreamerAudioMixer::unregisterProducer):
(WebCore::GStreamerAudioMixer::configureSourcePeriodTime):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h:
(WebCore::GStreamerAudioMixer::ensureState):
(WebCore::GStreamerAudioMixer::registerProducer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::createAutoAudioSink):
(WebCore::createPlatformAudioSink):
(WebCore::dumpBinToDotFile):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::createPlatformAudioSink):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createAudioSink):
(WebCore::MediaPlayerPrivateGStreamer::resolveAudioOutputDevice):
(WebCore::MediaPlayerPrivateGStreamer::applyAudioSinkDevice):
(WebCore::MediaPlayerPrivateGStreamer::audioOutputDeviceChanged):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkChangeState):
(webkitAudioSinkNew):
(webkitAudioSinkSetDevice):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.h:
(webkitAudioSinkNew):
(webkitAudioSinkSetDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::tearDown):
(WebCore::GStreamerCapturer::createSource): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
(WebCore::GStreamerCapturer::source):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::render):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::updateSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/308537@main">https://commits.webkit.org/308537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/507e1ce6c9c1d6469d4e85dc39fa23d7954b0bde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156505 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94726 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15355 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158840 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121993 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31296 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132472 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76438 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17696 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9240 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83684 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->