### PR TITLE
[libpas] Make pas_{small,tiny}_large_map_entry aware of delegation

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -323,6 +323,10 @@ bool pas_large_heap_try_shrink(uintptr_t begin,
     heap = map_entry.heap;
     type = pas_heap_for_large_heap(heap)->type;
 
+    // FIXME: if we ever want to support pas_shrink for delegating heaps,
+    // we need to add a new pathway for doing so here.
+    PAS_ASSERT(!map_entry.delegated_to_system_malloc);
+
     if (!new_size)
         new_size = heap_config->get_type_size(type);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_small_large_map_entry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_large_map_entry.h
@@ -107,6 +107,13 @@ static inline pas_large_heap* pas_small_large_map_entry_heap(pas_small_large_map
     return (pas_large_heap*)((uintptr_t)entry.encoded_heap * PAS_INTERNAL_MIN_ALIGN);
 }
 
+static inline bool pas_small_large_map_entry_delegated_to_system_malloc(
+    pas_small_large_map_entry entry)
+{
+    PAS_UNUSED_PARAM(entry);
+    return false;
+}
+
 static inline pas_large_map_entry pas_small_large_map_entry_get_entry(
     pas_small_large_map_entry entry)
 {
@@ -114,6 +121,7 @@ static inline pas_large_map_entry pas_small_large_map_entry_get_entry(
     result.begin = pas_small_large_map_entry_begin(entry);
     result.end = pas_small_large_map_entry_end(entry);
     result.heap = pas_small_large_map_entry_heap(entry);
+    result.delegated_to_system_malloc = pas_small_large_map_entry_delegated_to_system_malloc(entry);
     return result;
 }
 
@@ -123,7 +131,8 @@ static inline bool pas_small_large_map_entry_can_create(pas_large_map_entry entr
     result = pas_small_large_map_entry_create(entry);
     return entry.begin == pas_small_large_map_entry_begin(result)
         && entry.end == pas_small_large_map_entry_end(result)
-        && entry.heap == pas_small_large_map_entry_heap(result);
+        && entry.heap == pas_small_large_map_entry_heap(result)
+        && entry.delegated_to_system_malloc == pas_small_large_map_entry_delegated_to_system_malloc(result);
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_tiny_large_map_entry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_tiny_large_map_entry.h
@@ -91,6 +91,13 @@ static inline pas_large_heap* pas_tiny_large_map_entry_heap(pas_tiny_large_map_e
     return pas_heap_table[(uintptr_t)entry.bytes[3] | ((uintptr_t)entry.bytes[4] << 8)];
 }
 
+static inline bool pas_tiny_large_map_entry_delegated_to_system_malloc(
+    pas_tiny_large_map_entry entry)
+{
+    PAS_UNUSED_PARAM(entry);
+    return false;
+}
+
 static inline pas_large_map_entry pas_tiny_large_map_entry_get_entry(pas_tiny_large_map_entry entry,
                                                                      uintptr_t base)
 {
@@ -98,6 +105,7 @@ static inline pas_large_map_entry pas_tiny_large_map_entry_get_entry(pas_tiny_la
     result.begin = pas_tiny_large_map_entry_begin(entry, base);
     result.end = pas_tiny_large_map_entry_end(entry, base);
     result.heap = pas_tiny_large_map_entry_heap(entry);
+    result.delegated_to_system_malloc = pas_tiny_large_map_entry_delegated_to_system_malloc(entry);
     return result;
 }
 
@@ -130,7 +138,8 @@ static inline bool pas_tiny_large_map_entry_can_create(pas_large_map_entry entry
     }
     return entry.begin == pas_tiny_large_map_entry_begin(result, base)
         && entry.end == pas_tiny_large_map_entry_end(result, base)
-        && entry.heap == pas_tiny_large_map_entry_heap(result);
+        && entry.heap == pas_tiny_large_map_entry_heap(result)
+        && entry.delegated_to_system_malloc == pas_tiny_large_map_entry_delegated_to_system_malloc(result);
 }
 
 static inline pas_tiny_large_map_entry pas_tiny_large_map_entry_create_empty(void)


### PR DESCRIPTION
#### f209caf4db1270c6d2d54161c9fb0cb842f4be8d
<pre>
[libpas] Make pas_{small,tiny}_large_map_entry aware of delegation
<a href="https://bugs.webkit.org/show_bug.cgi?id=308695">https://bugs.webkit.org/show_bug.cgi?id=308695</a>
<a href="https://rdar.apple.com/170300268">rdar://170300268</a>

Reviewed by Daniel Liu.

When non-delegated allocations are stored in the large-heap, it is
possible that their metadata will be stored in the tiny_large_map
or the small_large_map, which are compressed versions of the normal
large-map.
When this happens, we need to ensure that at the point the large-map
reconstructs a large_map_entry from the compressed contents of those
heaps, it populates all fields in the entry, as the entry is not
guaranteed to be zero-filled beforehand. Previously, the
delegated_to_system_malloc field was not populated, and could thus
contain garbage from the stack, sometimes leading to libpas
asking libmalloc to free objects that were actually allocated via
libpas. This would always cause an immediate crash.
This also makes it clear that delegated allocations cannot be tracked
through the small/tiny large_map variants.

Canonical link: <a href="https://commits.webkit.org/308296@main">https://commits.webkit.org/308296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0759cebab1b602f889e7c36178a8af1f47854f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100321 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/094e90d9-1bfd-459d-9748-5d0b2f23d24d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113223 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80811 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e63980c7-4b50-4c7b-a747-eff3f7912a2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93978 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/171d1617-5f64-40cc-8bdb-1dcd00b0d39d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12463 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3057 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138901 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157946 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7721 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121244 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31133 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131692 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8533 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19030 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45650 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->