### PR TITLE
TESTING: GC_VALIDATION + collectContinuously + useZombieMode + Revert "Clean up opaque atomic variables"

### DIFF
--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -106,19 +106,22 @@ inline void Heap::writeBarrier(const JSCell* from, JSCell* to)
 #if ENABLE(WRITE_BARRIER_PROFILING)
     WriteBarrierCounters::countWriteBarrier();
 #endif
-    if (!from)
+    ASSERT_GC_OBJECT_LOOKS_VALID(const_cast<JSCell*>(from));
+    // FIXME: above assert verifies from is never nullptr so should be unnecessary
+    if (!from) [[unlikely]]
         return;
-    if (!to) [[likely]]
+    if (!to) [[unlikely]]
         return;
-    if (!isWithinThreshold(from->cellState(), barrierThreshold()))
-        return;
-    writeBarrierSlowPath(from);
+    ASSERT_GC_OBJECT_LOOKS_VALID(to);
+    if (isWithinThreshold(from->cellState(), barrierThreshold())) [[unlikely]]
+        writeBarrierSlowPath(from);
 }
 
 inline void Heap::writeBarrier(const JSCell* from)
 {
     ASSERT_GC_OBJECT_LOOKS_VALID(const_cast<JSCell*>(from));
-    if (!from)
+    // FIXME: above assert verifies from is never nullptr so should be unnecessary
+    if (!from) [[unlikely]]
         return;
     if (isWithinThreshold(from->cellState(), barrierThreshold())) [[unlikely]]
         writeBarrierSlowPath(from);

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -179,8 +179,12 @@ MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(
     , m_cells(cells.size())
     , m_callLinkInfos(WTF::move(callLinkInfos))
 {
-    for (unsigned i = cells.size(); i--;)
-        m_cells[i].set(vm, owner, cells[i]);
+    for (unsigned i = cells.size(); i--;) {
+        if (owner)
+            m_cells[i].set(vm, owner, cells[i]);
+        else
+            m_cells[i].setWithoutWriteBarrier(cells[i]);
+    }
 }
 
 template<typename Visitor>

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -27,7 +27,6 @@
 
 #include <atomic>
 #include <wtf/FastMalloc.h>
-#include <wtf/StdIntExtras.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -314,36 +313,14 @@ inline void dependentLoadLoadFence() { compilerFence(); }
 inline void dependentLoadLoadFence() { loadLoadFence(); }
 #endif
 
-// We use this primitive to hide an atomic variable from the optimizer.
 template<typename T>
-inline T opaque(T value)
+T opaque(T pointer)
 {
-    asm ("" : "+r"(value) ::);
-    return value;
+    asm volatile("" : "+r"(pointer) ::);
+    return pointer;
 }
 
-// We use this primitive on ARM to express memory ordering efficiently.
-template<typename T>
-inline T* addOpaqueZero(T* pointer, unsigned opaqueZero)
-{
-    ASSERT(!opaque(opaqueZero));
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // @safe
-    // Safety: This is bounds-safe because we're not actually adjusting the pointer, only pretending to.
-    return std::bit_cast<T*>(std::bit_cast<char*>(pointer) + opaqueZero);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
-using InternalDependencyType = UCPURegister;
-
-template<typename T>
-inline InternalDependencyType toInternalDependencyType(T value)
-{
-    if constexpr (std::is_pointer_v<T>)
-        return static_cast<InternalDependencyType>(reinterpret_cast<uintptr_t>(value));
-    else
-        return static_cast<InternalDependencyType>(value);
-}
+typedef unsigned InternalDependencyType;
 
 inline InternalDependencyType opaqueMixture()
 {
@@ -353,7 +330,13 @@ inline InternalDependencyType opaqueMixture()
 template<typename... Arguments, typename T>
 inline InternalDependencyType opaqueMixture(T value, Arguments... arguments)
 {
-    return opaqueMixture(arguments...) + toInternalDependencyType(opaque(value));
+    union {
+        InternalDependencyType copy;
+        T value;
+    } u;
+    u.copy = 0;
+    u.value = value;
+    return opaqueMixture(arguments...) + u.copy;
 }
 
 class Dependency {

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1560,6 +1560,17 @@ struct SizedUnsignedTrait<8> {
 template<typename T>
 using SameSizeUnsignedInteger = SizedUnsignedTrait<sizeof(T)>::Type;
 
+// We use this primitive on ARM to express memory ordering efficiently.
+template<typename T>
+inline T* addOpaqueZero(T* pointer, unsigned opaqueZero)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    // This is bounds-safe because opaqueZero is always zero.
+    return std::bit_cast<T*>(std::bit_cast<char*>(pointer) + opaqueZero);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+
 namespace Views {
 
 static constexpr auto dereferenceView = std::views::transform([](auto&& x) -> decltype(auto) { return *x; });
@@ -1582,6 +1593,7 @@ template<typename T, typename U> constexpr auto forward_like_preserving_const(U&
 using WTF::GB;
 using WTF::KB;
 using WTF::MB;
+using WTF::addOpaqueZero;
 using WTF::approximateBinarySearch;
 using WTF::asBytes;
 using WTF::asByteSpan;


### PR DESCRIPTION
#### 585ac651c446ef312c2a298f190ac9ddf7df7ed7
<pre>
Revert &quot;Clean up opaque atomic variables&quot;

This reverts commit dd44d905386dafa40def5c8c60a6e1181df80a00.
</pre>
----------------------------------------------------------------------
#### 1ce9fc287448978309bb91b3155b80faf2a758e9
<pre>
[JSC] add GC object validation to the two-arg Heap::writeBarrier(from, to) when GC_VALIDATION is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=308556">https://bugs.webkit.org/show_bug.cgi?id=308556</a>
<a href="https://rdar.apple.com/171085355">rdar://171085355</a>

Reviewed by NOBODY (OOPS!).

When called directly (i.e. not via WriteBarrier class), there is no
GC_VALIDATION for the Heap::writeBarrier(to, from) case. This function
is often used by WebCore, both directly and via JSValueInWrappedObject,
so it seems useful to have this validation.

So, add validation that to and from both look like valid GC objects.
GC_VALIDATION is enabled in !NDEBUG builds already.

Fix the static prediction hint on the if (!to). It should usually
be non-nullptr.

Write the two-arg and one-arg Heap::WriteBarrier isWithinThreshold guard
using the same (positive check) pattern for better readability.

The guards &apos;!from&apos; in both the two-arg and one-arg Heap::writeBarrier()
seem unnecessary since Debug builds verify they look like valid GC
objects which disallow nullptr. But let&apos;s change this in a future
commit to be careful.

There was only one place that was calling Heap::writeBarrier(to, from)
with an nullptr owner: MarkingGCAwareJITStubRoutine. Avoid doing that
so that we can always check from is a valid GC object.

Testing: Covered by existing tests with Debug builds. I also ran an EWS
tests with ENABLE_GC_VALIDATION=1 in Release builds and this change.

* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::writeBarrier):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/585ac651c446ef312c2a298f190ac9ddf7df7ed7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146829 "Failed to checkout and rebase branch from PR 59438") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19510 "Failed to checkout and rebase branch from PR 59438") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155497 "Failed to checkout and rebase branch from PR 59438") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/19969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19411 "Failed to checkout and rebase branch from PR 59438") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/155497 "Failed to checkout and rebase branch from PR 59438") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149792 "Failed to checkout and rebase branch from PR 59438") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/19969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/155497 "Failed to checkout and rebase branch from PR 59438") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/19969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/2941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138798 "Failed to checkout and rebase branch from PR 59438") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/19969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157829 "Failed to checkout and rebase branch from PR 59438") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7618 "Failed to checkout and rebase branch from PR 59438") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/157829 "Failed to checkout and rebase branch from PR 59438") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/19411 "Failed to checkout and rebase branch from PR 59438") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/157829 "Failed to checkout and rebase branch from PR 59438") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/13044 "Failed to checkout and rebase branch from PR 59438") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178118 "Failed to checkout and rebase branch from PR 59438") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/18927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/178118 "Failed to checkout and rebase branch from PR 59438") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->