### PR TITLE
Crash when using `shape-outside: shape(...)`

### DIFF
--- a/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-shape-function-crash-expected.txt
+++ b/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-shape-function-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-shape-function-crash.html
+++ b/LayoutTests/fast/shapes/shape-outside-floats/shape-outside-shape-function-crash.html
@@ -1,0 +1,11 @@
+<style>
+  #target { float: left; shape-outside: shape(nonzero from 0 0, line to 10px 10px); }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText()
+</script>
+<p>This test passes if it does not crash.</p>
+<div>
+<div id="target"></div>
+</div>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp
@@ -157,7 +157,7 @@ RefPtr<CSSValue> consumeOffsetPath(CSSParserTokenRange& range, CSS::PropertyPars
     auto consumeShape = [&]() -> bool {
         if (shapeOrRay)
             return false;
-        shapeOrRay = consumeBasicShape(range, state, PathParsingOption::RejectPathFillRule);
+        shapeOrRay = consumeBasicShape(range, state, BasicShapeParsingOptions::RejectPathFunctionFillRule);
         return !!shapeOrRay;
     };
     auto consumeBox = [&]() -> bool {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.h
@@ -38,15 +38,16 @@ struct PropertyParserState;
 
 namespace CSSPropertyParserHelpers {
 
-enum class PathParsingOption : uint8_t {
-    None = 0,
-    RejectPathFillRule = 1 << 0,
-    RejectPath = 1 << 1,
+enum class BasicShapeParsingOptions : uint8_t {
+    None                       = 0,
+    RejectPathFunctionFillRule = 1 << 0,
+    RejectPathFunction         = 1 << 1,
+    RejectShapeFunction        = 1 << 2,
 };
 
 // <basic-shape> = <circle()> | <ellipse() | <inset()> | <path()> | <polygon()> | <rect()> | <shape()> | <xywh()>
 // https://drafts.csswg.org/css-shapes/#typedef-basic-shape
-RefPtr<CSSValue> consumeBasicShape(CSSParserTokenRange&, CSS::PropertyParserState&, OptionSet<PathParsingOption>);
+RefPtr<CSSValue> consumeBasicShape(CSSParserTokenRange&, CSS::PropertyParserState&, OptionSet<BasicShapeParsingOptions>);
 
 // <path()> = path( <'fill-rule'>? , <string> )
 // https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path

--- a/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
@@ -78,6 +78,12 @@ auto CSSValueConversion<ShapeOutside>::operator()(BuilderState& state, const CSS
         processSingleValue(value);
 
     if (shape) {
+        // FIXME: Add support for `path()` and `shape()` functions in `shape-outside`.
+        if (WTF::holdsAlternative<PathFunction>(*shape) || WTF::holdsAlternative<ShapeFunction>(*shape)) {
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+
         if (referenceBox != CSSBoxType::BoxMissing)
             return ShapeOutside::ShapeAndShapeBox { .shape = WTF::move(*shape), .box = referenceBox };
         return ShapeOutside::Shape { WTF::move(*shape) };


### PR DESCRIPTION
#### 5a21376ccff417f7a84ab2bb894fe22bba7c06b3
<pre>
Crash when using `shape-outside: shape(...)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308649">https://bugs.webkit.org/show_bug.cgi?id=308649</a>

Reviewed by Simon Fraser.

Extends the list of rejected &lt;basic-shape&gt; functions for `shape-outside` to also
include `shape()`.

Also adds style building time check so that any non-parser code paths that might try
to construct a `shape-outside` property value don&apos;t succeed.

Test: fast/shapes/shape-outside-floats/shape-outside-shape-function-crash.html
* LayoutTests/fast/shapes/shape-outside-floats/shape-outside-shape-function-crash-expected.txt: Added.
* LayoutTests/fast/shapes/shape-outside-floats/shape-outside-shape-function-crash.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.h:
* Source/WebCore/style/values/shapes/StyleShapeOutside.cpp:

Canonical link: <a href="https://commits.webkit.org/308286@main">https://commits.webkit.org/308286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31a64c43011ecaa4dbce341ef6274ba7796ed5ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155714 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148906 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113297 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149994 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94053 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3156 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158045 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11450 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19514 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31125 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131767 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82884 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->