### PR TITLE
AX: AXSelectedTextChanged notifications are posted before the isolated tree is updated.

### DIFF
--- a/LayoutTests/accessibility/mac/textarea-selected-text-changed-notifications-expected.txt
+++ b/LayoutTests/accessibility/mac/textarea-selected-text-changed-notifications-expected.txt
@@ -1,0 +1,22 @@
+Tests the proper sequence of AXSelectedTextChanged notifications in textarea elements
+
+Select the word 'defg':
+Received AXSelectedTextChanged notification for '', AXRole: AXWebArea
+Selected text: 'defg'
+Received AXSelectedTextChanged notification for 'textarea', AXRole: AXTextArea
+Selected text: 'defg'
+Received AXSelectedTextChanged notification for 'textarea', AXRole: AXTextArea
+Selected text: 'defg'
+
+Move the insertion point to before 'o':
+Received AXSelectedTextChanged notification for '', AXRole: AXWebArea
+Insertion point before 'o'
+Received AXSelectedTextChanged notification for 'textarea', AXRole: AXTextArea
+Insertion point before 'o'
+Received AXSelectedTextChanged notification for 'textarea', AXRole: AXTextArea
+Insertion point before 'o'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a textarea:

--- a/LayoutTests/accessibility/mac/textarea-selected-text-changed-notifications.html
+++ b/LayoutTests/accessibility/mac/textarea-selected-text-changed-notifications.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<label for="textarea">This is a textarea:</label>
+<textarea id="textarea" rows="10" cols="33">abc defg hij klmnop</textarea>
+
+<script>
+let output = "Tests the proper sequence of AXSelectedTextChanged notifications in textarea elements\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    function outputNotification(axElement, notification) {
+        output += `Received ${notification} notification for '${axElement.domIdentifier}', ${axElement.role}\n`;
+        let selectionRange = axElement.selectedTextMarkerRange();
+        if (axElement.textMarkerRangeLength(selectionRange) > 0)
+            output += `Selected text: '${axElement.stringForTextMarkerRange(selectionRange)}'\n`;
+        else {
+            // Output the char to the right of the insertion point.
+            let start = axElement.startTextMarkerForTextMarkerRange(selectionRange);
+            let end = axElement.nextTextMarker(start);
+            let range = axElement.textMarkerRangeForMarkers(start, end);
+            output += `Insertion point before '${axElement.stringForTextMarkerRange(range)}'\n`;
+        }
+    }
+
+    setTimeout(async () => {
+        // Focus the textarea and select the word "defg" using DOM calls.
+        let textareaElement = document.getElementById("textarea");
+        textareaElement.focus();
+
+        output += `Select the word 'defg':\n`;
+        await waitForNotifications(null, "AXSelectedTextChanged", 3, () => {
+            textareaElement.setSelectionRange(4, 8);
+        }, outputNotification);
+
+        output += `\nMove the insertion point to before 'o':\n`;
+        await waitForNotifications(null, "AXSelectedTextChanged", 3, () => {
+            textareaElement.setSelectionRange(17, 17);
+        }, outputNotification);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2605,12 +2605,15 @@ void AXObjectCache::postTextStateChangeNotification(AccessibilityObject* object,
             return;
 #endif
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        // Update the isolated tree's selected text marker range before posting the
+        // notification, so that it is available when clients handle the notification.
+        onSelectedTextChanged(selection, axObject.get());
+#endif
+
         postTextSelectionChangePlatformNotification(axObject.get(), newIntent, selection);
     }
 
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    onSelectedTextChanged(selection, axObject.get());
-#endif
 #else // PLATFORM(COCOA) || USE(ATSPI)
     UNUSED_PARAM(object);
     UNUSED_PARAM(intent);


### PR DESCRIPTION
#### 4e41032eeaa72757c1dc764b823f847482646dcd
<pre>
AX: AXSelectedTextChanged notifications are posted before the isolated tree is updated.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308670">https://bugs.webkit.org/show_bug.cgi?id=308670</a>
&lt;<a href="https://rdar.apple.com/problem/171203002">rdar://problem/171203002</a>&gt;

Reviewed by Tyler Wilcock.

When postTextSelectionChangePlatformNotification fires, accessibility clients
(e.g. VoiceOver) handle the notification and query the isolated tree for the
current selected text marker range. However, onSelectedTextChanged — which
updates the isolated tree&apos;s selected text marker range — was being called
*after* the platform notification was posted. This meant clients could read
a stale selection from the isolated tree.

Fix this by moving the onSelectedTextChanged call to before
postTextSelectionChangePlatformNotification, so the isolated tree&apos;s selected
text marker range is already up-to-date when clients handle the notification.

Test: accessibility/mac/textarea-selected-text-changed-notifications.html
* LayoutTests/accessibility/mac/textarea-selected-text-changed-notifications-expected.txt: Added.
* LayoutTests/accessibility/mac/textarea-selected-text-changed-notifications.html: Added.
Before this change, this test would fail in ITM. With this change, it passes in both ITM on and off.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::postTextStateChangeNotification):

Canonical link: <a href="https://commits.webkit.org/308495@main">https://commits.webkit.org/308495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9913b9d2a1e04a6b19553c11452a4c5f858582f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101103 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc63c5f9-ee01-4329-aac6-60d05348eb32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113850 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81199 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94610 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a12657ed-4a0d-4dcd-911a-6e6f26069241) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15255 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13039 "Found 2 new API test failures: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText, TestWebKitAPI.IconLoading.AlreadyCachedIcon (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3811 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158705 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1840 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121877 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31273 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76298 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9125 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19517 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19668 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->