### PR TITLE
[JSC] Add pcrtoaddr to x64

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1089,11 +1089,7 @@ end
     btpnz t3, (constexpr CallLinkInfo::polymorphicCalleeMask), .found
 
 .notfound:
-if ARM64 or ARM64E
     pcrtoaddr _llint_default_call_trampoline, t5
-else
-    leap (_llint_default_call_trampoline), t5
-end
     loadp CallLinkInfo::m_codeBlock[t2], t3
     storep t3, (CodeBlock - CallerFrameAndPCSize)[sp]
     call _llint_default_call_trampoline
@@ -1220,10 +1216,6 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     unboxWasmCallee(ws0, ws1)
     storep ws0, UnboxedWasmCalleeStackSlot[cfr]
 
-    # on x86, PL will hold the PC relative offset for argumINT, then IB will take over
-    if X86_64
-        initPCRelative(ipint_entry, PL)
-    end
 ipintEntry()
 else
     break
@@ -1657,10 +1649,8 @@ if ARM64E
     pcrtoaddr _exit_implanted_slice, ws0
     tagCodePtr ws0, a0
     move ws0, r0
-elsif ARM64
+else
     pcrtoaddr _exit_implanted_slice, r0
-elsif X86_64
-    leap _exit_implanted_slice, r0
 end
     functionEpilogue()
     ret

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2180,9 +2180,6 @@ if C_LOOP
 else
     macro initPCRelative(kind, pcBase)
         if X86_64
-            call _%kind%_relativePCBase
-        _%kind%_relativePCBase:
-            pop pcBase
         elsif ARM64 or ARM64E
         elsif ARMv7
         _%kind%_relativePCBase:
@@ -2194,15 +2191,7 @@ else
     # The PC base is in t3, as this is what _llint_entry leaves behind through
     # initPCRelative(t3)
     macro setEntryAddressCommon(kind, index, label, map)
-        if X86_64
-            leap (label - _%kind%_relativePCBase)[t3], t4
-            move index, t5
-            storep t4, [map, t5, 8]
-        elsif ARM64 or RISCV64
-            pcrtoaddr label, t3
-            move index, t4
-            storep t3, [map, t4, PtrSize]
-        elsif ARM64E
+        if ARM64E
             pcrtoaddr label, t3
             move index, t4
             leap [map, t4, PtrSize], t4
@@ -2213,6 +2202,10 @@ else
             addp t4, t3, t4
             move index, t5
             storep t4, [map, t5, 4]
+        else # X86_64, ARM64, RISCV64
+            pcrtoaddr label, t3
+            move index, t4
+            storep t3, [map, t4, PtrSize]
         end
     end
 

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -1086,6 +1086,13 @@ class Instruction
             handleX86Op("xor#{x86Suffix(:quad)}", :quad)
         when "leap"
             emitX86Lea(operands[0], operands[1], :ptr)
+        when "pcrtoaddr"
+            labelRef = operands[0]
+            dst = operands[1]
+            if labelRef.is_a? LabelReference
+                labelRef.used
+            end
+            $asm.puts "leaq #{labelRef.asmLabel}(%rip), #{dst.x86Operand(:quad)}"
         when "loadi", "atomicloadi"
             $asm.puts "mov#{x86Suffix(:int)} #{x86LoadOperands(:int, :int)}"
         when "storei"


### PR DESCRIPTION
#### 5e96ef3f1a3d54045ebb760af5da6e108b6bc56e
<pre>
[JSC] Add pcrtoaddr to x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=308700">https://bugs.webkit.org/show_bug.cgi?id=308700</a>
<a href="https://rdar.apple.com/171232708">rdar://171232708</a>

Reviewed by Yijia Huang and Keith Miller.

Add pcrtoaddr to x64, which simplifies IPInt implementation in x64 since
we can have similar code to ARM64.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/offlineasm/x86.rb:

Canonical link: <a href="https://commits.webkit.org/308416@main">https://commits.webkit.org/308416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70a172a71aef192e5a5fba378a92440a4cc31213

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100317 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bead3928-e90e-42ab-92b6-e9ce0d651d81) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80805 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03ff4445-9a8c-48d1-b20f-1f7955ff00e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93976 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78060521-8b10-46bb-a3f6-14c7456524ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12460 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3053 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138897 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157942 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7717 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121243 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121446 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75379 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8527 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82781 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45649 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->