### PR TITLE
Adopt new RealityCoreRenderer changes

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit) && !os(visionOS)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
 
 internal import Metal
 @_weakLinked internal import USDKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit) && !os(visionOS)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
 
 @_weakLinked internal import USDKit
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -121,9 +121,9 @@ typedef NS_ENUM(uint8_t, WKBridgeDataUpdateType) {
 
 @interface WKBridgeBlendShapeData : NSObject
 
-@property (nonatomic, readonly) NSData *weights; // [Float]
-@property (nonatomic, readonly) NSArray<NSData *> *positionOffsets; // [[SIMD3<Float>]]
-@property (nonatomic, readonly) NSArray<NSData *> *normalOffsets; // [[SIMD3<Float>]]
+@property (nonatomic, readonly) NSData *weightsData; // [Float]
+@property (nonatomic, readonly) NSArray<NSData *> *positionOffsetsData; // [[SIMD3<Float>]]
+@property (nonatomic, readonly) NSArray<NSData *> *normalOffsetsData; // [[SIMD3<Float>]]
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithWeights:(NSData *)weights positionOffsets:(NSArray<NSData *> *)positionOffsets normalOffsets:(NSArray<NSData *> *)normalOffsets NS_DESIGNATED_INITIALIZER;
@@ -132,9 +132,9 @@ typedef NS_ENUM(uint8_t, WKBridgeDataUpdateType) {
 
 @interface WKBridgeRenormalizationData : NSObject
 
-@property (nonatomic, readonly) NSData *vertexIndicesPerTriangle; // [UInt32]
-@property (nonatomic, readonly) NSData *vertexAdjacencies; // [UInt32]
-@property (nonatomic, readonly) NSData *vertexAdjacencyEndIndices; // [UInt32]
+@property (nonatomic, readonly) NSData *vertexIndicesPerTriangleData; // [UInt32]
+@property (nonatomic, readonly) NSData *vertexAdjacenciesData; // [UInt32]
+@property (nonatomic, readonly) NSData *vertexAdjacencyEndIndicesData; // [UInt32]
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithVertexIndicesPerTriangle:(NSData *)vertexIndicesPerTriangle vertexAdjacencies:(NSData *)vertexAdjacencies vertexAdjacencyEndIndices:(NSData *)vertexAdjacencyEndIndices NS_DESIGNATED_INITIALIZER;

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -79,9 +79,10 @@ void RemoteMesh::setLabel(String&& label)
     m_backing->setLabel(WTF::move(label));
 }
 
-void RemoteMesh::update(const WebModel::UpdateMeshDescriptor& descriptor)
+void RemoteMesh::update(const WebModel::UpdateMeshDescriptor& descriptor, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_backing->update(descriptor);
+    completionHandler(true);
 }
 
 void RemoteMesh::render()
@@ -89,14 +90,16 @@ void RemoteMesh::render()
     m_backing->render();
 }
 
-void RemoteMesh::updateTexture(const WebModel::UpdateTextureDescriptor& descriptor)
+void RemoteMesh::updateTexture(const WebModel::UpdateTextureDescriptor& descriptor, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_backing->updateTexture(descriptor);
+    completionHandler(true);
 }
 
-void RemoteMesh::updateMaterial(const WebModel::UpdateMaterialDescriptor& descriptor)
+void RemoteMesh::updateMaterial(const WebModel::UpdateMaterialDescriptor& descriptor, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_backing->updateMaterial(descriptor);
+    completionHandler(true);
 }
 
 void RemoteMesh::updateTransform(const WebModel::Float4x4& transform)

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -91,9 +91,9 @@ private:
     void destruct();
 
     void setLabel(String&&);
-    void update(const WebModel::UpdateMeshDescriptor&);
-    void updateTexture(const WebModel::UpdateTextureDescriptor&);
-    void updateMaterial(const WebModel::UpdateMaterialDescriptor&);
+    void update(const WebModel::UpdateMeshDescriptor&, CompletionHandler<void(bool)>&&);
+    void updateTexture(const WebModel::UpdateTextureDescriptor&, CompletionHandler<void(bool)>&&);
+    void updateMaterial(const WebModel::UpdateMaterialDescriptor&, CompletionHandler<void(bool)>&&);
     void updateTransform(const WebModel::Float4x4& transform);
     void setCameraDistance(float);
     void play(bool);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -31,10 +31,10 @@
 messages -> RemoteMesh Stream {
     void SetLabel(String label)
     void Destruct()
-    void Update(struct WebModel::UpdateMeshDescriptor descriptor)
+    void Update(struct WebModel::UpdateMeshDescriptor descriptor) -> (bool success)
     void Render()
-    void UpdateTexture(struct WebModel::UpdateTextureDescriptor descriptor)
-    void UpdateMaterial(struct WebModel::UpdateMaterialDescriptor descriptor)
+    void UpdateTexture(struct WebModel::UpdateTextureDescriptor descriptor) -> (bool success)
+    void UpdateMaterial(struct WebModel::UpdateMaterialDescriptor descriptor) -> (bool success)
     void UpdateTransform(struct WebModel::Float4x4 transform)
     void SetCameraDistance(float distance)
     void Play(bool playing)

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -145,8 +145,9 @@ void RemoteMeshProxy::update(const WebModel::UpdateMeshDescriptor& descriptor)
     if (boundingBoxChanged)
         setCameraDistance(std::max(extents.x, extents.y) * .5f);
 
-    auto sendResult = send(Messages::RemoteMesh::Update(descriptor));
-    UNUSED_PARAM(sendResult);
+    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::Update(descriptor), [](auto) mutable {
+    });
+    UNUSED_VARIABLE(sendResult);
     if (boundingBoxChanged)
         setStageMode(m_stageMode);
 
@@ -176,8 +177,9 @@ void RemoteMeshProxy::setLabelInternal(const String& label)
 void RemoteMeshProxy::updateTexture(const WebModel::UpdateTextureDescriptor& descriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    auto sendResult = send(Messages::RemoteMesh::UpdateTexture(descriptor));
-    UNUSED_PARAM(sendResult);
+    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::UpdateTexture(descriptor), [](auto) mutable {
+    });
+    UNUSED_VARIABLE(sendResult);
 #else
     UNUSED_PARAM(descriptor);
 #endif
@@ -186,8 +188,9 @@ void RemoteMeshProxy::updateTexture(const WebModel::UpdateTextureDescriptor& des
 void RemoteMeshProxy::updateMaterial(const WebModel::UpdateMaterialDescriptor& descriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    auto sendResult = send(Messages::RemoteMesh::UpdateMaterial(descriptor));
-    UNUSED_PARAM(sendResult);
+    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::UpdateMaterial(descriptor), [](auto) mutable {
+    });
+    UNUSED_VARIABLE(sendResult);
 #else
     UNUSED_PARAM(descriptor);
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -82,6 +82,11 @@ private:
     {
         return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
+    template<typename T, typename C>
+    [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
+    {
+        return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), WTF::move(completionHandler), backing());
+    }
 
     void update(const WebModel::UpdateMeshDescriptor&) final;
     void updateTexture(const WebModel::UpdateTextureDescriptor&) final;

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -155,9 +155,9 @@ static std::optional<WebModel::BlendShapeData> toCpp(WKBridgeBlendShapeData* dat
         return std::nullopt;
 
     return WebModel::BlendShapeData {
-        .weights = toCpp<float>(data.weights),
-        .positionOffsets = toCpp<WebModel::Float3>(data.positionOffsets),
-        .normalOffsets = toCpp<WebModel::Float3>(data.normalOffsets)
+        .weights = toCpp<float>(data.weightsData),
+        .positionOffsets = toCpp<WebModel::Float3>(data.positionOffsetsData),
+        .normalOffsets = toCpp<WebModel::Float3>(data.normalOffsetsData)
     };
 }
 
@@ -167,9 +167,9 @@ static std::optional<WebModel::RenormalizationData> toCpp(WKBridgeRenormalizatio
         return std::nullopt;
 
     return WebModel::RenormalizationData {
-        .vertexIndicesPerTriangle = toCpp<uint32_t>(data.vertexIndicesPerTriangle),
-        .vertexAdjacencies = toCpp<uint32_t>(data.vertexAdjacencies),
-        .vertexAdjacencyEndIndices = toCpp<uint32_t>(data.vertexAdjacencyEndIndices)
+        .vertexIndicesPerTriangle = toCpp<uint32_t>(data.vertexIndicesPerTriangleData),
+        .vertexAdjacencies = toCpp<uint32_t>(data.vertexAdjacenciesData),
+        .vertexAdjacencyEndIndices = toCpp<uint32_t>(data.vertexAdjacencyEndIndicesData)
     };
 }
 


### PR DESCRIPTION
#### 534644cb68a0396b7c4c77eca53e2ef8ca520bae
<pre>
Adopt new RealityCoreRenderer changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308646">https://bugs.webkit.org/show_bug.cgi?id=308646</a>
<a href="https://rdar.apple.com/171090357">rdar://171090357</a>

Reviewed by Etienne Segonzac.

Adopt RealityCoreRenderer changes in RealityCoreRenderer-11

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(WKBridgeBlendShapeData.weights):
(WKBridgeBlendShapeData.positionOffsets):
(WKBridgeBlendShapeData.normalOffsets):
(WKBridgeRenormalizationData.vertexIndicesPerTriangle):
(WKBridgeRenormalizationData.vertexAdjacencies):
(WKBridgeRenormalizationData.vertexAdjacencyEndIndices):
* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.renderer):
(Renderer.renderTargetDescriptor):
(Renderer.pose):
(Renderer.createMaterialCompiler(_:rasterSampleCount:colorSpace:)):
(Renderer.setCameraDistance(_:)):
(Renderer.setCameraTransform(_:)):
(RealityCoreRenderer.encode(to:byteOffset:)): Deleted.
(Renderer.globalConstants): Deleted.
(Renderer.globalConstantsEncoder): Deleted.
(Renderer.renderWorkload): Deleted.
(Renderer.cameraPose): Deleted.
(Renderer.createMaterialCompiler(_:)): Deleted.
(Renderer.updateGlobalConstants(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(mapSemantic(_:)):
(_Proto_LowLevelMeshResource_v1.fromLlmDescriptor(_:)):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::update):
(WebKit::RemoteMesh::updateTexture):
(WebKit::RemoteMesh::updateMaterial):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift: Added.
(WKBridgeReceiver.deformers):
(WKBridgeReceiver.inputMeshDescription):
(WKBridgeSkinningData.makeDeformerDescription(_:)):
(WKBridgeBlendShapeData.makeDeformerDescription(_:)):
(WKBridgeRenormalizationData.makeDeformerDescription(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(logError(_:)):
(logInfo(_:)):
(WKBridgeUSDConfiguration.renderer):
(WKBridgeUSDConfiguration.renderTarget):
(WKBridgeUSDConfiguration.createMaterialCompiler):
(WKBridgeReceiver.lightingArgumentBuffer):
(WKBridgeReceiver.renderTarget):
(WKBridgeReceiver.meshInstancePlainArray):
(WKBridgeReceiver.meshInstances):
(WKBridgeReceiver.meshResources):
(WKBridgeReceiver.meshResourceToMaterials):
(WKBridgeReceiver.meshToMeshInstances):
(WKBridgeReceiver.meshTransforms):
(WKBridgeReceiver.rotationAngle):
(meshResourceToDeformationContext):
(Material.updateMaterial(_:)):
(toSGType(_:)): Deleted.
(toSGModuleReference(_:)): Deleted.
(toSGTypeDefinition(_:)): Deleted.
(toSGTypeReference(_:)): Deleted.
(toSGStructMember(_:)): Deleted.
(toSGEnumCase(_:)): Deleted.
(toSGFunction(_:)): Deleted.
(toSGFunctionArgument(_:)): Deleted.
(toSGModuleGraph(_:)): Deleted.
(toSGNode(_:)): Deleted.
(toSGNodeID(_:)): Deleted.
(toSGNodeInstruction(_:)): Deleted.
(toSGNodeInstructionFromFunctionCall(_:)): Deleted.
(toSGNodeInstructionFromFunctionConstant(_:literal:)): Deleted.
(toSGNodeInstructionFromLiteral(_:)): Deleted.
(toSGNodeInstructionFromArgument(_:)): Deleted.
(toSGNodeInstructionFromElement(_:name:)): Deleted.
(toSGLiteral(_:)): Deleted.
(toSGGraphEdge(_:ShaderGraph:String:)): Deleted.
(fromSGType(_:)): Deleted.
(fromSGModuleReferenceArray(_:)): Deleted.
(fromSGModuleReference(_:)): Deleted.
(fromSGTypeDefinitionArray(_:)): Deleted.
(fromSGTypeDefinition(_:)): Deleted.
(fromSGTypeReference(_:)): Deleted.
(fromSGStructMember(_:)): Deleted.
(fromSGEnumCase(_:)): Deleted.
(fromSGFunctionArray(_:)): Deleted.
(fromSGFunction(_:)): Deleted.
(fromSGFunctionArgument(_:)): Deleted.
(fromSGModuleGraphArray(_:)): Deleted.
(fromSGModuleGraph(_:)): Deleted.
(fromSGNode(_:)): Deleted.
(fromSGNodeID(_:)): Deleted.
(fromSGNodeInstruction(_:)): Deleted.
(fromSGLiteral(_:)): Deleted.
(fromSGGraphEdge(_:ShaderGraph:String:)): Deleted.
(MTLCaptureDescriptor.mapSemantic(_:)): Deleted.
(_Proto_LowLevelMeshResource_v1.fromLlmDescriptor(_:)): Deleted.
(isNonZero(_:)): Deleted.
(RenderTargetWrapper.descriptor): Deleted.
(WKBridgeUSDConfiguration.renderWorkload): Deleted.
(WKBridgeReceiver.deformers): Deleted.
(WKBridgeReceiver.inputMeshDescription): Deleted.
(WKBridgeSkinningData.makeDeformerDescription(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::setCameraDistance):
* Source/WebKit/GPUProcess/graphics/Model/WebKit_Internal.modulemap: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::toCpp):

Canonical link: <a href="https://commits.webkit.org/308315@main">https://commits.webkit.org/308315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bd442d291fdd18909fa7802e4f7e85db1a1bd21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155775 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/530199dd-3aac-446a-b9ef-e5392edba490) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113353 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/260b9dec-c1f8-403b-8586-59ded9929d8a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94111 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb74e5c1-bd60-4cb0-8c87-68718e3a8328) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14786 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3217 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124373 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158106 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121378 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19575 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31146 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131830 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8640 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82945 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18979 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->