### PR TITLE
::first-letter not updated when ::before pseudo-element is dynamically added

### DIFF
--- a/LayoutTests/fast/css/first-letter-removed-added-expected.txt
+++ b/LayoutTests/fast/css/first-letter-removed-added-expected.txt
@@ -11,7 +11,7 @@ Inline to Block
 Test 3:
 pseudo
 pseudo
-Test 4: (Currently failing)
+Test 4:
 pseudo
 pseudo
 Test 5:
@@ -31,7 +31,7 @@ To Non Float
 PASS document.getElementById('test1').offsetWidth == document.getElementById('ref1').offsetWidth is true
 PASS document.getElementById('test2').offsetHeight == document.getElementById('ref2').offsetHeight is true
 PASS document.getElementById('test3').offsetWidth == document.getElementById('ref3').offsetWidth is true
-FAIL document.getElementById('test4').offsetWidth == document.getElementById('ref4').offsetWidth should be true. Was false.
+PASS document.getElementById('test4').offsetWidth == document.getElementById('ref4').offsetWidth is true
 PASS document.getElementById('test5').offsetWidth == document.getElementById('ref5').offsetWidth is true
 PASS document.getElementById('test6').offsetWidth == document.getElementById('ref6').offsetWidth is true
 PASS document.getElementById('test7').offsetWidth == document.getElementById('ref7').offsetWidth is true

--- a/LayoutTests/fast/css/first-letter-removed-added.html
+++ b/LayoutTests/fast/css/first-letter-removed-added.html
@@ -28,7 +28,7 @@ Test 3:<br/>
 <div class="test"><span id="ref3" class="boxed">pseudo</span></div>
 <hr/>
 
-Test 4: (Currently failing)<br/>
+Test 4:<br/>
 <div class="test"><span id="test4" class="boxed">pseudo</span></div>
 <div class="test"><span id="ref4" class="boxed bef">pseudo</span></div>
 <hr/>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2534,9 +2534,7 @@ std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(Re
     // Don't recur
     if (style().pseudoElementType() == PseudoElementType::FirstLetter)
         return { };
-    
-    // FIXME: We need to destroy the first-letter object if it is no longer the first child. Need to find
-    // an efficient way to check for that situation though before implementing anything.
+
     RenderElement* firstLetterContainer = findFirstLetterBlock(this);
     if (!firstLetterContainer)
         return { };

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -28,6 +28,7 @@
 #include "NodeInlines.h"
 #include "RenderBlock.h"
 #include "RenderButton.h"
+#include "RenderDescendantIterator.h"
 #include "RenderInline.h"
 #include "RenderObjectDocument.h"
 #include "RenderSVGText.h"
@@ -143,16 +144,112 @@ void RenderTreeBuilder::FirstLetter::updateAfterDescendants(RenderBlock& block)
         return;
 
     // If the child already has style, then it has already been created, so we just want
-    // to update it.
+    // to update it — unless the first-letter target has become stale (e.g. a ::before
+    // pseudo-element was dynamically added before the existing first-letter wrapper).
     if (firstLetter->parent()->style().pseudoElementType() == PseudoElementType::FirstLetter) {
-        updateStyle(block, *firstLetter);
+        if (!isStaleFirstLetterRenderer(block, *firstLetter->parent())) {
+            updateStyle(block, *firstLetter);
+            return;
+        }
+        // The existing first-letter wrapper is stale. Destroy it and reconstitute
+        // the text, then re-find the actual first letter candidate.
+        destroyStaleFirstLetter(downcast<RenderBoxModelObject>(*firstLetter->parent()));
+
+        auto [newFirstLetter, newFirstLetterContainer] = block.firstLetterAndContainer();
+        if (!newFirstLetter || &block != newFirstLetterContainer)
+            return;
+        if (newFirstLetter->parent()->style().pseudoElementType() == PseudoElementType::FirstLetter) {
+            updateStyle(block, *newFirstLetter);
+            return;
+        }
+        if (!is<RenderText>(newFirstLetter))
+            return;
+        createRenderers(downcast<RenderText>(*newFirstLetter));
         return;
     }
 
     if (!is<RenderText>(firstLetter))
         return;
 
+    // There may also be an orphaned first-letter wrapper deeper in the tree
+    // (e.g. from a previous first-letter on different text). Clean it up first.
+    destroyStaleFirstLetterInBlock(block);
+
     createRenderers(downcast<RenderText>(*firstLetter));
+}
+
+bool RenderTreeBuilder::FirstLetter::isStaleFirstLetterRenderer(RenderBlock& block, RenderElement& firstLetterRenderer)
+{
+    // A ::first-letter renderer is stale when content that should logically
+    // precede it has been inserted after it in the render tree. This happens
+    // when a ::before pseudo-element is dynamically added: its renderer gets
+    // placed after the anonymous first-letter wrapper (which occupies the
+    // first-child slot) even though ::before content comes first in the
+    // formatted text.
+    ASSERT(firstLetterRenderer.isFirstLetter());
+
+    for (auto* ancestor = &firstLetterRenderer; ancestor && ancestor != &block; ancestor = ancestor->parent()) {
+        for (auto* sibling = ancestor->nextSibling(); sibling; sibling = sibling->nextSibling()) {
+            if (auto* siblingElement = dynamicDowncast<RenderElement>(sibling)) {
+                if (siblingElement->style().pseudoElementType() == PseudoElementType::Before)
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+void RenderTreeBuilder::FirstLetter::destroyStaleFirstLetter(RenderBoxModelObject& staleFirstLetter)
+{
+    // Get the remaining text fragment associated with the stale first-letter.
+    WeakPtr remainingText = staleFirstLetter.firstLetterRemainingText();
+
+    // Extract the original full text from the first-letter text fragment.
+    String firstLetterText;
+    if (auto* letterTextChild = staleFirstLetter.firstChild()) {
+        if (auto* letterFragment = dynamicDowncast<RenderTextFragment>(letterTextChild))
+            firstLetterText = letterFragment->originalText();
+    }
+
+    if (firstLetterText.isNull())
+        firstLetterText = emptyString();
+
+    // Destroy the stale first-letter wrapper and its children.
+    m_builder.destroy(staleFirstLetter, CanCollapseAnonymousBlock::No);
+
+    // If there was a remaining text fragment, replace it with a full text renderer
+    // containing the complete original text.
+    if (remainingText) {
+        RefPtr textNode = remainingText->textNode();
+        CheckedPtr parentRenderer = remainingText->parent();
+        WeakPtr nextSibling = remainingText->nextSibling();
+        WeakPtr inlineWrapperForDisplayContents = remainingText->inlineWrapperForDisplayContents();
+
+        String fullText = textNode ? textNode->data() : firstLetterText;
+
+        m_builder.destroy(*remainingText);
+
+        RenderPtr<RenderTextFragment> newText;
+        if (textNode) {
+            newText = createRenderer<RenderTextFragment>(*textNode, fullText, 0, fullText.length());
+            textNode->setRenderer(newText.get());
+        } else
+            newText = createRenderer<RenderTextFragment>(m_builder.m_view.document(), fullText, 0, fullText.length());
+
+        newText->setInlineWrapperForDisplayContents(inlineWrapperForDisplayContents.get());
+        m_builder.attach(*parentRenderer, WTF::move(newText), nextSibling.get());
+    }
+}
+
+void RenderTreeBuilder::FirstLetter::destroyStaleFirstLetterInBlock(RenderBlock& block)
+{
+    for (auto& descendant : descendantsOfType<RenderElement>(block)) {
+        if (descendant.isFirstLetter()) {
+            if (auto* firstLetterBox = dynamicDowncast<RenderBoxModelObject>(descendant))
+                destroyStaleFirstLetter(*firstLetterBox);
+            return;
+        }
+    }
 }
 
 void RenderTreeBuilder::FirstLetter::cleanupOnDestroy(RenderTextFragment& textFragment)
@@ -219,7 +316,7 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
         firstLetterContainer = textContentParent;
     if (!firstLetterContainer)
         return;
-    
+
     auto pseudoStyle = styleForFirstLetter(*firstLetterContainer);
     if (!pseudoStyle)
         return;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.h
@@ -44,6 +44,9 @@ public:
 private:
     void updateStyle(RenderBlock& firstLetterBlock, RenderObject& currentChild);
     void createRenderers(RenderText& currentTextChild);
+    bool isStaleFirstLetterRenderer(RenderBlock&, RenderElement& firstLetterRenderer);
+    void destroyStaleFirstLetter(RenderBoxModelObject& staleFirstLetter);
+    void destroyStaleFirstLetterInBlock(RenderBlock&);
 
     RenderTreeBuilder& m_builder;
 };


### PR DESCRIPTION
#### ea9133915c18257e0d996083773e42ef430af744
<pre>
::first-letter not updated when ::before pseudo-element is dynamically added
<a href="https://bugs.webkit.org/show_bug.cgi?id=47815">https://bugs.webkit.org/show_bug.cgi?id=47815</a>
<a href="https://rdar.apple.com/problem/96908042">rdar://problem/96908042</a>

Reviewed by NOBODY (OOPS!).

When a ::before pseudo-element is dynamically added to an element inside a
block with ::first-letter styling, the first-letter wrapper is not
invalidated. The ::before renderer gets inserted after the anonymous
first-letter wrapper in the render tree (because the wrapper occupies the
first-child slot), so firstLetterAndContainer() still finds the old
first-letter text and takes the &quot;already styled&quot; early return path.

Additionally, createRenderers() resolved ::first-letter style from the
immediate parent of the target text, which fails when the text is inside a
::before pseudo-element (since ::before doesn&apos;t have ::first-letter cached).

This patch:
- Detects stale first-letter renderers by checking if a ::before renderer
  appears as a next-sibling of the first-letter wrapper or its ancestors.
- Destroys the stale first-letter wrapper and reconstitutes its split text
  fragments before re-finding the actual first letter candidate.
- Passes the defining block to createRenderers() so ::first-letter style is
  resolved from the correct ancestor rather than the text&apos;s immediate parent.

* LayoutTests/fast/css/first-letter-removed-added-expected.txt:
* LayoutTests/fast/css/first-letter-removed-added.html:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::RenderTreeBuilder::FirstLetter::updateAfterDescendants):
(WebCore::RenderTreeBuilder::FirstLetter::isStaleFirstLetterRenderer):
(WebCore::RenderTreeBuilder::FirstLetter::destroyStaleFirstLetter):
(WebCore::RenderTreeBuilder::FirstLetter::destroyStaleFirstLetterInBlock):
(WebCore::RenderTreeBuilder::FirstLetter::createRenderers):
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea9133915c18257e0d996083773e42ef430af744

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100440 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a7a6852-3ee3-4ad5-ba0d-b4dbf44ef637) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80839 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a0c3988-3537-4cb2-b046-5f27d98e3f75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94048 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53a39d94-783b-4ddc-93f5-14bd2644c509) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12522 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3150 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158039 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121316 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121517 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75476 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8590 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82878 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18853 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->