### PR TITLE
[JSC] Unsound optimization in ReduceStrength regarding Int52-to-Int32 conversion pattern

### DIFF
--- a/JSTests/wasm/stress/b3-reduceStrength-trunc-sshr-add-unaligned.js
+++ b/JSTests/wasm/stress/b3-reduceStrength-trunc-sshr-add-unaligned.js
@@ -1,0 +1,84 @@
+// Wasm module equivalent to:
+// (module
+//   (func (export "test") (param i64) (result i32)
+//     local.get 0
+//     i64.const 2048
+//     i64.add
+//     i64.const 12
+//     i64.shr_s
+//     i32.wrap_i64
+//   )
+// )
+var wasm_code = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // Type section
+    0x01, 0x06,             // section id=1, size=6
+    0x01,                   // 1 type
+    0x60,                   // func type
+    0x01, 0x7e,             // 1 param: i64
+    0x01, 0x7f,             // 1 result: i32
+
+    // Function section
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // type index 0
+
+    // Export section
+    0x07, 0x08,             // section id=7, size=8
+    0x01,                   // 1 export
+    0x04,                   // name length=4
+    0x74, 0x65, 0x73, 0x74, // "test"
+    0x00,                   // func export
+    0x00,                   // func index 0
+
+    // Code section
+    0x0a, 0x0e,             // section id=10, size=14
+    0x01,                   // 1 function body
+    0x0c,                   // body size=12
+    0x00,                   // 0 locals
+    0x20, 0x00,             // local.get 0
+    0x42, 0x80, 0x10,       // i64.const 2048 (signed LEB128)
+    0x7c,                   // i64.add
+    0x42, 0x0c,             // i64.const 12 (signed LEB128)
+    0x87,                   // i64.shr_s
+    0xa7,                   // i32.wrap_i64
+    0x0b,                   // end
+]);
+
+var wasm_module = new WebAssembly.Module(wasm_code);
+var wasm_instance = new WebAssembly.Instance(wasm_module);
+var test = wasm_instance.exports.test;
+
+function expected(a) {
+    var result = (BigInt(a) + 2048n) >> 12n;
+    return Number(result);
+}
+
+// Warm up to trigger OMG compilation.
+for (var i = 0; i < 100; i++) {
+    var result = test(2048n);
+    if (result !== expected(2048))
+        throw new Error("FAIL: test(2048) = " + result + ", expected " + expected(2048));
+}
+
+// Test various values after OMG compilation.
+var testCases = [
+    [0n, expected(0)],
+    [2048n, expected(2048)],
+    [4095n, expected(4095)],
+    [4096n, expected(4096)],
+    [100000n, expected(100000)],
+    [-2048n, expected(-2048)],
+    [-1n, expected(-1)],
+    [1n, expected(1)],
+];
+
+for (var i = 0; i < testCases.length; i++) {
+    var input = testCases[i][0];
+    var exp = testCases[i][1];
+    var result = test(input);
+    if (result !== exp)
+        throw new Error("FAIL: test(" + input + ") = " + result + ", expected " + exp);
+}

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2287,7 +2287,8 @@ private:
                     case Add: {
                         // Turn this: Trunc(SShr(Add(@a, constant), $12))
                         // Into this: Add(Trunc(SShr(@a, $12), converted-constant)
-                        if (sshrArg0->child(1)->hasInt64()) {
+                        if (sshrArg0->child(1)->hasInt64()
+                            && !(sshrArg0->child(1)->asInt64() & ((1LL << JSValue::int52ShiftAmount) - 1))) {
                             auto* shiftAmount = m_value->child(0)->child(1);
                             int64_t constant = sshrArg0->child(1)->asInt64();
                             auto* shifted = m_insertionSet.insert<Value>(m_index, SShr, m_value->child(0)->origin(), sshrArg0->child(0), shiftAmount);

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1445,6 +1445,7 @@ void testSShrCompare64(int64_t);
 
 void testInt52RoundTripUnary(int32_t);
 void testInt52RoundTripBinary();
+void testTruncSShrAddUnalignedConstant();
 
 void testMulHigh32();
 void testMulHigh64();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -350,6 +350,7 @@ void run(const TestConfig* config)
     RUN(testIToDReducedToIToF32Arg());
     RUN_UNARY(testInt52RoundTripUnary, int32Operands());
     RUN(testInt52RoundTripBinary());
+    RUN(testTruncSShrAddUnalignedConstant());
 
 #if !CPU(ARM)
     RUN_UNARY(testCheckAddRemoveCheckWithSExt8, int8Operands());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -3129,6 +3129,38 @@ void testInt52RoundTripBinary()
     }
 }
 
+// Test that Trunc(SShr(Add(@a, unaligned-constant), $12)) produces the correct
+// result when the constant is not 12-bit aligned. This pattern arises from
+// WebAssembly's i32.wrap_i64(i64.shr_s(i64.add(@a, C), 12)) with arbitrary
+// 64-bit values.
+void testTruncSShrAddUnalignedConstant()
+{
+    // Use constant 2048 which is NOT 12-bit aligned (lower 12 bits are non-zero).
+    int64_t constant = 2048;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<int64_t>(proc, root);
+    Value* argA = arguments[0];
+    Value* node = root->appendNew<Value>(proc, Add, Origin(), argA, root->appendNew<Const64Value>(proc, Origin(), constant));
+    Value* shifted = root->appendNew<Value>(proc, SShr, Origin(), node, root->appendNew<Const32Value>(proc, Origin(), 12));
+    Value* result = root->appendNew<Value>(proc, Trunc, Origin(), shifted);
+    root->appendNew<Value>(proc, Return, Origin(), result);
+    auto code = compileProc(proc);
+
+    // a=2048, C=2048: (2048+2048)>>12 = 4096>>12 = 1
+    CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(2048)), static_cast<int32_t>((2048LL + constant) >> 12));
+    // a=0
+    CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(0)), static_cast<int32_t>((0LL + constant) >> 12));
+    // a=4095
+    CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(4095)), static_cast<int32_t>((4095LL + constant) >> 12));
+    // a=4096
+    CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(4096)), static_cast<int32_t>((4096LL + constant) >> 12));
+    // Large values
+    CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(100000)), static_cast<int32_t>((100000LL + constant) >> 12));
+    CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(-2048)), static_cast<int32_t>((-2048LL + constant) >> 12));
+}
+
 #endif // ENABLE(B3_JIT)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 1c537b0aea640597681150878d85e1bc0bc9ab09
<pre>
[JSC] Unsound optimization in ReduceStrength regarding Int52-to-Int32 conversion pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=308722">https://bugs.webkit.org/show_bug.cgi?id=308722</a>
<a href="https://rdar.apple.com/171147977">rdar://171147977</a>

Reviewed by Yijia Huang and Keith Miller.

The optimization is assuming that constant value&apos;s lower 12 bits are
zero, otherwise, addition can carry one bit. This patch ensures that
constant is not having lower 12 bits.

Tests: JSTests/wasm/stress/b3-reduceStrength-trunc-sshr-add-unaligned.js
       Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* JSTests/wasm/stress/b3-reduceStrength-trunc-sshr-add-unaligned.js: Added.
(expected):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testTruncSShrAddUnalignedConstant):

Canonical link: <a href="https://commits.webkit.org/308417@main">https://commits.webkit.org/308417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/290f7eae7ec7a1f987f7f3cfadd83572d18e515b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0148aa6d-7bee-46f6-b24e-c009efef0556) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113252 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80822 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e53b21ec-9031-4080-a7d8-1fd51ee70530) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f6e6a86-e272-40e9-9694-4865764c5c63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14710 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12489 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3101 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138945 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157990 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7765 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121279 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121480 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131727 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75427 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8555 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178296 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82829 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45654 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18863 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->