### PR TITLE
Absolutely positioned elements with intrinsic height incorrectly resolve percentage heights of children

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-auto-size">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Absolutely positioned block with height: fit-content should treat percentage height children as indefinite, sizing to content rather than containing block height.">
+<style>
+/*
+  The containing block (.container) is 50px tall. The abs-pos element has
+  height: fit-content. Its child has height: 100%, which should resolve as
+  indefinite (auto) since the parent has an intrinsic height. The child then
+  sizes to its content (100px), making the abs-pos element 100px tall.
+
+  If the bug exists, height: 100% resolves against the containing block (50px),
+  making the abs-pos element only 50px, exposing 50px of red below.
+*/
+.container {
+  position: relative;
+  width: 100px;
+  height: 50px;
+}
+
+.background {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+
+.abs {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: fit-content;
+  width: 100px;
+  background: green;
+}
+
+.child {
+  height: 100%;
+}
+
+.content {
+  height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="background">
+  <div class="container">
+    <div class="abs">
+      <div class="child">
+        <div class="content"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-auto-size">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Absolutely positioned flex container with height: fit-content should treat percentage height flex items as indefinite, sizing to content rather than containing block height.">
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 50px;
+}
+
+.background {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+
+.abs {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  height: fit-content;
+  width: 100px;
+  background: green;
+}
+
+.child {
+  height: 100%;
+}
+
+.content {
+  height: 100px;
+  width: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="background">
+  <div class="container">
+    <div class="abs">
+      <div class="child">
+        <div class="content"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-auto-size">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Absolutely positioned block with height: min-content should treat percentage height children as indefinite, sizing to content rather than containing block height.">
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 50px;
+}
+
+.background {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+
+.abs {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: min-content;
+  width: 100px;
+  background: green;
+}
+
+.child {
+  height: 100%;
+}
+
+.content {
+  height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="background">
+  <div class="container">
+    <div class="abs">
+      <div class="child">
+        <div class="content"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-auto-size">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Absolutely positioned block with height: max-content should treat percentage height children as indefinite, sizing to content rather than containing block height.">
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 50px;
+}
+
+.background {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+
+.abs {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: max-content;
+  width: 100px;
+  background: green;
+}
+
+.child {
+  height: 100%;
+}
+
+.content {
+  height: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="background">
+  <div class="container">
+    <div class="abs">
+      <div class="child">
+        <div class="content"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3073,7 +3073,13 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         // A positioned element that specified both top/bottom or that specifies
         // height should be treated as though it has a height explicitly specified
         // that can be used for any percentage computations.
-        auto isOutOfFlowPositionedWithSpecifiedHeight = isOutOfFlowPositioned() && (!style.logicalHeight().isAuto() || (!style.logicalTop().isAuto() && !style.logicalBottom().isAuto()));
+        // However, intrinsic heights (fit-content, min-content, max-content) are
+        // content-dependent and should be treated as indefinite for percentage
+        // resolution of children, since the actual height is not yet determined.
+        auto heightIsIntrinsic = style.logicalHeight().isIntrinsic() || style.logicalHeight().isLegacyIntrinsic();
+        auto hasNonIntrinsicSpecifiedHeight = !style.logicalHeight().isAuto() && !heightIsIntrinsic;
+        auto hasDefiniteHeightFromInsets = !style.logicalTop().isAuto() && !style.logicalBottom().isAuto() && style.logicalHeight().isAuto();
+        auto isOutOfFlowPositionedWithSpecifiedHeight = isOutOfFlowPositioned() && (hasNonIntrinsicSpecifiedHeight || hasDefiniteHeightFromInsets);
         if (isOutOfFlowPositionedWithSpecifiedHeight) {
             // Don't allow this to affect the block' size() member variable, since this
             // can get called while the block is still laying out its kids.


### PR DESCRIPTION
#### 823b59d3140eeb4533ec60c61d3f00c7a4c8ef68
<pre>
Absolutely positioned elements with intrinsic height incorrectly resolve percentage heights of children
<a href="https://bugs.webkit.org/show_bug.cgi?id=308648">https://bugs.webkit.org/show_bug.cgi?id=308648</a>
<a href="https://rdar.apple.com/171179193">rdar://171179193</a>

Reviewed by Sammy Gill.

When an absolutely positioned element has an intrinsic height value
(fit-content, min-content, max-content), its children with percentage
heights (e.g. height: 100%) should treat the parent&apos;s height as
indefinite, since the parent&apos;s height depends on the content being
sized. Instead, availableLogicalHeightForPercentageComputation() was
treating any non-auto height as definite, causing percentage heights
to resolve against the containing block&apos;s height rather than being
treated as auto.

This caused HeadlessUI popover panels (which use height: fit-content
on an absolutely positioned flex container) to collapse to the
navbar&apos;s height instead of sizing to their content.

The fix excludes intrinsic height values from the &quot;specified height&quot;
check in availableLogicalHeightForPercentageComputation(), so they
are treated as indefinite for percentage resolution of children.

Tests: imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html
       imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006.html
       imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007.html
       imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-007.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-008.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):

Canonical link: <a href="https://commits.webkit.org/308226@main">https://commits.webkit.org/308226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90623ec5dc65091ecf4b03fbbc99d9be2bc8cd1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100178 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7121338d-236a-4f2c-a0a9-75a4c0bd0bda) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113103 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5f357b5-eb3a-43e2-8c4d-93d18084a17a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93848 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d194e520-89bb-4241-a47c-42293bfd65a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14594 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12365 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2901 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157789 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/934 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121114 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31090 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75101 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8409 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82643 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18676 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->