### PR TITLE
Remove fooProtectedBar() methods from WebCore

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -141,10 +141,10 @@ static RetainPtr<id> makeNSArrayElement(const ApplePayInstallmentItem& item)
     // FIXME: This is a safer cpp false positive.
     SUPPRESS_UNRETAINED_ARG auto installmentItem = adoptNS([PAL::allocPKPaymentInstallmentItemInstance() init]);
     [installmentItem setInstallmentItemType:platformItemType(item.type)];
-    [installmentItem setAmount:toProtectedDecimalNumber(item.amount).get()];
+    [installmentItem setAmount:protect(toDecimalNumber(item.amount)).get()];
     [installmentItem setCurrencyCode:item.currencyCode.createNSString().get()];
     [installmentItem setProgramIdentifier:item.programIdentifier.createNSString().get()];
-    [installmentItem setApr:toProtectedDecimalNumber(item.apr).get()];
+    [installmentItem setApr:protect(toDecimalNumber(item.apr)).get()];
     [installmentItem setProgramTerms:item.programTerms.createNSString().get()];
     return installmentItem;
 }
@@ -189,10 +189,10 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
 
     [configuration setFeature:platformFeatureType(coreConfiguration.featureType)];
 
-    [configuration setBindingTotalAmount:toProtectedDecimalNumber(coreConfiguration.bindingTotalAmount).get()];
+    [configuration setBindingTotalAmount:protect(toDecimalNumber(coreConfiguration.bindingTotalAmount)).get()];
     [configuration setCurrencyCode:coreConfiguration.currencyCode.createNSString().get()];
     [configuration setInStorePurchase:coreConfiguration.isInStorePurchase];
-    [configuration setOpenToBuyThresholdAmount:toProtectedDecimalNumber(coreConfiguration.openToBuyThresholdAmount).get()];
+    [configuration setOpenToBuyThresholdAmount:protect(toDecimalNumber(coreConfiguration.openToBuyThresholdAmount)).get()];
 
     RetainPtr merchandisingImageData = adoptNS([[NSData alloc] initWithBase64EncodedString:coreConfiguration.merchandisingImageData.createNSString().get() options:0]);
     [configuration setMerchandisingImageData:merchandisingImageData.get()];

--- a/Source/WebCore/Modules/applepay/PaymentSummaryItems.h
+++ b/Source/WebCore/Modules/applepay/PaymentSummaryItems.h
@@ -65,7 +65,6 @@ WEBCORE_EXPORT RetainPtr<NSArray> platformDisbursementSummaryItems(const Vector<
 WEBCORE_EXPORT RetainPtr<NSArray> platformSummaryItems(const ApplePayLineItem& total, const Vector<ApplePayLineItem>&);
 
 WEBCORE_EXPORT NSDecimalNumber *toDecimalNumber(const String& amount);
-WEBCORE_EXPORT RetainPtr<NSDecimalNumber> toProtectedDecimalNumber(const String& amount);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -40,11 +40,6 @@ NSDecimalNumber *toDecimalNumber(const String& amount)
     return [NSDecimalNumber decimalNumberWithString:amount.createNSString().get() locale:@{ NSLocaleDecimalSeparator : @"." }];
 }
 
-RetainPtr<NSDecimalNumber> toProtectedDecimalNumber(const String& amount)
-{
-    return toDecimalNumber(amount);
-}
-
 static PKPaymentSummaryItemType NODELETE toPKPaymentSummaryItemType(ApplePayLineItem::Type type)
 {
     switch (type) {
@@ -64,11 +59,6 @@ namespace WebCore {
 static NSDate *toDate(WallTime date)
 {
     return [NSDate dateWithTimeIntervalSince1970:date.secondsSinceEpoch().value()];
-}
-
-static RetainPtr<NSDate> toProtectedDate(WallTime date)
-{
-    return toDate(date);
 }
 
 #endif // HAVE(PASSKIT_RECURRING_SUMMARY_ITEM) || HAVE(PASSKIT_DEFERRED_SUMMARY_ITEM)
@@ -99,13 +89,13 @@ RetainPtr<PKRecurringPaymentSummaryItem> platformRecurringSummaryItem(const Appl
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Recurring);
     // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKRecurringPaymentSummaryItem> summaryItem = [PAL::getPKRecurringPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    SUPPRESS_UNRETAINED_ARG RetainPtr<PKRecurringPaymentSummaryItem> summaryItem = [PAL::getPKRecurringPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.recurringPaymentStartDate.isNaN())
-        summaryItem.get().startDate = toProtectedDate(lineItem.recurringPaymentStartDate).get();
+        summaryItem.get().startDate = protect(toDate(lineItem.recurringPaymentStartDate)).get();
     summaryItem.get().intervalUnit = toCalendarUnit(lineItem.recurringPaymentIntervalUnit);
     summaryItem.get().intervalCount = lineItem.recurringPaymentIntervalCount;
     if (!lineItem.recurringPaymentEndDate.isNaN())
-        summaryItem.get().endDate = toProtectedDate(lineItem.recurringPaymentEndDate).get();
+        summaryItem.get().endDate = protect(toDate(lineItem.recurringPaymentEndDate)).get();
     return summaryItem;
 }
 
@@ -117,9 +107,9 @@ RetainPtr<PKDeferredPaymentSummaryItem> platformDeferredSummaryItem(const AppleP
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Deferred);
     // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKDeferredPaymentSummaryItem> summaryItem = [PAL::getPKDeferredPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    SUPPRESS_UNRETAINED_ARG RetainPtr<PKDeferredPaymentSummaryItem> summaryItem = [PAL::getPKDeferredPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
     if (!lineItem.deferredPaymentDate.isNaN())
-        summaryItem.get().deferredDate = toProtectedDate(lineItem.deferredPaymentDate).get();
+        summaryItem.get().deferredDate = protect(toDate(lineItem.deferredPaymentDate)).get();
     return summaryItem;
 }
 
@@ -131,8 +121,8 @@ RetainPtr<PKAutomaticReloadPaymentSummaryItem> platformAutomaticReloadSummaryIte
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::AutomaticReload);
     // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG RetainPtr<PKAutomaticReloadPaymentSummaryItem> summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
-    summaryItem.get().thresholdAmount = toProtectedDecimalNumber(lineItem.automaticReloadPaymentThresholdAmount).get();
+    SUPPRESS_UNRETAINED_ARG RetainPtr<PKAutomaticReloadPaymentSummaryItem> summaryItem = [PAL::getPKAutomaticReloadPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    summaryItem.get().thresholdAmount = protect(toDecimalNumber(lineItem.automaticReloadPaymentThresholdAmount)).get();
     return summaryItem;
 }
 
@@ -144,14 +134,14 @@ PKDisbursementSummaryItem *platformDisbursementSummaryItem(const ApplePayLineIte
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::Disbursement);
     // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKDisbursementSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get()];
+    SUPPRESS_UNRETAINED_ARG return [PAL::getPKDisbursementSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get()];
 }
 
 PKInstantFundsOutFeeSummaryItem *platformInstantFundsOutFeeSummaryItem(const ApplePayLineItem& lineItem)
 {
     ASSERT(lineItem.disbursementLineItemType == ApplePayLineItem::DisbursementLineItemType::InstantFundsOutFee);
     // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKInstantFundsOutFeeSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get()];
+    SUPPRESS_UNRETAINED_ARG return [PAL::getPKInstantFundsOutFeeSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get()];
 }
 
 #endif // HAVE(PASSKIT_DISBURSEMENTS)
@@ -190,7 +180,7 @@ RetainPtr<PKPaymentSummaryItem> platformSummaryItem(const ApplePayLineItem& line
     }
 
     // FIXME: This is a static analysis false positive (rdar://160259918).
-    SUPPRESS_UNRETAINED_ARG return [PAL::getPKPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:toProtectedDecimalNumber(lineItem.amount).get() type:toPKPaymentSummaryItemType(lineItem.type)];
+    SUPPRESS_UNRETAINED_ARG return [PAL::getPKPaymentSummaryItemClassSingleton() summaryItemWithLabel:lineItem.label.createNSString().get() amount:protect(toDecimalNumber(lineItem.amount)).get() type:toPKPaymentSummaryItemType(lineItem.type)];
 }
 
 #if HAVE(PASSKIT_DISBURSEMENTS)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -156,7 +156,7 @@ Vector<Ref<TextTrack>> MediaControlsHost::sortedTrackListForMenu(TextTrackList& 
     if (!page)
         return { };
 
-    return protect(page->group())->ensureProtectedCaptionPreferences()->sortedTrackListForMenu(&trackList, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
+    return protect(protect(page->group())->ensureCaptionPreferences())->sortedTrackListForMenu(&trackList, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
 }
 
 Vector<Ref<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackList& trackList)
@@ -165,7 +165,7 @@ Vector<Ref<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackList
     if (!page)
         return { };
 
-    return protect(page->group())->ensureProtectedCaptionPreferences()->sortedTrackListForMenu(&trackList);
+    return protect(protect(page->group())->ensureCaptionPreferences())->sortedTrackListForMenu(&trackList);
 }
 
 String MediaControlsHost::displayNameForTrack(const std::optional<TextOrAudioTrack>& track)
@@ -203,7 +203,7 @@ AtomString MediaControlsHost::captionDisplayMode() const
     if (!page)
         return emptyAtom();
 
-    switch (protect(page->group())->ensureProtectedCaptionPreferences()->captionDisplayMode()) {
+    switch (protect(protect(page->group())->ensureCaptionPreferences())->captionDisplayMode()) {
     case CaptionUserPreferences::CaptionDisplayMode::Automatic:
         return automaticKeyword();
     case CaptionUserPreferences::CaptionDisplayMode::ForcedOnly:
@@ -950,7 +950,7 @@ void MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary()
         }
     }
 
-    switch (protect(page->group())->ensureProtectedCaptionPreferences()->captionDisplayMode()) {
+    switch (protect(protect(page->group())->ensureCaptionPreferences())->captionDisplayMode()) {
     case CaptionUserPreferences::CaptionDisplayMode::Automatic:
         m_previouslySelectedTextTrack = TextTrack::captionMenuAutomaticItemSingleton();
         return;

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -106,11 +106,6 @@ PlatformSpeechSynthesizer& SpeechSynthesis::ensurePlatformSpeechSynthesizer()
     return *m_platformSpeechSynthesizer;
 }
 
-Ref<PlatformSpeechSynthesizer> SpeechSynthesis::ensureProtectedPlatformSpeechSynthesizer()
-{
-    return ensurePlatformSpeechSynthesizer();
-}
-
 const Vector<Ref<SpeechSynthesisVoice>>& SpeechSynthesis::getVoices()
 {
     if (RefPtr context = scriptExecutionContext()) {
@@ -125,7 +120,7 @@ const Vector<Ref<SpeechSynthesisVoice>>& SpeechSynthesis::getVoices()
 
     // If the voiceList is empty, that's the cue to get the voices from the platform again.
     RefPtr speechSynthesisClient = m_speechSynthesisClient.get();
-    auto& voiceList = speechSynthesisClient ? speechSynthesisClient->voiceList() : ensureProtectedPlatformSpeechSynthesizer()->voiceList();
+    auto& voiceList = speechSynthesisClient ? speechSynthesisClient->voiceList() : protect(ensurePlatformSpeechSynthesizer())->voiceList();
     m_voiceList = voiceList.map([](auto& voice) {
         return SpeechSynthesisVoice::create(Ref { voice });
     });
@@ -161,7 +156,7 @@ void SpeechSynthesis::startSpeakingImmediately(SpeechSynthesisUtterance& utteran
     if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
         speechSynthesisClient->speak(&utterance.platformUtterance());
     else
-        ensureProtectedPlatformSpeechSynthesizer()->speak(&utterance.platformUtterance());
+        protect(ensurePlatformSpeechSynthesizer())->speak(&utterance.platformUtterance());
 }
 
 void SpeechSynthesis::speak(SpeechSynthesisUtterance& utterance)

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -113,8 +113,7 @@ private:
     void eventListenersDidChange() final;
     
     PlatformSpeechSynthesizer& ensurePlatformSpeechSynthesizer();
-    Ref<PlatformSpeechSynthesizer> ensureProtectedPlatformSpeechSynthesizer();
-    
+
     SpeechSynthesisUtterance* currentSpeechUtterance();
 
     RefPtr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9956,11 +9956,6 @@ Document& Document::ensureTemplateDocument()
     return *m_templateDocument;
 }
 
-Ref<Document> Document::ensureProtectedTemplateDocument()
-{
-    return ensureTemplateDocument();
-}
-
 Ref<DocumentFragment> Document::documentFragmentForInnerOuterHTML()
 {
     if (!m_documentFragmentForInnerOuterHTML) [[unlikely]]

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1628,7 +1628,6 @@ public:
 
     const Document* templateDocument() const;
     Document& ensureTemplateDocument();
-    Ref<Document> ensureProtectedTemplateDocument();
     void setTemplateDocumentHost(Document* templateDocumentHost) { m_templateDocumentHost = templateDocumentHost; }
     Document* templateDocumentHost() { return m_templateDocumentHost.get(); }
     bool isTemplateDocument() const { return !!m_templateDocumentHost; }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3517,11 +3517,6 @@ ShadowRoot& Element::ensureUserAgentShadowRoot()
     return createUserAgentShadowRoot();
 }
 
-Ref<ShadowRoot> Element::ensureProtectedUserAgentShadowRoot()
-{
-    return ensureUserAgentShadowRoot();
-}
-
 ShadowRoot& Element::createUserAgentShadowRoot()
 {
     ASSERT(!userAgentShadowRoot());

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -467,7 +467,6 @@ public:
 
     WEBCORE_EXPORT ShadowRoot* NODELETE userAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();
-    Ref<ShadowRoot> ensureProtectedUserAgentShadowRoot();
     WEBCORE_EXPORT ShadowRoot& createUserAgentShadowRoot();
 
     void setIsDefinedCustomElement(JSCustomElementInterface&);

--- a/Source/WebCore/html/AttachmentAssociatedElement.cpp
+++ b/Source/WebCore/html/AttachmentAssociatedElement.cpp
@@ -36,28 +36,18 @@
 
 namespace WebCore {
 
-Ref<HTMLElement> AttachmentAssociatedElement::asProtectedHTMLElement()
-{
-    return asHTMLElement();
-}
-
-Ref<const HTMLElement> AttachmentAssociatedElement::asProtectedHTMLElement() const
-{
-    return asHTMLElement();
-}
-
 void AttachmentAssociatedElement::setAttachmentElement(Ref<HTMLAttachmentElement>&& attachment)
 {
     if (RefPtr existingAttachment = attachmentElement())
         existingAttachment->remove();
 
     attachment->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone, IsImportant::Yes);
-    asProtectedHTMLElement()->ensureProtectedUserAgentShadowRoot()->appendChild(WTF::move(attachment));
+    protect(protect(asHTMLElement())->ensureUserAgentShadowRoot())->appendChild(WTF::move(attachment));
 }
 
 RefPtr<HTMLAttachmentElement> AttachmentAssociatedElement::attachmentElement() const
 {
-    if (RefPtr shadowRoot = asProtectedHTMLElement()->userAgentShadowRoot())
+    if (RefPtr shadowRoot = protect(asHTMLElement())->userAgentShadowRoot())
         return childrenOfType<HTMLAttachmentElement>(*shadowRoot).first();
 
     return nullptr;

--- a/Source/WebCore/html/AttachmentAssociatedElement.h
+++ b/Source/WebCore/html/AttachmentAssociatedElement.h
@@ -52,9 +52,7 @@ public:
     virtual ~AttachmentAssociatedElement() = default;
 
     virtual HTMLElement& asHTMLElement() = 0;
-    Ref<HTMLElement> asProtectedHTMLElement();
     virtual const HTMLElement& asHTMLElement() const = 0;
-    Ref<const HTMLElement> asProtectedHTMLElement() const;
 
     virtual AttachmentAssociatedElementType attachmentAssociatedElementType() const = 0;
 

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -69,7 +69,7 @@ ExceptionOr<void> FormAssociatedCustomElement::setValidity(ValidityStateFlags va
     m_validityStateFlags = validityStateFlags;
     setCustomValidity(validityStateFlags.isValid() ? emptyString() : WTF::move(message));
 
-    if (validationAnchor && !asProtectedHTMLElement()->isShadowIncludingInclusiveAncestorOf(*validationAnchor))
+    if (validationAnchor && !protect(asHTMLElement())->isShadowIncludingInclusiveAncestorOf(*validationAnchor))
         return Exception { ExceptionCode::NotFoundError };
 
     m_validationAnchor = validationAnchor;
@@ -159,14 +159,14 @@ void FormAssociatedCustomElement::reset()
 {
     ASSERT(m_element->isDefinedCustomElement());
     setInteractedWithSinceLastFormSubmitEvent(false);
-    CustomElementReactionQueue::enqueueFormResetCallbackIfNeeded(asProtectedHTMLElement().get());
+    CustomElementReactionQueue::enqueueFormResetCallbackIfNeeded(protect(asHTMLElement()).get());
 }
 
 void FormAssociatedCustomElement::disabledStateChanged()
 {
     ASSERT(m_element->isDefinedCustomElement());
     ValidatedFormListedElement::disabledStateChanged();
-    CustomElementReactionQueue::enqueueFormDisabledCallbackIfNeeded(asProtectedHTMLElement().get(), isDisabled());
+    CustomElementReactionQueue::enqueueFormDisabledCallbackIfNeeded(protect(asHTMLElement()).get(), isDisabled());
 }
 
 void FormAssociatedCustomElement::didChangeForm()
@@ -174,7 +174,7 @@ void FormAssociatedCustomElement::didChangeForm()
     ASSERT(m_element->isDefinedCustomElement());
     ValidatedFormListedElement::didChangeForm();
     if (!belongsToFormThatIsBeingDestroyed())
-        CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded(asProtectedHTMLElement().get(), protect(form()).get());
+        CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded(protect(asHTMLElement()).get(), protect(form()).get());
 }
 
 void FormAssociatedCustomElement::willUpgrade()

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -32,9 +32,7 @@ public:
 
     virtual ~FormAssociatedElement() { RELEASE_ASSERT(!m_form); }
     virtual HTMLElement& asHTMLElement() = 0;
-    Ref<HTMLElement> asProtectedHTMLElement() { return asHTMLElement(); }
     virtual const HTMLElement& asHTMLElement() const = 0;
-    Ref<const HTMLElement> asProtectedHTMLElement() const { return asHTMLElement(); }
     virtual bool NODELETE isFormListedElement() const = 0;
 
     virtual void formWillBeDestroyed() { m_form = nullptr; }

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -43,7 +43,7 @@ HTMLFormElement* FormController::ownerForm(const FormListedElement& control)
     // Assume controls with form attribute have no owners because we restore
     // state during parsing and form owners of such controls might be
     // indeterminate.
-    return control.asProtectedHTMLElement()->hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
+    return protect(control.asHTMLElement())->hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
 }
 
 struct AtomStringVectorReader {

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -288,7 +288,7 @@ void FormListedElement::setCustomValidity(const String& error)
 void FormListedElement::resetFormAttributeTargetObserver()
 {
     ASSERT_WITH_SECURITY_IMPLICATION(asHTMLElement().isConnected());
-    m_formAttributeTargetObserver = makeUnique<FormAttributeTargetObserver>(asProtectedHTMLElement()->attributeWithoutSynchronization(formAttr), *this);
+    m_formAttributeTargetObserver = makeUnique<FormAttributeTargetObserver>(protect(asHTMLElement())->attributeWithoutSynchronization(formAttr), *this);
 }
 
 void FormListedElement::formAttributeTargetChanged()
@@ -298,12 +298,12 @@ void FormListedElement::formAttributeTargetChanged()
 
 const AtomString& FormListedElement::name() const
 {
-    const AtomString& name = asProtectedHTMLElement()->getNameAttribute();
+    const AtomString& name = protect(asHTMLElement())->getNameAttribute();
     return name.isNull() ? emptyAtom() : name;
 }
 
 FormAttributeTargetObserver::FormAttributeTargetObserver(const AtomString& id, FormListedElement& element)
-    : IdTargetObserver(protect(element.asProtectedHTMLElement()->treeScope())->idTargetObserverRegistry(), id)
+    : IdTargetObserver(protect(protect(element.asHTMLElement())->treeScope())->idTargetObserverRegistry(), id)
     , m_element(element)
 {
 }

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -858,7 +858,7 @@ void HTMLAttachmentElement::updateAttributes(std::optional<uint64_t>&& newFileSi
 {
     RefPtr<HTMLImageElement> enclosingImage;
     if (RefPtr associatedElement = this->associatedElement())
-        enclosingImage = dynamicDowncast<HTMLImageElement>(associatedElement->asProtectedHTMLElement());
+        enclosingImage = dynamicDowncast<HTMLImageElement>(protect(associatedElement->asHTMLElement()));
 
     if (!newFilename.isNull()) {
         if (enclosingImage)
@@ -909,7 +909,7 @@ void HTMLAttachmentElement::updateAssociatedElementWithData(const String& conten
 
     auto associatedElementType = associatedElement->attachmentAssociatedElementType();
     Ref document = this->document();
-    associatedElement->asProtectedHTMLElement()->setAttributeWithoutSynchronization((associatedElementType == AttachmentAssociatedElementType::Source) ? HTMLNames::srcsetAttr : HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(document, Blob::create(document.ptr(), buffer->extractData(), mimeType)) });
+    protect(associatedElement->asHTMLElement())->setAttributeWithoutSynchronization((associatedElementType == AttachmentAssociatedElementType::Source) ? HTMLNames::srcsetAttr : HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(document, Blob::create(document.ptr(), buffer->extractData(), mimeType)) });
 }
 
 void HTMLAttachmentElement::updateImage()

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -146,11 +146,6 @@ HTMLImageLoader& HTMLInputElement::ensureImageLoader()
     return *m_imageLoader;
 }
 
-Ref<HTMLImageLoader> HTMLInputElement::ensureProtectedImageLoader()
-{
-    return ensureImageLoader();
-}
-
 HTMLInputElement::~HTMLInputElement()
 {
     // Need to remove form association while this is still an HTMLInputElement

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -338,7 +338,6 @@ public:
 
     HTMLImageLoader* imageLoader() { return m_imageLoader.get(); }
     HTMLImageLoader& ensureImageLoader();
-    Ref<HTMLImageLoader> ensureProtectedImageLoader();
 
     void capsLockStateMayHaveChanged();
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8060,7 +8060,7 @@ CaptionUserPreferences::CaptionDisplayMode HTMLMediaElement::captionDisplayMode(
 {
     if (!m_captionDisplayMode) {
         if (RefPtr page = document().page())
-            m_captionDisplayMode = protect(page->group())->ensureProtectedCaptionPreferences()->captionDisplayMode();
+            m_captionDisplayMode = protect(protect(page->group())->ensureCaptionPreferences())->captionDisplayMode();
         else
             m_captionDisplayMode = CaptionUserPreferences::CaptionDisplayMode::Automatic;
     }
@@ -8637,7 +8637,7 @@ void HTMLMediaElement::shouldSuppressHDRDidChange()
 Vector<String> HTMLMediaElement::mediaPlayerPreferredAudioCharacteristics() const
 {
     if (RefPtr page = document().page())
-        return protect(page->group())->ensureProtectedCaptionPreferences()->preferredAudioCharacteristics();
+        return protect(protect(page->group())->ensureCaptionPreferences())->preferredAudioCharacteristics();
     return { };
 }
 

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -85,7 +85,7 @@ DocumentFragment& HTMLTemplateElement::content() const
 {
     ASSERT(!m_declarativeShadowRoot);
     if (!m_content)
-        lazyInitialize(m_content, TemplateContentDocumentFragment::create(protect(document())->ensureProtectedTemplateDocument(), *this));
+        lazyInitialize(m_content, TemplateContentDocumentFragment::create(protect(protect(document())->ensureTemplateDocument()), *this));
     return *m_content;
 }
 
@@ -165,7 +165,7 @@ void HTMLTemplateElement::didMoveToNewDocument(Document& oldDocument, Document& 
     if (!m_content)
         return;
     ASSERT_WITH_SECURITY_IMPLICATION(&document() == &newDocument);
-    m_content->setTreeScopeRecursively(newDocument.ensureProtectedTemplateDocument());
+    m_content->setTreeScopeRecursively(protect(newDocument.ensureTemplateDocument()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -125,7 +125,7 @@ void ImageInputType::attributeChanged(const QualifiedName& name)
     } else if (name == srcAttr) {
         if (RefPtr element = this->element()) {
             if (element->renderer())
-                element->ensureProtectedImageLoader()->updateFromElementIgnoringPreviousError();
+                protect(element->ensureImageLoader())->updateFromElementIgnoringPreviousError();
         }
     }
     BaseButtonInputType::attributeChanged(name);

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -260,7 +260,7 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
     if (!mediaElement)
         return;
 
-    float fontScale = protect(page->group())->ensureProtectedCaptionPreferences()->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
+    float fontScale = protect(protect(page->group())->ensureCaptionPreferences())->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
 
     // Caption fonts are defined as |size vh| units, so there's no need to
     // scale by display size. Since |vh| is a decimal percentage, multiply
@@ -297,7 +297,7 @@ void MediaControlTextTrackContainerElement::updateTextStrokeStyle()
     bool important;
 
     // FIXME: find a way to set this property in the stylesheet like the other user style preferences, see <https://bugs.webkit.org/show_bug.cgi?id=169874>.
-    if (protect(page->group())->ensureProtectedCaptionPreferences()->captionStrokeWidthForFont(m_fontSize, language, strokeWidth, important))
+    if (protect(protect(page->group())->ensureCaptionPreferences())->captionStrokeWidthForFont(m_fontSize, language, strokeWidth, important))
         setInlineStyleProperty(CSSPropertyStrokeWidth, strokeWidth, CSSUnitType::CSS_PX, important ? IsImportant::Yes : IsImportant::No);
 }
 
@@ -436,7 +436,7 @@ void MediaControlTextTrackContainerElement::captionPreferencesChanged()
 {
     if (RefPtr page = document().page()) {
         if (RefPtr previewCue = m_previewCue) {
-            previewCue->setText(protect(page->group())->ensureProtectedCaptionPreferences()->captionPreviewTitle());
+            previewCue->setText(protect(protect(page->group())->ensureCaptionPreferences())->captionPreviewTitle());
             previewCue->updateDisplayTree(MediaTime::zeroTime());
         }
     }
@@ -563,7 +563,7 @@ VTTCue& MediaControlTextTrackContainerElement::ensurePreviewCue() const
         m_previewCue->setIsActive(true);
 
         if (RefPtr page = document().page())
-            m_previewCue->setText(protect(page->group())->ensureProtectedCaptionPreferences()->captionPreviewTitle());
+            m_previewCue->setText(protect(protect(page->group())->ensureCaptionPreferences())->captionPreviewTitle());
 
         m_previewTrack->addCue(*m_previewCue);
     }

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -373,7 +373,7 @@ ExceptionOr<void> TextTrack::addCue(Ref<TextTrackCue>&& cue)
 
     // 2. Add cue to the method's TextTrack object's text track's text track list of cues.
     cue->setTrack(this);
-    ensureProtectedTextTrackCueList()->add(cue.copyRef());
+    protect(ensureTextTrackCueList())->add(cue.copyRef());
 
     m_clients.forEach([this, cue](auto& client) {
         client.textTrackAddCue(*this, cue);
@@ -469,7 +469,7 @@ void TextTrack::cueDidChange(TextTrackCue& cue, bool updateCueOrder)
 {
     // Make sure the TextTrackCueList order is up-to-date.
     if (updateCueOrder)
-        ensureProtectedTextTrackCueList()->updateCueIndex(cue);
+        protect(ensureTextTrackCueList())->updateCueIndex(cue);
 
     // ... and add it back again.
     m_clients.forEach([&](auto& client) {
@@ -505,11 +505,6 @@ TextTrackCueList& TextTrack::ensureTextTrackCueList()
     if (!m_cues)
         lazyInitialize(m_cues, TextTrackCueList::create());
     return *m_cues;
-}
-
-Ref<TextTrackCueList> TextTrack::ensureProtectedTextTrackCueList()
-{
-    return ensureTextTrackCueList();
 }
 
 int TextTrack::trackIndexRelativeToRenderedTracks()

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -173,7 +173,6 @@ private:
     RefPtr<VTTRegionList> m_regions;
 
     TextTrackCueList& ensureTextTrackCueList();
-    Ref<TextTrackCueList> ensureProtectedTextTrackCueList();
     Kind convertKind(const AtomString&);
 
     Mode m_mode { Mode::Disabled };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4095,7 +4095,7 @@ bool NODELETE Page::isMonitoringWheelEvents() const
 
 void Page::startMonitoringWheelEvents(bool clearLatchingState)
 {
-    ensureProtectedWheelEventTestMonitor()->clearAllTestDeferrals();
+    protect(ensureWheelEventTestMonitor())->clearAllTestDeferrals();
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
     if (clearLatchingState)
@@ -4117,11 +4117,6 @@ WheelEventTestMonitor& Page::ensureWheelEventTestMonitor()
         m_wheelEventTestMonitor = adoptRef(new WheelEventTestMonitor(*this));
 
     return *m_wheelEventTestMonitor;
-}
-
-Ref<WheelEventTestMonitor> Page::ensureProtectedWheelEventTestMonitor()
-{
-    return ensureWheelEventTestMonitor();
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1433,7 +1433,6 @@ private:
     RenderingUpdateScheduler* NODELETE existingRenderingUpdateScheduler();
 
     WheelEventTestMonitor& ensureWheelEventTestMonitor();
-    Ref<WheelEventTestMonitor> ensureProtectedWheelEventTestMonitor();
 
 #if ENABLE(IMAGE_ANALYSIS)
     void resetTextRecognitionResults();

--- a/Source/WebCore/page/PageGroup.cpp
+++ b/Source/WebCore/page/PageGroup.cpp
@@ -130,11 +130,6 @@ CaptionUserPreferences& PageGroup::ensureCaptionPreferences()
 
     return *m_captionPreferences;
 }
-
-Ref<CaptionUserPreferences> PageGroup::ensureProtectedCaptionPreferences()
-{
-    return ensureCaptionPreferences();
-}
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -61,7 +61,6 @@ public:
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT void captionPreferencesChanged();
     WEBCORE_EXPORT CaptionUserPreferences& ensureCaptionPreferences();
-    Ref<CaptionUserPreferences> ensureProtectedCaptionPreferences();
     CaptionUserPreferences* captionPreferences() const { return m_captionPreferences.get(); }
 #endif
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -62,7 +62,6 @@ private:
 
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     GameControllerHapticEngines& ensureHapticEngines();
-    Ref<GameControllerHapticEngines> ensureProtectedHapticEngines() { return ensureHapticEngines(); }
 #endif
 
     const RetainPtr<GCController> m_gcController;

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -184,7 +184,7 @@ GameControllerHapticEngines& GameControllerGamepad::ensureHapticEngines()
 void GameControllerGamepad::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
-    ensureProtectedHapticEngines()->playEffect(type, parameters, WTF::move(completionHandler));
+    protect(ensureHapticEngines())->playEffect(type, parameters, WTF::move(completionHandler));
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(parameters);

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -117,17 +117,13 @@ public:
 
 private:
     PlatformPathImpl& ensurePlatformPathImpl();
-    Ref<PlatformPathImpl> ensureProtectedPlatformPathImpl();
     PathImpl& setImpl(Ref<PathImpl>&&);
     WEBCORE_EXPORT PathImpl& ensureImpl();
-    WEBCORE_EXPORT Ref<PathImpl> ensureProtectedImpl();
 
     PathSegment* asSingle() { return std::get_if<PathSegment>(&m_data); }
     const PathSegment* asSingle() const { return std::get_if<PathSegment>(&m_data); }
 
     PathImpl* asImpl();
-    RefPtr<PathImpl> asProtectedImpl();
-    RefPtr<const PathImpl> asProtectedImpl() const;
 
     std::optional<FloatPoint> initialMoveToPoint() const;
 
@@ -151,7 +147,7 @@ inline void Path::moveTo(const FloatPoint& point)
     if (isEmpty())
         m_data = PathSegment(PathMoveTo { point });
     else
-        ensureProtectedImpl()->add(PathMoveTo { point });
+        protect(ensureImpl())->add(PathMoveTo { point });
 }
 
 inline void Path::addLineTo(const FloatPoint& point)
@@ -159,7 +155,7 @@ inline void Path::addLineTo(const FloatPoint& point)
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataLine { *initial, point });
     else
-        ensureProtectedImpl()->add(PathLineTo { point });
+        protect(ensureImpl())->add(PathLineTo { point });
 }
 
 inline void Path::addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint)
@@ -167,7 +163,7 @@ inline void Path::addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoin
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataQuadCurve { *initial, controlPoint, endPoint });
     else
-        ensureProtectedImpl()->add(PathQuadCurveTo { controlPoint, endPoint });
+        protect(ensureImpl())->add(PathQuadCurveTo { controlPoint, endPoint });
 }
 
 inline void Path::addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint)
@@ -175,7 +171,7 @@ inline void Path::addBezierCurveTo(const FloatPoint& controlPoint1, const FloatP
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataBezierCurve { *initial, controlPoint1, controlPoint2, endPoint });
     else
-        ensureProtectedImpl()->add(PathBezierCurveTo { controlPoint1, controlPoint2, endPoint });
+        protect(ensureImpl())->add(PathBezierCurveTo { controlPoint1, controlPoint2, endPoint });
 }
 
 inline void Path::addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius)
@@ -183,7 +179,7 @@ inline void Path::addArcTo(const FloatPoint& point1, const FloatPoint& point2, f
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataArc { *initial, point1, point2, radius });
     else
-        ensureProtectedImpl()->add(PathArcTo { point1, point2, radius });
+        protect(ensureImpl())->add(PathArcTo { point1, point2, radius });
 }
 
 inline void Path::addArc(const FloatPoint& point, float radius, float startAngle, float endAngle, RotationDirection direction)
@@ -197,7 +193,7 @@ inline void Path::addArc(const FloatPoint& point, float radius, float startAngle
     if (isEmpty())
         m_data = PathSegment(PathArc { point, radius, startAngle, endAngle, direction });
     else
-        ensureProtectedImpl()->add(PathArc { point, radius, startAngle, endAngle, direction });
+        protect(ensureImpl())->add(PathArc { point, radius, startAngle, endAngle, direction });
 }
 
 inline void Path::addEllipse(const FloatPoint& point, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection direction)
@@ -205,7 +201,7 @@ inline void Path::addEllipse(const FloatPoint& point, float radiusX, float radiu
     if (isEmpty())
         m_data = PathSegment(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
     else
-        ensureProtectedImpl()->add(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
+        protect(ensureImpl())->add(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
 }
 
 inline void Path::addEllipseInRect(const FloatRect& rect)
@@ -213,7 +209,7 @@ inline void Path::addEllipseInRect(const FloatRect& rect)
     if (isEmpty())
         m_data = PathSegment(PathEllipseInRect { rect });
     else
-        ensureProtectedImpl()->add(PathEllipseInRect { rect });
+        protect(ensureImpl())->add(PathEllipseInRect { rect });
 }
 
 inline void Path::addRect(const FloatRect& rect)
@@ -221,7 +217,7 @@ inline void Path::addRect(const FloatRect& rect)
     if (isEmpty())
         m_data = PathSegment(PathRect { rect });
     else
-        ensureProtectedImpl()->add(PathRect { rect });
+        protect(ensureImpl())->add(PathRect { rect });
 }
 
 inline void Path::closeSubpath()
@@ -237,7 +233,7 @@ inline void Path::closeSubpath()
         if (std::holds_alternative<PathCloseSubpath>(*data))
             return;
     }
-    auto impl = ensureProtectedImpl();
+    Ref impl = ensureImpl();
     if (impl->isClosed())
         return;
     impl->add(PathCloseSubpath { });
@@ -251,7 +247,7 @@ inline FloatPoint Path::currentPoint() const
         FloatPoint lastMoveToPoint;
         return segment->calculateEndPoint({ }, lastMoveToPoint);
     }
-    return asProtectedImpl()->currentPoint();
+    return protect(asImpl())->currentPoint();
 }
 
 inline std::optional<FloatPoint> Path::initialMoveToPoint() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -314,19 +314,13 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {
 
-static RefPtr<ImageDecoderAVFObjCSample> toProtectedSample(const PresentationOrderSampleMap::value_type& pair)
+static ImageDecoderAVFObjCSample* toSample(const PresentationOrderSampleMap::value_type& pair)
 {
     return downcast<ImageDecoderAVFObjCSample>(pair.second.ptr());
 }
 
 template <typename Iterator>
 ImageDecoderAVFObjCSample* toSample(Iterator iter)
-{
-    return downcast<ImageDecoderAVFObjCSample>(iter->second.ptr());
-}
-
-template <typename Iterator>
-RefPtr<ImageDecoderAVFObjCSample> toProtectedSample(Iterator iter)
 {
     return downcast<ImageDecoderAVFObjCSample>(iter->second.ptr());
 }
@@ -480,7 +474,7 @@ bool ImageDecoderAVFObjC::storeSampleBuffer(CMSampleBufferRef sampleBuffer)
     // obtain RGBA IOSurface-backed CVPixelBuffer from the decoding session is enough
     // to ensure the pixel buffer is not replaced in VTCreateCGImageFromCVPixelBuffer.
 
-    toProtectedSample(iter)->setImage(adoptCF(rawImage));
+    protect(toSample(iter))->setImage(adoptCF(rawImage));
 
     return true;
 }
@@ -698,7 +692,7 @@ void ImageDecoderAVFObjC::clearFrameBufferCache(size_t index)
 {
     size_t i = 0;
     for (auto& samplePair : m_sampleData.presentationOrder()) {
-        toProtectedSample(samplePair)->setImage(nullptr);
+        protect(toSample(samplePair))->setImage(nullptr);
         if (++i > index)
             break;
     }

--- a/Source/WebCore/platform/mac/ScrollingMomentumCalculatorMac.h
+++ b/Source/WebCore/platform/mac/ScrollingMomentumCalculatorMac.h
@@ -43,7 +43,6 @@ private:
     void destinationScrollOffsetDidChange() final;
 
     _NSScrollingMomentumCalculator *ensurePlatformMomentumCalculator();
-    RetainPtr<_NSScrollingMomentumCalculator> ensureProtectedPlatformMomentumCalculator();
     bool requiresMomentumScrolling();
     void setMomentumCalculatorDestinationOffset(FloatPoint);
 

--- a/Source/WebCore/platform/mac/ScrollingMomentumCalculatorMac.mm
+++ b/Source/WebCore/platform/mac/ScrollingMomentumCalculatorMac.mm
@@ -56,7 +56,7 @@ FloatPoint ScrollingMomentumCalculatorMac::scrollOffsetAfterElapsedTime(Seconds 
     if (!requiresMomentumScrolling())
         return destinationScrollOffset();
 
-    return [ensureProtectedPlatformMomentumCalculator() positionAfterDuration:elapsedTime.value()];
+    return [protect(ensurePlatformMomentumCalculator()) positionAfterDuration:elapsedTime.value()];
 }
 
 FloatPoint ScrollingMomentumCalculatorMac::predictedDestinationOffset()
@@ -92,7 +92,7 @@ Seconds ScrollingMomentumCalculatorMac::animationDuration()
     if (!requiresMomentumScrolling())
         return 0_s;
 
-    return Seconds([ensureProtectedPlatformMomentumCalculator() durationUntilStop]);
+    return Seconds([protect(ensurePlatformMomentumCalculator()) durationUntilStop]);
 }
 
 bool ScrollingMomentumCalculatorMac::requiresMomentumScrolling()
@@ -113,11 +113,6 @@ _NSScrollingMomentumCalculator *ScrollingMomentumCalculatorMac::ensurePlatformMo
     m_platformMomentumCalculator = adoptNS([[_NSScrollingMomentumCalculator alloc] initWithInitialOrigin:origin velocity:velocity documentFrame:contentFrame constrainedClippingOrigin:NSZeroPoint clippingSize:m_scrollExtents.viewportSize tolerance:NSMakeSize(1, 1)]);
     m_initialDestinationOffset = [m_platformMomentumCalculator destinationOrigin];
     return m_platformMomentumCalculator.get();
-}
-
-RetainPtr<_NSScrollingMomentumCalculator> ScrollingMomentumCalculatorMac::ensureProtectedPlatformMomentumCalculator()
-{
-    return ensurePlatformMomentumCalculator();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -144,7 +144,6 @@ private:
     ScriptExecutionContext* context() final { return scriptExecutionContext(); }
 
     SWClientConnection& ensureSWClientConnection();
-    Ref<SWClientConnection> ensureProtectedSWClientConnection();
 
     ScriptExecutionContext* scriptExecutionContext() const final;
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ServiceWorkerContainer; }

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
@@ -45,7 +45,7 @@ RetainPtr<PKPaymentTokenContext> platformPaymentTokenContext(const ApplePayPayme
     RetainPtr<NSString> merchantDomain;
     if (!webTokenContext.merchantDomain.isNull())
         merchantDomain = webTokenContext.merchantDomain.createNSString();
-    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier.createNSString().get() externalIdentifier:webTokenContext.externalIdentifier.createNSString().get() merchantName:webTokenContext.merchantName.createNSString().get() merchantDomain:merchantDomain.get() amount:WebCore::toProtectedDecimalNumber(webTokenContext.amount).get()]);
+    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier.createNSString().get() externalIdentifier:webTokenContext.externalIdentifier.createNSString().get() merchantName:webTokenContext.merchantName.createNSString().get() merchantDomain:merchantDomain.get() amount:protect(WebCore::toDecimalNumber(webTokenContext.amount)).get()]);
 }
 
 RetainPtr<NSArray<PKPaymentTokenContext *>> platformPaymentTokenContexts(const Vector<ApplePayPaymentTokenContext>& webTokenContexts)

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -190,7 +190,7 @@ static RetainPtr<PKDateComponentsRange> toPKDateComponentsRange(const WebCore::A
 
 RetainPtr<PKShippingMethod> toPKShippingMethod(const WebCore::ApplePayShippingMethod& shippingMethod)
 {
-    RetainPtr<PKShippingMethod> result = [PAL::getPKShippingMethodClassSingleton() summaryItemWithLabel:shippingMethod.label.createNSString().get() amount:WebCore::toProtectedDecimalNumber(shippingMethod.amount).get()];
+    RetainPtr result = [PAL::getPKShippingMethodClassSingleton() summaryItemWithLabel:shippingMethod.label.createNSString().get() amount:protect(WebCore::toDecimalNumber(shippingMethod.amount)).get()];
     [result setIdentifier:shippingMethod.identifier.createNSString().get()];
     [result setDetail:shippingMethod.detail.createNSString().get()];
 #if HAVE(PASSKIT_SHIPPING_METHOD_DATE_COMPONENTS_RANGE)


### PR DESCRIPTION
#### 8daa3e911a17a52a032560264da52f2e8675b344
<pre>
Remove fooProtectedBar() methods from WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=308710">https://bugs.webkit.org/show_bug.cgi?id=308710</a>

Reviewed by Chris Dumez.

And replace them with a protect() wrapper.

Canonical link: <a href="https://commits.webkit.org/308282@main">https://commits.webkit.org/308282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/915bf1f08b2384eb76360f0ce9e14f4bc2cf8f72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155677 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/facbd0b1-0f5c-4968-81cc-7848f7d82b4a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ff39851-5d5e-409d-856a-caee93c374e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15518 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94026 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/213ca89e-c62e-4219-aa51-a3d87303e1e4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3119 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158008 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121296 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131743 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17059 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82847 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18822 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->