### PR TITLE
Add isShowingColorPicker UIScriptController hook and waitForColorPickerToPresent UIHelper

### DIFF
--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -273,6 +273,7 @@ interface UIScriptController {
 
     // <input type=color>
     undefined setSelectedColorForColorPicker(double red, double green, double blue);
+    readonly attribute boolean isShowingColorPicker;
 
     undefined keyboardAccessoryBarNext();
     undefined keyboardAccessoryBarPrevious();

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -336,6 +336,7 @@ public:
     virtual JSObjectRef inputViewBounds() const { notImplemented(); return nullptr; }
     virtual void activateDataListSuggestion(unsigned, JSValueRef) { notImplemented(); }
     virtual void setSelectedColorForColorPicker(double, double, double) { notImplemented(); }
+    virtual bool isShowingColorPicker() const { notImplemented(); return false; }
     virtual void setAppAccentColor(unsigned short, unsigned short, unsigned short) { notImplemented(); }
 
     // Find in Page

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -145,6 +145,7 @@ private:
     bool isShowingDataListSuggestions() const override;
     void activateDataListSuggestion(unsigned, JSValueRef) override;
     void setSelectedColorForColorPicker(double, double, double) override;
+    bool isShowingColorPicker() const override;
     void setKeyboardInputModeIdentifier(JSStringRef) override;
     void setFocusStartsInputSessionPolicy(JSStringRef) override;
     void toggleCapsLock(JSValueRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1454,6 +1454,12 @@ void UIScriptControllerIOS::setSelectedColorForColorPicker(double red, double gr
     [webView() setSelectedColorForColorPicker:color];
 }
 
+bool UIScriptControllerIOS::isShowingColorPicker() const
+{
+    RetainPtr<UIViewController> presentedViewController = webView().window.rootViewController.presentedViewController;
+    return [presentedViewController.get() isKindOfClass:[UIColorPickerViewController class]];
+}
+
 void UIScriptControllerIOS::setKeyboardInputModeIdentifier(JSStringRef identifier)
 {
     TestController::singleton().setKeyboardInputModeIdentifier(toWTFString(identifier));

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
@@ -50,6 +50,7 @@ private:
     bool isShowingDataListSuggestions() const override;
     void activateDataListSuggestion(unsigned index, JSValueRef callback) override;
     void setSelectedColorForColorPicker(double, double, double) override;
+    bool isShowingColorPicker() const override;
     void beginBackSwipe(JSValueRef) override;
     void completeBackSwipe(JSValueRef) override;
     void playBackEventStream(JSStringRef, JSValueRef) override;

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -184,6 +184,11 @@ void UIScriptControllerMac::setSelectedColorForColorPicker(double red, double gr
     [webView() _setSelectedColorForColorPicker:color.get()];
 }
 
+bool UIScriptControllerMac::isShowingColorPicker() const
+{
+    return [findAllViewsInHierarchyOfType(webView().window.contentView, NSClassFromString(@"WKPopoverColorWell")) count];
+}
+
 NSTableView *UIScriptControllerMac::dataListSuggestionsTableView() const
 {
     for (NSWindow *childWindow in webView().window.childWindows) {


### PR DESCRIPTION
#### cb6bc66054e7b006e06f884d49dacb0deb44774c
<pre>
Add isShowingColorPicker UIScriptController hook and waitForColorPickerToPresent UIHelper
<a href="https://bugs.webkit.org/show_bug.cgi?id=308717">https://bugs.webkit.org/show_bug.cgi?id=308717</a>
<a href="https://rdar.apple.com/171246897">rdar://171246897</a>

Reviewed by Aditya Keerthi.

Add a isShowingColorPicker hook to UIScriptController so tests can
deterministically wait for the color picker.

On macOS, detection checks for WKPopoverColorWell in the window&apos;s view
hierarchy. On iOS, it checks whether the presented view controller is a
UIColorPickerViewController.

UIHelper.waitForColorPickerToPresent() uses willPresentPopoverCallback on
iOS and async polling on macOS.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.isShowingColorPicker):
(window.UIHelper.waitForColorPickerToPresent.return.new.Promise):
(window.UIHelper.waitForColorPickerToPresent):
(window.UIHelper.enterText): Deleted.
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::isShowingColorPicker const):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::isShowingColorPicker const):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.h:
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::isShowingColorPicker const):

Canonical link: <a href="https://commits.webkit.org/308409@main">https://commits.webkit.org/308409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bc91e040502b1b36afbded7bd489019085663a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100857 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/616f89b4-9393-4e41-9b7a-74b6fd3df4d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113639 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81038 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d17389c-b73b-406b-b251-b641dabeb7a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec615b70-844d-461d-8522-7b73aae4b33e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12821 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3565 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158456 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121666 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121865 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31208 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75949 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8902 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19541 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19329 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->