### PR TITLE
AX: Fix iframe aria-hidden propagation with ENABLE(ACCESSIBILITY_LOCAL_FRAME)

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -53,6 +53,7 @@ public:
     String ownerDebugDescription() const;
     String extraDebugInfo() const final;
 
+    AccessibilityObject* parentObject() const final;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AccessibilityObject* crossFrameParentObject() const final;
     AccessibilityObject* crossFrameChildObject() const final;
@@ -104,7 +105,6 @@ private:
     LocalFrameView* documentFrameView() const final;
     LayoutRect elementRect() const final;
     LayoutRect boundingBoxRect() const final { return elementRect(); }
-    AccessibilityObject* parentObject() const final;
     AccessibilityObject* horizontalScrollbar() const { return m_horizontalScrollbar.get(); }
     AccessibilityObject* verticalScrollbar() const { return m_verticalScrollbar.get(); }
     HTMLFrameOwnerElement* frameOwnerElement() const { return m_frameOwnerElement; }


### PR DESCRIPTION
#### 97f8688d9dc6398058115337983319ec22a22749
<pre>
AX: Fix iframe aria-hidden propagation with ENABLE(ACCESSIBILITY_LOCAL_FRAME)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308664">https://bugs.webkit.org/show_bug.cgi?id=308664</a>
<a href="https://rdar.apple.com/171197467">rdar://171197467</a>

Reviewed by Joshua Hoffman.

When aria-hidden changes from &quot;true&quot; to &quot;false&quot; on an iframe, the
AXLocalFrame transitions from ignored to unignored and calls
childrenChanged on its parent FrameHost ScrollView. However,
handleChildrenChanged hits an early return for objects with no node
and no renderer, so the ancestor chain walk never runs and the
isolated tree is never updated.

Fix this by propagating childrenChanged from the FrameHost ScrollView
up to its parent iframe element, which has both a node and a renderer
and can drive the ancestor chain walk correctly.

Fixes accessibility/mac/iframe-aria-hidden.html with ENABLE(ACCESSIBILITY_LOCAL_FRAME).

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleChildrenChanged):
* Source/WebCore/accessibility/AccessibilityScrollView.h:

Canonical link: <a href="https://commits.webkit.org/308323@main">https://commits.webkit.org/308323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e91aea84bc2dd9c198926ac9e1ddfd4f3980868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100235 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113153 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80767 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e9cc32c-052b-4dd2-bf91-1e4278a005d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93906 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27a70c8e-203f-4866-ae8c-2924f63f6c39) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14628 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12408 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2971 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157860 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121374 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31152 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131618 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75338 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8473 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18674 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18825 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->