### PR TITLE
execCommand('FormatBlock') does not preserve inline styles of the replaced block elements

### DIFF
--- a/LayoutTests/editing/execCommand/format-block-preserves-inline-style-expected.txt
+++ b/LayoutTests/editing/execCommand/format-block-preserves-inline-style-expected.txt
@@ -1,0 +1,41 @@
+This tests that FormatBlock preserves inline styles when converting between block elements.
+
+Before FormatBlock:
+| "\n"
+| <p>
+|   id="p1"
+|   style="color: blue"
+|   "Hello world"
+| "\n"
+| <p>
+|   id="p2"
+|   style="color: blue; font-size: 18px"
+|   "Styled text"
+| "\n"
+| <p>
+|   id="p3"
+|   "No style"
+| "\n"
+| <p>
+|   id="p4"
+|   style="color: red"
+|   "Cursor at end"
+| "\n"
+
+After FormatBlock:
+| "\n"
+| <div>
+|   style="color: blue;"
+|   "Hello world"
+| "\n"
+| <h1>
+|   style="color: blue; font-size: 18px;"
+|   "Styled text"
+| "\n"
+| <div>
+|   "No style"
+| "\n"
+| <div>
+|   style="color: red;"
+|   "Cursor at end<#selection-caret>"
+| "\n"

--- a/LayoutTests/editing/execCommand/format-block-preserves-inline-style.html
+++ b/LayoutTests/editing/execCommand/format-block-preserves-inline-style.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="test" contenteditable="true">
+<p id="p1" style="color: blue">Hello world</p>
+<p id="p2" style="color: blue; font-size: 18px">Styled text</p>
+<p id="p3">No style</p>
+<p id="p4" style="color: red">Cursor at end</p>
+</div>
+<script>
+
+Markup.description("This tests that FormatBlock preserves inline styles when converting between block elements.");
+Markup.dump("test", "Before FormatBlock");
+
+var s = window.getSelection();
+
+// Test 1: <p style="color: blue"> to <div> should preserve color.
+s.setPosition(document.getElementById("p1"), 0);
+document.execCommand("FormatBlock", false, "div");
+
+// Test 2: <p style="color: blue; font-size: 18px"> to <h1> should preserve all properties.
+s.setPosition(document.getElementById("p2"), 0);
+document.execCommand("FormatBlock", false, "h1");
+
+// Test 3: <p> with no style to <div> should have no style attribute.
+s.setPosition(document.getElementById("p3"), 0);
+document.execCommand("FormatBlock", false, "div");
+
+// Test 4: Cursor at end of paragraph (Yahoo Mail's exact scenario).
+var p4 = document.getElementById("p4");
+s.setPosition(p4.firstChild, p4.firstChild.length);
+document.execCommand("FormatBlock", false, "div");
+
+Markup.dump("test", "After FormatBlock");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/run/formatblock_4001-5000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/run/formatblock_4001-5000-expected.txt
@@ -868,7 +868,7 @@ PASS [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock"
 PASS [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("defaultparagraphseparator", false, "div") return value
 PASS [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("formatblock", false, "<p>") return value
 PASS [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" checks for modifications to non-editable content
-FAIL [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><span style=\"color:rgb(0, 0, 255)\">foo</span></p>" but got "<p>foo</p>"
+FAIL [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><span style=\"color:rgb(0, 0, 255)\">foo</span></p>" but got "<p style=\"color:rgb(0, 0, 255)\">foo</p>"
 PASS [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandIndeterm("stylewithcss") before
 FAIL [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandState("stylewithcss") before assert_equals: Wrong result returned expected false but got true
 PASS [["stylewithcss","true"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandValue("stylewithcss") before
@@ -891,7 +891,7 @@ PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock
 PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("defaultparagraphseparator", false, "div") return value
 PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("formatblock", false, "<p>") return value
 PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" checks for modifications to non-editable content
-FAIL [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><font color=\"#0000ff\">foo</font></p>" but got "<p>foo</p>"
+FAIL [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><font color=\"#0000ff\">foo</font></p>" but got "<p style=\"color:rgb(0, 0, 255)\">foo</p>"
 PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandIndeterm("stylewithcss") before
 PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandState("stylewithcss") before
 PASS [["stylewithcss","false"],["defaultparagraphseparator","div"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandValue("stylewithcss") before
@@ -914,7 +914,7 @@ PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","
 PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("defaultparagraphseparator", false, "p") return value
 PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("formatblock", false, "<p>") return value
 PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" checks for modifications to non-editable content
-FAIL [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><span style=\"color:rgb(0, 0, 255)\">foo</span></p>" but got "<p>foo</p>"
+FAIL [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><span style=\"color:rgb(0, 0, 255)\">foo</span></p>" but got "<p style=\"color:rgb(0, 0, 255)\">foo</p>"
 PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandIndeterm("stylewithcss") before
 PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandState("stylewithcss") before
 PASS [["stylewithcss","true"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandValue("stylewithcss") before
@@ -937,7 +937,7 @@ PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock",
 PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("defaultparagraphseparator", false, "p") return value
 PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>": execCommand("formatblock", false, "<p>") return value
 PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" checks for modifications to non-editable content
-FAIL [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><font color=\"#0000ff\">foo</font></p>" but got "<p>foo</p>"
+FAIL [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<p><font color=\"#0000ff\">foo</font></p>" but got "<p style=\"color:rgb(0, 0, 255)\">foo</p>"
 PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandIndeterm("stylewithcss") before
 PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandState("stylewithcss") before
 PASS [["stylewithcss","false"],["defaultparagraphseparator","p"],["formatblock","<p>"]] "<div style=color:blue>[foo]</div>" queryCommandValue("stylewithcss") before


### PR DESCRIPTION
#### 51dde913fc8d73958d25795795d6507e002b67bc
<pre>
execCommand(&apos;FormatBlock&apos;) does not preserve inline styles of the replaced block elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=47054">https://bugs.webkit.org/show_bug.cgi?id=47054</a>
<a href="https://rdar.apple.com/157657531">rdar://157657531</a>

Reviewed by Ryosuke Niwa.

When execCommand(&quot;formatBlock&quot;) converts one block element to another
(e.g. &lt;p&gt; to &lt;div&gt;), copy the style attribute from the original element
to the new one so inline styles like color and font-size are preserved.

Test: editing/execCommand/format-block-preserves-inline-style.html

* LayoutTests/editing/execCommand/format-block-preserves-inline-style-expected.txt: Added.
* LayoutTests/editing/execCommand/format-block-preserves-inline-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/editing/run/formatblock_4001-5000-expected.txt:
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::FormatBlockCommand::formatRange):

Canonical link: <a href="https://commits.webkit.org/308365@main">https://commits.webkit.org/308365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f75c4798702d5456b621dbaebe910d59eb72bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113352 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80867 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12562 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158104 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1235 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121377 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31185 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131820 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75541 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8634 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82943 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->