### PR TITLE
Bounds checking does not work in Memory64 in BBQ and introduce AddressType

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1423,6 +1423,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     tools/LLVMProfiling.h
     tools/SourceProfiler.h
 
+    wasm/WasmAddressType.h
     wasm/WasmBaselineData.h
     wasm/WasmBranchHints.h
     wasm/WasmCallProfile.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1912,6 +1912,7 @@
 		CEAE7D7B889B477BA93ABA6C /* ScriptFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 8852151A9C3842389B3215B7 /* ScriptFetcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CECFAD362372DAD000291599 /* FuzzerPredictions.h in Headers */ = {isa = PBXBuildFile; fileRef = CECFAD342372DAA700291599 /* FuzzerPredictions.h */; };
 		CECFAD372372DAD400291599 /* FileBasedFuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = CECFAD322372DAA700291599 /* FileBasedFuzzerAgent.h */; };
+		D61524302F4CF1BD004C8AF6 /* WasmAddressType.h in Headers */ = {isa = PBXBuildFile; fileRef = D615242F2F4CF1AB004C8AF6 /* WasmAddressType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D9722752DC54459B9125B539 /* JSModuleLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 77B25CB2C3094A92A38E1DB3 /* JSModuleLoader.h */; };
 		DC00039319D8BE6F00023EB0 /* DFGPreciseLocalClobberize.h in Headers */ = {isa = PBXBuildFile; fileRef = DC00039019D8BE6F00023EB0 /* DFGPreciseLocalClobberize.h */; };
 		DC0184191D10C1890057B053 /* JITWorklist.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0184181D10C1870057B053 /* JITWorklist.h */; };
@@ -5730,6 +5731,8 @@
 		CECFAD352372DAA700291599 /* FuzzerPredictions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FuzzerPredictions.cpp; sourceTree = "<group>"; };
 		D21202280AD4310C00ED79B6 /* DateConversion.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = DateConversion.cpp; sourceTree = "<group>"; };
 		D21202290AD4310C00ED79B6 /* DateConversion.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = DateConversion.h; sourceTree = "<group>"; };
+		D615242F2F4CF1AB004C8AF6 /* WasmAddressType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmAddressType.h; sourceTree = "<group>"; };
+		D61524352F4CF5D1004C8AF6 /* WasmAddressType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmAddressType.cpp; sourceTree = "<group>"; };
 		DC00039019D8BE6F00023EB0 /* DFGPreciseLocalClobberize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGPreciseLocalClobberize.h; path = dfg/DFGPreciseLocalClobberize.h; sourceTree = "<group>"; };
 		DC0184171D10C1870057B053 /* JITWorklist.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JITWorklist.cpp; sourceTree = "<group>"; };
 		DC0184181D10C1870057B053 /* JITWorklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JITWorklist.h; sourceTree = "<group>"; };
@@ -8158,6 +8161,8 @@
 				FFD49E662E276CA10083E383 /* debugger */,
 				AD2FCB8A1DB5840000B3E736 /* js */,
 				FED5FA3629A085BD00798A7F /* wasm.json */,
+				D61524352F4CF5D1004C8AF6 /* WasmAddressType.cpp */,
+				D615242F2F4CF1AB004C8AF6 /* WasmAddressType.h */,
 				E38416412E6FC06000591840 /* WasmBaselineData.h */,
 				E30D06B629C6C3E80014CCE7 /* WasmBBQDisassembler.cpp */,
 				E30D06B729C6C3E80014CCE7 /* WasmBBQDisassembler.h */,
@@ -12479,6 +12484,7 @@
 				FE6F56DE1E64EAD600D17801 /* VMTraps.h in Headers */,
 				FEF5B42C2628CBC80016E776 /* VMTrapsInlines.h in Headers */,
 				FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */,
+				D61524302F4CF1BD004C8AF6 /* WasmAddressType.h in Headers */,
 				E38416422E6FC06000591840 /* WasmBaselineData.h in Headers */,
 				E30D06B829C6C3EE0014CCE7 /* WasmBBQDisassembler.h in Headers */,
 				FED5FA3429A0859C00798A7F /* WasmBBQJIT.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1152,6 +1152,7 @@ tools/JSDollarVM.cpp
 tools/SourceProfiler.cpp
 tools/VMInspector.cpp
 
+wasm/WasmAddressType.cpp
 wasm/WasmOMGIRGenerator.cpp
 wasm/WasmBBQDisassembler.cpp
 wasm/WasmBBQJIT.cpp @no-unify

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2625,9 +2625,9 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentReceiveBroadcast, (JSGlobalObject* g
             auto handler = [&vm, jsMemory](Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); };
             RefPtr<Wasm::Memory> memory;
             if (auto shared = std::get<RefPtr<SharedArrayBufferContents>>(WTF::move(content)))
-                memory = Wasm::Memory::create(shared.releaseNonNull(), WTF::move(handler));
+                memory = Wasm::Memory::create(shared.releaseNonNull(), jsMemory->memory().addressType(), WTF::move(handler));
             else
-                memory = Wasm::Memory::createZeroSized(MemorySharingMode::Shared, WTF::move(handler));
+                memory = Wasm::Memory::createZeroSized(MemorySharingMode::Shared, jsMemory->memory().addressType(), WTF::move(handler));
             jsMemory->adopt(memory.releaseNonNull());
             return jsMemory;
         }

--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -1,5 +1,4 @@
-/*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+/* Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,56 +22,57 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <wtf/Platform.h>
+#include "config.h"
+#include "WasmAddressType.h"
 
 #if ENABLE(WEBASSEMBLY)
 
-#include <JavaScriptCore/GPRInfo.h>
-#include <JavaScriptCore/PageCount.h>
-#include <JavaScriptCore/RegisterSet.h>
-#include <JavaScriptCore/WasmAddressType.h>
-#include <JavaScriptCore/WasmMemory.h>
-#include <JavaScriptCore/WasmOps.h>
-
-#include <wtf/Forward.h>
-#include <wtf/Ref.h>
-#include <wtf/Vector.h>
+#include "WasmOps.h"
 
 namespace JSC { namespace Wasm {
 
-struct PinnedSizeRegisterInfo {
-    GPRReg boundsCheckingSizeRegister;
-    unsigned sizeOffset;
-};
 
-class MemoryInformation {
-public:
-    MemoryInformation()
-    {
-        ASSERT(!*this);
+AddressType::AddressType(AddressType::Kind addressType) : m_type(addressType) { };
+
+AddressType::AddressType(bool is64Bit) : m_type(is64Bit ? AddressType::I64 : AddressType::I32) { };
+
+
+AddressType::AddressType(TypeKind typeKind)
+{
+    switch (typeKind) {
+    case TypeKind::I32:
+        m_type = AddressType::I32;
+        break;
+    case TypeKind::I64:
+        m_type = AddressType::I64;
+        break;
+    default:
+        ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
     }
+}
 
-    MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport, bool isMemory64);
+TypeKind AddressType::asTypeKind() const
+{
+    switch (m_type) {
+    case AddressType::I32:
+        return TypeKind::I32;
+    case AddressType::I64:
+        return TypeKind::I64;
+    default:
+        ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
+    }
+}
 
-    PageCount initial() const { return m_initial; }
-    PageCount maximum() const { return m_maximum; }
-    bool isShared() const { return m_isShared; }
-    bool isImport() const { return m_isImport; }
-    AddressType addressType() const { return m_addressType; }
-    bool isMemory64() const { return m_addressType.is64Bit(); }
+bool operator==(const AddressType& lhs, const AddressType& rhs)
+{
+    return lhs.m_type == rhs.m_type;
+}
 
-    explicit operator bool() const { return !!m_initial; }
+bool operator!=(const AddressType& lhs, const AddressType& rhs)
+{
+    return lhs.m_type != rhs.m_type;
+}
 
-private:
-    PageCount m_initial { };
-    PageCount m_maximum { };
-    bool m_isShared { false };
-    bool m_isImport { false };
-    AddressType m_addressType;
-};
-
-} } // namespace JSC::Wasm
+} }
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmAddressType.h
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.h
@@ -1,5 +1,4 @@
-/*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+/* Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,54 +24,35 @@
 
 #pragma once
 
-#include <wtf/Platform.h>
-
 #if ENABLE(WEBASSEMBLY)
 
-#include <JavaScriptCore/GPRInfo.h>
-#include <JavaScriptCore/PageCount.h>
-#include <JavaScriptCore/RegisterSet.h>
-#include <JavaScriptCore/WasmAddressType.h>
-#include <JavaScriptCore/WasmMemory.h>
-#include <JavaScriptCore/WasmOps.h>
-
-#include <wtf/Forward.h>
-#include <wtf/Ref.h>
-#include <wtf/Vector.h>
-
 namespace JSC { namespace Wasm {
+enum class TypeKind : int8_t;
 
-struct PinnedSizeRegisterInfo {
-    GPRReg boundsCheckingSizeRegister;
-    unsigned sizeOffset;
-};
-
-class MemoryInformation {
+class AddressType {
 public:
-    MemoryInformation()
-    {
-        ASSERT(!*this);
-    }
+    enum class Kind : int8_t {
+        I32,
+        I64
+    };
+    using enum Kind;
+    AddressType() = default;
+    AddressType(TypeKind);
+    AddressType(AddressType::Kind);
+    explicit AddressType(bool is64bit);
 
-    MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport, bool isMemory64);
+    AddressType::Kind type() const { return m_type; }
+    TypeKind asTypeKind() const;
 
-    PageCount initial() const { return m_initial; }
-    PageCount maximum() const { return m_maximum; }
-    bool isShared() const { return m_isShared; }
-    bool isImport() const { return m_isImport; }
-    AddressType addressType() const { return m_addressType; }
-    bool isMemory64() const { return m_addressType.is64Bit(); }
-
-    explicit operator bool() const { return !!m_initial; }
+    friend bool operator==(const AddressType& lhs, const AddressType& rhs);
+    friend bool operator!=(const AddressType& lhs, const AddressType& rhs);
+    bool is64Bit() const { return m_type == AddressType::I64; }
 
 private:
-    PageCount m_initial { };
-    PageCount m_maximum { };
-    bool m_isShared { false };
-    bool m_isImport { false };
-    AddressType m_addressType;
+
+    AddressType::Kind m_type { AddressType::I32 };
 };
 
 } } // namespace JSC::Wasm
-
+    //
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -43,6 +43,7 @@
 #include "JSWebAssemblyStruct.h"
 #include "MacroAssembler.h"
 #include "RegisterSet.h"
+#include "WasmAddressType.h"
 #include "WasmBBQDisassembler.h"
 #include "WasmBaselineData.h"
 #include "WasmCallProfile.h"
@@ -1101,7 +1102,7 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 [[nodiscard]] PartialResult BBQJIT::addGrowMemory(Value delta, Value& result)
 {
     Vector<Value, 8> arguments = { instanceValue(), delta };
-    result = topValue(m_info.theOnlyMemory().addressType());
+    result = topValue(m_info.theOnlyMemory().addressType().asTypeKind());
     emitCCall(&operationGrowMemory, arguments, result);
     restoreWebAssemblyGlobalState();
 

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/MemoryMode.h>
 #include <JavaScriptCore/PageCount.h>
+#include <JavaScriptCore/WasmAddressType.h>
 #include <JavaScriptCore/WeakGCSet.h>
 
 #include <wtf/CagedPtr.h>
@@ -52,7 +53,6 @@ namespace JSC {
 class LLIntOffsetsExtractor;
 
 namespace Wasm {
-
 class Memory final : public RefCountedAndCanMakeWeakPtr<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Memory, JS_EXPORT_PRIVATE);
@@ -65,10 +65,10 @@ public:
     enum GrowSuccess { GrowSuccessTag };
 
     static Ref<Memory> create();
-    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<BufferMemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
-    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<SharedArrayBufferContents>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
-    JS_EXPORT_PRIVATE static Ref<Memory> createZeroSized(MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
-    static RefPtr<Memory> tryCreate(VM&, PageCount initial, PageCount maximum, MemorySharingMode, std::optional<MemoryMode> desiredMemoryMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<BufferMemoryHandle>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<SharedArrayBufferContents>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> createZeroSized(MemorySharingMode, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    static RefPtr<Memory> tryCreate(VM&, PageCount initial, PageCount maximum, MemorySharingMode, AddressType, std::optional<MemoryMode> desiredMemoryMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
 
     JS_EXPORT_PRIVATE ~Memory();
 
@@ -82,6 +82,7 @@ public:
     size_t mappedCapacity() const { return m_handle->mappedCapacity(); }
     PageCount initial() const { return m_handle->initial(); }
     PageCount maximum() const { return m_handle->maximum(); }
+    AddressType addressType() const { return m_addressType; }
     BufferMemoryHandle& handle() { return m_handle.get(); }
 
     MemorySharingMode sharingMode() const { return m_handle->sharingMode(); }
@@ -102,15 +103,16 @@ public:
 
 private:
     Memory();
-    Memory(Ref<BufferMemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
-    Memory(Ref<BufferMemoryHandle>&&, Ref<SharedArrayBufferContents>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
-    Memory(PageCount initial, PageCount maximum, MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(Ref<BufferMemoryHandle>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(Ref<BufferMemoryHandle>&&, Ref<SharedArrayBufferContents>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(PageCount initial, PageCount maximum, MemorySharingMode, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
 
     Expected<PageCount, GrowFailReason> growShared(VM&, PageCount);
 
     Ref<BufferMemoryHandle> m_handle;
     RefPtr<SharedArrayBufferContents> m_shared;
     WTF::Function<void(GrowSuccess, PageCount, PageCount)> m_growSuccessCallback;
+    AddressType m_addressType;
     // FIXME: If/When merging this into JSWebAssemblyMemory we should just use an unconditionalFinalizer.
 };
 

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
@@ -38,7 +38,7 @@ MemoryInformation::MemoryInformation(PageCount initial, PageCount maximum, bool 
     , m_maximum(maximum)
     , m_isShared(isShared)
     , m_isImport(isImport)
-    , m_isMemory64(isMemory64)
+    , m_addressType(isMemory64)
 {
     RELEASE_ASSERT(!!m_initial);
     RELEASE_ASSERT(!m_maximum || m_maximum >= m_initial);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -365,7 +365,7 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
             // We create a memory when it's a memory definition.
             auto* jsMemory = JSWebAssemblyMemory::create(vm, globalObject->webAssemblyMemoryStructure());
 
-            RefPtr<Memory> memory = Memory::tryCreate(vm, mem.initial(), mem.maximum(), mem.isShared() ? MemorySharingMode::Shared : MemorySharingMode::Default, std::nullopt,
+            RefPtr<Memory> memory = Memory::tryCreate(vm, mem.initial(), mem.maximum(), mem.isShared() ? MemorySharingMode::Shared : MemorySharingMode::Default, mem.addressType(), std::nullopt,
                 [&vm, jsMemory](Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) {
                     jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount);
                 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -122,7 +122,7 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
 
     auto* jsMemory = JSWebAssemblyMemory::create(vm, webAssemblyMemoryStructure);
 
-    RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, desiredMemoryMode,
+    RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, Wasm::AddressType { }, desiredMemoryMode,
         [&vm, jsMemory] (Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); });
     if (!memory) {
         throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -5529,10 +5529,10 @@ private:
                     fail();
                     return JSValue();
                 }
-                memory = Wasm::Memory::create(contents.releaseNonNull(), WTF::move(handler));
+                memory = Wasm::Memory::create(contents.releaseNonNull(), result->memory().addressType(), WTF::move(handler));
             } else {
                 // zero size & max-size.
-                memory = Wasm::Memory::createZeroSized(JSC::MemorySharingMode::Shared, WTF::move(handler));
+                memory = Wasm::Memory::createZeroSized(JSC::MemorySharingMode::Shared, result->memory().addressType(), WTF::move(handler));
             }
 
             result->adopt(memory.releaseNonNull());


### PR DESCRIPTION
#### 65324979850101adf0104d72890ffc4c70121513
<pre>
Bounds checking does not work in Memory64 in BBQ and introduce AddressType
<a href="https://bugs.webkit.org/show_bug.cgi?id=308684">https://bugs.webkit.org/show_bug.cgi?id=308684</a>
<a href="https://rdar.apple.com/171218345">rdar://171218345</a>

Reviewed by Keith Miller.

Currently, signalling still works in BBQ while using Memory64, which will
fail. I disallowed this by setting bounds checking as the memory mode when
the address type is i64 during memory creation.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmAddressType.cpp: Copied from Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp.
(JSC::Wasm::AddressType::AddressType):
(JSC::Wasm::AddressType::asTypeKind const):
(JSC::Wasm::operator==):
(JSC::Wasm::operator!=):
* Source/JavaScriptCore/wasm/WasmAddressType.h: Copied from Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp.
(JSC::Wasm::AddressType::type const):
(JSC::Wasm::AddressType::is64Bit const):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addGrowMemory):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPrepareAndMaterializePointerApply):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::Memory):
(JSC::Wasm::Memory::create):
(JSC::Wasm::Memory::createZeroSized):
(JSC::Wasm::Memory::tryCreate):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp:
(JSC::Wasm::MemoryInformation::MemoryInformation):
(JSC::Wasm::MemoryInformation::addressType const):
(JSC::Wasm::MemoryInformation::isMemory64 const):
* Source/JavaScriptCore/wasm/WasmMemoryInformation.h:
(JSC::Wasm::MemoryInformation::isMemory64 const): Deleted.
(JSC::Wasm::MemoryInformation::addressType const): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::WebAssemblyMemoryConstructor::createMemoryFromDescriptor):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTerminal):

Canonical link: <a href="https://commits.webkit.org/308379@main">https://commits.webkit.org/308379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43dd4e515cdf09ab54299af8437c52bfe0f93dbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100540 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8201fd05-8abd-4acc-b37a-02d2749f8c7a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113386 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80885 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b0448dd-37a5-4f93-9988-60a34b2eea7f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94146 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d06b6fc7-c47c-435b-abd7-b42a649f45c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14806 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12586 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3250 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139094 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158139 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7914 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1270 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121412 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31190 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75576 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8665 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178445 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82978 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45672 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19012 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->