### PR TITLE
[webkitapipy] Support conditional allowlist entries based on OS / SDK version

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py
@@ -23,8 +23,10 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass, field
+from decimal import Decimal
 from pathlib import Path
 from enum import Enum
 from typing import Any, NamedTuple, Optional, Union
@@ -41,6 +43,8 @@ if sys.version_info < (3, 11):
 else:
     from enum import StrEnum
 
+VERSION_REQ = re.compile(r'(?P<platform>[a-zA-Z]+) ?(?P<op>==|!=|>|>=|<=|<) '
+                         r'?(?P<version>\d+(\.\d+\*?|\.\*)?)', flags=re.ASCII)
 
 @dataclass
 class AllowedSPI:
@@ -51,6 +55,8 @@ class AllowedSPI:
     selectors: list[Selector]
     classes: list[str]
     requires: list[str] = field(default_factory=list)
+    requires_os: list[RequiredVersion] = field(default_factory=list)
+    requires_sdk: list[RequiredVersion] = field(default_factory=list)
     allow_unused: bool = False
 
     class Selector(NamedTuple):
@@ -60,6 +66,11 @@ class AllowedSPI:
     class Bugs(NamedTuple):
         request: Optional[str]
         cleanup: Optional[str]
+
+    class RequiredVersion(NamedTuple):
+        platform: str
+        operator: str
+        version: str
 
 
 class AllowedReason(StrEnum):
@@ -79,6 +90,30 @@ class AllowedReason(StrEnum):
     # For SPI that has same behavior as API except in internal builds.
     EQUIVALENT_API = 'equivalent-api'
 
+
+def _transform_wildcard_version(op: str, version: str) -> tuple[str, str]:
+    '''
+    As syntactic sugar, transform a gte (<=) version clause ending in a
+    wildcard into its logical equivalent. This is helpful to avoid writing what
+    appear to be unreleased marketing versions in allowlists. For example:
+
+        iOS <= 26.*      =>     iOS < 27.00
+        iOS <= 26.3*     =>     iOS < 26.40
+    '''
+    if op != '<=':
+        raise ValueError(op)
+
+    new_version = Decimal(version.replace('*', '99'))
+    # `exponent` represents the location of the decimal point, which varies
+    # based on where the "*" appeared. For example: 26.* => 26.99 => E -2
+    _, _, exponent = new_version.as_tuple()
+    assert isinstance(exponent, int), \
+        f'exponent of version number "{version}" outside representible bounds'
+    # Increment to the next possible new_version number.
+    new_version += Decimal(10) ** exponent
+    # Major and minor components must be no more than two digits.
+    new_version = min(new_version, Decimal('99.99'))
+    return '<', f'{new_version:.2f}'
 
 @dataclass
 class AllowList:
@@ -110,9 +145,32 @@ class AllowList:
                 bugs = AllowedSPI.Bugs(entry.pop('request', None),
                                        entry.pop('cleanup', None))
                 allow_unused = bool(entry.pop('allow-unused', False))
+
+                requires_os: list[AllowedSPI.RequiredVersion] = []
+                requires_sdk: list[AllowedSPI.RequiredVersion] = []
+                for required_versions, key in ((requires_os, 'requires-os'),
+                                               (requires_sdk, 'requires-sdk')):
+                    for clause in entry.pop(key, []):
+                        m = VERSION_REQ.fullmatch(clause)
+                        if not m:
+                            raise ValueError('unmatched requirement '
+                                             f'clause: "{clause}"')
+                        platform, op, version = m.group('platform', 'op',
+                                                        'version')
+                        if version.endswith('*'):
+                            if op != '<=':
+                                raise ValueError('wildcard in required version '
+                                                 'only supported when operator '
+                                                 f'is "<=": "{clause}"')
+                            op, version = _transform_wildcard_version(op, version)
+                        required_versions.append(
+                            AllowedSPI.RequiredVersion(platform, op,
+                                                       version))
                 allow = AllowedSPI(reason=reason, bugs=bugs, symbols=syms,
                                    selectors=sels, classes=clss, requires=reqs,
-                                   allow_unused=allow_unused)
+                                   allow_unused=allow_unused,
+                                   requires_os=requires_os,
+                                   requires_sdk=requires_sdk)
 
                 if reason == AllowedReason.TEMPORARY_USAGE:
                     if not bugs.cleanup:
@@ -124,8 +182,16 @@ class AllowList:
                         raise ValueError('Allowlist entries marked '
                                          'temporary-usage must have a '
                                          f'"cleanup" bug: {allow}')
-                elif reason not in (AllowedReason.LEGACY,
-                                    AllowedReason.STAGING):
+                elif reason == AllowedReason.STAGING:
+                    pass
+                    # FIXME: Disabled while allowlist entries are cleaned up,
+                    # cf. rdar://170360205
+                    # if not requires_sdk:
+                    #     raise ValueError('Allowlist entries marked staging '
+                    #                      'must have a "requires-sdk" clause '
+                    #                      'that specifies which SDK(s) do not '
+                    #                      'yet have the API avaiable: {allow}')
+                elif reason != AllowedReason.LEGACY:
                     if not bugs.request:
                         raise ValueError('Allowlist entries must have a '
                                          f'"request" bug: {allow}')

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py
@@ -25,7 +25,7 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-from .allow import AllowList, AllowedSPI, AllowedReason
+from .allow import AllowList, AllowedSPI, AllowedReason, _transform_wildcard_version
 
 Toml = b'''
 [[temporary-usage]]
@@ -39,6 +39,8 @@ classes = ["NSTemporarilyAllowed"]
 request = "rdar://234567890"
 symbols = ["Permanent1", "Permanent2"]
 requires = ["ENABLE_FOO", "!ENABLE_BAR"]
+requires-os = ["iOS<26.0", "iOS>=18.2"]
+requires-sdk = [ "iOS <= 26.*" ]
 '''
 
 A1 = AllowedSPI(reason=AllowedReason.TEMPORARY_USAGE,
@@ -50,7 +52,10 @@ A1 = AllowedSPI(reason=AllowedReason.TEMPORARY_USAGE,
 A2 = AllowedSPI(reason=AllowedReason.NOT_WEB_ESSENTIAL,
                 bugs=AllowedSPI.Bugs(request='rdar://234567890', cleanup=None),
                 symbols=['_Permanent1', '_Permanent2'],
-                selectors=[], classes=[], requires=['ENABLE_FOO', '!ENABLE_BAR'])
+                selectors=[], classes=[], requires=['ENABLE_FOO', '!ENABLE_BAR'],
+                requires_os=[AllowedSPI.RequiredVersion('iOS', '<', '26.0'),
+                             AllowedSPI.RequiredVersion('iOS', '>=', '18.2')],
+                requires_sdk=[AllowedSPI.RequiredVersion('iOS', '<', '27.00')])
 
 
 class TestAllowList(TestCase):
@@ -131,7 +136,6 @@ class TestAllowList(TestCase):
                  'requires': ['A', 'B', 'A']}
             ]})
 
-
     def test_no_string(self):
         with self.assertRaisesRegex(ValueError, '"Foo" in allowlist is a '
                                     'string, expected a list'):
@@ -139,3 +143,42 @@ class TestAllowList(TestCase):
                 {'request': 'rdar://1', 'cleanup': 'rdar://2',
                  'classes': 'Foo'},
             ]})
+
+    def test_invalid_version_requirements(self):
+        with self.assertRaisesRegex(ValueError, 'unmatched requirement'):
+            AllowList.from_dict({'temporary-usage': [
+                {'request': 'rdar://1', 'cleanup': 'rdar://2',
+                 'classes': ['Foo'], 'requires-os': ['15.0 < macOS']}
+            ]})
+        with self.assertRaisesRegex(ValueError, 'unmatched requirement'):
+            AllowList.from_dict({'temporary-usage': [
+                {'request': 'rdar://1', 'cleanup': 'rdar://2',
+                 'classes': ['Foo'], 'requires-os': ['macOS=15.0']}
+            ]})
+
+    def test_required_fields(self):
+        with self.assertRaisesRegex(ValueError, 'must have a "cleanup" bug'):
+            AllowList.from_dict({'temporary-usage': [
+                {'request': 'rdar://1', 'classes': ['Foo']}
+            ]})
+
+        # FIXME: Disabled while allowlist entries are cleaned up,
+        # cf. rdar://170360205
+        # with self.assertRaisesRegex(ValueError, 'must have a "requires-sdk" '
+        #                             'clause'):
+        #     AllowList.from_dict({'staging': [
+        #         {'classes': ['Foo']}
+        #     ]})
+
+    def test_wildcard_version(self):
+        self.assertEqual(_transform_wildcard_version('<=', '26.*'), ('<', '27.00'))
+        self.assertEqual(_transform_wildcard_version('<=', '26.3*'), ('<', '26.40'))
+        self.assertEqual(_transform_wildcard_version('<=', '26.9*'), ('<', '27.00'))
+        self.assertEqual(_transform_wildcard_version('<=', '26.0*'), ('<', '26.10'))
+        # Kind of nonsensical, but syntactically valid.
+        self.assertEqual(_transform_wildcard_version('<=', '26.30*'), ('<', '26.31'))
+        self.assertEqual(_transform_wildcard_version('<=', '*'), ('<', '99.99'))
+        with self.assertRaises(ValueError):
+            _transform_wildcard_version('<', '26.*')
+            _transform_wildcard_version('==', '26.*')
+            _transform_wildcard_version('!=', '26.*')

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/macho.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/macho.py
@@ -37,6 +37,9 @@ objc_fully_qualified_method = re.compile(r'[-+]\[(?P<class>\S+) (?P<selector>[^\
 class APIReport:
     file: Path
     arch: str
+    platform: str
+    min_os: str
+    sdk: str
 
     exports: set[str] = field(default_factory=set)
     methods: set[APIReport.Selector] = field(default_factory=set)
@@ -50,7 +53,7 @@ class APIReport:
     @classmethod
     def from_binary(cls, binary_path: Path, *, arch: str,
                     exports_only: bool = False) -> APIReport:
-        dyld_args = ['-arch', arch, '-exports', '-objc']
+        dyld_args = ['-arch', arch, '-platform', '-exports', '-objc']
         if not exports_only:
             dyld_args.extend(('-imports',
                               # WebKit binaries typically use __DATA_CONST, but
@@ -62,16 +65,26 @@ class APIReport:
         dyld = subprocess.run(('xcrun', 'dyld_info', *dyld_args, binary_path),
                               check=True, stdout=subprocess.PIPE, text=True)
 
-        report = cls(file=binary_path, arch=arch)
-        report._populate_from_dyld_info(dyld.stdout)
-        return report
+        return cls._from_dyld_info(binary_path, arch, dyld.stdout)
 
-    def _populate_from_dyld_info(self, dyld_output: str):
-        Sect = Enum('Sect', 'EXPORTS IMPORTS OBJC SELREFS DLSYM GETCLASS')
+    @classmethod
+    def _from_dyld_info(cls, binary_path: Path, arch: str,
+                        dyld_output: str) -> APIReport:
+        Sect = Enum('Sect', 'PLATFORM EXPORTS IMPORTS OBJC SELREFS DLSYM '
+                    'GETCLASS')
         in_section = None
         next_cstr = bytearray()
+        seen_platform = False
 
-        header_line = f'{self.file} [{self.arch}]:'
+        platform: str
+        min_os: str
+        sdk: str
+        exports: set[str] = set()
+        methods: set[APIReport.Selector] = set()
+        imports: set[str] = set()
+        selrefs: set[str] = set()
+
+        header_line = f'{binary_path} [{arch}]:'
         for line in dyld_output.splitlines():
             # Each of dyld_info's flags prints its own section of the output.
             # In this line-based parser, keep track of which section we are in,
@@ -82,7 +95,9 @@ class APIReport:
                 continue
 
             # Detect changes to the section of output.
-            if line == '-exports:':
+            if line == '-platform:':
+                in_section = Sect.PLATFORM
+            elif line == '-exports:':
                 in_section = Sect.EXPORTS
             elif line == '-imports:':
                 in_section = Sect.IMPORTS
@@ -97,6 +112,17 @@ class APIReport:
                 in_section = Sect.GETCLASS
 
             # Parse symbol information based on the current section.
+            elif in_section == Sect.PLATFORM:
+                # ```
+                # platform     minOS      sdk
+                #      iOS     26.0      26.0
+                # ```
+                if not seen_platform:
+                    assert line.split() == ['platform', 'minOS', 'sdk'], \
+                        'dyld_info -platform info in unexpected format'
+                    seen_platform = True
+                    continue
+                platform, min_os, sdk = line.split()
             elif in_section == Sect.EXPORTS:
                 # Address in binary and symbol name:
                 # ```
@@ -105,7 +131,7 @@ class APIReport:
                 offset, symbol = line.split(maxsplit=1)
                 # skip the header line
                 if offset != 'offset':
-                    self.exports.add(symbol)
+                    exports.add(symbol)
             elif in_section == Sect.IMPORTS:
                 # Hexadecimal index, symbol name, optional linkage tag, and
                 # containing dylib as recorded in the two-level namespace:
@@ -115,7 +141,7 @@ class APIReport:
                 idx, symbol, metadata = line.split(maxsplit=2)
                 dylib = metadata[metadata.index('(from ') + 6:-1]
                 if dylib != '<this-image>':
-                    self.imports.add(symbol)
+                    imports.add(symbol)
             elif in_section == Sect.OBJC:
                 # ObjC-like declaration for classes and protocols with method
                 # names and method addresses for classes:
@@ -138,11 +164,11 @@ class APIReport:
                 # ```
                 m = objc_fully_qualified_method.search(line)
                 if m:
-                    sel = self.Selector._make(m.group('selector', 'class'))
-                    self.methods.add(sel)
+                    sel = cls.Selector._make(m.group('selector', 'class'))
+                    methods.add(sel)
                 elif '@interface' not in line and \
                         '@protocol' not in line and '@end' not in line:
-                    print(f'warning:{self.file} unrecognized '
+                    print(f'warning:{binary_path} unrecognized '
                           f'dyld_info -objc line: "{line}"', file=sys.stderr)
             elif in_section == Sect.SELREFS:
                 # Address in binary of selref data, followed by selector
@@ -151,7 +177,7 @@ class APIReport:
                 # 0x0A8043D8  "interruption:"
                 # ```
                 address, quoted_name = line.split(maxsplit=1)
-                self.selrefs.add(quoted_name.strip('"'))
+                selrefs.add(quoted_name.strip('"'))
             elif in_section in (Sect.DLSYM, Sect.GETCLASS):
                 # hexdump-style output, separated by lines containing symbol
                 # names:
@@ -169,10 +195,14 @@ class APIReport:
                         continue
                     name = next_cstr.decode()
                     if in_section == Sect.GETCLASS:
-                        self.imports.add(f'_OBJC_CLASS_$_{name}')
+                        imports.add(f'_OBJC_CLASS_$_{name}')
                     else:
-                        self.imports.add(f'_{name}')
+                        imports.add(f'_{name}')
                     del next_cstr[:]
             else:
-                print(f'warning:{self.file}: unrecognized '
+                print(f'warning:{binary_path}: unrecognized '
                       f'dyld_info line: "{line}"', file=sys.stderr)
+
+        return cls(file=binary_path, arch=arch, platform=platform,
+                   min_os=min_os, sdk=sdk, exports=exports, methods=methods,
+                   imports=imports, selrefs=selrefs)

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
@@ -297,7 +297,7 @@ def main(argv: Optional[list[str]] = None):
         with db:
             db.add_allowlist(use_input(path))
     if args.defines:
-        db.add_defines(args.defines)
+        db.add_conditions({d: 1 for d in args.defines})
 
     if program_additions:
         reporter = program_additions.configure_reporter(args, db)


### PR DESCRIPTION
#### 22027c3bc06fd3fbe4caf05651c03aa2071a5a9b
<pre>
[webkitapipy] Support conditional allowlist entries based on OS / SDK version
<a href="https://bugs.webkit.org/show_bug.cgi?id=302293">https://bugs.webkit.org/show_bug.cgi?id=302293</a>
<a href="https://rdar.apple.com/164435576">rdar://164435576</a>

Reviewed by Sam Sneddon. Reland of 308228@main with accidental allowlist
code changes (from a forthcoming PR) removed.

There are some cases where a more general OS or SDK version check is
superior to conditionalizing an allowlist entry based on a
wtf/Platform.h flag:

- Staged API adoption is based on forward-declaring API that has yet to
  appear in the builds of the SDK. Until it does, it will look like SPI
  to the tool. But its usability (and whether or not it is API) is not based
  on a WebKit feature flag, it&apos;s based on the SDK vesrion.

- API from frameworks that WebKit builds with internally (such as
  AuthenticationServices.framework) may have already shipped in new
  SDKs, but when building against older SDKs appears as SPI. Again, the
  SDK is what determines whether the usage looks like SPI.

To support these use cases, add optional &quot;request-os&quot; and &quot;requires-sdk&quot; version
requirement keys to the allowlist format. Each is a list of strings with
the form &quot;&lt;platform&gt; &lt;operator&gt; &lt;version&gt;&quot;. For example:

    [[staging]]
    classes = [MyNewClass]
    requires = [ENABLE_MY_NEW_FEATURE]
    requires-sdk = [&quot;iOS &lt; 26.2&quot;]

Special wildcard syntactic sugar is available for the purpose of
avoiding writing a misleading marketing version. A requirement like:

    iOS &lt; 26.0

may be written as:

    iOS &lt;= 25.*

At parse time the wildcard expression is transformed into its logical
equivalent.

In the SDKDB cache, this is implemented by extending the existing
&quot;conditional chain&quot; mechanism used for Platform flags. Conditionals now
have a value (WTF-style defines are all value &quot;1&quot;), and each link in the
chain has an associated operator.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py:
(AllowedSPI):
(AllowedSPI.RequiredVersion):
(_transform_wildcard_version):
(AllowList.from_dict):

* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py:
(TestAllowList.test_repeated_requirements):
(TestAllowList.test_no_string):
(TestAllowList):
(TestAllowList.test_invalid_version_requirements):
(TestAllowList.test_required_fields):

(TestAllowList.test_wildcard_version):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/macho.py: Read the
  platform and versions from each binary&apos;s Mach-O header.
(APIReport):
(APIReport.from_binary):
(APIReport._from_dyld_info):
(APIReport._populate_from_dyld_info):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py:
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(apply_operator_sql):
(semver_to_int): Used to store version numbers as 6-digit integers, for
  easy comparison, similar to what OS headers do.
(SDKDB._initialize_db):
(SDKDB._initialize_temporary_schema):
(SDKDB._add_allowlist):
(SDKDB.add_conditions): New entrypoint for add_defines which takes
  key-value pairs instead of just keys.
(SDKDB._add_imports):
(SDKDB.audit):
(SDKDB.add_defines): Deleted.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.test_entries_removed_when_binary_updated):
(TestSDKDB.test_audit_allowed_conditional):
(TestSDKDB.test_audit_missing_name_conditional):
(TestSDKDB.test_audit_missing_name_negated_conditional):
(TestSDKDB.test_audit_allowed_negated_conditional):
(TestSDKDB.test_audit_allowed_multiple_conditions):
(TestSDKDB.test_audit_missing_name_multiple_conditions):
(TestSDKDB.test_audit_missing_name_multiple_conditions_negation):
(TestSDKDB):
(TestSDKDB.test_audit_minos_conditions):
(TestSDKDB.test_audit_api_in_loaded_and_unloaded_library):
(TestSDKDB.test_audit_allow_different_fully_qualified_methods_same_name):
(TestSDKDB.test_audit_unnecessary_allow_unqualified_methods_same_name):

Canonical link: <a href="https://commits.webkit.org/308247@main">https://commits.webkit.org/308247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfa2a3c214c117675ef0c4d41ee613f2202ee378

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19599 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155601 "Failed to checkout and rebase branch from PR 59464") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19500 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/155601 "Failed to checkout and rebase branch from PR 59464") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149881 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/13189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/155601 "Failed to checkout and rebase branch from PR 59464") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/146243 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3043 "Failed to checkout and rebase branch from PR 59464") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/13189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157932 "Failed to checkout and rebase branch from PR 59464") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/157932 "Failed to checkout and rebase branch from PR 59464") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/157932 "Failed to checkout and rebase branch from PR 59464") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/13189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22662 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19016 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->