### PR TITLE
[Safer CPP] Address regressions in ContextMenuController.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -429,7 +429,6 @@ loader/cache/CachedSVGFont.cpp
 mathml/MathMLElement.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
-[ macOS ] page/ContextMenuController.cpp
 [ iOS ] page/DOMTimer.cpp
 [ Mac ] page/DOMWindow.cpp
 page/DragController.cpp

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1570,10 +1570,11 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
 
     bool shouldEnable = true;
     bool shouldCheck = false; 
+    Ref frameEditor = frame->editor();
 
     switch (item.action()) {
         case ContextMenuItemTagCheckSpelling:
-            shouldEnable = protect(frame->editor())->canEdit();
+            shouldEnable = frameEditor->canEdit();
             break;
         case ContextMenuItemTagDefaultDirection:
             shouldCheck = false;
@@ -1582,53 +1583,53 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagLeftToRight:
         case ContextMenuItemTagRightToLeft: {
             String direction = item.action() == ContextMenuItemTagLeftToRight ? "ltr"_s : "rtl"_s;
-            shouldCheck = protect(frame->editor())->selectionHasStyle(CSSPropertyDirection, direction) != TriState::False;
+            shouldCheck = frameEditor->selectionHasStyle(CSSPropertyDirection, direction) != TriState::False;
             shouldEnable = true;
             break;
         }
         case ContextMenuItemTagTextDirectionDefault: {
-            Editor::Command command = protect(frame->editor())->command("MakeTextWritingDirectionNatural"_s);
+            Editor::Command command = frameEditor->command("MakeTextWritingDirectionNatural"_s);
             shouldCheck = command.state() == TriState::True;
             shouldEnable = command.isEnabled();
             break;
         }
         case ContextMenuItemTagTextDirectionLeftToRight: {
-            Editor::Command command = protect(frame->editor())->command("MakeTextWritingDirectionLeftToRight"_s);
+            Editor::Command command = frameEditor->command("MakeTextWritingDirectionLeftToRight"_s);
             shouldCheck = command.state() == TriState::True;
             shouldEnable = command.isEnabled();
             break;
         }
         case ContextMenuItemTagTextDirectionRightToLeft: {
-            Editor::Command command = protect(frame->editor())->command("MakeTextWritingDirectionRightToLeft"_s);
+            Editor::Command command = frameEditor->command("MakeTextWritingDirectionRightToLeft"_s);
             shouldCheck = command.state() == TriState::True;
             shouldEnable = command.isEnabled();
             break;
         }
         case ContextMenuItemTagCopy:
-            shouldEnable = protect(frame->editor())->canDHTMLCopy() || protect(frame->editor())->canCopy();
+            shouldEnable = frameEditor->canDHTMLCopy() || frameEditor->canCopy();
             break;
         case ContextMenuItemTagCut:
-            shouldEnable = protect(frame->editor())->canDHTMLCut() || protect(frame->editor())->canCut();
+            shouldEnable = frameEditor->canDHTMLCut() || frameEditor->canCut();
             break;
         case ContextMenuItemTagIgnoreSpelling:
         case ContextMenuItemTagLearnSpelling:
             shouldEnable = frame->selection().isRange();
             break;
         case ContextMenuItemTagPaste:
-            shouldEnable = protect(frame->editor())->canDHTMLPaste() || protect(frame->editor())->canEdit();
+            shouldEnable = frameEditor->canDHTMLPaste() || frameEditor->canEdit();
             break;
         case ContextMenuItemTagCopyLinkWithHighlight:
             shouldEnable = shouldEnableCopyLinkWithHighlight();
             break;
 #if PLATFORM(GTK)
         case ContextMenuItemTagPasteAsPlainText:
-            shouldEnable = frame->editor().canDHTMLPaste() || frame->editor().canEdit();
+            shouldEnable = frameEditor->canDHTMLPaste() || frameEditor->canEdit();
             break;
         case ContextMenuItemTagDelete:
-            shouldEnable = frame->editor().canDelete();
+            shouldEnable = frameEditor->canDelete();
             break;
         case ContextMenuItemTagInsertEmoji:
-            shouldEnable = frame->editor().canEdit();
+            shouldEnable = frameEditor->canEdit();
             break;
         case ContextMenuItemTagSelectAll:
         case ContextMenuItemTagInputMethods:
@@ -1647,43 +1648,43 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             break;
 #endif
         case ContextMenuItemTagUnderline: {
-            shouldCheck = protect(frame->editor())->selectionHasStyle(CSSPropertyWebkitTextDecorationsInEffect, "underline"_s) != TriState::False;
-            shouldEnable = protect(frame->editor())->canEditRichly();
+            shouldCheck = frameEditor->selectionHasStyle(CSSPropertyWebkitTextDecorationsInEffect, "underline"_s) != TriState::False;
+            shouldEnable = frameEditor->canEditRichly();
             break;
         }
         case ContextMenuItemTagLookUpInDictionary:
             shouldEnable = frame->selection().isRange();
             break;
         case ContextMenuItemTagCheckGrammarWithSpelling:
-            if (protect(frame->editor())->isGrammarCheckingEnabled())
+            if (frameEditor->isGrammarCheckingEnabled())
                 shouldCheck = true;
             shouldEnable = true;
             break;
         case ContextMenuItemTagItalic: {
-            shouldCheck = protect(frame->editor())->selectionHasStyle(CSSPropertyFontStyle, "italic"_s) != TriState::False;
-            shouldEnable = frame->editor().canEditRichly();
+            shouldCheck = frameEditor->selectionHasStyle(CSSPropertyFontStyle, "italic"_s) != TriState::False;
+            shouldEnable = frameEditor->canEditRichly();
             break;
         }
         case ContextMenuItemTagBold: {
-            shouldCheck = protect(frame->editor())->selectionHasStyle(CSSPropertyFontWeight, "bold"_s) != TriState::False;
-            shouldEnable = frame->editor().canEditRichly();
+            shouldCheck = frameEditor->selectionHasStyle(CSSPropertyFontWeight, "bold"_s) != TriState::False;
+            shouldEnable = frameEditor->canEditRichly();
             break;
         }
         case ContextMenuItemTagOutline:
             shouldEnable = false;
             break;
         case ContextMenuItemTagShowSpellingPanel:
-            if (protect(frame->editor())->spellingPanelIsShowing())
+            if (frameEditor->spellingPanelIsShowing())
                 item.setTitle(contextMenuItemTagShowSpellingPanel(false));
             else
                 item.setTitle(contextMenuItemTagShowSpellingPanel(true));
-            shouldEnable = frame->editor().canEdit();
+            shouldEnable = frameEditor->canEdit();
             break;
         case ContextMenuItemTagNoGuessesFound:
             shouldEnable = false;
             break;
         case ContextMenuItemTagCheckSpellingWhileTyping:
-            shouldCheck = protect(frame->editor())->isContinuousSpellCheckingEnabled();
+            shouldCheck = frameEditor->isContinuousSpellCheckingEnabled();
             break;
         case ContextMenuItemTagAddHighlightToCurrentQuickNote:
             shouldEnable = frame->selection().isRange();
@@ -1696,11 +1697,11 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagTransformationsMenu:
             break;
         case ContextMenuItemTagShowSubstitutions:
-            if (protect(frame->editor())->substitutionsPanelIsShowing())
+            if (frameEditor->substitutionsPanelIsShowing())
                 item.setTitle(contextMenuItemTagShowSubstitutions(false));
             else
                 item.setTitle(contextMenuItemTagShowSubstitutions(true));
-            shouldEnable = frame->editor().canEdit();
+            shouldEnable = frameEditor->canEdit();
             break;
         case ContextMenuItemTagMakeUpperCase:
         case ContextMenuItemTagMakeLowerCase:
@@ -1708,29 +1709,29 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagChangeBack:
         case ContextMenuItemTagConvertToTraditionalChinese:
         case ContextMenuItemTagConvertToSimplifiedChinese:
-            shouldEnable = frame->editor().canEdit();
+            shouldEnable = frameEditor->canEdit();
             break;
         case ContextMenuItemTagCorrectSpellingAutomatically:
-            shouldCheck = frame->editor().isAutomaticSpellingCorrectionEnabled();
-            shouldEnable = frame->editor().canEnableAutomaticSpellingCorrection();
+            shouldCheck = frameEditor->isAutomaticSpellingCorrectionEnabled();
+            shouldEnable = frameEditor->canEnableAutomaticSpellingCorrection();
             break;
         case ContextMenuItemTagSmartCopyPaste:
-            shouldCheck = frame->editor().smartInsertDeleteEnabled();
+            shouldCheck = frameEditor->smartInsertDeleteEnabled();
             break;
         case ContextMenuItemTagSmartQuotes:
-            shouldCheck = frame->editor().isAutomaticQuoteSubstitutionEnabled();
+            shouldCheck = frameEditor->isAutomaticQuoteSubstitutionEnabled();
             break;
         case ContextMenuItemTagSmartDashes:
-            shouldCheck = frame->editor().isAutomaticDashSubstitutionEnabled();
+            shouldCheck = frameEditor->isAutomaticDashSubstitutionEnabled();
             break;
         case ContextMenuItemTagSmartLists:
-            shouldCheck = frame->editor().isSmartListsEnabled();
+            shouldCheck = frameEditor->isSmartListsEnabled();
             break;
         case ContextMenuItemTagSmartLinks:
-            shouldCheck = frame->editor().isAutomaticLinkDetectionEnabled();
+            shouldCheck = frameEditor->isAutomaticLinkDetectionEnabled();
             break;
         case ContextMenuItemTagTextReplacement:
-            shouldCheck = frame->editor().isAutomaticTextReplacementEnabled();
+            shouldCheck = frameEditor->isAutomaticTextReplacementEnabled();
             break;
         case ContextMenuItemTagStopSpeaking:
             shouldEnable = m_client->isSpeaking();
@@ -1753,7 +1754,7 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             shouldEnable = !frame->loader().documentLoader()->isLoadingInAPISense();
             break;
         case ContextMenuItemTagFontMenu:
-            shouldEnable = frame->editor().canEditRichly();
+            shouldEnable = frameEditor->canEditRichly();
             break;
 #else
         case ContextMenuItemTagGoBack:


### PR DESCRIPTION
#### 01df0e19be90a6263dca19cfbb642fb9470af4ef
<pre>
[Safer CPP] Address regressions in ContextMenuController.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=308702">https://bugs.webkit.org/show_bug.cgi?id=308702</a>
<a href="https://rdar.apple.com/171234761">rdar://171234761</a>

Reviewed by Chris Dumez.

Address reported Safer CPP regressions.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):

Canonical link: <a href="https://commits.webkit.org/308303@main">https://commits.webkit.org/308303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70adc15ed99358124cf25470a3234233f166af71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155701 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7aacadc-86c1-4668-9e48-dbf6432dfc99) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113287 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df8c42f6-a97c-4c1d-b0c0-2a440b780889) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94043 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2907a07-5a4d-4feb-a098-fa259c235159) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12517 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3143 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158032 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1163 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121311 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31137 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131756 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8580 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19116 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82871 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18846 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18905 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->