### PR TITLE
[Debug] TestWebKitAPI.SiteIsolation.IframeRedirectCrossSite is a flaky crash

### DIFF
--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -95,8 +95,6 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
     else
         m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, page.backForwardListMessageReceiver());
 
-    m_process->addRemotePageProxy(*this);
-
     RefPtr protectedPage = m_page.get();
     if (!protectedPage)
         return;
@@ -107,6 +105,8 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
     if (protectedPage->preferences().backgroundWebContentRunningBoardThrottlingEnabled())
         m_process->setRunningBoardThrottlingEnabled();
 #endif
+
+    m_process->addRemotePageProxy(*this);
 }
 
 void RemotePageProxy::disconnect()


### PR DESCRIPTION
#### f8b4e5094028d024603ad99388618561675d802a
<pre>
[Debug] TestWebKitAPI.SiteIsolation.IframeRedirectCrossSite is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=308673">https://bugs.webkit.org/show_bug.cgi?id=308673</a>
<a href="https://rdar.apple.com/171199621">rdar://171199621</a>

Reviewed by Sihui Liu.

Take activities on remote pages before adding the new remote page to the process&apos; remote pages.
Otherwise the new remote page will be ref&apos;d before it has been set as adopted, causing a debug
assert.

* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):

Canonical link: <a href="https://commits.webkit.org/308281@main">https://commits.webkit.org/308281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31162139ce0d8b7af1a28a183efee45023bb3a48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100262 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba79b3b9-8658-4e5b-a3a6-269c24330d69) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80781 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54094097-9381-44e7-8f02-f69bbba5896b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93930 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/110075c5-6070-48c7-9d97-ea3694275f27) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2998 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124238 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157887 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121193 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131604 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8469 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82726 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18852 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->