### PR TITLE
AX: Ensure that the accessibility tree is created when adding a notification listener.

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
@@ -57,6 +57,10 @@ bool AccessibilityController::addNotificationListener(JSContextRef context, JSVa
     if (m_globalNotificationHandler)
         return false;
 
+    // Ensure the accessibility tree is built before we start observing
+    // notifications, otherwise notifications may never be posted.
+    _WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context));
+
     m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_globalNotificationHandler setCallback:functionCallback];
     [m_globalNotificationHandler startObserving];

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -79,6 +79,10 @@ bool AccessibilityController::addNotificationListener(JSContextRef context, JSVa
     if (m_globalNotificationHandler)
         return false;
 
+    // Ensure the accessibility tree is built before we start observing
+    // notifications, otherwise notifications may never be posted.
+    _WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context));
+
     m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_globalNotificationHandler.get() setCallback:functionCallback];
     [m_globalNotificationHandler.get() startObserving];


### PR DESCRIPTION
#### b9e9405cc26a7ec5554213b6d5fd31e19ace23ac
<pre>
AX: Ensure that the accessibility tree is created when adding a notification listener.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308647">https://bugs.webkit.org/show_bug.cgi?id=308647</a>
&lt;<a href="https://rdar.apple.com/problem/171173160">rdar://problem/171173160</a>&gt;

Reviewed by Tyler Wilcock (OOPS\!).

When a layout test calls `addNotificationListener` to observe accessibility
notifications, it&apos;s possible that the accessibility tree hasn&apos;t been built
yet. If the tree doesn&apos;t exist, notifications like AXLoadComplete are never
posted, causing tests that wait for those notifications to time out.

Fix this by calling `_WKAccessibilityRootObjectForTesting` at the start of
`addNotificationListener` on both macOS and iOS. This forces the
accessibility tree to be created (if it hasn&apos;t been already) before we
begin observing, ensuring that subsequent accessibility events are properly
dispatched.

* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm:
(WTR::AccessibilityController::addNotificationListener):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::addNotificationListener):

Canonical link: <a href="https://commits.webkit.org/308259@main">https://commits.webkit.org/308259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32f16009d6f891414f850fb9acd7b988150f44bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100207 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/279cb240-5ffc-4e58-9e7e-eb072ab3ab57) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113124 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80760 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ed518bc-84a5-43bf-8da1-8fb3a88fe009) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15374 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93869 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d37d9fa-b4fc-4e52-af43-05a7087cf7b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14610 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12387 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2930 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157818 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11331 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121134 "1 failures") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121346 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31112 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75147 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16949 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18916 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18646 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->