### PR TITLE
Fix SafeCPP issues for Font-related files at Source/WebCore/platform/graphics/cocoa

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -79,10 +79,8 @@ platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
 [ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cocoa/CMUtilities.mm
-platform/graphics/cocoa/FontCacheCoreText.cpp
 platform/graphics/cocoa/GraphicsContextCocoa.mm
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
-platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
 platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/cocoa/WebCoreCALayerExtras.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -45,7 +45,6 @@ platform/graphics/cg/ImageDecoderCG.cpp
 [ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cocoa/CMUtilities.mm
-platform/graphics/cocoa/FontPlatformDataCocoa.mm
 platform/graphics/cocoa/GraphicsContextCocoa.mm
 [ Mac ] platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm

--- a/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
@@ -56,11 +56,11 @@ RefPtr<SharedBuffer> FontPlatformData::platformOpenTypeTable(uint32_t) const
 
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames shouldLocalizeAxisNames) const
 {
-    auto platformFont = ctFont();
+    RetainPtr platformFont = ctFont();
     if (!platformFont)
         return { };
     
-    return WTF::map(defaultVariationValues(platformFont, shouldLocalizeAxisNames), [](auto&& entry) {
+    return WTF::map(defaultVariationValues(platformFont.get(), shouldLocalizeAxisNames), [](auto&& entry) {
         auto& [tag, values] = entry;
         return FontPlatformData::FontVariationAxis { values.axisName, String(tag), values.defaultValue, values.minimumValue, values.maximumValue };
     });

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -84,7 +84,7 @@ RetainPtr<CTFontRef> SystemFontDatabaseCoreText::createSystemDesignFont(SystemFo
 RetainPtr<CTFontRef> SystemFontDatabaseCoreText::createTextStyleFont(const CascadeListParameters& parameters)
 {
     RetainPtr<CFStringRef> localeString = parameters.locale.isEmpty() ? nullptr : parameters.locale.string().createCFString();
-    auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(parameters.fontName.string().createCFString().get(), contentSizeCategory(), localeString.get()));
+    auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(parameters.fontName.string().createCFString().get(), protect(contentSizeCategory()).get(), localeString.get()));
     // FIXME: Use createFontByApplyingWeightWidthItalicsAndFallbackBehavior().
     CTFontSymbolicTraits traits = (parameters.weight >= kCTFontWeightSemibold ? kCTFontTraitBold : 0)
         | (parameters.width >= kCTFontWidthSemiExpanded ? kCTFontTraitExpanded : 0)
@@ -400,7 +400,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand fontShort
 
     auto interrogateTextStyleShorthandItem = [] (CFStringRef textStyle) {
         CGFloat weight = 0;
-        float size = CTFontDescriptorGetTextStyleSize(textStyle, contentSizeCategory(), fontPlatform(), &weight, nullptr);
+        float size = CTFontDescriptorGetTextStyleSize(textStyle, protect(contentSizeCategory()).get(), fontPlatform(), &weight, nullptr);
         auto cssWeight = normalizeCTWeight(weight);
         return SystemFontShorthandInfo { textStyle, size, FontSelectionValue(cssWeight) };
     };


### PR DESCRIPTION
#### def6645cc9b3611dd04097bcd1b51c99c90345b9
<pre>
Fix SafeCPP issues for Font-related files at Source/WebCore/platform/graphics/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=308674">https://bugs.webkit.org/show_bug.cgi?id=308674</a>
<a href="https://rdar.apple.com/problem/171207441">rdar://problem/171207441</a>

Reviewed by Sammy Gill.

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::fontDescriptorWithFamilySpecialCase):
(WebCore::FontCache::systemFallbackForCharacterCluster):
* Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm:
(WebCore::FontPlatformData::variationAxes const):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
(WebCore::SystemFontDatabaseCoreText::createTextStyleFont):
(WebCore::SystemFontDatabase::platformSystemFontShorthandInfo):

Canonical link: <a href="https://commits.webkit.org/308312@main">https://commits.webkit.org/308312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285733ca5a8a9b15456c33b5f1ff9720d4c6405c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155743 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84faab8c-8032-4964-94d7-622cb66e63f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/990dd32e-d5ad-4b54-a05f-5b144d3e9419) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94080 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12542 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3185 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158074 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121346 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121547 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31143 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131802 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8620 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19039 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->