### PR TITLE
[iOS] compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html is a flaky image diff

### DIFF
--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Expected result: plain white page with no visible blue (since there are no boxes in this reference). -->
 <html>
 <head>
 <style>
@@ -23,6 +24,5 @@
 </script>
 </head>
 <body onload="runTest();">
-  On success, the blue reference box should be invisible (covered by the fixed box).
 </body>
 </html>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- Test that fixed position elements positioned correctly when page scale < 1 with visual viewport disabled.
+     On success, the blue reference box should be invisible (covered by the fixed white box). -->
 <html>
 <head>
 <style>
@@ -43,7 +45,6 @@
 </script>
 </head>
 <body onload="runTest();">
-  On success, the blue reference box should be invisible (covered by the fixed box).
   <div class="reference"></div>
   <div class="fixed"></div>
 </body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8491,5 +8491,3 @@ imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-across-elem
 # webkit.org/b/308506 UnifiedPDFPlugin on iOS should receive full annotations support
 pdf/annotations [ Skip ]
 pdf/pdf-in-iframe-with-text-annotation.html [ Skip ]
-
-webkit.org/b/308658 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 2cf83d8695f88d229798a8f8e718352fd454555d
<pre>
[iOS] compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html is a flaky image diff
<a href="https://rdar.apple.com/171189471">rdar://171189471</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308658">https://bugs.webkit.org/show_bug.cgi?id=308658</a>

Reviewed by NOBODY (OOPS!).

This test is failing when the text is rendering with subtle subpixel antialiasing differences between runs,
causing image comparison failures. However, there are no diffs in what the text is actually testing.

The following patch removes the informational text from both test files:
    - Moved the test description to an HTML comment (preserving documentation)
    - Removed the text from the rendered body (eliminating antialiasing flakiness)

* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html:
* LayoutTests/platform/ios/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cf83d8695f88d229798a8f8e718352fd454555d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19516 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13104 "Failed to checkout and rebase branch from PR 59442") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155503 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100224 "Failed to checkout and rebase branch from PR 59442") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113135 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/100224 "Failed to checkout and rebase branch from PR 59442") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14621 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12397 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124207 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9797 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157835 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121145 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121359 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19327 "Failed to checkout and rebase branch from PR 59442") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131551 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75169 "Failed to checkout and rebase branch from PR 59442") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8433 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18933 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18663 "Failed to checkout and rebase branch from PR 59442") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18814 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18722 "Failed to checkout and rebase branch from PR 59442") | | | 
<!--EWS-Status-Bubble-End-->