### PR TITLE
Unreviewed macOS build fix after 308251@main

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2259,6 +2259,11 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     return _page.get();
 }
 
+- (RefPtr<WebKit::WebPageProxy>)_protectedPage
+{
+    return _page.get();
+}
+
 #if PLATFORM(MAC)
 - (WebKit::WebViewImpl *)_impl
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -659,6 +659,7 @@ struct PerWebProcessState {
 
 - (WKPageRef)_pageForTesting;
 - (NakedPtr<WebKit::WebPageProxy>)_page;
+- (RefPtr<WebKit::WebPageProxy>)_protectedPage;
 #if PLATFORM(MAC)
 - (nullable WebKit::WebViewImpl *)_impl;
 #endif

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -43,7 +43,7 @@ extension WKTextSelectionController {
     }
 
     func addTextSelectionManager() {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return
         }
 
@@ -63,7 +63,7 @@ extension WKTextSelectionController {
     }
 
     func selectionDidChange() {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return
         }
 
@@ -77,7 +77,7 @@ extension WKTextSelectionController {
 @implementation
 extension WKTextSelectionController {
     var insertionCursorRect: NSRect {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return .zero
         }
 
@@ -89,7 +89,7 @@ extension WKTextSelectionController {
     }
 
     var selectionIsInsertionPoint: Bool {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return false
         }
 
@@ -101,7 +101,7 @@ extension WKTextSelectionController {
     func isTextSelected(at point: NSPoint) -> Bool {
         // The `point` location is relative to the view.
 
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return false
         }
 
@@ -147,7 +147,7 @@ extension WKTextSelectionController {
     func moveInsertionCursor(to point: NSPoint, placeAtWordBoundary: Bool) async -> Bool {
         // A return value of `true` indicates the selection has changed.
 
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return false
         }
 
@@ -188,7 +188,7 @@ extension WKTextSelectionController {
     func showContextMenu(at point: NSPoint) {
         // The `point` location is relative to the window.
 
-        guard let page = view._page(), let impl = unsafe view._impl() else {
+        guard let page = view._protectedPage().get(), let impl = unsafe view._impl() else {
             return
         }
 
@@ -226,7 +226,7 @@ extension WKTextSelectionController {
 
     @objc(dragSelectionWithGesture:completionHandler:)
     func dragSelection(withGesture gesture: NSGestureRecognizer, completionHandler: @escaping @Sendable (NSDraggingSession) -> Void) {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return
         }
 
@@ -235,7 +235,7 @@ extension WKTextSelectionController {
 
     @objc(beginRangeSelectionAtPoint:withGranularity:)
     func beginRangeSelection(at point: NSPoint, with granularity: NSTextSelection.Granularity) {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return
         }
 
@@ -256,7 +256,7 @@ extension WKTextSelectionController {
 
     @objc(continueRangeSelectionAtPoint:)
     func continueRangeSelection(at point: NSPoint) {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return
         }
 
@@ -279,7 +279,7 @@ extension WKTextSelectionController {
 
     @objc(endRangeSelectionAtPoint:)
     func endRangeSelection(at point: NSPoint) {
-        guard let page = view._page() else {
+        guard let page = view._protectedPage().get() else {
             return
         }
 


### PR DESCRIPTION
#### 466341d077302b4d1ffd851fa2c729f23c63400e
<pre>
Unreviewed macOS build fix after 308251@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=308701">https://bugs.webkit.org/show_bug.cgi?id=308701</a>

Do a very partial revert of 308251@main to address the build errors on
internal macOS bots.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _protectedPage]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.addTextSelectionManager):
(WKTextSelectionController.selectionDidChange):
(WKTextSelectionController.insertionCursorRect):
(WKTextSelectionController.selectionIsInsertionPoint):
(WKTextSelectionController.isTextSelected(at:)):
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
(WKTextSelectionController.showContextMenu(at:)):
(WKTextSelectionController.dragSelection(withGesture:completionHandler:)):
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.continueRangeSelection(at:)):
(WKTextSelectionController.endRangeSelection(at:)):

Canonical link: <a href="https://commits.webkit.org/308258@main">https://commits.webkit.org/308258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f21e36dcb672f451ef45720cb9b6bc1fa7d0043a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19615 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155617 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19516 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/113224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/93979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157948 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/121449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22665 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19032 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->