### PR TITLE
Regression(302941@main): inline asm in WTF::opaque() needs to be volatile.

### DIFF
--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -318,7 +318,7 @@ inline void dependentLoadLoadFence() { loadLoadFence(); }
 template<typename T>
 inline T opaque(T value)
 {
-    asm ("" : "+r"(value) ::);
+    asm volatile("" : "+r"(value) ::);
     return value;
 }
 


### PR DESCRIPTION
#### 9f672ca021c275f16c00128faaf983f3390b8499
<pre>
Regression(302941@main): inline asm in WTF::opaque() needs to be volatile.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308660">https://bugs.webkit.org/show_bug.cgi?id=308660</a>
<a href="https://rdar.apple.com/171189396">rdar://171189396</a>

Reviewed by Dan Hecht.

Otherwise, compiler optimizations may elide or relocate the asm statement.

See <a href="https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Extended-Asm.html">https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Extended-Asm.html</a>:
```
If an asm has output operands, GCC assumes for optimization purposes the instruction has no side
effects except to change the output operands. This does not mean instructions with a side effect
cannot be used, but you must be careful, because the compiler may eliminate them if the output
operands aren&apos;t used, or move them out of loops, or replace two with one if they constitute a
common subexpression. Also, if your instruction does have a side effect on a variable that
otherwise appears not to change, the old value of the variable may be reused later if it happens
to be found in a register.

You can prevent an asm instruction from being deleted by writing the keyword volatile after the
asm. For example:

     #define get_and_set_priority(new)              \
     ({ int __old;                                  \
        asm volatile (&quot;get_and_set_priority %0, %1&quot; \
                      : &quot;=g&quot; (__old) : &quot;g&quot; (new));  \
        __old; })
```

This bug introduces race conditions into the code that are difficult to test for.  This fix is
also effectively a partial revert of 302941@main.  Hence, no new test.

* Source/WTF/wtf/Atomics.h:
(WTF::opaque):

Canonical link: <a href="https://commits.webkit.org/308243@main">https://commits.webkit.org/308243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2dd389da814a418f525747ece10131ef7aa14bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19514 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155501 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16517ec1-f277-4e0f-8f7e-5db0c62cd721) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12bdac80-7c53-4f83-8c7e-3705db6d3c6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15401 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93882 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bf9459a-f638-4db1-b51d-5137d022c777) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2945 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138802 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157833 "") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7622 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/157833 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16228 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/157833 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19325 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16961 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82686 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45635 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->