### PR TITLE
[Scroll Anchoring] Anchoring can cause pages to scroll to negative offsets

### DIFF
--- a/LayoutTests/fast/dom/elementFromPoint-relative-to-viewport.html
+++ b/LayoutTests/fast/dom/elementFromPoint-relative-to-viewport.html
@@ -1,6 +1,9 @@
 
 <script src="../../resources/js-test-pre.js"></script>
 <style>
+    body {
+        width: 1200px;
+    }
     .test {
         width: 100px;
         height: 100px;

--- a/LayoutTests/fast/scrolling/scroll-anchoring-constraints-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-constraints-expected.txt
@@ -1,0 +1,5 @@
+PASS window.scrollY is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring-constraints.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-constraints.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .above-top {
+            margin-top: -2000px;
+            height: 2500px;
+            border: 1px solid black;
+        }
+        
+        #changer {
+            height: 1800px;
+            width: 100%;
+            background-color: orange;
+        }
+        
+        .anchor {
+            width: 100%;
+            height: 300px;
+            background-color: cyan;
+        }
+        
+        body.changed #changer {
+            height: 100px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        window.addEventListener('load', async () => {
+            await UIHelper.delayFor(0);
+            // Need to scroll to trigger anchoring.
+            window.scrollTo(0, 10);
+
+            await UIHelper.renderingUpdate();
+            document.body.classList.add('changed');
+            
+            shouldBe('window.scrollY', '0');
+
+            window.scrollTo(0, 0);
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="above-top">
+        <div id="changer"></div>
+        <div class="anchor"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/compositing/geometry/fixed-in-composited-expected.txt
+++ b/LayoutTests/platform/ios/compositing/geometry/fixed-in-composited-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 60x60
   RenderBlock {DIV} at (0,0) size 60x60 [bgcolor=#0000FF33]
 layer at (95,145) size 50x50
   RenderBlock (positioned) zI: 1 {DIV} at (95,145) size 50x50
-layer at (70,70) size 100x100
+layer at (20,70) size 100x100
   RenderBlock (positioned) {DIV} at (20,20) size 100x100 [bgcolor=#008000]
 layer at (200,100) size 50x50
   RenderBlock (positioned) zI: 1 {DIV} at (200,100) size 50x50
@@ -28,4 +28,4 @@ layer at (400,100) size 100x100
   RenderBlock {DIV} at (0,0) size 100x100
 layer at (420,120) size 100x100
   RenderBlock (positioned) {DIV} at (20,20) size 100x100 [bgcolor=#008000]
-scrolled to 50,50
+scrolled to 0,50

--- a/LayoutTests/platform/ios/compositing/geometry/horizontal-scroll-composited-expected.txt
+++ b/LayoutTests/platform/ios/compositing/geometry/horizontal-scroll-composited-expected.txt
@@ -5,4 +5,4 @@ layer at (0,0) size 800x822
     RenderBody {BODY} at (8,8) size 600x806
 layer at (8,8) size 1006x806
   RenderBlock {DIV} at (0,0) size 1006x806 [border: (3px solid #FF0000)]
-scrolled to 300,0
+scrolled to 214,0

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scrollIntoView_include=root-inline-end-block-end-behavior-auto-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scrollIntoView_include=root-inline-end-block-end-behavior-auto-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Tests scrollend event for scrollIntoView with behavior 'auto' on root. assert_equals: HTML.scrollIntoView scrollLeft expected 10000 but got 2200
-

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -398,9 +398,13 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
     bool inProgrammaticScroll = scrollableArea.currentScrollType() == ScrollType::Programmatic;
 
     if ((inProgrammaticScroll && options.animated == ScrollIsAnimated::No) || inBackForwardCache) {
+        auto adjustedScrollPosition = scrollPosition;
+        if (options.clamping == ScrollClamping::Clamped)
+            adjustedScrollPosition = scrollableArea.adjustScrollPositionWithinRange(scrollPosition);
+
         auto scrollUpdate = ScrollUpdate {
             .nodeID = *scrollingNodeID,
-            .scrollPosition = scrollPosition,
+            .scrollPosition = adjustedScrollPosition,
             .data = ScrollUpdateData {
                 .updateType = ScrollUpdateType::PositionUpdate,
                 .updateLayerPositionAction = ScrollingLayerPositionAction::Set,

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -255,7 +255,7 @@ public:
     ScrollPosition maximumScrollPosition() const override; // The maximum position we can be scrolled to.
 
     // Adjust the passed in scroll position to keep it between the minimum and maximum positions.
-    ScrollPosition adjustScrollPositionWithinRange(const ScrollPosition&) const;
+    ScrollPosition adjustScrollPositionWithinRange(const ScrollPosition&) const override;
     int scrollX() const { return scrollPosition().x(); }
     int scrollY() const { return scrollPosition().y(); }
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -276,6 +276,11 @@ public:
     WEBCORE_EXPORT virtual ScrollPosition minimumScrollPosition() const;
     WEBCORE_EXPORT virtual ScrollPosition maximumScrollPosition() const;
 
+    virtual ScrollPosition adjustScrollPositionWithinRange(const ScrollPosition& position) const
+    {
+        return constrainedScrollPosition(position);
+    }
+
     ScrollPosition constrainedScrollPosition(const ScrollPosition& position) const
     {
         return position.constrainedBetween(minimumScrollPosition(), maximumScrollPosition());


### PR DESCRIPTION
#### 37264fe399965bb5936fd6191ac27e284dc4bf90
<pre>
[Scroll Anchoring] Anchoring can cause pages to scroll to negative offsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=308689">https://bugs.webkit.org/show_bug.cgi?id=308689</a>
<a href="https://rdar.apple.com/171221075">rdar://171221075</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Scroll anchoring adjustments are issued with `ScrollClamping::Clamped`, but the
path through `AsyncScrollingCoordinator::requestScrollToPosition()` that
applies the ScrollUpdate synchronously does not express clamping, so we need
to do a manual clamp here, using `adjustScrollPositionWithinRange()` which is
made virtual, and consults `allowsUnclampedScrollPosition` on ScrollView.

This was seen in a (broken) scroll anchoring scenario on reddit, and resulted
in missing content.

Test: fast/scrolling/scroll-anchoring-constraints.html

* LayoutTests/fast/dom/elementFromPoint-relative-to-viewport.html: Make it side scrollable.
* LayoutTests/fast/scrolling/scroll-anchoring-constraints-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring-constraints.html: Added.
* LayoutTests/platform/ios/compositing/geometry/fixed-in-composited-expected.txt:
* LayoutTests/platform/ios/compositing/geometry/horizontal-scroll-composited-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scrollIntoView_include=root-inline-end-block-end-behavior-auto-expected.txt: Removed.
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::adjustScrollPositionWithinRange const):

Canonical link: <a href="https://commits.webkit.org/308320@main">https://commits.webkit.org/308320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/167164cd6ef8bff9f9e5b35d608e8c3bfa63266b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155805 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30bac177-bf16-4f21-8b6e-fb2d9e02af37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113382 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24535261-6eb5-430f-8456-b3aeb5297f32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94140 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14803 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12585 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3247 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158136 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1267 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11541 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121408 "Found 1 new test failure: media/media-vp8-webm-seek-to-start.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121609 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31149 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131858 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8663 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19101 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->