### PR TITLE
LocalFrame::frameWasDisconnectedFromOwner does not properly reset RenderView

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1338,10 +1338,7 @@ void LocalFrame::frameWasDisconnectedFromOwner() const
     if (!m_doc)
         return;
 
-    if (RefPtr window = m_doc->window())
-        window->willDetachDocumentFromFrame();
-
-    protect(document())->detachFromFrame();
+    protect(document())->willBeRemovedFromFrame();
 }
 
 void LocalFrame::storageAccessExceptionReceivedForDomain(const RegistrableDomain& domain)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -143,6 +143,7 @@ Tests/WebKitCocoa/FullscreenScrollAndResize.mm @nonARC
 Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm @nonARC
 Tests/WebKitCocoa/GPUProcess.mm @nonARC
 Tests/WebKitCocoa/Geolocation.mm @nonARC
+Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.mm @nonARC
 Tests/WebKitCocoa/GetDisplayMedia.mm @nonARC
 Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm @nonARC
 Tests/WebKitCocoa/GetResourceData.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -403,6 +403,9 @@
 		76E182DD1547569100F1FADD /* WillSendSubmitEvent_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 76E182DC1547569100F1FADD /* WillSendSubmitEvent_Bundle.cpp */; };
 		79C5D431209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm in Sources */ = {isa = PBXBuildFile; fileRef = 79C5D430209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm */; };
 		7A0509411FB9F06400B33FB8 /* JSONValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A0509401FB9F04400B33FB8 /* JSONValue.cpp */; };
+		7A305A572F4E78840090F18A /* GetComputedStyleAfterIframeRemoval-subframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A305A4D2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval-subframe.html */; };
+		7A305A582F4E78840090F18A /* GetComputedStyleAfterIframeRemoval.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7A305A4B2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval.html */; };
+		7A305A5C2F4E87300090F18A /* GetComputedStyleAfterIframeRemovalPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A305A4E2F4E78520090F18A /* GetComputedStyleAfterIframeRemovalPlugIn.mm */; };
 		7A32D74A1F02151500162C44 /* FileMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A32D7491F02151500162C44 /* FileMonitor.cpp */; };
 		7A7B0E7F1EAFE4C3006AB8AE /* LimitTitleSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A7B0E7E1EAFE454006AB8AE /* LimitTitleSize.mm */; };
 		7A89BB682331643A0042CB1E /* BundleFormDelegatePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A89BB662331635D0042CB1E /* BundleFormDelegatePlugIn.mm */; };
@@ -2049,6 +2052,8 @@
 				A17C46B92C98E54B0023F3C7 /* geolocationGetCurrentPositionWithHighAccuracy.html in Copy Resources */,
 				A17C46BA2C98E54B0023F3C7 /* geolocationWatchPosition.html in Copy Resources */,
 				A17C46BB2C98E54B0023F3C7 /* geolocationWatchPositionWithHighAccuracy.html in Copy Resources */,
+				7A305A572F4E78840090F18A /* GetComputedStyleAfterIframeRemoval-subframe.html in Copy Resources */,
+				7A305A582F4E78840090F18A /* GetComputedStyleAfterIframeRemoval.html in Copy Resources */,
 				A17C47752C98E5C20023F3C7 /* getDisplayMedia.html in Copy Resources */,
 				A17C47762C98E5C20023F3C7 /* GetSessionCookie.html in Copy Resources */,
 				A17C46BC2C98E54B0023F3C7 /* getUserMedia-webaudio.html in Copy Resources */,
@@ -3394,6 +3399,11 @@
 		7A010BCC1D877C0D00EDE72A /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		7A0509401FB9F04400B33FB8 /* JSONValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSONValue.cpp; sourceTree = "<group>"; };
 		7A1458FB1AD5C03500E06772 /* mouse-button-listener.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "mouse-button-listener.html"; sourceTree = "<group>"; };
+		7A305A4B2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = GetComputedStyleAfterIframeRemoval.html; sourceTree = "<group>"; };
+		7A305A4C2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GetComputedStyleAfterIframeRemoval.mm; sourceTree = "<group>"; };
+		7A305A4D2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval-subframe.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "GetComputedStyleAfterIframeRemoval-subframe.html"; sourceTree = "<group>"; };
+		7A305A4E2F4E78520090F18A /* GetComputedStyleAfterIframeRemovalPlugIn.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GetComputedStyleAfterIframeRemovalPlugIn.mm; sourceTree = "<group>"; };
+		7A305A4F2F4E78520090F18A /* GetComputedStyleAfterIframeRemovalProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GetComputedStyleAfterIframeRemovalProtocol.h; sourceTree = "<group>"; };
 		7A32D7491F02151500162C44 /* FileMonitor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileMonitor.cpp; sourceTree = "<group>"; };
 		7A33FF2F27C82F0B00D7E03E /* LockdownModePDF.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = LockdownModePDF.html; sourceTree = "<group>"; };
 		7A33FF3227C8314D00D7E03E /* webkit-logo.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "webkit-logo.pdf"; sourceTree = "<group>"; };
@@ -4961,6 +4971,9 @@
 				CD7FC5D82CDAF7160032C1FC /* FullscreenScrollAndResize.mm */,
 				F4BDA42E27F8BF2F00F9647D /* FullscreenVideoTextRecognition.mm */,
 				631EFFF51E7B5E8D00D2EBB8 /* Geolocation.mm */,
+				7A305A4C2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval.mm */,
+				7A305A4E2F4E78520090F18A /* GetComputedStyleAfterIframeRemovalPlugIn.mm */,
+				7A305A4F2F4E78520090F18A /* GetComputedStyleAfterIframeRemovalProtocol.h */,
 				07E1F6A01FFC3A080096C7EC /* GetDisplayMedia.mm */,
 				0738012E275EADAB000FA77C /* GetDisplayMediaWindowAndScreen.mm */,
 				2DADF26221CB8F32003D3E3A /* GetResourceData.mm */,
@@ -5940,6 +5953,8 @@
 				93A9BF6027BF5AE4000B44D3 /* general-storage-directory.origin */,
 				936EC36527BA3AF200AFA8AE /* general-storage-directory.salt */,
 				636353A61E9861940009F8AF /* GeolocationGetCurrentPositionResult.html */,
+				7A305A4D2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval-subframe.html */,
+				7A305A4B2F4E78520090F18A /* GetComputedStyleAfterIframeRemoval.html */,
 				07E1F6A11FFC44F90096C7EC /* getDisplayMedia.html */,
 				467C565121B5ECDF0057516D /* GetSessionCookie.html */,
 				F47D30ED1ED28A6C000482E1 /* gif-and-file-input.html */,
@@ -8361,6 +8376,7 @@
 				A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */,
 				5C121E8D2410704900486F9B /* ContentWorldPlugIn.mm in Sources */,
 				F4B0168425AE08F800E445C4 /* DisableSpellcheckPlugIn.mm in Sources */,
+				7A305A5C2F4E87300090F18A /* GetComputedStyleAfterIframeRemovalPlugIn.mm in Sources */,
 				F460F65B261119580064F2B6 /* InjectedBundleHitTestPlugIn.mm in Sources */,
 				0E404A8C2166DE0A008271BA /* InjectedBundleNodeHandleIsSelectElement.mm in Sources */,
 				79C5D431209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval-subframe.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval-subframe.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div id="target" style="margin-top:10px; padding-left:2em; font-size:16px; width:10vw; max-width:50vw;">target content</div>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>iframe with styled content</title></head>
+<body>
+<iframe id="testFrame" src="GetComputedStyleAfterIframeRemoval-subframe.html"></iframe>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.mm
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "GetComputedStyleAfterIframeRemovalProtocol.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/_WKRemoteObjectInterface.h>
+#import <WebKit/_WKRemoteObjectRegistry.h>
+#import <wtf/RetainPtr.h>
+
+// FIXME(rdar://171294437): Disabling the back/forward cache explicitly is (for some reason) not available
+// on iOS, so we can only run this test on macOS at present.
+#if PLATFORM(MAC)
+
+static bool didReceiveResult;
+
+@interface GetComputedStyleAfterIframeRemovalObject : NSObject <GetComputedStyleAfterIframeRemovalProtocol>
+@end
+
+@implementation GetComputedStyleAfterIframeRemovalObject
+
+- (void)didNotCrashWithResult:(NSString *)result
+{
+    // After disconnectContentFrame() completes, the iframe's render tree should have been torn down.
+    // Viewport factors should resolve to zero, and width:10vw should compute "0px".
+    EXPECT_WK_STREQ(result, @"0px");
+    didReceiveResult = true;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+TEST(WebKit, GetComputedStyleAfterIframeOwnerDestructionDoesNotCrash)
+{
+    RetainPtr configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"GetComputedStyleAfterIframeRemovalPlugIn"]);
+    // Disabling the back/forward cache explicitly is (for some reason) not available on iOS.
+    // Disable the Back-Forward Cache so that navigating away from the first page immediately
+    // triggers HTMLFrameOwnerElement::disconnectContentFrame() on its subframes. Otherwise we can't
+    // test the frame teardown in this test.
+    [[configuration preferences] _setUsesPageCache:NO];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr object = adoptNS([[GetComputedStyleAfterIframeRemovalObject alloc] init]);
+    RetainPtr interface = retainPtr([_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(GetComputedStyleAfterIframeRemovalProtocol)]);
+    [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface.get()];
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    NSURL *pageURL = [NSBundle.test_resourcesBundle URLForResource:@"GetComputedStyleAfterIframeRemoval" withExtension:@"html"];
+    [webView loadFileURL:pageURL allowingReadAccessToURL:pageURL.URLByDeletingLastPathComponent];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Navigate to a second page to trigger HTMLFrameOwnerElement::disconnectContentFrame()
+    [webView loadHTMLString:@"<html><body>second page</body></html>" baseURL:nil];
+
+    TestWebKitAPI::Util::run(&didReceiveResult);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalPlugIn.mm
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "GetComputedStyleAfterIframeRemovalProtocol.h"
+#import <WebKit/WKWebProcessPlugIn.h>
+#import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <WebKit/WKWebProcessPlugInFrame.h>
+#import <WebKit/WKWebProcessPlugInLoadDelegate.h>
+#import <WebKit/WKWebProcessPlugInScriptWorld.h>
+#import <WebKit/_WKRemoteObjectInterface.h>
+#import <WebKit/_WKRemoteObjectRegistry.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+// FIXME(rdar://171294437): Disabling the back/forward cache explicitly is (for some reason) not available
+// on iOS, so we can only run this test on macOS at present.
+#if PLATFORM(MAC)
+
+// This plugin verifies the render tree cleanup invariant established by the fix in
+// LocalFrame::frameWasDisconnectedFromOwner() (rdar://171020009).
+//
+// After an iframe is disconnected via HTMLFrameOwnerElement::disconnectContentFrame(),
+// the iframe's render tree must be fully torn down before any code observes the
+// post-disconnection state. The plugin uses didRemoveFrameFromHierarchy: to detect
+// frame removal, then schedules a dispatch_async block to run after the full
+// disconnectContentFrame() call stack (including disconnectOwnerElement()) unwinds.
+// It then calls getComputedStyle on an element styled with a viewport unit (width:10vw).
+// Because the render tree is gone, m_renderView is null, viewport factors resolve to
+// zero, and the result is "0px" — confirming that the render tree is cleanly torn down.
+
+@interface GetComputedStyleAfterIframeRemovalPlugIn : NSObject <WKWebProcessPlugIn, WKWebProcessPlugInLoadDelegate>
+@end
+
+@implementation GetComputedStyleAfterIframeRemovalPlugIn {
+    RetainPtr<WKWebProcessPlugInBrowserContextController> _browserContextController;
+    RetainPtr<id<GetComputedStyleAfterIframeRemovalProtocol>> _remoteObject;
+
+    RetainPtr<JSContext> _savedIframeContext;
+    BOOL _hasSavedIframeContext;
+    BOOL _didReport;
+}
+
+- (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
+{
+    _browserContextController = browserContextController;
+
+    auto interface = retainPtr([_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(GetComputedStyleAfterIframeRemovalProtocol)]);
+    _remoteObject = [[browserContextController _remoteObjectRegistry] remoteObjectProxyWithInterface:interface.get()];
+
+    [browserContextController setLoadDelegate:self];
+}
+
+- (void)webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller didFinishDocumentLoadForFrame:(WKWebProcessPlugInFrame *)frame
+{
+    // Save state only from the subframe (non-main frame) with the styled target element.
+    if (frame.isMainFrame || _hasSavedIframeContext)
+        return;
+
+    JSContext *context = [frame jsContextForWorld:WKWebProcessPlugInScriptWorld.normalWorld];
+    if (!context)
+        return;
+
+    // Check that the target element exists in this frame.
+    JSValue *element = [context evaluateScript:@"document.getElementById('target')"];
+    if (!element || [element isNull] || [element isUndefined])
+        return;
+
+    _savedIframeContext = context;
+    _hasSavedIframeContext = YES;
+}
+
+- (void)webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller didRemoveFrameFromHierarchy:(WKWebProcessPlugInFrame *)frame
+{
+    if (frame.isMainFrame || !_hasSavedIframeContext || _didReport)
+        return;
+
+    _hasSavedIframeContext = NO;
+    _didReport = YES;
+
+    RetainPtr<JSContext> savedContext = _savedIframeContext;
+    RetainPtr<id<GetComputedStyleAfterIframeRemovalProtocol>> remoteObject = _remoteObject;
+    _savedIframeContext = nil;
+
+    // dispatch_async ensures this block runs after the entire disconnectContentFrame()
+    // call stack unwinds — including disconnectOwnerElement() -> frameWasDisconnectedFromOwner().
+    // At that point the render tree is fully torn down.
+    dispatch_async(mainDispatchQueueSingleton(), ^{
+        JSValue *result = [savedContext.get() evaluateScript:
+            @"(function() {"
+                "var el = document.getElementById('target');"
+                "if (!el) return '(element gone)';"
+                "try {"
+                "    return window.getComputedStyle(el).width;"
+                "} catch(e) {"
+                "    return '(exception: ' + e + ')';"
+                "}})()"];
+
+        NSString *resultString = (result && ![result isNull] && ![result isUndefined]) ? [result toString] : @"(null)";
+        [remoteObject.get() didNotCrashWithResult:resultString];
+    });
+}
+
+@end
+
+#endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalProtocol.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalProtocol.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+@protocol GetComputedStyleAfterIframeRemovalProtocol <NSObject>
+- (void)didNotCrashWithResult:(NSString *)result;
+@end


### PR DESCRIPTION
#### 7ff8905cfd095d76e97e6adc5846bf065d486323
<pre>
LocalFrame::frameWasDisconnectedFromOwner does not properly reset RenderView
<a href="https://bugs.webkit.org/show_bug.cgi?id=308573">https://bugs.webkit.org/show_bug.cgi?id=308573</a>
<a href="https://rdar.apple.com/171101953">rdar://171101953</a>

Reviewed by Ryosuke Niwa.

The Document object holds a unique_ptr to a RenderView (m_renderView) that holds a CheckedRef
to a LocalFrameView. The LocalFrameView is an aspect of the m_frame member of the Document.
When the Document detaches from a frame, the RenderView pointer it holds is no longer valid.
Crash data indicated that the RenderView was not being properly cleaned up when the frame
member was cleared or changed.

This seems to be because of Document::frameWasDisconnectedFromOwner (and more recent Site
Isolation versions of this logic) improperly called Document::detachFromFrame directly,
rather than Document::willBeRemovedFromFrame, which handles the bookkeeping for keeping
RenderView (as well as selection views, etc.) in sync.

A new API test was added to confirm the RenderView is fully cleaned up when the frame
is detached from the document.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval-subframe.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalPlugIn.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalProtocol.h

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameWasDisconnectedFromOwner const): Switch from calling
detachFromFrame directly, and instead call willBeRemovedFromFrame (which calls detachFromFrame
after completing some cleanup).
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval-subframe.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemoval.mm: Added.
(-[GetComputedStyleAfterIframeRemovalObject didNotCrashWithResult:]):
(TestWebKitAPI::TEST(WebKit, GetComputedStyleAfterIframeOwnerDestructionDoesNotCrash)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalPlugIn.mm: Added.
(-[GetComputedStyleAfterIframeRemovalPlugIn webProcessPlugIn:didCreateBrowserContextController:]):
(-[GetComputedStyleAfterIframeRemovalPlugIn webProcessPlugInBrowserContextController:didFinishDocumentLoadForFrame:]):
(-[GetComputedStyleAfterIframeRemovalPlugIn webProcessPlugInBrowserContextController:didRemoveFrameFromHierarchy:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetComputedStyleAfterIframeRemovalProtocol.h: Added.

Canonical link: <a href="https://commits.webkit.org/308317@main">https://commits.webkit.org/308317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20489af3275131f31ae7acc1f32271599bca0d72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100495 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b21803b5-1dcf-4c31-9822-5095493bc9e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113344 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9674320-f7af-43b1-b967-3ca3fecb9037) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94100 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e966ad6-3569-4e68-b996-3bb1b382a37d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14777 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1225 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121367 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121568 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31147 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131813 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8629 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82933 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18967 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->