### PR TITLE
[JSC] JSNativeStdFunction should be able to safely capture

### DIFF
--- a/JSTests/stress/capturing-native-function.js
+++ b/JSTests/stress/capturing-native-function.js
@@ -1,0 +1,18 @@
+function assertNotUndefined(x) {
+    if (x === undefined)
+        throw new Error("Bad assertion!");
+}
+
+let weakRefs = [];
+let functions = [];
+for (let i = 0; i < 1000; ++i) {
+    let o = { i };
+    weakRefs.push(new WeakRef(o));
+    functions.push(createNoopNativeFunctionWithCapture(o));
+}
+setTimeout(() => {
+    gc();
+    for (let weakRef of weakRefs) {
+        assertNotUndefined(weakRef.deref());
+    }
+});

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -378,6 +378,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionGenerateHeapSnapshot);
 static JSC_DECLARE_HOST_FUNCTION(functionGenerateHeapSnapshotForGCDebugging);
 static JSC_DECLARE_HOST_FUNCTION(functionResetSuperSamplerState);
 static JSC_DECLARE_HOST_FUNCTION(functionEnsureArrayStorage);
+static JSC_DECLARE_HOST_FUNCTION(functionCreateNoopNativeFunctionWithCapture);
 #if ENABLE(SAMPLING_PROFILER)
 static JSC_DECLARE_HOST_FUNCTION(functionStartSamplingProfiler);
 static JSC_DECLARE_HOST_FUNCTION(functionSamplingProfilerStackTraces);
@@ -747,6 +748,7 @@ private:
         addFunction(vm, "generateHeapSnapshotForGCDebugging"_s, functionGenerateHeapSnapshotForGCDebugging, 0);
         addFunction(vm, "resetSuperSamplerState"_s, functionResetSuperSamplerState, 0);
         addFunction(vm, "ensureArrayStorage"_s, functionEnsureArrayStorage, 0);
+        addFunction(vm, "createNoopNativeFunctionWithCapture"_s, functionCreateNoopNativeFunctionWithCapture, 1);
 #if ENABLE(SAMPLING_PROFILER)
         addFunction(vm, "startSamplingProfiler"_s, functionStartSamplingProfiler, 0);
         addFunction(vm, "samplingProfilerStackTraces"_s, functionSamplingProfilerStackTraces, 0);
@@ -3230,6 +3232,19 @@ JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObje
             object->ensureArrayStorage(vm);
     }
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionCreateNoopNativeFunctionWithCapture, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+
+    JSValue arg0 = callFrame->argument(0);
+
+    auto function = JSNativeStdFunction::create(vm, globalObject, 0, { }, [arg0](JSGlobalObject*, CallFrame*) {
+        return JSValue::encode(arg0);
+    }, arg0);
+
+    return JSValue::encode(function);
 }
 
 #if ENABLE(SAMPLING_PROFILER)

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp
@@ -35,18 +35,13 @@ const ClassInfo JSNativeStdFunction::s_info = { "Function"_s, &Base::s_info, nul
 
 static JSC_DECLARE_HOST_FUNCTION(runStdFunction);
 
-JSNativeStdFunction::JSNativeStdFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, NativeStdFunction&& function)
-    : Base(vm, executable, globalObject, structure)
-    , m_function(WTF::move(function))
-{
-}
-
 template<typename Visitor>
 void JSNativeStdFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     JSNativeStdFunction* thisObject = jsCast<JSNativeStdFunction*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_captures.begin(), thisObject->m_captures.end());
 }
 
 DEFINE_VISIT_CHILDREN(JSNativeStdFunction);
@@ -55,6 +50,11 @@ void JSNativeStdFunction::finishCreation(VM& vm, NativeExecutable* executable, u
 {
     Base::finishCreation(vm, executable, length, name);
     ASSERT(inherits(info()));
+}
+
+NativeExecutable* JSNativeStdFunction::getHostFunction(VM& vm, Intrinsic intrinsic, NativeFunction nativeConstructor, const String& name)
+{
+    return vm.getHostFunction(runStdFunction, ImplementationVisibility::Private, intrinsic, nativeConstructor, nullptr, name);
 }
 
 JSC_DEFINE_HOST_FUNCTION(runStdFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
@@ -56,15 +56,33 @@ public:
 
     JS_EXPORT_PRIVATE static JSNativeStdFunction* create(VM&, JSGlobalObject*, unsigned length, const String& name, NativeStdFunction&&, Intrinsic = NoIntrinsic, NativeFunction nativeConstructor = callHostFunctionAsConstructor);
 
+    static JSNativeStdFunction* create(VM& vm, JSGlobalObject* globalObject, unsigned length, const String& name, NativeStdFunction&& nativeFunction, auto... captures)
+        requires (sizeof...(captures) > 0)
+    {
+        NativeExecutable* executable = getHostFunction(vm, NoIntrinsic, callHostFunctionAsConstructor, name);
+        Structure* structure = globalObject->nativeStdFunctionStructure();
+        JSNativeStdFunction* function = new (NotNull, allocateCell<JSNativeStdFunction>(vm)) JSNativeStdFunction(vm, executable, globalObject, structure, WTF::move(nativeFunction), captures...);
+        function->finishCreation(vm, executable, length, name);
+        return function;
+    }
+
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     const NativeStdFunction& function() { return m_function; }
 
 private:
-    JSNativeStdFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, NativeStdFunction&&);
-    void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
+    JSNativeStdFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, NativeStdFunction&& function, auto... captures)
+        : Base(vm, executable, globalObject, structure)
+        , m_function(WTF::move(function))
+        , m_captures { WriteBarrier<Unknown>(vm, this, captures)... }
+    {
+    }
+
+    JS_EXPORT_PRIVATE void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
+    JS_EXPORT_PRIVATE static NativeExecutable* getHostFunction(VM&, Intrinsic, NativeFunction, const String& name);
 
     NativeStdFunction m_function;
+    FixedVector<WriteBarrier<Unknown>> m_captures;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 8ed6b76ec394845da5f1f694d529e535f1b05277
<pre>
[JSC] JSNativeStdFunction should be able to safely capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=308686">https://bugs.webkit.org/show_bug.cgi?id=308686</a>
<a href="https://rdar.apple.com/171220159">rdar://171220159</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Currently, there&apos;s no way to safely keep the captures of lambdas passed to JSNativeStdFunction::create alive
other than use of Strong, which has its own problems. This PR allows captured JSValues to be passed along to
JSNativeStdFunction::create and stored in a FixedVector of WriteBarriers.

Test: JSTests/stress/capturing-native-function.js

* JSTests/stress/capturing-native-function.js: Added.
(assertNotUndefined):
(setTimeout):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION): Added createNoopNativeFunctionWithCapture for tests.
* Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp:
(JSC::JSNativeStdFunction::visitChildrenImpl): Visit captures.
(JSC::JSNativeStdFunction::getHostFunction):
(JSC::JSNativeStdFunction::JSNativeStdFunction): Deleted.
* Source/JavaScriptCore/runtime/JSNativeStdFunction.h:

Canonical link: <a href="https://commits.webkit.org/308472@main">https://commits.webkit.org/308472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89059bc65b8632a6c1b35d242af7385ce3c0a6a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100727 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113539 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80977 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7369a35e-c2e7-4f80-8d3b-d02ed3781bab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94296 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee4fee73-7c77-4cda-96ab-f0d537a22fdc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12723 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3435 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139282 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158326 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8100 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1464 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121565 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31253 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132005 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75783 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8799 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178629 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83173 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45750 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19141 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19292 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19199 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->