### PR TITLE
Remove toProtectedImpl() method

### DIFF
--- a/Source/WebKit/Shared/API/c/WKArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKArray.cpp
@@ -55,7 +55,7 @@ WKArrayRef WKArrayCreateAdoptingValues(WKTypeRef* rawValues, size_t numberOfValu
 
 WKTypeRef WKArrayGetItemAtIndex(WKArrayRef arrayRef, size_t index)
 {
-    return WebKit::toAPI(protect(WebKit::toProtectedImpl(arrayRef)->at(index)).get());
+    return WebKit::toAPI(protect(protect(WebKit::toImpl(arrayRef))->at(index)).get());
 }
 
 size_t WKArrayGetSize(WKArrayRef arrayRef)

--- a/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
@@ -44,7 +44,7 @@ WKTypeID WKContextMenuItemGetTypeID()
 WKContextMenuItemRef WKContextMenuItemCreateAsAction(WKContextMenuItemTag tag, WKStringRef title, bool enabled)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPILeakingRef(WebKit::WebContextMenuItem::create(WebKit::WebContextMenuItemData(WebCore::ContextMenuItemType::Action, WebKit::toImpl(tag), WebKit::toProtectedImpl(title)->string(), enabled, false)));
+    return WebKit::toAPILeakingRef(WebKit::WebContextMenuItem::create(WebKit::WebContextMenuItemData(WebCore::ContextMenuItemType::Action, WebKit::toImpl(tag), protect(WebKit::toImpl(title))->string(), enabled, false)));
 #else
     UNUSED_PARAM(tag);
     UNUSED_PARAM(title);
@@ -56,7 +56,7 @@ WKContextMenuItemRef WKContextMenuItemCreateAsAction(WKContextMenuItemTag tag, W
 WKContextMenuItemRef WKContextMenuItemCreateAsCheckableAction(WKContextMenuItemTag tag, WKStringRef title, bool enabled, bool checked)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPILeakingRef(WebKit::WebContextMenuItem::create(WebKit::WebContextMenuItemData(WebCore::ContextMenuItemType::CheckableAction, WebKit::toImpl(tag), WebKit::toProtectedImpl(title)->string(), enabled, checked)));
+    return WebKit::toAPILeakingRef(WebKit::WebContextMenuItem::create(WebKit::WebContextMenuItemData(WebCore::ContextMenuItemType::CheckableAction, WebKit::toImpl(tag), protect(WebKit::toImpl(title))->string(), enabled, checked)));
 #else
     UNUSED_PARAM(tag);
     UNUSED_PARAM(title);
@@ -69,7 +69,7 @@ WKContextMenuItemRef WKContextMenuItemCreateAsCheckableAction(WKContextMenuItemT
 WKContextMenuItemRef WKContextMenuItemCreateAsSubmenu(WKStringRef title, bool enabled, WKArrayRef submenuItems)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPILeakingRef(WebKit::WebContextMenuItem::create(WebKit::toProtectedImpl(title)->string(), enabled, WebKit::toProtectedImpl(submenuItems).get()));
+    return WebKit::toAPILeakingRef(WebKit::WebContextMenuItem::create(protect(WebKit::toImpl(title))->string(), enabled, protect(WebKit::toImpl(submenuItems)).get()));
 #else
     UNUSED_PARAM(title);
     UNUSED_PARAM(enabled);
@@ -140,7 +140,7 @@ bool WKContextMenuItemGetChecked(WKContextMenuItemRef itemRef)
 WKArrayRef WKContextMenuCopySubmenuItems(WKContextMenuItemRef itemRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(itemRef)->submenuItemsAsAPIArray());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(itemRef))->submenuItemsAsAPIArray());
 #else
     UNUSED_PARAM(itemRef);
     return 0;
@@ -150,7 +150,7 @@ WKArrayRef WKContextMenuCopySubmenuItems(WKContextMenuItemRef itemRef)
 WKTypeRef WKContextMenuItemGetUserData(WKContextMenuItemRef itemRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPI(protect(WebKit::toProtectedImpl(itemRef)->userData()).get());
+    return WebKit::toAPI(protect(protect(WebKit::toImpl(itemRef))->userData()).get());
 #else
     UNUSED_PARAM(itemRef);
     return 0;
@@ -160,7 +160,7 @@ WKTypeRef WKContextMenuItemGetUserData(WKContextMenuItemRef itemRef)
 void WKContextMenuItemSetUserData(WKContextMenuItemRef itemRef, WKTypeRef userDataRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    WebKit::toProtectedImpl(itemRef)->setUserData(WebKit::toProtectedImpl(userDataRef).get());
+    protect(WebKit::toImpl(itemRef))->setUserData(protect(WebKit::toImpl(userDataRef)).get());
 #else
     UNUSED_PARAM(itemRef);
     UNUSED_PARAM(userDataRef);

--- a/Source/WebKit/Shared/API/c/WKDictionary.cpp
+++ b/Source/WebKit/Shared/API/c/WKDictionary.cpp
@@ -43,14 +43,14 @@ WK_EXPORT WKDictionaryRef WKDictionaryCreate(const WKStringRef* rawKeys, const W
     API::Dictionary::MapType map;
     map.reserveInitialCapacity(numberOfValues);
     for (size_t i = 0; i < numberOfValues; ++i)
-        map.add(WebKit::toProtectedImpl(keys[i])->string(), WebKit::toImpl(values[i]));
+        map.add(protect(WebKit::toImpl(keys[i]))->string(), WebKit::toImpl(values[i]));
 
     return WebKit::toAPILeakingRef(API::Dictionary::create(WTF::move(map)));
 }
 
 WKTypeRef WKDictionaryGetItemForKey(WKDictionaryRef dictionaryRef, WKStringRef key)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(dictionaryRef)->getProtected(WebKit::toProtectedImpl(key)->string()).get());
+    return WebKit::toAPI(protect(WebKit::toImpl(dictionaryRef))->getProtected(protect(WebKit::toImpl(key))->string()).get());
 }
 
 size_t WKDictionaryGetSize(WKDictionaryRef dictionaryRef)
@@ -60,5 +60,5 @@ size_t WKDictionaryGetSize(WKDictionaryRef dictionaryRef)
 
 WKArrayRef WKDictionaryCopyKeys(WKDictionaryRef dictionaryRef)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(dictionaryRef)->keys());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(dictionaryRef))->keys());
 }

--- a/Source/WebKit/Shared/API/c/WKErrorRef.cpp
+++ b/Source/WebKit/Shared/API/c/WKErrorRef.cpp
@@ -41,12 +41,12 @@ WKStringRef WKErrorCopyWKErrorDomain()
 
 WKStringRef WKErrorCopyDomain(WKErrorRef errorRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(errorRef)->domain());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(errorRef))->domain());
 }
 
 int WKErrorGetErrorCode(WKErrorRef errorRef)
 {
-    auto errorCode = WebKit::toProtectedImpl(errorRef)->errorCode();
+    auto errorCode = protect(WebKit::toImpl(errorRef))->errorCode();
     switch (errorCode) {
     case API::Error::Policy::CannotShowMIMEType:
         return kWKErrorCodeCannotShowMIMEType;
@@ -87,10 +87,10 @@ int WKErrorGetErrorCode(WKErrorRef errorRef)
 
 WKURLRef WKErrorCopyFailingURL(WKErrorRef errorRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(errorRef)->failingURL());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(errorRef))->failingURL());
 }
 
 WKStringRef WKErrorCopyLocalizedDescription(WKErrorRef errorRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(errorRef)->localizedDescription());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(errorRef))->localizedDescription());
 }

--- a/Source/WebKit/Shared/API/c/WKImage.cpp
+++ b/Source/WebKit/Shared/API/c/WKImage.cpp
@@ -41,5 +41,5 @@ WKImageRef WKImageCreate(WKSize size, WKImageOptions options)
 
 WKSize WKImageGetSize(WKImageRef imageRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(imageRef)->size());
+    return WebKit::toAPI(protect(WebKit::toImpl(imageRef))->size());
 }

--- a/Source/WebKit/Shared/API/c/WKMutableDictionary.cpp
+++ b/Source/WebKit/Shared/API/c/WKMutableDictionary.cpp
@@ -41,6 +41,6 @@ WKMutableDictionaryRef WKMutableDictionaryCreateWithCapacity(size_t capacity)
 
 bool WKDictionarySetItem(WKMutableDictionaryRef dictionaryRef, WKStringRef keyRef, WKTypeRef itemRef)
 {
-    return WebKit::toProtectedImpl(dictionaryRef)->set(WebKit::toProtectedImpl(keyRef)->string(), WebKit::toImpl(itemRef));
+    return protect(WebKit::toImpl(dictionaryRef))->set(protect(WebKit::toImpl(keyRef))->string(), WebKit::toImpl(itemRef));
 }
 

--- a/Source/WebKit/Shared/API/c/WKSecurityOriginRef.cpp
+++ b/Source/WebKit/Shared/API/c/WKSecurityOriginRef.cpp
@@ -37,12 +37,12 @@ WKTypeID WKSecurityOriginGetTypeID()
 
 WKSecurityOriginRef WKSecurityOriginCreateFromString(WKStringRef string)
 {
-    return WebKit::toAPILeakingRef(API::SecurityOrigin::create(WebCore::SecurityOrigin::createFromString(WebKit::toProtectedImpl(string)->string())));
+    return WebKit::toAPILeakingRef(API::SecurityOrigin::create(WebCore::SecurityOrigin::createFromString(protect(WebKit::toImpl(string))->string())));
 }
 
 WKSecurityOriginRef WKSecurityOriginCreateFromDatabaseIdentifier(WKStringRef identifier)
 {
-    auto origin = WebCore::SecurityOriginData::fromDatabaseIdentifier(WebKit::toProtectedImpl(identifier)->string());
+    auto origin = WebCore::SecurityOriginData::fromDatabaseIdentifier(protect(WebKit::toImpl(identifier))->string());
     if (!origin)
         return nullptr;
     return WebKit::toAPILeakingRef(API::SecurityOrigin::create(origin.value().securityOrigin()));
@@ -53,7 +53,7 @@ WKSecurityOriginRef WKSecurityOriginCreate(WKStringRef protocol, WKStringRef hos
     std::optional<uint16_t> validPort;
     if (port && port <= std::numeric_limits<uint16_t>::max())
         validPort = port;
-    return WebKit::toAPILeakingRef(API::SecurityOrigin::create(WebKit::toProtectedImpl(protocol)->string(), WebKit::toProtectedImpl(host)->string(), validPort));
+    return WebKit::toAPILeakingRef(API::SecurityOrigin::create(protect(WebKit::toImpl(protocol))->string(), protect(WebKit::toImpl(host))->string(), validPort));
 }
 
 WKStringRef WKSecurityOriginCopyDatabaseIdentifier(WKSecurityOriginRef securityOrigin)

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -157,12 +157,6 @@ auto toImpl(T t) -> ImplType*
         return downcast<ImplType>(API::Object::unwrap(static_cast<void*>(const_cast<typename std::remove_const<typename std::remove_pointer<T>::type>::type*>(t))));
 }
 
-template<typename T, typename ImplType = typename APITypeInfo<T>::ImplType>
-auto toProtectedImpl(T t) -> RefPtr<ImplType>
-{
-    return toImpl<T>(t);
-}
-
 template<typename ImplType, typename APIType = typename ImplTypeInfo<ImplType>::APIType>
 class ProxyingRefPtr {
 public:
@@ -217,14 +211,14 @@ inline String toWTFString(WKStringRef stringRef)
 {
     if (!stringRef)
         return String();
-    return toProtectedImpl(stringRef)->string();
+    return protect(toImpl(stringRef))->string();
 }
 
 inline String toWTFString(WKURLRef urlRef)
 {
     if (!urlRef)
         return String();
-    return toProtectedImpl(urlRef)->string();
+    return protect(toImpl(urlRef))->string();
 }
 
 inline ProxyingRefPtr<API::Error> toAPI(const WebCore::ResourceError& error)

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -51,12 +51,12 @@ WKStringRef WKStringCreateWithUTF8CStringWithLength(const char* string, size_t s
 
 bool WKStringIsEmpty(WKStringRef stringRef)
 {
-    return WebKit::toProtectedImpl(stringRef)->stringView().isEmpty();
+    return protect(WebKit::toImpl(stringRef))->stringView().isEmpty();
 }
 
 size_t WKStringGetLength(WKStringRef stringRef)
 {
-    return WebKit::toProtectedImpl(stringRef)->stringView().length();
+    return protect(WebKit::toImpl(stringRef))->stringView().length();
 }
 
 size_t WKStringGetCharacters(WKStringRef stringRef, WKChar* buffer, size_t bufferLength)
@@ -64,7 +64,7 @@ size_t WKStringGetCharacters(WKStringRef stringRef, WKChar* buffer, size_t buffe
     static_assert(sizeof(WKChar) == sizeof(char16_t), "Size of WKChar must match size of char16_t");
 
     unsigned unsignedBufferLength = std::min<size_t>(bufferLength, std::numeric_limits<unsigned>::max());
-    auto substring = WebKit::toProtectedImpl(stringRef)->stringView().left(unsignedBufferLength);
+    auto substring = protect(WebKit::toImpl(stringRef))->stringView().left(unsignedBufferLength);
 
     substring.getCharacters(unsafeMakeSpan(reinterpret_cast<char16_t*>(buffer), bufferLength));
     return substring.length();
@@ -72,7 +72,7 @@ size_t WKStringGetCharacters(WKStringRef stringRef, WKChar* buffer, size_t buffe
 
 size_t WKStringGetMaximumUTF8CStringSize(WKStringRef stringRef)
 {
-    return static_cast<size_t>(WebKit::toProtectedImpl(stringRef)->stringView().length()) * 3 + 1;
+    return static_cast<size_t>(protect(WebKit::toImpl(stringRef))->stringView().length()) * 3 + 1;
 }
 
 enum StrictType { NonStrict = false, Strict = true };
@@ -83,7 +83,7 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
     if (!bufferSize)
         return 0;
 
-    auto string = WebKit::toProtectedImpl(stringRef)->stringView();
+    auto string = protect(WebKit::toImpl(stringRef))->stringView();
 
     auto target = unsafeMakeSpan(byteCast<char8_t>(buffer), bufferSize);
     WTF::Unicode::ConversionResult<char8_t> result;
@@ -115,21 +115,21 @@ size_t WKStringGetUTF8CStringNonStrict(WKStringRef stringRef, char* buffer, size
 
 bool WKStringIsEqual(WKStringRef aRef, WKStringRef bRef)
 {
-    return WebKit::toProtectedImpl(aRef)->stringView() == WebKit::toProtectedImpl(bRef)->stringView();
+    return protect(WebKit::toImpl(aRef))->stringView() == protect(WebKit::toImpl(bRef))->stringView();
 }
 
 bool WKStringIsEqualToUTF8CString(WKStringRef aRef, const char* b)
 {
     // FIXME: Should we add a fast path that avoids memory allocation when the string is all ASCII?
     // FIXME: We can do even the general case more efficiently if we write a function in StringView that understands UTF-8 C strings.
-    return WebKit::toProtectedImpl(aRef)->stringView() == WTF::String::fromUTF8(b);
+    return protect(WebKit::toImpl(aRef))->stringView() == WTF::String::fromUTF8(b);
 }
 
 bool WKStringIsEqualToUTF8CStringIgnoringCase(WKStringRef aRef, const char* b)
 {
     // FIXME: Should we add a fast path that avoids memory allocation when the string is all ASCII?
     // FIXME: We can do even the general case more efficiently if we write a function in StringView that understands UTF-8 C strings.
-    return equalIgnoringASCIICase(WebKit::toProtectedImpl(aRef)->stringView(), WTF::String::fromUTF8(b));
+    return equalIgnoringASCIICase(protect(WebKit::toImpl(aRef))->stringView(), WTF::String::fromUTF8(b));
 }
 
 WKStringRef WKStringCreateWithJSString(JSStringRef jsStringRef)
@@ -143,5 +143,5 @@ JSStringRef WKStringCopyJSString(WKStringRef stringRef)
 {
     JSC::initialize();
     WebCore::populateJITOperations();
-    return OpaqueJSString::tryCreate(WebKit::toProtectedImpl(stringRef)->string()).leakRef();
+    return OpaqueJSString::tryCreate(protect(WebKit::toImpl(stringRef))->string()).leakRef();
 }

--- a/Source/WebKit/Shared/API/c/WKType.cpp
+++ b/Source/WebKit/Shared/API/c/WKType.cpp
@@ -31,7 +31,7 @@
 
 WKTypeID WKGetTypeID(WKTypeRef typeRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(typeRef)->type());
+    return WebKit::toAPI(protect(WebKit::toImpl(typeRef))->type());
 }
 
 WKTypeRef WKRetain(WKTypeRef typeRef)

--- a/Source/WebKit/Shared/API/c/WKURL.cpp
+++ b/Source/WebKit/Shared/API/c/WKURL.cpp
@@ -45,7 +45,7 @@ WKURLRef WKURLCreateWithUTF8String(const char* string, size_t length)
 
 WKURLRef WKURLCreateWithBaseURL(WKURLRef baseURL, const char* relative)
 {
-    return WebKit::toAPILeakingRef(API::URL::create(WebKit::toProtectedImpl(baseURL).get(), String::fromUTF8(relative)));
+    return WebKit::toAPILeakingRef(API::URL::create(protect(WebKit::toImpl(baseURL)).get(), String::fromUTF8(relative)));
 }
 
 WKStringRef WKURLCopyString(WKURLRef url)
@@ -55,25 +55,25 @@ WKStringRef WKURLCopyString(WKURLRef url)
 
 bool WKURLIsEqual(WKURLRef a, WKURLRef b)
 {
-    return API::URL::equals(*WebKit::toProtectedImpl(a), *WebKit::toProtectedImpl(b));
+    return API::URL::equals(*protect(WebKit::toImpl(a)), *protect(WebKit::toImpl(b)));
 }
 
 WKStringRef WKURLCopyHostName(WKURLRef url)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(url)->host());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(url))->host());
 }
 
 WKStringRef WKURLCopyScheme(WKURLRef url)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(url)->protocol());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(url))->protocol());
 }
 
 WK_EXPORT WKStringRef WKURLCopyPath(WKURLRef url)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(url)->path());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(url))->path());
 }
 
 WKStringRef WKURLCopyLastPathComponent(WKURLRef url)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(url)->lastPathComponent());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(url))->lastPathComponent());
 }

--- a/Source/WebKit/Shared/API/c/WKUserContentURLPattern.cpp
+++ b/Source/WebKit/Shared/API/c/WKUserContentURLPattern.cpp
@@ -37,7 +37,7 @@ WKTypeID WKUserContentURLPatternGetTypeID()
 
 WKUserContentURLPatternRef WKUserContentURLPatternCreate(WKStringRef patternRef)
 {
-    return WebKit::toAPILeakingRef(API::UserContentURLPattern::create(WebKit::toProtectedImpl(patternRef)->string()));
+    return WebKit::toAPILeakingRef(API::UserContentURLPattern::create(protect(WebKit::toImpl(patternRef))->string()));
 }
 
 WKStringRef WKUserContentURLPatternCopyHost(WKUserContentURLPatternRef urlPatternRef)
@@ -57,7 +57,7 @@ bool WKUserContentURLPatternIsValid(WKUserContentURLPatternRef urlPatternRef)
 
 bool WKUserContentURLPatternMatchesURL(WKUserContentURLPatternRef urlPatternRef, WKURLRef urlRef)
 {
-    return WebKit::toProtectedImpl(urlPatternRef)->matchesURL(WebKit::toWTFString(urlRef));
+    return protect(WebKit::toImpl(urlPatternRef))->matchesURL(WebKit::toWTFString(urlRef));
 }
 
 bool WKUserContentURLPatternMatchesSubdomains(WKUserContentURLPatternRef urlPatternRef)

--- a/Source/WebKit/Shared/API/c/mac/WKWebArchiveRef.cpp
+++ b/Source/WebKit/Shared/API/c/mac/WKWebArchiveRef.cpp
@@ -43,41 +43,41 @@ WKTypeID WKWebArchiveGetTypeID()
 
 WKWebArchiveRef WKWebArchiveCreate(WKWebArchiveResourceRef mainResourceRef, WKArrayRef subresourcesRef, WKArrayRef subframeArchivesRef)
 {
-    auto webArchive = API::WebArchive::create(WebKit::toProtectedImpl(mainResourceRef).get(), WebKit::toImpl(subresourcesRef), WebKit::toImpl(subframeArchivesRef));
+    auto webArchive = API::WebArchive::create(protect(WebKit::toImpl(mainResourceRef)).get(), WebKit::toImpl(subresourcesRef), WebKit::toImpl(subframeArchivesRef));
     return WebKit::toAPILeakingRef(WTF::move(webArchive));
 }
 
 WKWebArchiveRef WKWebArchiveCreateWithData(WKDataRef dataRef)
 {
-    auto webArchive = API::WebArchive::create(WebKit::toProtectedImpl(dataRef).get());
+    auto webArchive = API::WebArchive::create(protect(WebKit::toImpl(dataRef)).get());
     return WebKit::toAPILeakingRef(WTF::move(webArchive));
 }
 
 WKWebArchiveRef WKWebArchiveCreateFromRange(WKBundleRangeHandleRef rangeHandleRef)
 {
-    Ref webArchive = API::WebArchive::create(makeSimpleRange(WebKit::toProtectedImpl(rangeHandleRef)->coreRange()));
+    Ref webArchive = API::WebArchive::create(makeSimpleRange(protect(WebKit::toImpl(rangeHandleRef))->coreRange()));
     return WebKit::toAPILeakingRef(WTF::move(webArchive));
 }
 
 WKWebArchiveResourceRef WKWebArchiveCopyMainResource(WKWebArchiveRef webArchiveRef)
 {
-    RefPtr<API::WebArchiveResource> mainResource = WebKit::toProtectedImpl(webArchiveRef)->mainResource();
+    RefPtr<API::WebArchiveResource> mainResource = protect(WebKit::toImpl(webArchiveRef))->mainResource();
     return WebKit::toAPILeakingRef(WTF::move(mainResource));
 }
 
 WKArrayRef WKWebArchiveCopySubresources(WKWebArchiveRef webArchiveRef)
 {
-    RefPtr<API::Array> subresources = WebKit::toProtectedImpl(webArchiveRef)->subresources();
+    RefPtr<API::Array> subresources = protect(WebKit::toImpl(webArchiveRef))->subresources();
     return WebKit::toAPILeakingRef(WTF::move(subresources));
 }
 
 WKArrayRef WKWebArchiveCopySubframeArchives(WKWebArchiveRef webArchiveRef)
 {
-    RefPtr<API::Array> subframeArchives = WebKit::toProtectedImpl(webArchiveRef)->subframeArchives();
+    RefPtr<API::Array> subframeArchives = protect(WebKit::toImpl(webArchiveRef))->subframeArchives();
     return WebKit::toAPILeakingRef(WTF::move(subframeArchives));
 }
 
 WKDataRef WKWebArchiveCopyData(WKWebArchiveRef webArchiveRef)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(webArchiveRef)->data());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(webArchiveRef))->data());
 }

--- a/Source/WebKit/Shared/API/c/mac/WKWebArchiveResource.cpp
+++ b/Source/WebKit/Shared/API/c/mac/WKWebArchiveResource.cpp
@@ -37,26 +37,26 @@ WKTypeID WKWebArchiveResourceGetTypeID()
 
 WKWebArchiveResourceRef WKWebArchiveResourceCreate(WKDataRef dataRef, WKURLRef URLRef, WKStringRef MIMETypeRef, WKStringRef textEncodingRef)
 {
-    auto webArchiveResource = API::WebArchiveResource::create(WebKit::toProtectedImpl(dataRef).get(), WebKit::toWTFString(URLRef), WebKit::toWTFString(MIMETypeRef), WebKit::toWTFString(textEncodingRef));
+    auto webArchiveResource = API::WebArchiveResource::create(protect(WebKit::toImpl(dataRef)).get(), WebKit::toWTFString(URLRef), WebKit::toWTFString(MIMETypeRef), WebKit::toWTFString(textEncodingRef));
     return WebKit::toAPILeakingRef(WTF::move(webArchiveResource));
 }
 
 WKDataRef WKWebArchiveResourceCopyData(WKWebArchiveResourceRef webArchiveResourceRef)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(webArchiveResourceRef)->data());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(webArchiveResourceRef))->data());
 }
 
 WKURLRef WKWebArchiveResourceCopyURL(WKWebArchiveResourceRef webArchiveResourceRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(webArchiveResourceRef)->url());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(webArchiveResourceRef))->url());
 }
 
 WKStringRef WKWebArchiveResourceCopyMIMEType(WKWebArchiveResourceRef webArchiveResourceRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(webArchiveResourceRef)->mimeType());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(webArchiveResourceRef))->mimeType());
 }
 
 WKStringRef WKWebArchiveResourceCopyTextEncoding(WKWebArchiveResourceRef webArchiveResourceRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(webArchiveResourceRef)->textEncoding());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(webArchiveResourceRef))->textEncoding());
 }

--- a/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
@@ -46,12 +46,12 @@ WKAuthenticationDecisionListenerRef WKAuthenticationChallengeGetDecisionListener
 
 WKProtectionSpaceRef WKAuthenticationChallengeGetProtectionSpace(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(protect(toProtectedImpl(challenge)->protectionSpace()).get());
+    return toAPI(protect(protect(toImpl(challenge))->protectionSpace()).get());
 }
 
 WKCredentialRef WKAuthenticationChallengeGetProposedCredential(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(protect(toProtectedImpl(challenge)->proposedCredential()).get());
+    return toAPI(protect(protect(toImpl(challenge))->proposedCredential()).get());
 }
 
 int WKAuthenticationChallengeGetPreviousFailureCount(WKAuthenticationChallengeRef challenge)

--- a/Source/WebKit/UIProcess/API/C/WKAuthenticationDecisionListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKAuthenticationDecisionListener.cpp
@@ -41,15 +41,15 @@ WKTypeID WKAuthenticationDecisionListenerGetTypeID()
 
 void WKAuthenticationDecisionListenerUseCredential(WKAuthenticationDecisionListenerRef authenticationListener, WKCredentialRef credential)
 {
-    WebKit::toProtectedImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::UseCredential, credential ? WebKit::toProtectedImpl(credential)->credential() : WebCore::Credential());
+    protect(WebKit::toImpl(authenticationListener))->completeChallenge(AuthenticationChallengeDisposition::UseCredential, credential ? protect(WebKit::toImpl(credential))->credential() : WebCore::Credential());
 }
 
 void WKAuthenticationDecisionListenerCancel(WKAuthenticationDecisionListenerRef authenticationListener)
 {
-    WebKit::toProtectedImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::Cancel);
+    protect(WebKit::toImpl(authenticationListener))->completeChallenge(AuthenticationChallengeDisposition::Cancel);
 }
 
 void WKAuthenticationDecisionListenerRejectProtectionSpaceAndContinue(WKAuthenticationDecisionListenerRef authenticationListener)
 {
-    WebKit::toProtectedImpl(authenticationListener)->completeChallenge(AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
+    protect(WebKit::toImpl(authenticationListener))->completeChallenge(AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
 }

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -40,45 +40,45 @@ WKTypeID WKBackForwardListGetTypeID()
 
 WKBackForwardListItemRef WKBackForwardListGetCurrentItem(WKBackForwardListRef listRef)
 {
-    return toAPI(protect(toProtectedImpl(listRef)->currentItem()).get());
+    return toAPI(protect(protect(toImpl(listRef))->currentItem()).get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetBackItem(WKBackForwardListRef listRef)
 {
-    return toAPI(protect(toProtectedImpl(listRef)->backItem()).get());
+    return toAPI(protect(protect(toImpl(listRef))->backItem()).get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetForwardItem(WKBackForwardListRef listRef)
 {
-    return toAPI(protect(toProtectedImpl(listRef)->forwardItem()).get());
+    return toAPI(protect(protect(toImpl(listRef))->forwardItem()).get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetItemAtIndex(WKBackForwardListRef listRef, int index)
 {
-    return toAPI(protect(toProtectedImpl(listRef)->itemAtIndex(index)).get());
+    return toAPI(protect(protect(toImpl(listRef))->itemAtIndex(index)).get());
 }
 
 void WKBackForwardListClear(WKBackForwardListRef listRef)
 {
-    toProtectedImpl(listRef)->clear();
+    protect(toImpl(listRef))->clear();
 }
 
 unsigned WKBackForwardListGetBackListCount(WKBackForwardListRef listRef)
 {
-    return toProtectedImpl(listRef)->backListCount();
+    return protect(toImpl(listRef))->backListCount();
 }
 
 unsigned WKBackForwardListGetForwardListCount(WKBackForwardListRef listRef)
 {
-    return toProtectedImpl(listRef)->forwardListCount();
+    return protect(toImpl(listRef))->forwardListCount();
 }
 
 WKArrayRef WKBackForwardListCopyBackListWithLimit(WKBackForwardListRef listRef, unsigned limit)
 {
-    return toAPILeakingRef(toProtectedImpl(listRef)->backListAsAPIArrayWithLimit(limit));
+    return toAPILeakingRef(protect(toImpl(listRef))->backListAsAPIArrayWithLimit(limit));
 }
 
 WKArrayRef WKBackForwardListCopyForwardListWithLimit(WKBackForwardListRef listRef, unsigned limit)
 {
-    return toAPILeakingRef(toProtectedImpl(listRef)->forwardListAsAPIArrayWithLimit(limit));
+    return toAPILeakingRef(protect(toImpl(listRef))->forwardListAsAPIArrayWithLimit(limit));
 }

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -94,12 +94,12 @@ WKContextRef WKContextCreateWithConfiguration(WKContextConfigurationRef configur
 
 void WKContextSetClient(WKContextRef contextRef, const WKContextClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(contextRef)->initializeClient(wkClient);
+    protect(WebKit::toImpl(contextRef))->initializeClient(wkClient);
 }
 
 void WKContextSetInjectedBundleClient(WKContextRef contextRef, const WKContextInjectedBundleClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(contextRef)->setInjectedBundleClient(makeUnique<WebKit::WebContextInjectedBundleClient>(wkClient));
+    protect(WebKit::toImpl(contextRef))->setInjectedBundleClient(makeUnique<WebKit::WebContextInjectedBundleClient>(wkClient));
 }
 
 void WKContextSetHistoryClient(WKContextRef contextRef, const WKContextHistoryClientBase* wkClient)
@@ -253,7 +253,7 @@ void WKContextSetDownloadClient(WKContextRef context, const WKContextDownloadCli
         }
         WKContextRef m_context;
     };
-    WebKit::toProtectedImpl(context)->setLegacyDownloadClient(adoptRef(*new LegacyDownloadClient(wkClient, context)));
+    protect(WebKit::toImpl(context))->setLegacyDownloadClient(adoptRef(*new LegacyDownloadClient(wkClient, context)));
 }
 
 void WKContextSetInitializationUserDataForInjectedBundle(WKContextRef contextRef,  WKTypeRef userDataRef)
@@ -263,7 +263,7 @@ void WKContextSetInitializationUserDataForInjectedBundle(WKContextRef contextRef
 
 void WKContextPostMessageToInjectedBundle(WKContextRef contextRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toProtectedImpl(contextRef)->postMessageToInjectedBundle(WebKit::toProtectedImpl(messageNameRef)->string(), WebKit::toProtectedImpl(messageBodyRef).get());
+    protect(WebKit::toImpl(contextRef))->postMessageToInjectedBundle(protect(WebKit::toImpl(messageNameRef))->string(), protect(WebKit::toImpl(messageBodyRef)).get());
 }
 
 void WKContextGetGlobalStatistics(WKContextStatistics* statistics)
@@ -277,7 +277,7 @@ void WKContextGetGlobalStatistics(WKContextStatistics* statistics)
 
 void WKContextAddVisitedLink(WKContextRef contextRef, WKStringRef visitedURL)
 {
-    String visitedURLString = WebKit::toProtectedImpl(visitedURL)->string();
+    String visitedURLString = protect(WebKit::toImpl(visitedURL))->string();
     if (visitedURLString.isEmpty())
         return;
 
@@ -312,12 +312,12 @@ unsigned WKContextGetMaximumNumberOfProcesses(WKContextRef)
 
 void WKContextSetAlwaysUsesComplexTextCodePath(WKContextRef contextRef, bool alwaysUseComplexTextCodePath)
 {
-    WebKit::toProtectedImpl(contextRef)->setAlwaysUsesComplexTextCodePath(alwaysUseComplexTextCodePath);
+    protect(WebKit::toImpl(contextRef))->setAlwaysUsesComplexTextCodePath(alwaysUseComplexTextCodePath);
 }
 
 void WKContextSetDisableFontSubpixelAntialiasingForTesting(WKContextRef contextRef, bool disable)
 {
-    WebKit::toProtectedImpl(contextRef)->setDisableFontSubpixelAntialiasingForTesting(disable);
+    protect(WebKit::toImpl(contextRef))->setDisableFontSubpixelAntialiasingForTesting(disable);
 }
 
 void WKContextSetAdditionalPluginsDirectory(WKContextRef contextRef, WKStringRef pluginsDirectory)
@@ -333,32 +333,32 @@ void WKContextRefreshPlugIns(WKContextRef context)
 
 void WKContextRegisterURLSchemeAsEmptyDocument(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsEmptyDocument(WebKit::toProtectedImpl(urlScheme)->string());
+    protect(WebKit::toImpl(contextRef))->registerURLSchemeAsEmptyDocument(protect(WebKit::toImpl(urlScheme))->string());
 }
 
 void WKContextRegisterURLSchemeAsSecure(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsSecure(WebKit::toProtectedImpl(urlScheme)->string());
+    protect(WebKit::toImpl(contextRef))->registerURLSchemeAsSecure(protect(WebKit::toImpl(urlScheme))->string());
 }
 
 void WKContextRegisterURLSchemeAsBypassingContentSecurityPolicy(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsBypassingContentSecurityPolicy(WebKit::toProtectedImpl(urlScheme)->string());
+    protect(WebKit::toImpl(contextRef))->registerURLSchemeAsBypassingContentSecurityPolicy(protect(WebKit::toImpl(urlScheme))->string());
 }
 
 void WKContextRegisterURLSchemeAsCachePartitioned(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsCachePartitioned(WebKit::toProtectedImpl(urlScheme)->string());
+    protect(WebKit::toImpl(contextRef))->registerURLSchemeAsCachePartitioned(protect(WebKit::toImpl(urlScheme))->string());
 }
 
 void WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toProtectedImpl(contextRef)->registerURLSchemeAsCanDisplayOnlyIfCanRequest(WebKit::toProtectedImpl(urlScheme)->string());
+    protect(WebKit::toImpl(contextRef))->registerURLSchemeAsCanDisplayOnlyIfCanRequest(protect(WebKit::toImpl(urlScheme))->string());
 }
 
 void WKContextSetDomainRelaxationForbiddenForURLScheme(WKContextRef contextRef, WKStringRef urlScheme)
 {
-    WebKit::toProtectedImpl(contextRef)->setDomainRelaxationForbiddenForURLScheme(WebKit::toProtectedImpl(urlScheme)->string());
+    protect(WebKit::toImpl(contextRef))->setDomainRelaxationForbiddenForURLScheme(protect(WebKit::toImpl(urlScheme))->string());
 }
 
 void WKContextSetCanHandleHTTPSServerTrustEvaluation(WKContextRef contextRef, bool value)
@@ -399,7 +399,7 @@ WKWebsiteDataStoreRef WKContextGetWebsiteDataStore(WKContextRef)
 
 WKGeolocationManagerRef WKContextGetGeolocationManager(WKContextRef contextRef)
 {
-    return WebKit::toAPI(protect(WebKit::toProtectedImpl(contextRef)->supplement<WebKit::WebGeolocationManagerProxy>()).get());
+    return WebKit::toAPI(protect(protect(WebKit::toImpl(contextRef))->supplement<WebKit::WebGeolocationManagerProxy>()).get());
 }
 
 WKIconDatabaseRef WKContextGetIconDatabase(WKContextRef)
@@ -414,7 +414,7 @@ WKKeyValueStorageManagerRef WKContextGetKeyValueStorageManager(WKContextRef cont
 
 WKNotificationManagerRef WKContextGetNotificationManager(WKContextRef contextRef)
 {
-    return WebKit::toAPI(protect(WebKit::toProtectedImpl(contextRef)->supplement<WebKit::WebNotificationManagerProxy>()).get());
+    return WebKit::toAPI(protect(protect(WebKit::toImpl(contextRef))->supplement<WebKit::WebNotificationManagerProxy>()).get());
 }
 
 WKResourceCacheManagerRef WKContextGetResourceCacheManager(WKContextRef context)
@@ -424,12 +424,12 @@ WKResourceCacheManagerRef WKContextGetResourceCacheManager(WKContextRef context)
 
 void WKContextStartMemorySampler(WKContextRef contextRef, WKDoubleRef interval)
 {
-    WebKit::toProtectedImpl(contextRef)->startMemorySampler(WebKit::toImpl(interval)->value());
+    protect(WebKit::toImpl(contextRef))->startMemorySampler(WebKit::toImpl(interval)->value());
 }
 
 void WKContextStopMemorySampler(WKContextRef contextRef)
 {
-    WebKit::toProtectedImpl(contextRef)->stopMemorySampler();
+    protect(WebKit::toImpl(contextRef))->stopMemorySampler();
 }
 
 void WKContextSetIconDatabasePath(WKContextRef, WKStringRef)
@@ -442,22 +442,22 @@ void WKContextAllowSpecificHTTPSCertificateForHost(WKContextRef, WKCertificateIn
 
 void WKContextDisableProcessTermination(WKContextRef contextRef)
 {
-    WebKit::toProtectedImpl(contextRef)->disableProcessTermination();
+    protect(WebKit::toImpl(contextRef))->disableProcessTermination();
 }
 
 void WKContextEnableProcessTermination(WKContextRef contextRef)
 {
-    WebKit::toProtectedImpl(contextRef)->enableProcessTermination();
+    protect(WebKit::toImpl(contextRef))->enableProcessTermination();
 }
 
 void WKContextSetHTTPPipeliningEnabled(WKContextRef contextRef, bool enabled)
 {
-    WebKit::toProtectedImpl(contextRef)->setHTTPPipeliningEnabled(enabled);
+    protect(WebKit::toImpl(contextRef))->setHTTPPipeliningEnabled(enabled);
 }
 
 void WKContextWarmInitialProcess(WKContextRef contextRef)
 {
-    WebKit::toProtectedImpl(contextRef)->prewarmProcess();
+    protect(WebKit::toImpl(contextRef))->prewarmProcess();
 }
 
 void WKContextGetStatistics(WKContextRef contextRef, void* context, WKContextGetStatisticsFunction callback)
@@ -475,17 +475,17 @@ bool WKContextJavaScriptConfigurationFileEnabled(WKContextRef contextRef)
 
 void WKContextSetJavaScriptConfigurationFileEnabled(WKContextRef contextRef, bool enable)
 {
-    WebKit::toProtectedImpl(contextRef)->setJavaScriptConfigurationFileEnabled(enable);
+    protect(WebKit::toImpl(contextRef))->setJavaScriptConfigurationFileEnabled(enable);
 }
 
 void WKContextGarbageCollectJavaScriptObjects(WKContextRef contextRef)
 {
-    WebKit::toProtectedImpl(contextRef)->garbageCollectJavaScriptObjects();
+    protect(WebKit::toImpl(contextRef))->garbageCollectJavaScriptObjects();
 }
 
 void WKContextSetJavaScriptGarbageCollectorTimerEnabled(WKContextRef contextRef, bool enable)
 {
-    WebKit::toProtectedImpl(contextRef)->setJavaScriptGarbageCollectorTimerEnabled(enable);
+    protect(WebKit::toImpl(contextRef))->setJavaScriptGarbageCollectorTimerEnabled(enable);
 }
 
 WKDictionaryRef WKContextCopyPlugInAutoStartOriginHashes(WKContextRef)
@@ -512,12 +512,12 @@ void WKContextSetInvalidMessageFunction(WKContextInvalidMessageFunction invalidM
 
 void WKContextSetMemoryCacheDisabled(WKContextRef contextRef, bool disabled)
 {
-    WebKit::toProtectedImpl(contextRef)->setMemoryCacheDisabled(disabled);
+    protect(WebKit::toImpl(contextRef))->setMemoryCacheDisabled(disabled);
 }
 
 void WKContextSetFontAllowList(WKContextRef contextRef, WKArrayRef arrayRef)
 {
-    WebKit::toProtectedImpl(contextRef)->setFontAllowList(WebKit::toProtectedImpl(arrayRef).get());
+    protect(WebKit::toImpl(contextRef))->setFontAllowList(protect(WebKit::toImpl(arrayRef)).get());
 }
 
 void WKContextTerminateGPUProcess(WKContextRef)
@@ -530,7 +530,7 @@ void WKContextTerminateGPUProcess(WKContextRef)
 
 void WKContextTerminateServiceWorkers(WKContextRef context)
 {
-    WebKit::toProtectedImpl(context)->terminateServiceWorkers();
+    protect(WebKit::toImpl(context))->terminateServiceWorkers();
 }
 
 void WKContextAddSupportedPlugin(WKContextRef contextRef, WKStringRef domainRef, WKStringRef nameRef, WKArrayRef mimeTypesRef, WKArrayRef extensionsRef)
@@ -543,7 +543,7 @@ void WKContextClearSupportedPlugins(WKContextRef contextRef)
 
 void WKContextClearCurrentModifierStateForTesting(WKContextRef contextRef)
 {
-    WebKit::toProtectedImpl(contextRef)->clearCurrentModifierStateForTesting();
+    protect(WebKit::toImpl(contextRef))->clearCurrentModifierStateForTesting();
 }
 
 void WKContextSetUseSeparateServiceWorkerProcess(WKContextRef, bool useSeparateServiceWorkerProcess)
@@ -562,7 +562,7 @@ WKArrayRef WKContextCopyLocalhostAliases(WKContextRef)
 
 void WKContextSetLocalhostAliases(WKContextRef, WKArrayRef localhostAliases)
 {
-    for (const auto& hostname : WebKit::toProtectedImpl(localhostAliases)->toStringVector())
+    for (const auto& hostname : protect(WebKit::toImpl(localhostAliases))->toStringVector())
         WebKit::LegacyGlobalSettings::singleton().registerHostnameAsLocal(hostname);
 }
 
@@ -577,7 +577,7 @@ void WKContextClearMockGamepadsForTesting(WKContextRef)
 void WKContextSetResourceMonitorURLsForTesting(WKContextRef contextRef, WKStringRef rulesText, void* context, WKContextSetResourceMonitorURLsFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS) && PLATFORM(COCOA)
-    WebKit::toProtectedImpl(contextRef)->setResourceMonitorURLsForTesting(WebKit::toWTFString(rulesText), [context, callback] {
+    protect(WebKit::toImpl(contextRef))->setResourceMonitorURLsForTesting(WebKit::toWTFString(rulesText), [context, callback] {
         if (callback)
             callback(context);
     });

--- a/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
@@ -68,7 +68,7 @@ WKStringRef WKContextConfigurationCopyInjectedBundlePath(WKContextConfigurationR
 
 void WKContextConfigurationSetInjectedBundlePath(WKContextConfigurationRef configuration, WKStringRef injectedBundlePath)
 {
-    protect(toImpl(configuration))->setInjectedBundlePath(toProtectedImpl(injectedBundlePath)->string());
+    protect(toImpl(configuration))->setInjectedBundlePath(protect(toImpl(injectedBundlePath))->string());
 }
 
 WKArrayRef WKContextConfigurationCopyCustomClassesForParameterCoder(WKContextConfigurationRef configuration)
@@ -147,7 +147,7 @@ void WKContextConfigurationSetOverrideLanguages(WKContextConfigurationRef, WKArr
     // FIXME: This is an SPI function, and is only (supposed to be) used for testing.
     // However, playwright automation tests rely on it.
     // See https://bugs.webkit.org/show_bug.cgi?id=242827 for details.
-    WebKit::setOverrideLanguages(toProtectedImpl(overrideLanguages)->toStringVector());
+    WebKit::setOverrideLanguages(protect(toImpl(overrideLanguages))->toStringVector());
 }
 
 bool WKContextConfigurationProcessSwapsOnNavigation(WKContextConfigurationRef configuration)
@@ -215,5 +215,5 @@ WKStringRef WKContextConfigurationCopyTimeZoneOverride(WKContextConfigurationRef
 
 void WKContextConfigurationSetTimeZoneOverride(WKContextConfigurationRef configuration, WKStringRef timeZoneOverride)
 {
-    protect(toImpl(configuration))->setTimeZoneOverride(toProtectedImpl(timeZoneOverride)->string());
+    protect(toImpl(configuration))->setTimeZoneOverride(protect(toImpl(timeZoneOverride))->string());
 }

--- a/Source/WebKit/UIProcess/API/C/WKContextMenuListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContextMenuListener.cpp
@@ -57,7 +57,7 @@ void WKContextMenuListenerUseContextMenuItems(WKContextMenuListenerRef listenerR
         items.append(item.releaseNonNull());
     }
 
-    toProtectedImpl(listenerRef)->useContextMenuItems(WTF::move(items));
+    protect(toImpl(listenerRef))->useContextMenuItems(WTF::move(items));
 #else
     UNUSED_PARAM(listenerRef);
     UNUSED_PARAM(arrayRef);

--- a/Source/WebKit/UIProcess/API/C/WKCredential.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKCredential.cpp
@@ -39,7 +39,7 @@ WKTypeID WKCredentialGetTypeID()
 
 WKCredentialRef WKCredentialCreate(WKStringRef username, WKStringRef password, WKCredentialPersistence persistence)
 {
-    return toAPILeakingRef(WebCredential::create(WebCore::Credential(toProtectedImpl(username)->string(), toProtectedImpl(password)->string(), toCredentialPersistence(persistence))));
+    return toAPILeakingRef(WebCredential::create(WebCore::Credential(protect(toImpl(username))->string(), protect(toImpl(password))->string(), toCredentialPersistence(persistence))));
 }
 
 WKCredentialRef WKCredentialCreateWithCertificateInfo(WKCertificateInfoRef certificateInfo)
@@ -49,5 +49,5 @@ WKCredentialRef WKCredentialCreateWithCertificateInfo(WKCertificateInfoRef certi
 
 WKStringRef WKCredentialCopyUser(WKCredentialRef credentialRef)
 {
-    return toCopiedAPI(toProtectedImpl(credentialRef)->credential().user());
+    return toCopiedAPI(protect(toImpl(credentialRef))->credential().user());
 }

--- a/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
@@ -56,7 +56,7 @@ WKURLRequestRef WKDownloadCopyRequest(WKDownloadRef download)
 
 void WKDownloadCancel(WKDownloadRef download, const void* functionContext, WKDownloadCancelCallback callback)
 {
-    return toProtectedImpl(download)->cancel([functionContext, callback](auto* resumeData) {
+    return protect(toImpl(download))->cancel([functionContext, callback](auto* resumeData) {
         if (callback)
             callback(toAPI(resumeData), functionContext);
     });
@@ -64,7 +64,7 @@ void WKDownloadCancel(WKDownloadRef download, const void* functionContext, WKDow
 
 WKPageRef WKDownloadGetOriginatingPage(WKDownloadRef download)
 {
-    RefPtr originatingPage = toProtectedImpl(download)->originatingPage();
+    RefPtr originatingPage = protect(toImpl(download))->originatingPage();
     return toAPI(originatingPage.get());
 }
 
@@ -148,5 +148,5 @@ void WKDownloadSetClient(WKDownloadRef download, WKDownloadClientBase* client)
         }
     };
 
-    toProtectedImpl(download)->setClient(adoptRef(*new DownloadClient(client)));
+    protect(toImpl(download))->setClient(adoptRef(*new DownloadClient(client)));
 }

--- a/Source/WebKit/UIProcess/API/C/WKFormSubmissionListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKFormSubmissionListener.cpp
@@ -38,5 +38,5 @@ WKTypeID WKFormSubmissionListenerGetTypeID()
 
 void WKFormSubmissionListenerContinue(WKFormSubmissionListenerRef submissionListener)
 {
-    toProtectedImpl(submissionListener)->continueSubmission();
+    protect(toImpl(submissionListener))->continueSubmission();
 }

--- a/Source/WebKit/UIProcess/API/C/WKFrame.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKFrame.cpp
@@ -42,7 +42,7 @@ WKTypeID WKFrameGetTypeID()
 
 bool WKFrameIsMainFrame(WKFrameRef frameRef)
 {
-    return toProtectedImpl(frameRef)->isMainFrame();
+    return protect(toImpl(frameRef))->isMainFrame();
 }
 
 WKFrameLoadState WKFrameGetFrameLoadState(WKFrameRef frameRef)
@@ -92,7 +92,7 @@ WKStringRef WKFrameCopyTitle(WKFrameRef frameRef)
 
 WKPageRef WKFrameGetPage(WKFrameRef frameRef)
 {
-    return toAPI(protect(toProtectedImpl(frameRef)->page()).get());
+    return toAPI(protect(protect(toImpl(frameRef))->page()).get());
 }
 
 WKCertificateInfoRef WKFrameGetCertificateInfo(WKFrameRef frameRef)
@@ -102,7 +102,7 @@ WKCertificateInfoRef WKFrameGetCertificateInfo(WKFrameRef frameRef)
 
 bool WKFrameCanProvideSource(WKFrameRef frameRef)
 {
-    return toProtectedImpl(frameRef)->canProvideSource();
+    return protect(toImpl(frameRef))->canProvideSource();
 }
 
 bool WKFrameCanShowMIMEType(WKFrameRef, WKStringRef)
@@ -112,12 +112,12 @@ bool WKFrameCanShowMIMEType(WKFrameRef, WKStringRef)
 
 bool WKFrameIsDisplayingStandaloneImageDocument(WKFrameRef frameRef)
 {
-    return toProtectedImpl(frameRef)->isDisplayingStandaloneImageDocument();
+    return protect(toImpl(frameRef))->isDisplayingStandaloneImageDocument();
 }
 
 bool WKFrameIsDisplayingMarkupDocument(WKFrameRef frameRef)
 {
-    return toProtectedImpl(frameRef)->isDisplayingMarkupDocument();
+    return protect(toImpl(frameRef))->isDisplayingMarkupDocument();
 }
 
 bool WKFrameIsFrameSet(WKFrameRef frameRef)
@@ -127,7 +127,7 @@ bool WKFrameIsFrameSet(WKFrameRef frameRef)
 
 WKFrameHandleRef WKFrameCreateFrameHandle(WKFrameRef frameRef)
 {
-    return toAPILeakingRef(API::FrameHandle::create(toProtectedImpl(frameRef)->frameID()));
+    return toAPILeakingRef(API::FrameHandle::create(protect(toImpl(frameRef))->frameID()));
 }
 
 WKFrameInfoRef WKFrameCreateFrameInfo(WKFrameRef frameRef)
@@ -137,21 +137,21 @@ WKFrameInfoRef WKFrameCreateFrameInfo(WKFrameRef frameRef)
 
 void WKFrameGetMainResourceData(WKFrameRef frameRef, WKFrameGetResourceDataFunction callback, void* context)
 {
-    toProtectedImpl(frameRef)->getMainResourceData([context, callback] (API::Data* data) {
+    protect(toImpl(frameRef))->getMainResourceData([context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 }
 
 void WKFrameGetResourceData(WKFrameRef frameRef, WKURLRef resourceURL, WKFrameGetResourceDataFunction callback, void* context)
 {
-    toProtectedImpl(frameRef)->getResourceData(toProtectedImpl(resourceURL).get(), [context, callback] (API::Data* data) {
+    protect(toImpl(frameRef))->getResourceData(protect(toImpl(resourceURL)).get(), [context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 }
 
 void WKFrameGetWebArchive(WKFrameRef frameRef, WKFrameGetWebArchiveFunction callback, void* context)
 {
-    toProtectedImpl(frameRef)->getWebArchive([context, callback] (API::Data* data) {
+    protect(toImpl(frameRef))->getWebArchive([context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 }

--- a/Source/WebKit/UIProcess/API/C/WKFrameInfoRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKFrameInfoRef.cpp
@@ -39,7 +39,7 @@ WKTypeID WKFrameInfoGetTypeID()
 
 WKFrameHandleRef WKFrameInfoCreateFrameHandleRef(WKFrameInfoRef frameInfo)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(frameInfo)->handle());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(frameInfo))->handle());
 }
 
 WKSecurityOriginRef WKFrameInfoCopySecurityOrigin(WKFrameInfoRef frameInfo)
@@ -55,5 +55,5 @@ bool WKFrameInfoGetIsMainFrame(WKFrameInfoRef frameInfo)
 
 WKPageRef WKFrameInfoGetPage(WKFrameInfoRef frameInfo)
 {
-    return WebKit::toAPI(RefPtr { WebKit::toProtectedImpl(frameInfo)->page() }.get());
+    return WebKit::toAPI(RefPtr { protect(WebKit::toImpl(frameInfo))->page() }.get());
 }

--- a/Source/WebKit/UIProcess/API/C/WKFramePolicyListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKFramePolicyListener.cpp
@@ -43,17 +43,17 @@ WKTypeID WKFramePolicyListenerGetTypeID()
 
 void WKFramePolicyListenerUse(WKFramePolicyListenerRef policyListenerRef)
 {
-    toProtectedImpl(policyListenerRef)->use();
+    protect(toImpl(policyListenerRef))->use();
 }
 
 void WKFramePolicyListenerUseInNewProcess(WKFramePolicyListenerRef policyListenerRef)
 {
-    toProtectedImpl(policyListenerRef)->use(nullptr, ProcessSwapRequestedByClient::Yes);
+    protect(toImpl(policyListenerRef))->use(nullptr, ProcessSwapRequestedByClient::Yes);
 }
 
 static void useWithPolicies(WKFramePolicyListenerRef policyListenerRef, WKWebsitePoliciesRef websitePolicies, ProcessSwapRequestedByClient processSwapRequestedByClient)
 {
-    toProtectedImpl(policyListenerRef)->use(toProtectedImpl(websitePolicies).get(), processSwapRequestedByClient);
+    protect(toImpl(policyListenerRef))->use(protect(toImpl(websitePolicies)).get(), processSwapRequestedByClient);
 }
 
 void WKFramePolicyListenerUseWithPolicies(WKFramePolicyListenerRef policyListenerRef, WKWebsitePoliciesRef websitePolicies)
@@ -68,10 +68,10 @@ void WKFramePolicyListenerUseInNewProcessWithPolicies(WKFramePolicyListenerRef p
 
 void WKFramePolicyListenerDownload(WKFramePolicyListenerRef policyListenerRef)
 {
-    toProtectedImpl(policyListenerRef)->download();
+    protect(toImpl(policyListenerRef))->download();
 }
 
 void WKFramePolicyListenerIgnore(WKFramePolicyListenerRef policyListenerRef)
 {
-    toProtectedImpl(policyListenerRef)->ignore();
+    protect(toImpl(policyListenerRef))->ignore();
 }

--- a/Source/WebKit/UIProcess/API/C/WKGeolocationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKGeolocationManager.cpp
@@ -40,20 +40,20 @@ WKTypeID WKGeolocationManagerGetTypeID()
 
 void WKGeolocationManagerSetProvider(WKGeolocationManagerRef geolocationManagerRef, const WKGeolocationProviderBase* wkProvider)
 {
-    toProtectedImpl(geolocationManagerRef)->setProvider(makeUnique<WebGeolocationProvider>(wkProvider));
+    protect(toImpl(geolocationManagerRef))->setProvider(makeUnique<WebGeolocationProvider>(wkProvider));
 }
 
 void WKGeolocationManagerProviderDidChangePosition(WKGeolocationManagerRef geolocationManagerRef, WKGeolocationPositionRef positionRef)
 {
-    toProtectedImpl(geolocationManagerRef)->providerDidChangePosition(toProtectedImpl(positionRef).get());
+    protect(toImpl(geolocationManagerRef))->providerDidChangePosition(protect(toImpl(positionRef)).get());
 }
 
 void WKGeolocationManagerProviderDidFailToDeterminePosition(WKGeolocationManagerRef geolocationManagerRef)
 {
-    toProtectedImpl(geolocationManagerRef)->providerDidFailToDeterminePosition();
+    protect(toImpl(geolocationManagerRef))->providerDidFailToDeterminePosition();
 }
 
 void WKGeolocationManagerProviderDidFailToDeterminePositionWithErrorMessage(WKGeolocationManagerRef geolocationManagerRef, WKStringRef errorMessage)
 {
-    toProtectedImpl(geolocationManagerRef)->providerDidFailToDeterminePosition(toWTFString(errorMessage));
+    protect(toImpl(geolocationManagerRef))->providerDidFailToDeterminePosition(toWTFString(errorMessage));
 }

--- a/Source/WebKit/UIProcess/API/C/WKGeolocationPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKGeolocationPermissionRequest.cpp
@@ -38,10 +38,10 @@ WKTypeID WKGeolocationPermissionRequestGetTypeID()
 
 void WKGeolocationPermissionRequestAllow(WKGeolocationPermissionRequestRef geolocationPermissionRequestRef)
 {
-    return toProtectedImpl(geolocationPermissionRequestRef)->allow();
+    return protect(toImpl(geolocationPermissionRequestRef))->allow();
 }
 
 void WKGeolocationPermissionRequestDeny(WKGeolocationPermissionRequestRef geolocationPermissionRequestRef)
 {
-    return toProtectedImpl(geolocationPermissionRequestRef)->deny();
+    return protect(toImpl(geolocationPermissionRequestRef))->deny();
 }

--- a/Source/WebKit/UIProcess/API/C/WKHTTPCookieStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKHTTPCookieStoreRef.cpp
@@ -36,7 +36,7 @@ WKTypeID WKHTTPCookieStoreGetTypeID()
 
 void WKHTTPCookieStoreDeleteAllCookies(WKHTTPCookieStoreRef cookieStore, void* context, WKHTTPCookieStoreDeleteAllCookiesFunction callback)
 {
-    WebKit::toProtectedImpl(cookieStore)->deleteAllCookies([context, callback] {
+    protect(WebKit::toImpl(cookieStore))->deleteAllCookies([context, callback] {
         if (callback)
             callback(context);
     });
@@ -44,7 +44,7 @@ void WKHTTPCookieStoreDeleteAllCookies(WKHTTPCookieStoreRef cookieStore, void* c
 
 void WKHTTPCookieStoreSetHTTPCookieAcceptPolicy(WKHTTPCookieStoreRef cookieStore, WKHTTPCookieAcceptPolicy policy, void* context, WKHTTPCookieStoreSetHTTPCookieAcceptPolicyFunction callback)
 {
-    WebKit::toProtectedImpl(cookieStore)->setHTTPCookieAcceptPolicy(WebKit::toHTTPCookieAcceptPolicy(policy), [context, callback] {
+    protect(WebKit::toImpl(cookieStore))->setHTTPCookieAcceptPolicy(WebKit::toHTTPCookieAcceptPolicy(policy), [context, callback] {
         if (callback)
             callback(context);
     });

--- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
@@ -42,62 +42,62 @@ WKTypeID WKInspectorGetTypeID()
 
 WKPageRef WKInspectorGetPage(WKInspectorRef inspectorRef)
 {
-    return toAPI(protect(toProtectedImpl(inspectorRef)->inspectedPage()).get());
+    return toAPI(protect(protect(toImpl(inspectorRef))->inspectedPage()).get());
 }
 
 bool WKInspectorIsConnected(WKInspectorRef inspectorRef)
 {
-    return toProtectedImpl(inspectorRef)->isConnected();
+    return protect(toImpl(inspectorRef))->isConnected();
 }
 
 bool WKInspectorIsVisible(WKInspectorRef inspectorRef)
 {
-    return toProtectedImpl(inspectorRef)->isVisible();
+    return protect(toImpl(inspectorRef))->isVisible();
 }
 
 bool WKInspectorIsFront(WKInspectorRef inspectorRef)
 {
-    return toProtectedImpl(inspectorRef)->isFront();
+    return protect(toImpl(inspectorRef))->isFront();
 }
 
 void WKInspectorConnect(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->connect();
+    protect(toImpl(inspectorRef))->connect();
 }
 
 void WKInspectorShow(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->show();
+    protect(toImpl(inspectorRef))->show();
 }
 
 void WKInspectorHide(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->hide();
+    protect(toImpl(inspectorRef))->hide();
 }
 
 void WKInspectorClose(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->close();
+    protect(toImpl(inspectorRef))->close();
 }
 
 void WKInspectorShowConsole(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->showConsole();
+    protect(toImpl(inspectorRef))->showConsole();
 }
 
 void WKInspectorShowResources(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->showResources();
+    protect(toImpl(inspectorRef))->showResources();
 }
 
 void WKInspectorShowMainResourceForFrame(WKInspectorRef inspectorRef, WKFrameRef frameRef)
 {
-    toProtectedImpl(inspectorRef)->showMainResourceForFrame(toProtectedImpl(frameRef)->frameID());
+    protect(toImpl(inspectorRef))->showMainResourceForFrame(protect(toImpl(frameRef))->frameID());
 }
 
 bool WKInspectorIsAttached(WKInspectorRef inspectorRef)
 {
-    return toProtectedImpl(inspectorRef)->isAttached();
+    return protect(toImpl(inspectorRef))->isAttached();
 }
 
 void WKInspectorAttach(WKInspectorRef inspectorRef)
@@ -108,27 +108,27 @@ void WKInspectorAttach(WKInspectorRef inspectorRef)
 
 void WKInspectorDetach(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->detach();
+    protect(toImpl(inspectorRef))->detach();
 }
 
 bool WKInspectorIsProfilingPage(WKInspectorRef inspectorRef)
 {
-    return toProtectedImpl(inspectorRef)->isProfilingPage();
+    return protect(toImpl(inspectorRef))->isProfilingPage();
 }
 
 void WKInspectorTogglePageProfiling(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->togglePageProfiling();
+    protect(toImpl(inspectorRef))->togglePageProfiling();
 }
 
 bool WKInspectorIsElementSelectionActive(WKInspectorRef inspectorRef)
 {
-    return toProtectedImpl(inspectorRef)->isElementSelectionActive();
+    return protect(toImpl(inspectorRef))->isElementSelectionActive();
 }
 
 void WKInspectorToggleElementSelection(WKInspectorRef inspectorRef)
 {
-    toProtectedImpl(inspectorRef)->toggleElementSelection();
+    protect(toImpl(inspectorRef))->toggleElementSelection();
 }
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/C/WKJSHandleRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKJSHandleRef.cpp
@@ -37,5 +37,5 @@ WKTypeID WKJSHandleGetTypeID()
 
 WKFrameInfoRef WKJSHandleCopyFrameInfo(WKJSHandleRef handle)
 {
-    return WebKit::toAPILeakingRef(API::FrameInfo::create(WebKit::FrameInfoData { WebKit::toProtectedImpl(handle)->info().frameInfo }));
+    return WebKit::toAPILeakingRef(API::FrameInfo::create(WebKit::FrameInfoData { protect(WebKit::toImpl(handle))->info().frameInfo }));
 }

--- a/Source/WebKit/UIProcess/API/C/WKMediaKeySystemPermissionCallback.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMediaKeySystemPermissionCallback.cpp
@@ -39,5 +39,5 @@ WKTypeID WKMediaKeySystemPermissionCallbackGetTypeID()
 
 void WKMediaKeySystemPermissionCallbackComplete(WKMediaKeySystemPermissionCallbackRef permissionCallback, bool granted)
 {
-    return toProtectedImpl(permissionCallback)->complete(granted);
+    return protect(toImpl(permissionCallback))->complete(granted);
 }

--- a/Source/WebKit/UIProcess/API/C/WKMessageListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMessageListener.cpp
@@ -38,5 +38,5 @@ WKTypeID WKMessageListenerGetTypeID()
 
 void WKMessageListenerSendReply(WKMessageListenerRef listenerRef, WKTypeRef value)
 {
-    toProtectedImpl(listenerRef)->sendReply(toImpl(value));
+    protect(toImpl(listenerRef))->sendReply(toImpl(value));
 }

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
@@ -39,7 +39,7 @@ using namespace WebKit;
 void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties, bool isDefault)
 {
 #if ENABLE(MEDIA_STREAM)
-    String typeString = WebKit::toProtectedImpl(type)->string();
+    String typeString = protect(WebKit::toImpl(type))->string();
     Variant<WebCore::MockMicrophoneProperties, WebCore::MockSpeakerProperties, WebCore::MockCameraProperties, WebCore::MockDisplayProperties> deviceProperties;
     if (typeString == "camera"_s) {
         WebCore::MockCameraProperties cameraProperties;
@@ -72,26 +72,26 @@ void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStri
         }
     }
 
-    toProtectedImpl(context)->addMockMediaDevice({ WebKit::toProtectedImpl(persistentId)->string(), WebKit::toProtectedImpl(label)->string(), flags, isDefault, WTF::move(deviceProperties) });
+    protect(toImpl(context))->addMockMediaDevice({ protect(WebKit::toImpl(persistentId))->string(), protect(WebKit::toImpl(label))->string(), flags, isDefault, WTF::move(deviceProperties) });
 #endif
 }
 
 void WKClearMockMediaDevices(WKContextRef context)
 {
-    toProtectedImpl(context)->clearMockMediaDevices();
+    protect(toImpl(context))->clearMockMediaDevices();
 }
 
 void WKRemoveMockMediaDevice(WKContextRef context, WKStringRef persistentId)
 {
-    toProtectedImpl(context)->removeMockMediaDevice(WebKit::toProtectedImpl(persistentId)->string());
+    protect(toImpl(context))->removeMockMediaDevice(protect(WebKit::toImpl(persistentId))->string());
 }
 
 void WKResetMockMediaDevices(WKContextRef context)
 {
-    toProtectedImpl(context)->resetMockMediaDevices();
+    protect(toImpl(context))->resetMockMediaDevices();
 }
 
 void WKSetMockMediaDeviceIsEphemeral(WKContextRef context, WKStringRef persistentId, bool isEphemeral)
 {
-    toProtectedImpl(context)->setMockMediaDeviceIsEphemeral(WebKit::toProtectedImpl(persistentId)->string(), isEphemeral);
+    protect(toImpl(context))->setMockMediaDeviceIsEphemeral(protect(WebKit::toImpl(persistentId))->string(), isEphemeral);
 }

--- a/Source/WebKit/UIProcess/API/C/WKNotification.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.cpp
@@ -81,7 +81,7 @@ WKStringRef WKNotificationCopyDir(WKNotificationRef notification)
 
 WKSecurityOriginRef WKNotificationGetSecurityOrigin(WKNotificationRef notification)
 {
-    return toAPI(RefPtr { toProtectedImpl(notification)->origin() }.get());
+    return toAPI(RefPtr { protect(toImpl(notification))->origin() }.get());
 }
 
 uint64_t WKNotificationGetID(WKNotificationRef notification)

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -42,17 +42,17 @@ WKTypeID WKNotificationManagerGetTypeID()
 
 void WKNotificationManagerSetProvider(WKNotificationManagerRef managerRef, const WKNotificationProviderBase* wkProvider)
 {
-    toProtectedImpl(managerRef)->setProvider(makeUnique<WebNotificationProvider>(wkProvider));
+    protect(toImpl(managerRef))->setProvider(makeUnique<WebNotificationProvider>(wkProvider));
 }
 
 void WKNotificationManagerProviderDidShowNotification(WKNotificationManagerRef managerRef, uint64_t notificationID)
 {
-    toProtectedImpl(managerRef)->providerDidShowNotification(WebNotificationIdentifier { notificationID });
+    protect(toImpl(managerRef))->providerDidShowNotification(WebNotificationIdentifier { notificationID });
 }
 
 void WKNotificationManagerProviderDidClickNotification(WKNotificationManagerRef managerRef, uint64_t notificationID)
 {
-    toProtectedImpl(managerRef)->providerDidClickNotification(WebNotificationIdentifier { notificationID });
+    protect(toImpl(managerRef))->providerDidClickNotification(WebNotificationIdentifier { notificationID });
 }
 
 void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRef managerRef, WKDataRef identifier)
@@ -61,22 +61,22 @@ void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRe
     if (span.size() != 16)
         return;
 
-    toProtectedImpl(managerRef)->providerDidClickNotification(WTF::UUID { std::span<const uint8_t, 16> { span } });
+    protect(toImpl(managerRef))->providerDidClickNotification(WTF::UUID { std::span<const uint8_t, 16> { span } });
 }
 
 void WKNotificationManagerProviderDidCloseNotifications(WKNotificationManagerRef managerRef, WKArrayRef notificationIDs)
 {
-    toProtectedImpl(managerRef)->providerDidCloseNotifications(toProtectedImpl(notificationIDs).get());
+    protect(toImpl(managerRef))->providerDidCloseNotifications(protect(toImpl(notificationIDs)).get());
 }
 
 void WKNotificationManagerProviderDidUpdateNotificationPolicy(WKNotificationManagerRef managerRef, WKSecurityOriginRef origin, bool allowed)
 {
-    toProtectedImpl(managerRef)->providerDidUpdateNotificationPolicy(toProtectedImpl(origin).get(), allowed);
+    protect(toImpl(managerRef))->providerDidUpdateNotificationPolicy(protect(toImpl(origin)).get(), allowed);
 }
 
 void WKNotificationManagerProviderDidRemoveNotificationPolicies(WKNotificationManagerRef managerRef, WKArrayRef origins)
 {
-    toProtectedImpl(managerRef)->providerDidRemoveNotificationPolicies(toProtectedImpl(origins).get());
+    protect(toImpl(managerRef))->providerDidRemoveNotificationPolicies(protect(toImpl(origins)).get());
 }
 
 WKNotificationManagerRef WKNotificationManagerGetSharedServiceWorkerNotificationManager()

--- a/Source/WebKit/UIProcess/API/C/WKNotificationPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationPermissionRequest.cpp
@@ -38,10 +38,10 @@ WKTypeID WKNotificationPermissionRequestGetTypeID()
 
 void WKNotificationPermissionRequestAllow(WKNotificationPermissionRequestRef notificationPermissionRequest)
 {
-    return toProtectedImpl(notificationPermissionRequest)->didReceiveDecision(true);
+    return protect(toImpl(notificationPermissionRequest))->didReceiveDecision(true);
 }
 
 void WKNotificationPermissionRequestDeny(WKNotificationPermissionRequestRef notificationPermissionRequest)
 {
-    return toProtectedImpl(notificationPermissionRequest)->didReceiveDecision(false);
+    return protect(toImpl(notificationPermissionRequest))->didReceiveDecision(false);
 }

--- a/Source/WebKit/UIProcess/API/C/WKOpenPanelParametersRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKOpenPanelParametersRef.cpp
@@ -50,17 +50,17 @@ bool WKOpenPanelParametersGetAllowsMultipleFiles(WKOpenPanelParametersRef parame
 
 WKArrayRef WKOpenPanelParametersCopyAcceptedMIMETypes(WKOpenPanelParametersRef parametersRef)
 {
-    return toAPILeakingRef(toProtectedImpl(parametersRef)->acceptMIMETypes());
+    return toAPILeakingRef(protect(toImpl(parametersRef))->acceptMIMETypes());
 }
 
 WKArrayRef WKOpenPanelParametersCopyAcceptedFileExtensions(WKOpenPanelParametersRef parametersRef)
 {
-    return toAPILeakingRef(toProtectedImpl(parametersRef)->acceptFileExtensions());
+    return toAPILeakingRef(protect(toImpl(parametersRef))->acceptFileExtensions());
 }
 
 WKArrayRef WKOpenPanelParametersCopyAllowedMIMETypes(WKOpenPanelParametersRef parametersRef)
 {
-    return toAPILeakingRef(toProtectedImpl(parametersRef)->allowedMIMETypes());
+    return toAPILeakingRef(protect(toImpl(parametersRef))->allowedMIMETypes());
 }
 
 // Deprecated.
@@ -81,5 +81,5 @@ bool WKOpenPanelParametersGetMediaCaptureType(WKOpenPanelParametersRef parameter
 
 WKArrayRef WKOpenPanelParametersCopySelectedFileNames(WKOpenPanelParametersRef parametersRef)
 {
-    return toAPILeakingRef(toProtectedImpl(parametersRef)->selectedFileNames());
+    return toAPILeakingRef(protect(toImpl(parametersRef))->selectedFileNames());
 }

--- a/Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp
@@ -59,16 +59,16 @@ static Vector<String> filePathsFromFileURLs(const API::Array& fileURLs)
 #if PLATFORM(IOS_FAMILY)
 void WKOpenPanelResultListenerChooseMediaFiles(WKOpenPanelResultListenerRef listenerRef, WKArrayRef fileURLsRef, WKStringRef displayString, WKDataRef iconImageDataRef)
 {
-    toProtectedImpl(listenerRef)->chooseFiles(filePathsFromFileURLs(*toProtectedImpl(fileURLsRef)), toProtectedImpl(displayString)->string(), toProtectedImpl(iconImageDataRef).get());
+    protect(toImpl(listenerRef))->chooseFiles(filePathsFromFileURLs(*protect(toImpl(fileURLsRef))), protect(toImpl(displayString))->string(), protect(toImpl(iconImageDataRef)).get());
 }
 #endif
 
 void WKOpenPanelResultListenerChooseFiles(WKOpenPanelResultListenerRef listenerRef, WKArrayRef fileURLsRef, WKArrayRef allowedMimeTypesRef)
 {
-    toProtectedImpl(listenerRef)->chooseFiles(filePathsFromFileURLs(*toProtectedImpl(fileURLsRef)), toProtectedImpl(allowedMimeTypesRef)->toStringVector());
+    protect(toImpl(listenerRef))->chooseFiles(filePathsFromFileURLs(*protect(toImpl(fileURLsRef))), protect(toImpl(allowedMimeTypesRef))->toStringVector());
 }
 
 void WKOpenPanelResultListenerCancel(WKOpenPanelResultListenerRef listenerRef)
 {
-    toProtectedImpl(listenerRef)->cancel();
+    protect(toImpl(listenerRef))->cancel();
 }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -188,7 +188,7 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE static void crashBecausePageIsSuspended()
     CRASH();
 }
 
-#define CRASH_IF_SUSPENDED if (pageRef && toProtectedImpl(pageRef)->isSuspended()) [[unlikely]] \
+#define CRASH_IF_SUSPENDED if (pageRef && protect(toImpl(pageRef))->isSuspended()) [[unlikely]] \
     crashBecausePageIsSuspended()
 
 WKTypeID WKPageGetTypeID()
@@ -198,7 +198,7 @@ WKTypeID WKPageGetTypeID()
 
 WKContextRef WKPageGetContext(WKPageRef pageRef)
 {
-    return toAPI(protect(toProtectedImpl(pageRef)->configuration().processPool()).ptr());
+    return toAPI(protect(protect(toImpl(pageRef))->configuration().processPool()).ptr());
 }
 
 WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
@@ -208,66 +208,66 @@ WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
 
 WKPageConfigurationRef WKPageCopyPageConfiguration(WKPageRef pageRef)
 {
-    return toAPILeakingRef(toProtectedImpl(pageRef)->configuration().copy());
+    return toAPILeakingRef(protect(toImpl(pageRef))->configuration().copy());
 }
 
 void WKPageLoadURL(WKPageRef pageRef, WKURLRef URLRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) });
+    protect(toImpl(pageRef))->loadRequest(URL { toWTFString(URLRef) });
 }
 
 void WKPageLoadURLWithShouldOpenExternalURLsPolicy(WKPageRef pageRef, WKURLRef URLRef, bool shouldOpenExternalURLs)
 {
     CRASH_IF_SUSPENDED;
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy = shouldOpenExternalURLs ? WebCore::ShouldOpenExternalURLsPolicy::ShouldAllow : WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow;
-    toProtectedImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, shouldOpenExternalURLsPolicy);
+    protect(toImpl(pageRef))->loadRequest(URL { toWTFString(URLRef) }, shouldOpenExternalURLsPolicy);
 }
 
 void WKPageLoadURLWithUserData(WKPageRef pageRef, WKURLRef URLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->loadRequest(URL { toWTFString(URLRef) }, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, nullptr, toProtectedImpl(userDataRef).get());
+    protect(toImpl(pageRef))->loadRequest(URL { toWTFString(URLRef) }, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, nullptr, protect(toImpl(userDataRef)).get());
 }
 
 void WKPageLoadURLRequest(WKPageRef pageRef, WKURLRequestRef urlRequestRef)
 {
     CRASH_IF_SUSPENDED;
-    auto resourceRequest = toProtectedImpl(urlRequestRef)->resourceRequest();
-    toProtectedImpl(pageRef)->loadRequest(WTF::move(resourceRequest));
+    auto resourceRequest = protect(toImpl(urlRequestRef))->resourceRequest();
+    protect(toImpl(pageRef))->loadRequest(WTF::move(resourceRequest));
 }
 
 void WKPageLoadURLRequestWithUserData(WKPageRef pageRef, WKURLRequestRef urlRequestRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    auto resourceRequest = toProtectedImpl(urlRequestRef)->resourceRequest();
-    toProtectedImpl(pageRef)->loadRequest(WTF::move(resourceRequest), WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, nullptr, toProtectedImpl(userDataRef).get());
+    auto resourceRequest = protect(toImpl(urlRequestRef))->resourceRequest();
+    protect(toImpl(pageRef))->loadRequest(WTF::move(resourceRequest), WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, WebCore::NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, nullptr, protect(toImpl(userDataRef)).get());
 }
 
 void WKPageLoadFile(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL));
+    protect(toImpl(pageRef))->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL));
 }
 
 void WKPageLoadFileWithUserData(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL), toProtectedImpl(userDataRef).get());
+    protect(toImpl(pageRef))->loadFile(toWTFString(fileURL), toWTFString(resourceDirectoryURL), protect(toImpl(userDataRef)).get());
 }
 
 void WKPageLoadData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef)
 {
     CRASH_IF_SUSPENDED;
     // FIXME: Use WebCore::DataSegment::Provider to remove this unnecessary copy.
-    toProtectedImpl(pageRef)->loadData(WebCore::SharedBuffer::create(toProtectedImpl(dataRef)->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
+    protect(toImpl(pageRef))->loadData(WebCore::SharedBuffer::create(protect(toImpl(dataRef))->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
 }
 
 void WKPageLoadDataWithUserData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
     // FIXME: Use WebCore::DataSegment::Provider to remove this unnecessary copy.
-    toProtectedImpl(pageRef)->loadData(WebCore::SharedBuffer::create(toProtectedImpl(dataRef)->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toProtectedImpl(userDataRef).get());
+    protect(toImpl(pageRef))->loadData(WebCore::SharedBuffer::create(protect(toImpl(dataRef))->span()), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), protect(toImpl(userDataRef)).get());
 }
 
 static String encodingOf(const String& string)
@@ -295,7 +295,7 @@ static void loadString(WKPageRef pageRef, WKStringRef stringRef, const String& m
 {
     String string = toWTFString(stringRef);
     // FIXME: Use WebCore::DataSegment::Provider to remove this unnecessary copy.
-    toProtectedImpl(pageRef)->loadData(WebCore::SharedBuffer::create(dataFrom(string)), mimeType, encodingOf(string), baseURL, toProtectedImpl(userDataRef).get());
+    protect(toImpl(pageRef))->loadData(WebCore::SharedBuffer::create(dataFrom(string)), mimeType, encodingOf(string), baseURL, protect(toImpl(userDataRef)).get());
 }
 
 void WKPageLoadHTMLString(WKPageRef pageRef, WKStringRef htmlStringRef, WKURLRef baseURLRef)
@@ -314,7 +314,7 @@ void WKPageLoadAlternateHTMLString(WKPageRef pageRef, WKStringRef htmlStringRef,
 {
     CRASH_IF_SUSPENDED;
     String string = toWTFString(htmlStringRef);
-    toProtectedImpl(pageRef)->loadAlternateHTML(dataReferenceFrom(string), encodingOf(string), URL { toWTFString(baseURLRef) }, URL { toWTFString(unreachableURLRef) }, nullptr);
+    protect(toImpl(pageRef))->loadAlternateHTML(dataReferenceFrom(string), encodingOf(string), URL { toWTFString(baseURLRef) }, URL { toWTFString(unreachableURLRef) }, nullptr);
 }
 
 void WKPageLoadPlainTextString(WKPageRef pageRef, WKStringRef plainTextStringRef)
@@ -332,7 +332,7 @@ void WKPageLoadPlainTextStringWithUserData(WKPageRef pageRef, WKStringRef plainT
 void WKPageStopLoading(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->stopLoading();
+    protect(toImpl(pageRef))->stopLoading();
 }
 
 void WKPageReload(WKPageRef pageRef)
@@ -344,31 +344,31 @@ void WKPageReload(WKPageRef pageRef)
         reloadOptions.add(WebCore::ReloadOption::ExpiredOnly);
 #endif
 
-    toProtectedImpl(pageRef)->reload(reloadOptions);
+    protect(toImpl(pageRef))->reload(reloadOptions);
 }
 
 void WKPageReloadWithoutContentBlockers(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->reload(WebCore::ReloadOption::DisableContentBlockers);
+    protect(toImpl(pageRef))->reload(WebCore::ReloadOption::DisableContentBlockers);
 }
 
 void WKPageReloadFromOrigin(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->reload(WebCore::ReloadOption::FromOrigin);
+    protect(toImpl(pageRef))->reload(WebCore::ReloadOption::FromOrigin);
 }
 
 void WKPageReloadExpiredOnly(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->reload(WebCore::ReloadOption::ExpiredOnly);
+    protect(toImpl(pageRef))->reload(WebCore::ReloadOption::ExpiredOnly);
 }
 
 bool WKPageTryClose(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    return toProtectedImpl(pageRef)->tryClose();
+    return protect(toImpl(pageRef))->tryClose();
 }
 
 void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef originString)
@@ -383,29 +383,29 @@ void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef originStrin
 
 void WKPageClose(WKPageRef pageRef)
 {
-    toProtectedImpl(pageRef)->close();
+    protect(toImpl(pageRef))->close();
 }
 
 bool WKPageIsClosed(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->isClosed();
+    return protect(toImpl(pageRef))->isClosed();
 }
 
 void WKPageGoForward(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->goForward();
+    protect(toImpl(pageRef))->goForward();
 }
 
 bool WKPageCanGoForward(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->backForwardListWrapper().forwardItem();
+    return protect(toImpl(pageRef))->backForwardListWrapper().forwardItem();
 }
 
 void WKPageGoBack(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    Ref page = *toProtectedImpl(pageRef);
+    Ref page = *protect(toImpl(pageRef));
     if (RefPtr pageClient = page->pageClient(); pageClient->hasBrowsingWarning()) {
         WKPageReload(pageRef);
         return;
@@ -415,52 +415,52 @@ void WKPageGoBack(WKPageRef pageRef)
 
 bool WKPageCanGoBack(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->backForwardListWrapper().backItem();
+    return protect(toImpl(pageRef))->backForwardListWrapper().backItem();
 }
 
 void WKPageGoToBackForwardListItem(WKPageRef pageRef, WKBackForwardListItemRef itemRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->goToBackForwardItem(*toProtectedImpl(itemRef));
+    protect(toImpl(pageRef))->goToBackForwardItem(*protect(toImpl(itemRef)));
 }
 
 void WKPageTryRestoreScrollPosition(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->tryRestoreScrollPosition();
+    protect(toImpl(pageRef))->tryRestoreScrollPosition();
 }
 
 WKBackForwardListRef WKPageGetBackForwardList(WKPageRef pageRef)
 {
-    return toAPI(&toProtectedImpl(pageRef)->backForwardListWrapper());
+    return toAPI(&protect(toImpl(pageRef))->backForwardListWrapper());
 }
 
 bool WKPageWillHandleHorizontalScrollEvents(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->willHandleHorizontalScrollEvents();
+    return protect(toImpl(pageRef))->willHandleHorizontalScrollEvents();
 }
 
 void WKPageUpdateWebsitePolicies(WKPageRef pageRef, WKWebsitePoliciesRef websitePoliciesRef)
 {
     CRASH_IF_SUSPENDED;
-    RELEASE_ASSERT_WITH_MESSAGE(!toProtectedImpl(websitePoliciesRef)->websiteDataStore(), "Setting WebsitePolicies.websiteDataStore is only supported during WKFramePolicyListenerUseWithPolicies().");
-    RELEASE_ASSERT_WITH_MESSAGE(!toProtectedImpl(websitePoliciesRef)->userContentController(), "Setting WebsitePolicies.userContentController is only supported during WKFramePolicyListenerUseWithPolicies().");
-    toProtectedImpl(pageRef)->updateWebsitePolicies(*toProtectedImpl(websitePoliciesRef));
+    RELEASE_ASSERT_WITH_MESSAGE(!protect(toImpl(websitePoliciesRef))->websiteDataStore(), "Setting WebsitePolicies.websiteDataStore is only supported during WKFramePolicyListenerUseWithPolicies().");
+    RELEASE_ASSERT_WITH_MESSAGE(!protect(toImpl(websitePoliciesRef))->userContentController(), "Setting WebsitePolicies.userContentController is only supported during WKFramePolicyListenerUseWithPolicies().");
+    protect(toImpl(pageRef))->updateWebsitePolicies(*protect(toImpl(websitePoliciesRef)));
 }
 
 WKStringRef WKPageCopyTitle(WKPageRef pageRef)
 {
-    return toCopiedAPI(protect(toProtectedImpl(pageRef)->pageLoadState())->title());
+    return toCopiedAPI(protect(protect(toImpl(pageRef))->pageLoadState())->title());
 }
 
 WKFrameRef WKPageGetMainFrame(WKPageRef pageRef)
 {
-    return toAPI(protect(toProtectedImpl(pageRef)->mainFrame()).get());
+    return toAPI(protect(protect(toImpl(pageRef))->mainFrame()).get());
 }
 
 WKFrameRef WKPageGetFocusedFrame(WKPageRef pageRef)
 {
-    return toAPI(protect(toProtectedImpl(pageRef)->focusedFrame()).get());
+    return toAPI(protect(protect(toImpl(pageRef))->focusedFrame()).get());
 }
 
 WKFrameRef WKPageGetFrameSetLargestFrame(WKPageRef pageRef)
@@ -470,77 +470,77 @@ WKFrameRef WKPageGetFrameSetLargestFrame(WKPageRef pageRef)
 
 uint64_t WKPageGetRenderTreeSize(WKPageRef page)
 {
-    return toProtectedImpl(page)->renderTreeSize();
+    return protect(toImpl(page))->renderTreeSize();
 }
 
 WKWebsiteDataStoreRef WKPageGetWebsiteDataStore(WKPageRef page)
 {
-    return toAPI(protect(toProtectedImpl(page)->websiteDataStore()).ptr());
+    return toAPI(protect(protect(toImpl(page))->websiteDataStore()).ptr());
 }
 
 WKInspectorRef WKPageGetInspector(WKPageRef pageRef)
 {
-    return toAPI(protect(toProtectedImpl(pageRef)->inspector()).get());
+    return toAPI(protect(protect(toImpl(pageRef))->inspector()).get());
 }
 
 double WKPageGetEstimatedProgress(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->estimatedProgress();
+    return protect(toImpl(pageRef))->estimatedProgress();
 }
 
 WKStringRef WKPageCopyUserAgent(WKPageRef pageRef)
 {
-    return toCopiedAPI(toProtectedImpl(pageRef)->userAgent());
+    return toCopiedAPI(protect(toImpl(pageRef))->userAgent());
 }
 
 WKStringRef WKPageCopyApplicationNameForUserAgent(WKPageRef pageRef)
 {
-    return toCopiedAPI(toProtectedImpl(pageRef)->applicationNameForUserAgent());
+    return toCopiedAPI(protect(toImpl(pageRef))->applicationNameForUserAgent());
 }
 
 void WKPageSetApplicationNameForUserAgent(WKPageRef pageRef, WKStringRef applicationNameRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setApplicationNameForUserAgent(toWTFString(applicationNameRef));
+    protect(toImpl(pageRef))->setApplicationNameForUserAgent(toWTFString(applicationNameRef));
 }
 
 WKStringRef WKPageCopyCustomUserAgent(WKPageRef pageRef)
 {
-    return toCopiedAPI(toProtectedImpl(pageRef)->customUserAgent());
+    return toCopiedAPI(protect(toImpl(pageRef))->customUserAgent());
 }
 
 void WKPageSetCustomUserAgent(WKPageRef pageRef, WKStringRef userAgentRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setCustomUserAgent(toWTFString(userAgentRef));
+    protect(toImpl(pageRef))->setCustomUserAgent(toWTFString(userAgentRef));
 }
 
 bool WKPageSupportsTextEncoding(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->supportsTextEncoding();
+    return protect(toImpl(pageRef))->supportsTextEncoding();
 }
 
 WKStringRef WKPageCopyCustomTextEncodingName(WKPageRef pageRef)
 {
-    return toCopiedAPI(toProtectedImpl(pageRef)->customTextEncodingName());
+    return toCopiedAPI(protect(toImpl(pageRef))->customTextEncodingName());
 }
 
 void WKPageSetCustomTextEncodingName(WKPageRef pageRef, WKStringRef encodingNameRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setCustomTextEncodingName(toWTFString(encodingNameRef));
+    protect(toImpl(pageRef))->setCustomTextEncodingName(toWTFString(encodingNameRef));
 }
 
 void WKPageTerminate(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    protect(toProtectedImpl(pageRef)->legacyMainFrameProcess())->requestTermination(ProcessTerminationReason::RequestedByClient);
+    protect(protect(toImpl(pageRef))->legacyMainFrameProcess())->requestTermination(ProcessTerminationReason::RequestedByClient);
 }
 
 void WKPageResetStateBetweenTests(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting())
         pageForTesting->resetStateBetweenTests();
 }
 
@@ -562,7 +562,7 @@ WKTypeRef WKPageCopySessionState(WKPageRef pageRef, void* context, WKPageSession
     bool shouldReturnData = !(reinterpret_cast<uintptr_t>(context) & 1);
     context = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(context) & ~1);
 
-    auto sessionState = toProtectedImpl(pageRef)->sessionState([pageRef, context, filter](WebBackForwardListItem& item) {
+    auto sessionState = protect(toImpl(pageRef))->sessionState([pageRef, context, filter](WebBackForwardListItem& item) {
         if (filter) {
             if (!filter(pageRef, WKPageGetSessionBackForwardListItemValueType(), toAPI(&item), context))
                 return false;
@@ -586,16 +586,16 @@ static void restoreFromSessionState(WKPageRef pageRef, WKTypeRef sessionStateRef
     SessionState sessionState;
 
     // FIXME: This is for backwards compatibility with Safari. Remove it once Safari no longer depends on it.
-    if (toProtectedImpl(sessionStateRef)->type() == API::Object::Type::Data) {
-        if (!decodeLegacySessionState(toProtectedImpl(static_cast<WKDataRef>(sessionStateRef))->span(), sessionState))
+    if (protect(toImpl(sessionStateRef))->type() == API::Object::Type::Data) {
+        if (!decodeLegacySessionState(protect(toImpl(static_cast<WKDataRef>(sessionStateRef)))->span(), sessionState))
             return;
     } else {
-        ASSERT(toProtectedImpl(sessionStateRef)->type() == API::Object::Type::SessionState);
+        ASSERT(protect(toImpl(sessionStateRef))->type() == API::Object::Type::SessionState);
 
-        sessionState = toProtectedImpl(static_cast<WKSessionStateRef>(sessionStateRef))->sessionState();
+        sessionState = protect(toImpl(static_cast<WKSessionStateRef>(sessionStateRef)))->sessionState();
     }
 
-    toProtectedImpl(pageRef)->restoreFromSessionState(WTF::move(sessionState), navigate);
+    protect(toImpl(pageRef))->restoreFromSessionState(WTF::move(sessionState), navigate);
 }
 
 void WKPageRestoreFromSessionState(WKPageRef pageRef, WKTypeRef sessionStateRef)
@@ -612,42 +612,42 @@ void WKPageRestoreFromSessionStateWithoutNavigation(WKPageRef pageRef, WKTypeRef
 
 double WKPageGetTextZoomFactor(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->textZoomFactor();
+    return protect(toImpl(pageRef))->textZoomFactor();
 }
 
 double WKPageGetBackingScaleFactor(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->deviceScaleFactor();
+    return protect(toImpl(pageRef))->deviceScaleFactor();
 }
 
 void WKPageSetCustomBackingScaleFactor(WKPageRef pageRef, double customScaleFactor)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setCustomDeviceScaleFactor(customScaleFactor, [] { });
+    protect(toImpl(pageRef))->setCustomDeviceScaleFactor(customScaleFactor, [] { });
 }
 
 void WKPageSetCustomBackingScaleFactorWithCallback(WKPageRef pageRef, double customScaleFactor, void* context, WKPageSetCustomBackingScaleFactorFunction completionHandler)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setCustomDeviceScaleFactor(customScaleFactor, [context, completionHandler] {
+    protect(toImpl(pageRef))->setCustomDeviceScaleFactor(customScaleFactor, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 bool WKPageSupportsTextZoom(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->supportsTextZoom();
+    return protect(toImpl(pageRef))->supportsTextZoom();
 }
 
 void WKPageSetTextZoomFactor(WKPageRef pageRef, double zoomFactor)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setTextZoomFactor(zoomFactor);
+    protect(toImpl(pageRef))->setTextZoomFactor(zoomFactor);
 }
 
 double WKPageGetPageZoomFactor(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pageZoomFactor();
+    return protect(toImpl(pageRef))->pageZoomFactor();
 }
 
 void WKPageSetPageZoomFactor(WKPageRef pageRef, double zoomFactor)
@@ -655,170 +655,170 @@ void WKPageSetPageZoomFactor(WKPageRef pageRef, double zoomFactor)
     CRASH_IF_SUSPENDED;
     if (zoomFactor <= 0)
         return;
-    toProtectedImpl(pageRef)->setPageZoomFactor(zoomFactor);
+    protect(toImpl(pageRef))->setPageZoomFactor(zoomFactor);
 }
 
 void WKPageSetPageAndTextZoomFactors(WKPageRef pageRef, double pageZoomFactor, double textZoomFactor)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setPageAndTextZoomFactors(pageZoomFactor, textZoomFactor);
+    protect(toImpl(pageRef))->setPageAndTextZoomFactors(pageZoomFactor, textZoomFactor);
 }
 
 void WKPageSetScaleFactor(WKPageRef pageRef, double scale, WKPoint origin)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->scalePage(scale, toIntPoint(origin), [] { });
+    protect(toImpl(pageRef))->scalePage(scale, toIntPoint(origin), [] { });
 }
 
 double WKPageGetScaleFactor(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pageScaleFactor();
+    return protect(toImpl(pageRef))->pageScaleFactor();
 }
 
 void WKPageSetUseFixedLayout(WKPageRef pageRef, bool fixed)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setUseFixedLayout(fixed);
+    protect(toImpl(pageRef))->setUseFixedLayout(fixed);
 }
 
 void WKPageSetFixedLayoutSize(WKPageRef pageRef, WKSize size)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setFixedLayoutSize(toIntSize(size));
+    protect(toImpl(pageRef))->setFixedLayoutSize(toIntSize(size));
 }
 
 bool WKPageUseFixedLayout(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->useFixedLayout();
+    return protect(toImpl(pageRef))->useFixedLayout();
 }
 
 WKSize WKPageFixedLayoutSize(WKPageRef pageRef)
 {
-    return toAPI(toProtectedImpl(pageRef)->fixedLayoutSize());
+    return toAPI(protect(toImpl(pageRef))->fixedLayoutSize());
 }
 
 void WKPageListenForLayoutMilestones(WKPageRef pageRef, WKLayoutMilestones milestones)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->listenForLayoutMilestones(toLayoutMilestones(milestones));
+    protect(toImpl(pageRef))->listenForLayoutMilestones(toLayoutMilestones(milestones));
 }
 
 bool WKPageHasHorizontalScrollbar(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->hasHorizontalScrollbar();
+    return protect(toImpl(pageRef))->hasHorizontalScrollbar();
 }
 
 bool WKPageHasVerticalScrollbar(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->hasVerticalScrollbar();
+    return protect(toImpl(pageRef))->hasVerticalScrollbar();
 }
 
 void WKPageSetSuppressScrollbarAnimations(WKPageRef pageRef, bool suppressAnimations)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setSuppressScrollbarAnimations(suppressAnimations);
+    protect(toImpl(pageRef))->setSuppressScrollbarAnimations(suppressAnimations);
 }
 
 bool WKPageAreScrollbarAnimationsSuppressed(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->areScrollbarAnimationsSuppressed();
+    return protect(toImpl(pageRef))->areScrollbarAnimationsSuppressed();
 }
 
 bool WKPageIsPinnedToLeftSide(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pinnedState().left();
+    return protect(toImpl(pageRef))->pinnedState().left();
 }
 
 bool WKPageIsPinnedToRightSide(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pinnedState().right();
+    return protect(toImpl(pageRef))->pinnedState().right();
 }
 
 bool WKPageIsPinnedToTopSide(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pinnedState().top();
+    return protect(toImpl(pageRef))->pinnedState().top();
 }
 
 bool WKPageIsPinnedToBottomSide(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pinnedState().bottom();
+    return protect(toImpl(pageRef))->pinnedState().bottom();
 }
 
 bool WKPageRubberBandsAtLeft(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->rubberBandableEdges().left();
+    return protect(toImpl(pageRef))->rubberBandableEdges().left();
 }
 
 void WKPageSetRubberBandsAtLeft(WKPageRef pageRef, bool rubberBandsAtLeft)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setRubberBandsAtLeft(rubberBandsAtLeft);
+    protect(toImpl(pageRef))->setRubberBandsAtLeft(rubberBandsAtLeft);
 }
 
 bool WKPageRubberBandsAtRight(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->rubberBandableEdges().right();
+    return protect(toImpl(pageRef))->rubberBandableEdges().right();
 }
 
 void WKPageSetRubberBandsAtRight(WKPageRef pageRef, bool rubberBandsAtRight)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setRubberBandsAtRight(rubberBandsAtRight);
+    protect(toImpl(pageRef))->setRubberBandsAtRight(rubberBandsAtRight);
 }
 
 bool WKPageRubberBandsAtTop(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->rubberBandableEdges().top();
+    return protect(toImpl(pageRef))->rubberBandableEdges().top();
 }
 
 void WKPageSetRubberBandsAtTop(WKPageRef pageRef, bool rubberBandsAtTop)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setRubberBandsAtTop(rubberBandsAtTop);
+    protect(toImpl(pageRef))->setRubberBandsAtTop(rubberBandsAtTop);
 }
 
 bool WKPageRubberBandsAtBottom(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->rubberBandableEdges().bottom();
+    return protect(toImpl(pageRef))->rubberBandableEdges().bottom();
 }
 
 void WKPageSetRubberBandsAtBottom(WKPageRef pageRef, bool rubberBandsAtBottom)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setRubberBandsAtBottom(rubberBandsAtBottom);
+    protect(toImpl(pageRef))->setRubberBandsAtBottom(rubberBandsAtBottom);
 }
 
 bool WKPageVerticalRubberBandingIsEnabled(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->verticalRubberBandingIsEnabled();
+    return protect(toImpl(pageRef))->verticalRubberBandingIsEnabled();
 }
 
 void WKPageSetEnableVerticalRubberBanding(WKPageRef pageRef, bool enableVerticalRubberBanding)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setEnableVerticalRubberBanding(enableVerticalRubberBanding);
+    protect(toImpl(pageRef))->setEnableVerticalRubberBanding(enableVerticalRubberBanding);
 }
 
 bool WKPageHorizontalRubberBandingIsEnabled(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->horizontalRubberBandingIsEnabled();
+    return protect(toImpl(pageRef))->horizontalRubberBandingIsEnabled();
 }
 
 void WKPageSetEnableHorizontalRubberBanding(WKPageRef pageRef, bool enableHorizontalRubberBanding)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setEnableHorizontalRubberBanding(enableHorizontalRubberBanding);
+    protect(toImpl(pageRef))->setEnableHorizontalRubberBanding(enableHorizontalRubberBanding);
 }
 
 void WKPageSetBackgroundExtendsBeyondPage(WKPageRef pageRef, bool backgroundExtendsBeyondPage)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setBackgroundExtendsBeyondPage(backgroundExtendsBeyondPage);
+    protect(toImpl(pageRef))->setBackgroundExtendsBeyondPage(backgroundExtendsBeyondPage);
 }
 
 bool WKPageBackgroundExtendsBeyondPage(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->backgroundExtendsBeyondPage();
+    return protect(toImpl(pageRef))->backgroundExtendsBeyondPage();
 }
 
 void WKPageSetPaginationMode(WKPageRef pageRef, WKPaginationMode paginationMode)
@@ -844,12 +844,12 @@ void WKPageSetPaginationMode(WKPageRef pageRef, WKPaginationMode paginationMode)
     default:
         return;
     }
-    toProtectedImpl(pageRef)->setPaginationMode(mode);
+    protect(toImpl(pageRef))->setPaginationMode(mode);
 }
 
 WKPaginationMode WKPageGetPaginationMode(WKPageRef pageRef)
 {
-    switch (toProtectedImpl(pageRef)->paginationMode()) {
+    switch (protect(toImpl(pageRef))->paginationMode()) {
     case WebCore::Pagination::Mode::Unpaginated:
         return kWKPaginationModeUnpaginated;
     case WebCore::Pagination::Mode::LeftToRightPaginated:
@@ -869,34 +869,34 @@ WKPaginationMode WKPageGetPaginationMode(WKPageRef pageRef)
 void WKPageSetPaginationBehavesLikeColumns(WKPageRef pageRef, bool behavesLikeColumns)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setPaginationBehavesLikeColumns(behavesLikeColumns);
+    protect(toImpl(pageRef))->setPaginationBehavesLikeColumns(behavesLikeColumns);
 }
 
 bool WKPageGetPaginationBehavesLikeColumns(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->paginationBehavesLikeColumns();
+    return protect(toImpl(pageRef))->paginationBehavesLikeColumns();
 }
 
 void WKPageSetPageLength(WKPageRef pageRef, double pageLength)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setPageLength(pageLength);
+    protect(toImpl(pageRef))->setPageLength(pageLength);
 }
 
 double WKPageGetPageLength(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pageLength();
+    return protect(toImpl(pageRef))->pageLength();
 }
 
 void WKPageSetGapBetweenPages(WKPageRef pageRef, double gap)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setGapBetweenPages(gap);
+    protect(toImpl(pageRef))->setGapBetweenPages(gap);
 }
 
 double WKPageGetGapBetweenPages(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->gapBetweenPages();
+    return protect(toImpl(pageRef))->gapBetweenPages();
 }
 
 void WKPageSetPaginationLineGridEnabled(WKPageRef, bool)
@@ -910,76 +910,76 @@ bool WKPageGetPaginationLineGridEnabled(WKPageRef)
 
 unsigned WKPageGetPageCount(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->pageCount();
+    return protect(toImpl(pageRef))->pageCount();
 }
 
 bool WKPageCanDelete(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->canDelete();
+    return protect(toImpl(pageRef))->canDelete();
 }
 
 bool WKPageHasSelectedRange(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->hasSelectedRange();
+    return protect(toImpl(pageRef))->hasSelectedRange();
 }
 
 bool WKPageIsContentEditable(WKPageRef pageRef)
 {
-    return toProtectedImpl(pageRef)->isContentEditable();
+    return protect(toImpl(pageRef))->isContentEditable();
 }
 
 void WKPageSetMaintainsInactiveSelection(WKPageRef pageRef, bool newValue)
 {
     CRASH_IF_SUSPENDED;
-    return toProtectedImpl(pageRef)->setMaintainsInactiveSelection(newValue);
+    return protect(toImpl(pageRef))->setMaintainsInactiveSelection(newValue);
 }
 
 void WKPageCenterSelectionInVisibleArea(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    return toProtectedImpl(pageRef)->centerSelectionInVisibleArea();
+    return protect(toImpl(pageRef))->centerSelectionInVisibleArea();
 }
 
 void WKPageFindStringMatches(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->findStringMatches(toProtectedImpl(string)->string(), toFindOptions(options), maxMatchCount);
+    protect(toImpl(pageRef))->findStringMatches(protect(toImpl(string))->string(), toFindOptions(options), maxMatchCount);
 }
 
 void WKPageGetImageForFindMatch(WKPageRef pageRef, int32_t matchIndex)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getImageForFindMatch(matchIndex);
+    protect(toImpl(pageRef))->getImageForFindMatch(matchIndex);
 }
 
 void WKPageSelectFindMatch(WKPageRef pageRef, int32_t matchIndex)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->selectFindMatch(matchIndex);
+    protect(toImpl(pageRef))->selectFindMatch(matchIndex);
 }
 
 void WKPageIndicateFindMatch(WKPageRef pageRef, uint32_t matchIndex)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->indicateFindMatch(matchIndex);
+    protect(toImpl(pageRef))->indicateFindMatch(matchIndex);
 }
 
 void WKPageFindString(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->findString(toProtectedImpl(string)->string(), toFindOptions(options), maxMatchCount);
+    protect(toImpl(pageRef))->findString(protect(toImpl(string))->string(), toFindOptions(options), maxMatchCount);
 }
 
 void WKPageHideFindUI(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->hideFindUI();
+    protect(toImpl(pageRef))->hideFindUI();
 }
 
 void WKPageCountStringMatches(WKPageRef pageRef, WKStringRef string, WKFindOptions options, unsigned maxMatchCount)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->countStringMatches(toProtectedImpl(string)->string(), toFindOptions(options), maxMatchCount);
+    protect(toImpl(pageRef))->countStringMatches(protect(toImpl(string))->string(), toFindOptions(options), maxMatchCount);
 }
 
 void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuClientBase* wkClient)
@@ -1074,7 +1074,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
         }
     };
 
-    toProtectedImpl(pageRef)->setContextMenuClient(makeUnique<ContextMenuClient>(wkClient));
+    protect(toImpl(pageRef))->setContextMenuClient(makeUnique<ContextMenuClient>(wkClient));
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(wkClient);
@@ -1083,7 +1083,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
 
 void WKPageSetPageDiagnosticLoggingClient(WKPageRef pageRef, const WKPageDiagnosticLoggingClientBase* wkClient)
 {
-    toProtectedImpl(pageRef)->setDiagnosticLoggingClient(makeUnique<WebPageDiagnosticLoggingClient>(wkClient));
+    protect(toImpl(pageRef))->setDiagnosticLoggingClient(makeUnique<WebPageDiagnosticLoggingClient>(wkClient));
 }
 
 void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkClient)
@@ -1122,7 +1122,7 @@ void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkCl
         }
     };
 
-    toProtectedImpl(pageRef)->setFindClient(makeUnique<FindClient>(wkClient));
+    protect(toImpl(pageRef))->setFindClient(makeUnique<FindClient>(wkClient));
 }
 
 void WKPageSetPageFindMatchesClient(WKPageRef pageRef, const WKPageFindMatchesClientBase* wkClient)
@@ -1159,18 +1159,18 @@ void WKPageSetPageFindMatchesClient(WKPageRef pageRef, const WKPageFindMatchesCl
         }
     };
 
-    toProtectedImpl(pageRef)->setFindMatchesClient(makeUnique<FindMatchesClient>(wkClient));
+    protect(toImpl(pageRef))->setFindMatchesClient(makeUnique<FindMatchesClient>(wkClient));
 }
 
 void WKPageSetPageInjectedBundleClient(WKPageRef pageRef, const WKPageInjectedBundleClientBase* wkClient)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setInjectedBundleClient(wkClient);
+    protect(toImpl(pageRef))->setInjectedBundleClient(wkClient);
 }
 
 void WKCompletionListenerComplete(WKCompletionListenerRef listener, WKTypeRef result)
 {
-    toProtectedImpl(listener)->complete(result);
+    protect(toImpl(listener))->complete(result);
 }
 
 void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScreenClientBase* client)
@@ -1236,7 +1236,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
     [[maybe_unused]] FullScreenClientForTesting::WTFDidOverrideDeleteForCheckedPtr makeGCCHappy { 0 };
 
     auto fullscreenClient = client ? makeUnique<FullScreenClientForTesting>(client, toImpl(pageRef)) : nullptr;
-    toProtectedImpl(pageRef)->setFullScreenClientForTesting(WTF::move(fullscreenClient));
+    protect(toImpl(pageRef))->setFullScreenClientForTesting(WTF::move(fullscreenClient));
 #else
     UNUSED_PARAM(client);
 #endif
@@ -1246,7 +1246,7 @@ void WKPageRequestExitFullScreen(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(FULLSCREEN_API)
-    if (RefPtr manager = toProtectedImpl(pageRef)->fullScreenManager())
+    if (RefPtr manager = protect(toImpl(pageRef))->fullScreenManager())
         manager->requestExitFullScreen();
 #endif
 }
@@ -1254,7 +1254,7 @@ void WKPageRequestExitFullScreen(WKPageRef pageRef)
 void WKPageSetPageFormClient(WKPageRef pageRef, const WKPageFormClientBase* wkClient)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setFormClient(makeUnique<WebFormClient>(wkClient));
+    protect(toImpl(pageRef))->setFormClient(makeUnique<WebFormClient>(wkClient));
 }
 
 void WKPageSetPageLoaderClient(WKPageRef pageRef, const WKPageLoaderClientBase* wkClient)
@@ -1398,7 +1398,7 @@ void WKPageSetPageLoaderClient(WKPageRef pageRef, const WKPageLoaderClientBase* 
         }
     };
 
-    RefPtr webPageProxy = toProtectedImpl(pageRef);
+    RefPtr webPageProxy = toImpl(pageRef);
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // GCC 10 gets confused here and warns that WKPageSetPagePolicyClient is deprecated when we call
@@ -1487,7 +1487,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // GCC 10 gets confused here and warns that WKPageSetPagePolicyClient is deprecated when we call
     // makeUnique<PolicyClient>(). This seems to be a GCC bug. It's not really appropriate to use
     // ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END here because we are not using a deprecated symbol.
-    toProtectedImpl(pageRef)->setPolicyClient(makeUnique<PolicyClient>(wkClient));
+    protect(toImpl(pageRef))->setPolicyClient(makeUnique<PolicyClient>(wkClient));
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -1654,7 +1654,7 @@ WKTypeID WKPageRunBeforeUnloadConfirmPanelResultListenerGetTypeID()
 
 void WKPageRunBeforeUnloadConfirmPanelResultListenerCall(WKPageRunBeforeUnloadConfirmPanelResultListenerRef listener, bool result)
 {
-    toProtectedImpl(listener)->call(result);
+    protect(toImpl(listener))->call(result);
 }
 
 WKTypeID WKPageRunJavaScriptAlertResultListenerGetTypeID()
@@ -1664,7 +1664,7 @@ WKTypeID WKPageRunJavaScriptAlertResultListenerGetTypeID()
 
 void WKPageRunJavaScriptAlertResultListenerCall(WKPageRunJavaScriptAlertResultListenerRef listener)
 {
-    toProtectedImpl(listener)->call();
+    protect(toImpl(listener))->call();
 }
 
 WKTypeID WKPageRunJavaScriptConfirmResultListenerGetTypeID()
@@ -1674,7 +1674,7 @@ WKTypeID WKPageRunJavaScriptConfirmResultListenerGetTypeID()
 
 void WKPageRunJavaScriptConfirmResultListenerCall(WKPageRunJavaScriptConfirmResultListenerRef listener, bool result)
 {
-    toProtectedImpl(listener)->call(result);
+    protect(toImpl(listener))->call(result);
 }
 
 WKTypeID WKPageRunJavaScriptPromptResultListenerGetTypeID()
@@ -1684,7 +1684,7 @@ WKTypeID WKPageRunJavaScriptPromptResultListenerGetTypeID()
 
 void WKPageRunJavaScriptPromptResultListenerCall(WKPageRunJavaScriptPromptResultListenerRef listener, WKStringRef result)
 {
-    toProtectedImpl(listener)->call(toWTFString(result));
+    protect(toImpl(listener))->call(toWTFString(result));
 }
 
 WKTypeID WKPageRequestStorageAccessConfirmResultListenerGetTypeID()
@@ -1694,7 +1694,7 @@ WKTypeID WKPageRequestStorageAccessConfirmResultListenerGetTypeID()
 
 void WKPageRequestStorageAccessConfirmResultListenerCall(WKPageRequestStorageAccessConfirmResultListenerRef listener, bool result)
 {
-    toProtectedImpl(listener)->call(result);
+    protect(toImpl(listener))->call(result);
 }
 
 void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient)
@@ -2317,7 +2317,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         }
     };
 
-    toProtectedImpl(pageRef)->setUIClient(makeUnique<UIClient>(wkClient));
+    protect(toImpl(pageRef))->setUIClient(makeUnique<UIClient>(wkClient));
 }
 
 void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClientBase* wkClient)
@@ -2517,7 +2517,7 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
 #endif
     };
 
-    toProtectedImpl(pageRef)->setNavigationClient(makeUniqueRef<NavigationClient>(wkClient));
+    protect(toImpl(pageRef))->setNavigationClient(makeUniqueRef<NavigationClient>(wkClient));
 }
 
 class StateClient final : public RefCounted<StateClient>, public API::Client<WKPageStateClientBase>, public PageLoadState::Observer {
@@ -2689,9 +2689,9 @@ void WKPageSetPageStateClient(WKPageRef pageRef, WKPageStateClientBase* client)
 {
     CRASH_IF_SUSPENDED;
     if (client)
-        toProtectedImpl(pageRef)->setPageLoadStateObserver(StateClient::create(client));
+        protect(toImpl(pageRef))->setPageLoadStateObserver(StateClient::create(client));
     else
-        toProtectedImpl(pageRef)->setPageLoadStateObserver(nullptr);
+        protect(toImpl(pageRef))->setPageLoadStateObserver(nullptr);
 }
 
 void WKPageEvaluateJavaScriptInMainFrame(WKPageRef pageRef, WKStringRef scriptRef, void* context, WKPageEvaluateJavaScriptFunction callback)
@@ -2702,7 +2702,7 @@ void WKPageEvaluateJavaScriptInMainFrame(WKPageRef pageRef, WKStringRef scriptRe
 void WKPageEvaluateJavaScriptInFrame(WKPageRef pageRef, WKFrameInfoRef frame, WKStringRef scriptRef, void* context, WKPageEvaluateJavaScriptFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    auto scriptString = IPC::TransferString::create(toProtectedImpl(scriptRef)->stringView());
+    auto scriptString = IPC::TransferString::create(protect(toImpl(scriptRef))->stringView());
     if (!scriptString) {
         if (callback)
             callback(nullptr, nullptr, context);
@@ -2710,7 +2710,7 @@ void WKPageEvaluateJavaScriptInFrame(WKPageRef pageRef, WKFrameInfoRef frame, WK
     };
 
     auto frameID = frame ? std::optional(toImpl(frame)->frameInfoData().frameID) : std::nullopt;
-    toProtectedImpl(pageRef)->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
+    protect(toImpl(pageRef))->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
         WTF::move(*scriptString),
         JSC::SourceTaintedOrigin::Untainted,
         URL { },
@@ -2741,7 +2741,7 @@ static void callAsyncJavaScript(bool withUserGesture, WKPageRef page, WKStringRe
         }
         return { WTF::move(result) };
     };
-    auto scriptString = IPC::TransferString::create(toProtectedImpl(script)->stringView());
+    auto scriptString = IPC::TransferString::create(protect(toImpl(script))->stringView());
     if (!scriptString) {
         if (callback)
             callback(nullptr, nullptr, context);
@@ -2749,12 +2749,12 @@ static void callAsyncJavaScript(bool withUserGesture, WKPageRef page, WKStringRe
     }
 
     auto frameID = frame ? std::optional(toImpl(frame)->frameInfoData().frameID) : std::nullopt;
-    toProtectedImpl(page)->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
+    protect(toImpl(page))->runJavaScriptInFrameInScriptWorld(WebKit::RunJavaScriptParameters {
         WTF::move(*scriptString),
         JSC::SourceTaintedOrigin::Untainted,
         URL { },
         WebCore::RunAsAsyncFunction::Yes,
-        extractArguments(toProtectedImpl(arguments).get()),
+        extractArguments(protect(toImpl(arguments)).get()),
         withUserGesture ? WebCore::ForceUserGesture::Yes : WebCore::ForceUserGesture::No,
         RemoveTransientActivation::Yes
     }, frameID, API::ContentWorld::pageContentWorldSingleton(), !!callback, [context, callback] (auto&& result) {
@@ -2787,31 +2787,31 @@ static CompletionHandler<void(const String&)> toStringCallback(void* context, vo
 void WKPageRenderTreeExternalRepresentation(WKPageRef pageRef, void* context, WKPageRenderTreeExternalRepresentationFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getRenderTreeExternalRepresentation(toStringCallback(context, callback));
+    protect(toImpl(pageRef))->getRenderTreeExternalRepresentation(toStringCallback(context, callback));
 }
 
 void WKPageGetSourceForFrame(WKPageRef pageRef, WKFrameRef frameRef, void* context, WKPageGetSourceForFrameFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getSourceForFrame(toProtectedImpl(frameRef).get(), toStringCallback(context, callback));
+    protect(toImpl(pageRef))->getSourceForFrame(protect(toImpl(frameRef)).get(), toStringCallback(context, callback));
 }
 
 void WKPageGetContentsAsString(WKPageRef pageRef, void* context, WKPageGetContentsAsStringFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getContentsAsString(ContentAsStringIncludesChildFrames::No, toStringCallback(context, callback));
+    protect(toImpl(pageRef))->getContentsAsString(ContentAsStringIncludesChildFrames::No, toStringCallback(context, callback));
 }
 
 void WKPageGetBytecodeProfile(WKPageRef pageRef, void* context, WKPageGetBytecodeProfileFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getBytecodeProfile(toStringCallback(context, callback));
+    protect(toImpl(pageRef))->getBytecodeProfile(toStringCallback(context, callback));
 }
 
 void WKPageGetSamplingProfilerOutput(WKPageRef pageRef, void* context, WKPageGetSamplingProfilerOutputFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getSamplingProfilerOutput(toStringCallback(context, callback));
+    protect(toImpl(pageRef))->getSamplingProfilerOutput(toStringCallback(context, callback));
 }
 
 void WKPageGetSelectionAsWebArchiveData(WKPageRef pageRef, void* context, WKPageGetSelectionAsWebArchiveDataFunction callback)
@@ -2822,7 +2822,7 @@ void WKPageGetContentsAsMHTMLData(WKPageRef pageRef, void* context, WKPageGetCon
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MHTML)
-    toProtectedImpl(pageRef)->getContentsAsMHTMLData([context, callback] (API::Data* data) {
+    protect(toImpl(pageRef))->getContentsAsMHTMLData([context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 #else
@@ -2835,14 +2835,14 @@ void WKPageGetContentsAsMHTMLData(WKPageRef pageRef, void* context, WKPageGetCon
 void WKPageForceRepaint(WKPageRef pageRef, void* context, WKPageForceRepaintFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->updateRenderingWithForcedRepaint([context, callback]() {
+    protect(toImpl(pageRef))->updateRenderingWithForcedRepaint([context, callback]() {
         callback(nullptr, context);
     });
 }
 
 WK_EXPORT WKURLRef WKPageCopyPendingAPIRequestURL(WKPageRef pageRef)
 {
-    const String& pendingAPIRequestURL = toProtectedImpl(pageRef)->pageLoadState().pendingAPIRequestURL();
+    const String& pendingAPIRequestURL = protect(toImpl(pageRef))->pageLoadState().pendingAPIRequestURL();
 
     if (pendingAPIRequestURL.isNull())
         return nullptr;
@@ -2852,29 +2852,29 @@ WK_EXPORT WKURLRef WKPageCopyPendingAPIRequestURL(WKPageRef pageRef)
 
 WKURLRef WKPageCopyActiveURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(protect(toProtectedImpl(pageRef)->pageLoadState())->activeURL());
+    return toCopiedURLAPI(protect(protect(toImpl(pageRef))->pageLoadState())->activeURL());
 }
 
 WKURLRef WKPageCopyProvisionalURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(toProtectedImpl(pageRef)->pageLoadState().provisionalURL());
+    return toCopiedURLAPI(protect(toImpl(pageRef))->pageLoadState().provisionalURL());
 }
 
 WKURLRef WKPageCopyCommittedURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(toProtectedImpl(pageRef)->pageLoadState().url());
+    return toCopiedURLAPI(protect(toImpl(pageRef))->pageLoadState().url());
 }
 
 WKStringRef WKPageCopyStandardUserAgentWithApplicationName(WKStringRef applicationName)
 {
-    return toCopiedAPI(WebPageProxy::standardUserAgent(toProtectedImpl(applicationName)->string()));
+    return toCopiedAPI(WebPageProxy::standardUserAgent(protect(toImpl(applicationName))->string()));
 }
 
 void WKPageValidateCommand(WKPageRef pageRef, WKStringRef command, void* context, WKPageValidateCommandCallback callback)
 {
     CRASH_IF_SUSPENDED;
-    auto commandName = toProtectedImpl(command)->string();
-    toProtectedImpl(pageRef)->validateCommand(commandName, [context, callback, commandName](bool isEnabled, int32_t state) {
+    auto commandName = protect(toImpl(command))->string();
+    protect(toImpl(pageRef))->validateCommand(commandName, [context, callback, commandName](bool isEnabled, int32_t state) {
         callback(toAPI(API::String::create(commandName).ptr()), isEnabled, state, nullptr, context);
     });
 }
@@ -2882,7 +2882,7 @@ void WKPageValidateCommand(WKPageRef pageRef, WKStringRef command, void* context
 void WKPageExecuteCommand(WKPageRef pageRef, WKStringRef command)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->executeEditCommand(toProtectedImpl(command)->string());
+    protect(toImpl(pageRef))->executeEditCommand(protect(toImpl(command))->string());
 }
 
 static PrintInfo printInfoFromWKPrintInfo(const WKPrintInfo& printInfo)
@@ -2897,7 +2897,7 @@ static PrintInfo printInfoFromWKPrintInfo(const WKPrintInfo& printInfo)
 void WKPageComputePagesForPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo printInfo, WKPageComputePagesForPrintingFunction callback, void* context)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->computePagesForPrinting(toProtectedImpl(frame)->frameID(), printInfoFromWKPrintInfo(printInfo), [context, callback](const Vector<WebCore::IntRect>& rects, double scaleFactor, const WebCore::FloatBoxExtent& computedPageMargin) {
+    protect(toImpl(pageRef))->computePagesForPrinting(protect(toImpl(frame))->frameID(), printInfoFromWKPrintInfo(printInfo), [context, callback](const Vector<WebCore::IntRect>& rects, double scaleFactor, const WebCore::FloatBoxExtent& computedPageMargin) {
         auto wkRects = rects.map([](auto& rect) { return toAPI(rect); });
         callback(wkRects.mutableSpan().data(), wkRects.size(), scaleFactor, nullptr, context);
     });
@@ -2907,7 +2907,7 @@ void WKPageComputePagesForPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintI
 void WKPageDrawPagesToPDF(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo printInfo, uint32_t first, uint32_t count, WKPageDrawToPDFFunction callback, void* context)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->drawPagesToPDF(*toProtectedImpl(frame), printInfoFromWKPrintInfo(printInfo), first, count, [context, callback] (API::Data* data) {
+    protect(toImpl(pageRef))->drawPagesToPDF(*protect(toImpl(frame)), printInfoFromWKPrintInfo(printInfo), first, count, [context, callback] (API::Data* data) {
         callback(toAPI(data), nullptr, context);
     });
 }
@@ -2916,30 +2916,30 @@ void WKPageDrawPagesToPDF(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo print
 void WKPageBeginPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintInfo printInfo)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->beginPrinting(toProtectedImpl(frame).get(), printInfoFromWKPrintInfo(printInfo));
+    protect(toImpl(pageRef))->beginPrinting(protect(toImpl(frame)).get(), printInfoFromWKPrintInfo(printInfo));
 }
 
 void WKPageEndPrinting(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->endPrinting();
+    protect(toImpl(pageRef))->endPrinting();
 }
 
 bool WKPageGetIsControlledByAutomation(WKPageRef page)
 {
-    return toProtectedImpl(page)->isControlledByAutomation();
+    return protect(toImpl(page))->isControlledByAutomation();
 }
 
 void WKPageSetControlledByAutomation(WKPageRef pageRef, bool controlled)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setControlledByAutomation(controlled);
+    protect(toImpl(pageRef))->setControlledByAutomation(controlled);
 }
 
 bool WKPageGetAllowsRemoteInspection(WKPageRef page)
 {
 #if ENABLE(REMOTE_INSPECTOR)
-    return toProtectedImpl(page)->inspectable();
+    return protect(toImpl(page))->inspectable();
 #else
     UNUSED_PARAM(page);
     return false;
@@ -2950,7 +2950,7 @@ void WKPageSetAllowsRemoteInspection(WKPageRef pageRef, bool allow)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(REMOTE_INSPECTOR)
-    toProtectedImpl(pageRef)->setInspectable(allow);
+    protect(toImpl(pageRef))->setInspectable(allow);
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(allow);
@@ -2959,7 +2959,7 @@ void WKPageSetAllowsRemoteInspection(WKPageRef pageRef, bool allow)
 
 void WKPageShowWebInspectorForTesting(WKPageRef pageRef)
 {
-    RefPtr<WebInspectorUIProxy> inspector = toProtectedImpl(pageRef)->inspector();
+    RefPtr<WebInspectorUIProxy> inspector = protect(toImpl(pageRef))->inspector();
     inspector->markAsUnderTest();
     inspector->show();
 }
@@ -2967,7 +2967,7 @@ void WKPageShowWebInspectorForTesting(WKPageRef pageRef)
 void WKPageSetMediaVolume(WKPageRef pageRef, float volume)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setMediaVolume(volume);
+    protect(toImpl(pageRef))->setMediaVolume(volume);
 }
 
 void WKPageSetMuted(WKPageRef pageRef, WKMediaMutedState mutedState)
@@ -3000,25 +3000,25 @@ void WKPageSetMuted(WKPageRef pageRef, WKMediaMutedState mutedState)
     if (mutedState & kWKMediaMicrophoneCaptureUnmuted)
         coreState.remove(WebCore::MediaProducerMutedState::AudioCaptureIsMuted);
 
-    toProtectedImpl(pageRef)->setMuted(coreState, WebKit::WebPageProxy::FromApplication::Yes);
+    protect(toImpl(pageRef))->setMuted(coreState, WebKit::WebPageProxy::FromApplication::Yes);
 }
 
 void WKPageSetMediaCaptureEnabled(WKPageRef pageRef, bool enabled)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setMediaCaptureEnabled(enabled);
+    protect(toImpl(pageRef))->setMediaCaptureEnabled(enabled);
 }
 
 bool WKPageGetMediaCaptureEnabled(WKPageRef page)
 {
-    return toProtectedImpl(page)->mediaCaptureEnabled();
+    return protect(toImpl(page))->mediaCaptureEnabled();
 }
 
 void WKPageClearUserMediaState(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM)
-    toProtectedImpl(pageRef)->clearUserMediaState();
+    protect(toImpl(pageRef))->clearUserMediaState();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -3026,15 +3026,16 @@ void WKPageClearUserMediaState(WKPageRef pageRef)
 
 void WKPagePostMessageToInjectedBundle(WKPageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    toProtectedImpl(pageRef)->postMessageToInjectedBundle(toProtectedImpl(messageNameRef)->string(), toProtectedImpl(messageBodyRef).get());
+    protect(toImpl(pageRef))->postMessageToInjectedBundle(protect(toImpl(messageNameRef))->string(), protect(toImpl(messageBodyRef)).get());
 }
 
 WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
 {
     Vector<RefPtr<API::Object>> relatedPages;
 
-    for (Ref page : protect(toProtectedImpl(pageRef)->legacyMainFrameProcess())->pages()) {
-        if (page.ptr() != toProtectedImpl(pageRef))
+    RefPtr pageImpl = toImpl(pageRef);
+    for (Ref page : protect(pageImpl->legacyMainFrameProcess())->pages()) {
+        if (page.ptr() != pageImpl)
             relatedPages.append(WTF::move(page));
     }
 
@@ -3043,9 +3044,9 @@ WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
 
 WKFrameRef WKPageLookUpFrameFromHandle(WKPageRef pageRef, WKFrameHandleRef handleRef)
 {
-    RefPtr page = toProtectedImpl(pageRef);
-    RefPtr frame = WebFrameProxy::webFrame(toProtectedImpl(handleRef)->frameID());
-    if (!frame || frame->page() != page.get())
+    RefPtr pageImpl = toImpl(pageRef);
+    RefPtr frame = WebFrameProxy::webFrame(protect(toImpl(handleRef))->frameID());
+    if (!frame || frame->page() != pageImpl)
         return nullptr;
 
     return toAPI(frame.get());
@@ -3054,14 +3055,14 @@ WKFrameRef WKPageLookUpFrameFromHandle(WKPageRef pageRef, WKFrameHandleRef handl
 void WKPageSetMayStartMediaWhenInWindow(WKPageRef pageRef, bool mayStartMedia)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setMayStartMediaWhenInWindow(mayStartMedia);
+    protect(toImpl(pageRef))->setMayStartMediaWhenInWindow(mayStartMedia);
 }
 
 void WKPageSelectContextMenuItem(WKPageRef pageRef, WKContextMenuItemRef item, WKFrameInfoRef frameInfo)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(CONTEXT_MENUS)
-    toProtectedImpl(pageRef)->contextMenuItemSelected((toProtectedImpl(item)->data()), toProtectedImpl(frameInfo)->frameInfoData());
+    protect(toImpl(pageRef))->contextMenuItemSelected((protect(toImpl(item))->data()), protect(toImpl(frameInfo))->frameInfoData());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(item);
@@ -3070,7 +3071,7 @@ void WKPageSelectContextMenuItem(WKPageRef pageRef, WKContextMenuItemRef item, W
 
 WKScrollPinningBehavior WKPageGetScrollPinningBehavior(WKPageRef page)
 {
-    ScrollPinningBehavior pinning = toProtectedImpl(page)->scrollPinningBehavior();
+    ScrollPinningBehavior pinning = protect(toImpl(page))->scrollPinningBehavior();
     
     switch (pinning) {
     case WebCore::ScrollPinningBehavior::DoNotPin:
@@ -3104,28 +3105,28 @@ void WKPageSetScrollPinningBehavior(WKPageRef pageRef, WKScrollPinningBehavior p
         ASSERT_NOT_REACHED();
     }
     
-    toProtectedImpl(pageRef)->setScrollPinningBehavior(corePinning);
+    protect(toImpl(pageRef))->setScrollPinningBehavior(corePinning);
 }
 
 bool WKPageGetAddsVisitedLinks(WKPageRef page)
 {
-    return toProtectedImpl(page)->addsVisitedLinks();
+    return protect(toImpl(page))->addsVisitedLinks();
 }
 
 void WKPageSetAddsVisitedLinks(WKPageRef pageRef, bool addsVisitedLinks)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setAddsVisitedLinks(addsVisitedLinks);
+    protect(toImpl(pageRef))->setAddsVisitedLinks(addsVisitedLinks);
 }
 
 bool WKPageIsPlayingAudio(WKPageRef page)
 {
-    return toProtectedImpl(page)->isPlayingAudio();
+    return protect(toImpl(page))->isPlayingAudio();
 }
 
 WKMediaState WKPageGetMediaState(WKPageRef page)
 {
-    WebCore::MediaProducerMediaStateFlags coreState = toProtectedImpl(page)->reportedMediaState();
+    WebCore::MediaProducerMediaStateFlags coreState = protect(toImpl(page))->reportedMediaState();
     WKMediaState state = kWKMediaIsNotPlaying;
 
     if (coreState & WebCore::MediaProducerMediaState::IsPlayingAudio)
@@ -3155,14 +3156,14 @@ WKMediaState WKPageGetMediaState(WKPageRef page)
 void WKPageClearWheelEventTestMonitor(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting())
         pageForTesting->clearWheelEventTestMonitor();
 }
 
 void WKPageCallAfterNextPresentationUpdate(WKPageRef pageRef, void* context, WKPagePostPresentationUpdateFunction callback)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->callAfterNextPresentationUpdate([context, callback] {
+    protect(toImpl(pageRef))->callAfterNextPresentationUpdate([context, callback] {
         callback(nullptr, context);
     });
 }
@@ -3171,24 +3172,24 @@ void WKPageSetIgnoresViewportScaleLimits(WKPageRef pageRef, bool ignoresViewport
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(META_VIEWPORT)
-    toProtectedImpl(pageRef)->setForceAlwaysUserScalable(ignoresViewportScaleLimits);
+    protect(toImpl(pageRef))->setForceAlwaysUserScalable(ignoresViewportScaleLimits);
 #endif
 }
 
 void WKPageSetUseDarkAppearanceForTesting(WKPageRef pageRef, bool useDarkAppearance)
 {
-    toProtectedImpl(pageRef)->setUseDarkAppearanceForTesting(useDarkAppearance);
+    protect(toImpl(pageRef))->setUseDarkAppearanceForTesting(useDarkAppearance);
 }
 
 ProcessID WKPageGetProcessIdentifier(WKPageRef page)
 {
-    return toProtectedImpl(page)->legacyMainFrameProcessID();
+    return protect(toImpl(page))->legacyMainFrameProcessID();
 }
 
 ProcessID WKPageGetGPUProcessIdentifier(WKPageRef page)
 {
 #if ENABLE(GPU_PROCESS)
-    RefPtr gpuProcess = toProtectedImpl(page)->configuration().processPool().gpuProcess();
+    RefPtr gpuProcess = protect(toImpl(page))->configuration().processPool().gpuProcess();
     if (!gpuProcess)
         return 0;
     return gpuProcess->processID();
@@ -3201,7 +3202,7 @@ void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApp
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(APPLICATION_MANIFEST)
-    toProtectedImpl(pageRef)->getApplicationManifest([function, context](const std::optional<WebCore::ApplicationManifest>& manifest) {
+    protect(toImpl(pageRef))->getApplicationManifest([function, context](const std::optional<WebCore::ApplicationManifest>& manifest) {
         function(context);
     });
 #else
@@ -3213,7 +3214,7 @@ void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApp
 void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClickMeasurementFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(nullptr, callbackContext);
 
@@ -3225,7 +3226,7 @@ void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClick
 void WKPageClearPrivateClickMeasurement(WKPageRef pageRef, WKPageClearPrivateClickMeasurementFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3237,7 +3238,7 @@ void WKPageClearPrivateClickMeasurement(WKPageRef pageRef, WKPageClearPrivateCli
 void WKPageSetPrivateClickMeasurementOverrideTimerForTesting(WKPageRef pageRef, bool value, WKPageSetPrivateClickMeasurementOverrideTimerForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3249,7 +3250,7 @@ void WKPageSetPrivateClickMeasurementOverrideTimerForTesting(WKPageRef pageRef, 
 void WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3261,7 +3262,7 @@ void WKPageMarkAttributedPrivateClickMeasurementsAsExpiredForTesting(WKPageRef p
 void WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting(WKPageRef pageRef, bool value, WKPageSetPrivateClickMeasurementEphemeralMeasurementForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3273,7 +3274,7 @@ void WKPageSetPrivateClickMeasurementEphemeralMeasurementForTesting(WKPageRef pa
 void WKPageSimulatePrivateClickMeasurementSessionRestart(WKPageRef pageRef, WKPageSimulatePrivateClickMeasurementSessionRestartFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3285,7 +3286,7 @@ void WKPageSimulatePrivateClickMeasurementSessionRestart(WKPageRef pageRef, WKPa
 void WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting(WKPageRef pageRef, WKURLRef URLRef, WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3297,7 +3298,7 @@ void WKPageSetPrivateClickMeasurementTokenPublicKeyURLForTesting(WKPageRef pageR
 void WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting(WKPageRef pageRef, WKURLRef URLRef, WKPageSetPrivateClickMeasurementTokenSignatureURLForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3309,7 +3310,7 @@ void WKPageSetPrivateClickMeasurementTokenSignatureURLForTesting(WKPageRef pageR
 void WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting(WKPageRef pageRef, WKURLRef sourceURL, WKURLRef destinationURL, WKPageSetPrivateClickMeasurementAttributionReportURLsForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3321,7 +3322,7 @@ void WKPageSetPrivateClickMeasurementAttributionReportURLsForTesting(WKPageRef p
 void WKPageMarkPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WKPageMarkPrivateClickMeasurementsAsExpiredForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3333,7 +3334,7 @@ void WKPageMarkPrivateClickMeasurementsAsExpiredForTesting(WKPageRef pageRef, WK
 void WKPageSetPCMFraudPreventionValuesForTesting(WKPageRef pageRef, WKStringRef unlinkableToken, WKStringRef secretToken, WKStringRef signature, WKStringRef keyID, WKPageSetPCMFraudPreventionValuesForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3345,7 +3346,7 @@ void WKPageSetPCMFraudPreventionValuesForTesting(WKPageRef pageRef, WKStringRef 
 void WKPageSetPrivateClickMeasurementAppBundleIDForTesting(WKPageRef pageRef, WKStringRef appBundleIDForTesting, WKPageSetPrivateClickMeasurementAppBundleIDForTestingFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(callbackContext);
 
@@ -3357,7 +3358,7 @@ void WKPageSetPrivateClickMeasurementAppBundleIDForTesting(WKPageRef pageRef, WK
 void WKPageSetMockCameraOrientationForTesting(WKPageRef pageRef, uint64_t rotation, WKStringRef persistentId)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setMediaCaptureRotationForTesting(rotation, toWTFString(persistentId));
+    protect(toImpl(pageRef))->setMediaCaptureRotationForTesting(rotation, toWTFString(persistentId));
 }
 
 bool WKPageIsMockRealtimeMediaSourceCenterEnabled(WKPageRef)
@@ -3373,14 +3374,14 @@ void WKPageSetMockCaptureDevicesInterrupted(WKPageRef pageRef, bool isCameraInte
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM) && ENABLE(GPU_PROCESS)
-    Ref preferences = toProtectedImpl(pageRef)->preferences();
+    Ref preferences = protect(toImpl(pageRef))->preferences();
     if (preferences->useGPUProcessForMediaEnabled()) {
-        Ref gpuProcess = protect(toProtectedImpl(pageRef)->configuration().processPool())->ensureGPUProcess();
+        Ref gpuProcess = protect(protect(toImpl(pageRef))->configuration().processPool())->ensureGPUProcess();
         gpuProcess->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
     }
 #endif
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
-    toProtectedImpl(pageRef)->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
+    protect(toImpl(pageRef))->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
 #endif
 }
 
@@ -3389,17 +3390,17 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forCame
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM)
 #if USE(GSTREAMER)
-    toProtectedImpl(pageRef)->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
+    protect(toImpl(pageRef))->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #else
     MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #endif // USE(GSTREAMER)
 
 #if ENABLE(GPU_PROCESS)
-    Ref preferences = toProtectedImpl(pageRef)->preferences();
+    Ref preferences = protect(toImpl(pageRef))->preferences();
     if (!preferences->useGPUProcessForMediaEnabled())
         return;
 
-    Ref gpuProcess = protect(toProtectedImpl(pageRef)->configuration().processPool())->ensureGPUProcess();
+    Ref gpuProcess = protect(protect(toImpl(pageRef))->configuration().processPool())->ensureGPUProcess();
     gpuProcess->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #endif // ENABLE(GPU_PROCESS)
 
@@ -3409,7 +3410,7 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forCame
 void WKPageLoadedSubresourceDomains(WKPageRef pageRef, WKPageLoadedSubresourceDomainsFunction callback, void* callbackContext)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->getLoadedSubresourceDomains([callbackContext, callback](Vector<RegistrableDomain>&& domains) {
+    protect(toImpl(pageRef))->getLoadedSubresourceDomains([callbackContext, callback](Vector<RegistrableDomain>&& domains) {
         Vector<RefPtr<API::Object>> apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
             return API::String::create(String(domain.string()));
         });
@@ -3420,52 +3421,52 @@ void WKPageLoadedSubresourceDomains(WKPageRef pageRef, WKPageLoadedSubresourceDo
 void WKPageClearLoadedSubresourceDomains(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->clearLoadedSubresourceDomains();
+    protect(toImpl(pageRef))->clearLoadedSubresourceDomains();
 }
 
 void WKPageSetMediaCaptureReportingDelayForTesting(WKPageRef pageRef, double delay)
 {
     CRASH_IF_SUSPENDED;
-    toProtectedImpl(pageRef)->setMediaCaptureReportingDelay(Seconds(delay));
+    protect(toImpl(pageRef))->setMediaCaptureReportingDelay(Seconds(delay));
 }
 
 void WKPageDispatchActivityStateUpdateForTesting(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
+    if (RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting())
         pageForTesting->dispatchActivityStateUpdate();
 }
 
 void WKPageClearNotificationPermissionState(WKPageRef pageRef)
 {
 #if ENABLE(NOTIFICATIONS)
-    toProtectedImpl(pageRef)->clearNotificationPermissionState();
+    protect(toImpl(pageRef))->clearNotificationPermissionState();
 #endif
 }
 
 void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKStringRef value)
 {
-    toProtectedImpl(pageRef)->executeEditCommand(toProtectedImpl(command)->string(), toProtectedImpl(value)->string());
+    protect(toImpl(pageRef))->executeEditCommand(protect(toImpl(command))->string(), protect(toImpl(value))->string());
 }
 
 bool WKPageIsEditingCommandEnabledForTesting(WKPageRef pageRef, WKStringRef command)
 {
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return false;
 
-    return pageForTesting->isEditingCommandEnabled(toProtectedImpl(command)->string());
+    return pageForTesting->isEditingCommandEnabled(protect(toImpl(command))->string());
 }
 
 void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, bool allowed)
 {
-    if (RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting())
-        pageForTesting->setPermissionLevel(toProtectedImpl(origin)->string(), allowed);
+    if (RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting())
+        pageForTesting->setPermissionLevel(protect(toImpl(origin))->string(), allowed);
 }
 
 void WKPageSetObscuredContentInsetsForTesting(WKPageRef pageRef, float top, float right, float bottom, float left, void* context, WKPageSetObscuredContentInsetsForTestingFunction callback)
 {
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return callback(context);
 
@@ -3476,14 +3477,14 @@ void WKPageSetObscuredContentInsetsForTesting(WKPageRef pageRef, float top, floa
 
 void WKPageSetPageScaleFactorForTesting(WKPageRef pageRef, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler)
 {
-    toProtectedImpl(pageRef)->scalePage(scaleFactor, toIntPoint(point), [context, completionHandler] {
+    protect(toImpl(pageRef))->scalePage(scaleFactor, toIntPoint(point), [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKPageClearBackForwardListForTesting(WKPageRef pageRef, void* context, WKPageClearBackForwardListForTestingFunction completionHandler)
 {
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return completionHandler(context);
 
@@ -3494,7 +3495,7 @@ void WKPageClearBackForwardListForTesting(WKPageRef pageRef, void* context, WKPa
 
 void WKPageSetTracksRepaintsForTesting(WKPageRef pageRef, void* context, bool trackRepaints, WKPageSetTracksRepaintsForTestingFunction completionHandler)
 {
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return completionHandler(context);
 
@@ -3505,7 +3506,7 @@ void WKPageSetTracksRepaintsForTesting(WKPageRef pageRef, void* context, bool tr
 
 void WKPageDisplayAndTrackRepaintsForTesting(WKPageRef pageRef, void* context, WKPageDisplayAndTrackRepaintsForTestingFunction completionHandler)
 {
-    RefPtr pageForTesting = toProtectedImpl(pageRef)->pageForTesting();
+    RefPtr pageForTesting = protect(toImpl(pageRef))->pageForTesting();
     if (!pageForTesting)
         return completionHandler(context);
 
@@ -3516,20 +3517,20 @@ void WKPageDisplayAndTrackRepaintsForTesting(WKPageRef pageRef, void* context, W
 
 void WKPageFindStringForTesting(WKPageRef pageRef, void* context, WKStringRef string, WKFindOptions options, unsigned maxMatchCount, WKPageFindStringForTestingFunction completionHandler)
 {
-    toProtectedImpl(pageRef)->findString(toWTFString(string), toFindOptions(options), maxMatchCount, [context, completionHandler] (bool found) {
+    protect(toImpl(pageRef))->findString(toWTFString(string), toFindOptions(options), maxMatchCount, [context, completionHandler] (bool found) {
         completionHandler(found, context);
     });
 }
 
 void WKPageClearBackForwardCache(WKPageRef page)
 {
-    RefPtr protectedPage = toProtectedImpl(page);
-    protect(protectedPage->backForwardCache())->removeEntriesForPage(*protectedPage);
+    RefPtr pageImpl = toImpl(page);
+    protect(pageImpl->backForwardCache())->removeEntriesForPage(*pageImpl);
 }
 
 void WKPageDoAfterProcessingAllPendingMouseEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingMouseEventsFunction completionHandler)
 {
-    toProtectedImpl(page)->doAfterProcessingAllPendingMouseEvents([context, completionHandler] {
+    protect(toImpl(page))->doAfterProcessingAllPendingMouseEvents([context, completionHandler] {
         completionHandler(context);
     });
 }

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -49,12 +49,12 @@ WKPageConfigurationRef WKPageConfigurationCreate()
 
 WKContextRef WKPageConfigurationGetContext(WKPageConfigurationRef configuration)
 {
-    return toAPI(protect(toProtectedImpl(configuration)->processPool()).get());
+    return toAPI(protect(protect(toImpl(configuration))->processPool()).get());
 }
 
 void WKPageConfigurationSetContext(WKPageConfigurationRef configuration, WKContextRef context)
 {
-    toProtectedImpl(configuration)->setProcessPool(toProtectedImpl(context));
+    protect(toImpl(configuration))->setProcessPool(protect(toImpl(context)));
 }
 
 WKPageGroupRef WKPageConfigurationGetPageGroup(WKPageConfigurationRef)
@@ -68,75 +68,75 @@ void WKPageConfigurationSetPageGroup(WKPageConfigurationRef, WKPageGroupRef)
 
 WKUserContentControllerRef WKPageConfigurationGetUserContentController(WKPageConfigurationRef configuration)
 {
-    return toAPI(protect(toProtectedImpl(configuration)->userContentController()).get());
+    return toAPI(protect(protect(toImpl(configuration))->userContentController()).get());
 }
 
 void WKPageConfigurationSetUserContentController(WKPageConfigurationRef configuration, WKUserContentControllerRef userContentController)
 {
-    toProtectedImpl(configuration)->setUserContentController(toProtectedImpl(userContentController));
+    protect(toImpl(configuration))->setUserContentController(protect(toImpl(userContentController)));
 }
 
 WKPreferencesRef WKPageConfigurationGetPreferences(WKPageConfigurationRef configuration)
 {
-    return toAPI(protect(toProtectedImpl(configuration)->preferences()).get());
+    return toAPI(protect(protect(toImpl(configuration))->preferences()).get());
 }
 
 void WKPageConfigurationSetPreferences(WKPageConfigurationRef configuration, WKPreferencesRef preferences)
 {
-    toProtectedImpl(configuration)->setPreferences(toProtectedImpl(preferences));
+    protect(toImpl(configuration))->setPreferences(protect(toImpl(preferences)));
 }
 
 WKPageRef WKPageConfigurationGetRelatedPage(WKPageConfigurationRef configuration)
 {
-    return toAPI(protect(toProtectedImpl(configuration)->relatedPage()).get());
+    return toAPI(protect(protect(toImpl(configuration))->relatedPage()).get());
 }
 
 void WKPageConfigurationSetRelatedPage(WKPageConfigurationRef configuration, WKPageRef relatedPage)
 {
-    toProtectedImpl(configuration)->setRelatedPage(toProtectedImpl(relatedPage));
+    protect(toImpl(configuration))->setRelatedPage(protect(toImpl(relatedPage)));
 }
 
 WKWebsiteDataStoreRef WKPageConfigurationGetWebsiteDataStore(WKPageConfigurationRef configuration)
 {
-    return toAPI(protect(toProtectedImpl(configuration)->websiteDataStore()).get());
+    return toAPI(protect(protect(toImpl(configuration))->websiteDataStore()).get());
 }
 
 void WKPageConfigurationSetWebsiteDataStore(WKPageConfigurationRef configuration, WKWebsiteDataStoreRef websiteDataStore)
 {
-    toProtectedImpl(configuration)->setWebsiteDataStore(toProtectedImpl(websiteDataStore));
+    protect(toImpl(configuration))->setWebsiteDataStore(protect(toImpl(websiteDataStore)));
 }
 
 void WKPageConfigurationSetInitialCapitalizationEnabled(WKPageConfigurationRef configuration, bool enabled)
 {
-    toProtectedImpl(configuration)->setInitialCapitalizationEnabled(enabled);
+    protect(toImpl(configuration))->setInitialCapitalizationEnabled(enabled);
 }
 
 void WKPageConfigurationSetBackgroundCPULimit(WKPageConfigurationRef configuration, double cpuLimit)
 {
-    toProtectedImpl(configuration)->setCPULimit(cpuLimit);
+    protect(toImpl(configuration))->setCPULimit(cpuLimit);
 }
 
 void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration, bool allowTestOnlyIPC)
 {
-    toProtectedImpl(configuration)->setAllowTestOnlyIPC(allowTestOnlyIPC);
+    protect(toImpl(configuration))->setAllowTestOnlyIPC(allowTestOnlyIPC);
 }
 
 void WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(WKPageConfigurationRef configuration, bool should)
 {
-    toProtectedImpl(configuration)->setShouldSendConsoleLogsToUIProcessForTesting(should);
+    protect(toImpl(configuration))->setShouldSendConsoleLogsToUIProcessForTesting(should);
 }
 
 void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
 {
-    toProtectedImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
+    protect(toImpl(configuration))->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
 }
 
 WKWebsitePoliciesRef WKPageConfigurationGetDefaultWebsitePolicies(WKPageConfigurationRef configuration)
 {
-    return toAPI(protect(toProtectedImpl(configuration)->defaultWebsitePolicies()).get());
+    return toAPI(protect(protect(toImpl(configuration))->defaultWebsitePolicies()).get());
 }
 
 void WKPageConfigurationSetDefaultWebsitePolicies(WKPageConfigurationRef configuration, WKWebsitePoliciesRef policies)
 {
-    toProtectedImpl(configuration)->setDefaultWebsitePolicies(toProtectedImpl(policies));
+    protect(toImpl(configuration))->setDefaultWebsitePolicies(protect(toImpl(policies)));
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -52,17 +52,17 @@ WKPreferencesRef WKPreferencesCreateWithIdentifier(WKStringRef identifierRef)
 
 WKPreferencesRef WKPreferencesCreateCopy(WKPreferencesRef preferencesRef)
 {
-    return toAPILeakingRef(toProtectedImpl(preferencesRef)->copy());
+    return toAPILeakingRef(protect(toImpl(preferencesRef))->copy());
 }
 
 void WKPreferencesStartBatchingUpdates(WKPreferencesRef preferencesRef)
 {
-    toProtectedImpl(preferencesRef)->startBatchingUpdates();
+    protect(toImpl(preferencesRef))->startBatchingUpdates();
 }
 
 void WKPreferencesEndBatchingUpdates(WKPreferencesRef preferencesRef)
 {
-    toProtectedImpl(preferencesRef)->endBatchingUpdates();
+    protect(toImpl(preferencesRef))->endBatchingUpdates();
 }
 
 WKArrayRef WKPreferencesCopyExperimentalFeatures(WKPreferencesRef preferencesRef)
@@ -73,12 +73,12 @@ WKArrayRef WKPreferencesCopyExperimentalFeatures(WKPreferencesRef preferencesRef
 
 void WKPreferencesEnableAllExperimentalFeatures(WKPreferencesRef preferencesRef)
 {
-    toProtectedImpl(preferencesRef)->enableAllExperimentalFeatures();
+    protect(toImpl(preferencesRef))->enableAllExperimentalFeatures();
 }
 
 void WKPreferencesSetExperimentalFeatureForKey(WKPreferencesRef preferencesRef, bool value, WKStringRef experimentalFeatureKey)
 {
-    toProtectedImpl(preferencesRef)->setFeatureEnabledForKey(toWTFString(experimentalFeatureKey), value);
+    protect(toImpl(preferencesRef))->setFeatureEnabledForKey(toWTFString(experimentalFeatureKey), value);
 }
 
 WKArrayRef WKPreferencesCopyInternalDebugFeatures(WKPreferencesRef preferencesRef)
@@ -89,1535 +89,1535 @@ WKArrayRef WKPreferencesCopyInternalDebugFeatures(WKPreferencesRef preferencesRe
 
 void WKPreferencesResetAllInternalDebugFeatures(WKPreferencesRef preferencesRef)
 {
-    toProtectedImpl(preferencesRef)->resetAllInternalDebugFeatures();
+    protect(toImpl(preferencesRef))->resetAllInternalDebugFeatures();
 }
 
 void WKPreferencesSetInternalDebugFeatureForKey(WKPreferencesRef preferencesRef, bool value, WKStringRef internalDebugFeatureKey)
 {
-    toProtectedImpl(preferencesRef)->setFeatureEnabledForKey(toWTFString(internalDebugFeatureKey), value);
+    protect(toImpl(preferencesRef))->setFeatureEnabledForKey(toWTFString(internalDebugFeatureKey), value);
 }
 
 void WKPreferencesSetBoolValueForKeyForTesting(WKPreferencesRef preferencesRef, bool value, WKStringRef key)
 {
-    toProtectedImpl(preferencesRef)->setBoolValueForKey(toWTFString(key), value, true);
+    protect(toImpl(preferencesRef))->setBoolValueForKey(toWTFString(key), value, true);
 }
 
 void WKPreferencesSetDoubleValueForKeyForTesting(WKPreferencesRef preferencesRef, double value, WKStringRef key)
 {
-    toProtectedImpl(preferencesRef)->setBoolValueForKey(toWTFString(key), value, true);
+    protect(toImpl(preferencesRef))->setBoolValueForKey(toWTFString(key), value, true);
 }
 
 void WKPreferencesSetUInt32ValueForKeyForTesting(WKPreferencesRef preferencesRef, uint32_t value, WKStringRef key)
 {
-    toProtectedImpl(preferencesRef)->setUInt32ValueForKey(toWTFString(key), value, true);
+    protect(toImpl(preferencesRef))->setUInt32ValueForKey(toWTFString(key), value, true);
 }
 
 void WKPreferencesSetStringValueForKeyForTesting(WKPreferencesRef preferencesRef, WKStringRef value, WKStringRef key)
 {
-    toProtectedImpl(preferencesRef)->setStringValueForKey(toWTFString(key), toWTFString(value), true);
+    protect(toImpl(preferencesRef))->setStringValueForKey(toWTFString(key), toWTFString(value), true);
 }
 
 void WKPreferencesResetTestRunnerOverrides(WKPreferencesRef preferencesRef)
 {
     // Currently we reset the overrides on the web process when preferencesDidChange() is called. Since WTR preferences
     // are usually always the same (in the UI process), they are not sent to web process, not triggering the reset.
-    toProtectedImpl(preferencesRef)->forceUpdate();
+    protect(toImpl(preferencesRef))->forceUpdate();
 }
 
 void WKPreferencesSetJavaScriptEnabled(WKPreferencesRef preferencesRef, bool javaScriptEnabled)
 {
-    toProtectedImpl(preferencesRef)->setJavaScriptEnabled(javaScriptEnabled);
+    protect(toImpl(preferencesRef))->setJavaScriptEnabled(javaScriptEnabled);
 }
 
 bool WKPreferencesGetJavaScriptEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->javaScriptEnabled();
+    return protect(toImpl(preferencesRef))->javaScriptEnabled();
 }
 
 void WKPreferencesSetJavaScriptMarkupEnabled(WKPreferencesRef preferencesRef, bool javaScriptMarkupEnabled)
 {
-    toProtectedImpl(preferencesRef)->setJavaScriptMarkupEnabled(javaScriptMarkupEnabled);
+    protect(toImpl(preferencesRef))->setJavaScriptMarkupEnabled(javaScriptMarkupEnabled);
 }
 
 bool WKPreferencesGetJavaScriptMarkupEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->javaScriptMarkupEnabled();
+    return protect(toImpl(preferencesRef))->javaScriptMarkupEnabled();
 }
 
 void WKPreferencesSetLoadsImagesAutomatically(WKPreferencesRef preferencesRef, bool loadsImagesAutomatically)
 {
-    toProtectedImpl(preferencesRef)->setLoadsImagesAutomatically(loadsImagesAutomatically);
+    protect(toImpl(preferencesRef))->setLoadsImagesAutomatically(loadsImagesAutomatically);
 }
 
 bool WKPreferencesGetLoadsImagesAutomatically(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->loadsImagesAutomatically();
+    return protect(toImpl(preferencesRef))->loadsImagesAutomatically();
 }
 
 void WKPreferencesSetLocalStorageEnabled(WKPreferencesRef preferencesRef, bool localStorageEnabled)
 {
-    toProtectedImpl(preferencesRef)->setLocalStorageEnabled(localStorageEnabled);
+    protect(toImpl(preferencesRef))->setLocalStorageEnabled(localStorageEnabled);
 }
 
 bool WKPreferencesGetLocalStorageEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->localStorageEnabled();
+    return protect(toImpl(preferencesRef))->localStorageEnabled();
 }
 
 void WKPreferencesSetDatabasesEnabled(WKPreferencesRef preferencesRef, bool databasesEnabled)
 {
-    toProtectedImpl(preferencesRef)->setDatabasesEnabled(databasesEnabled);
+    protect(toImpl(preferencesRef))->setDatabasesEnabled(databasesEnabled);
 }
 
 bool WKPreferencesGetDatabasesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->databasesEnabled();
+    return protect(toImpl(preferencesRef))->databasesEnabled();
 }
 
 void WKPreferencesSetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef preferencesRef, bool javaScriptCanOpenWindowsAutomatically)
 {
-    toProtectedImpl(preferencesRef)->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
+    protect(toImpl(preferencesRef))->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
 }
 
 bool WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->javaScriptCanOpenWindowsAutomatically();
+    return protect(toImpl(preferencesRef))->javaScriptCanOpenWindowsAutomatically();
 }
 
 void WKPreferencesSetStandardFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setStandardFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setStandardFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyStandardFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->standardFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->standardFontFamily());
 }
 
 void WKPreferencesSetFixedFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setFixedFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setFixedFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyFixedFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->fixedFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->fixedFontFamily());
 }
 
 void WKPreferencesSetSerifFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setSerifFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setSerifFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopySerifFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->serifFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->serifFontFamily());
 }
 
 void WKPreferencesSetSansSerifFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setSansSerifFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setSansSerifFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopySansSerifFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->sansSerifFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->sansSerifFontFamily());
 }
 
 void WKPreferencesSetCursiveFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setCursiveFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setCursiveFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyCursiveFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->cursiveFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->cursiveFontFamily());
 }
 
 void WKPreferencesSetFantasyFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setFantasyFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setFantasyFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyFantasyFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->fantasyFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->fantasyFontFamily());
 }
 
 void WKPreferencesSetPictographFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setPictographFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setPictographFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyPictographFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->pictographFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->pictographFontFamily());
 }
 
 void WKPreferencesSetMathFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
-    toProtectedImpl(preferencesRef)->setMathFontFamily(toWTFString(family));
+    protect(toImpl(preferencesRef))->setMathFontFamily(toWTFString(family));
 }
 
 WKStringRef WKPreferencesCopyMathFontFamily(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->mathFontFamily());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->mathFontFamily());
 }
 
 void WKPreferencesSetDefaultFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
-    toProtectedImpl(preferencesRef)->setDefaultFontSize(size);
+    protect(toImpl(preferencesRef))->setDefaultFontSize(size);
 }
 
 uint32_t WKPreferencesGetDefaultFontSize(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->defaultFontSize();
+    return protect(toImpl(preferencesRef))->defaultFontSize();
 }
 
 void WKPreferencesSetDefaultFixedFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
-    toProtectedImpl(preferencesRef)->setDefaultFixedFontSize(size);
+    protect(toImpl(preferencesRef))->setDefaultFixedFontSize(size);
 }
 
 uint32_t WKPreferencesGetDefaultFixedFontSize(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->defaultFixedFontSize();
+    return protect(toImpl(preferencesRef))->defaultFixedFontSize();
 }
 
 void WKPreferencesSetMinimumFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
-    toProtectedImpl(preferencesRef)->setMinimumFontSize(size);
+    protect(toImpl(preferencesRef))->setMinimumFontSize(size);
 }
 
 uint32_t WKPreferencesGetMinimumFontSize(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->minimumFontSize();
+    return protect(toImpl(preferencesRef))->minimumFontSize();
 }
 
 
 void WKPreferencesSetCookieEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setCookieEnabled(enabled);
+    protect(toImpl(preferencesRef))->setCookieEnabled(enabled);
 }
 
 bool WKPreferencesGetCookieEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->cookieEnabled();
+    return protect(toImpl(preferencesRef))->cookieEnabled();
 }
 
 void WKPreferencesSetEditableLinkBehavior(WKPreferencesRef preferencesRef, WKEditableLinkBehavior wkBehavior)
 {
-    toProtectedImpl(preferencesRef)->setEditableLinkBehavior(static_cast<uint32_t>(toEditableLinkBehavior(wkBehavior)));
+    protect(toImpl(preferencesRef))->setEditableLinkBehavior(static_cast<uint32_t>(toEditableLinkBehavior(wkBehavior)));
 }
 
 WKEditableLinkBehavior WKPreferencesGetEditableLinkBehavior(WKPreferencesRef preferencesRef)
 {
-    return toAPI(static_cast<WebCore::EditableLinkBehavior>(toProtectedImpl(preferencesRef)->editableLinkBehavior()));
+    return toAPI(static_cast<WebCore::EditableLinkBehavior>(protect(toImpl(preferencesRef))->editableLinkBehavior()));
 }
 
 void WKPreferencesSetDefaultTextEncodingName(WKPreferencesRef preferencesRef, WKStringRef name)
 {
-    toProtectedImpl(preferencesRef)->setDefaultTextEncodingName(toWTFString(name));
+    protect(toImpl(preferencesRef))->setDefaultTextEncodingName(toWTFString(name));
 }
 
 WKStringRef WKPreferencesCopyDefaultTextEncodingName(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->defaultTextEncodingName());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->defaultTextEncodingName());
 }
 
 void WKPreferencesSetDeveloperExtrasEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setDeveloperExtrasEnabled(enabled);
+    protect(toImpl(preferencesRef))->setDeveloperExtrasEnabled(enabled);
 }
 
 bool WKPreferencesGetDeveloperExtrasEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->developerExtrasEnabled();
+    return protect(toImpl(preferencesRef))->developerExtrasEnabled();
 }
 
 void WKPreferencesSetJavaScriptRuntimeFlags(WKPreferencesRef preferencesRef, WKJavaScriptRuntimeFlagSet javaScriptRuntimeFlagSet)
 {
-    toProtectedImpl(preferencesRef)->setJavaScriptRuntimeFlags(javaScriptRuntimeFlagSet);
+    protect(toImpl(preferencesRef))->setJavaScriptRuntimeFlags(javaScriptRuntimeFlagSet);
 }
 
 WKJavaScriptRuntimeFlagSet WKPreferencesGetJavaScriptRuntimeFlags(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->javaScriptRuntimeFlags();
+    return protect(toImpl(preferencesRef))->javaScriptRuntimeFlags();
 }
 
 void WKPreferencesSetTextAreasAreResizable(WKPreferencesRef preferencesRef, bool resizable)
 {
-    toProtectedImpl(preferencesRef)->setTextAreasAreResizable(resizable);
+    protect(toImpl(preferencesRef))->setTextAreasAreResizable(resizable);
 }
 
 bool WKPreferencesGetTextAreasAreResizable(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->textAreasAreResizable();
+    return protect(toImpl(preferencesRef))->textAreasAreResizable();
 }
 
 void WKPreferencesSetAcceleratedDrawingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setAcceleratedDrawingEnabled(flag);
+    protect(toImpl(preferencesRef))->setAcceleratedDrawingEnabled(flag);
 }
 
 bool WKPreferencesGetAcceleratedDrawingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->acceleratedDrawingEnabled();
+    return protect(toImpl(preferencesRef))->acceleratedDrawingEnabled();
 }
 
 void WKPreferencesSetCanvasUsesAcceleratedDrawing(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setCanvasUsesAcceleratedDrawing(flag);
+    protect(toImpl(preferencesRef))->setCanvasUsesAcceleratedDrawing(flag);
 }
 
 bool WKPreferencesGetCanvasUsesAcceleratedDrawing(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->canvasUsesAcceleratedDrawing();
+    return protect(toImpl(preferencesRef))->canvasUsesAcceleratedDrawing();
 }
 
 void WKPreferencesSetAcceleratedCompositingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setAcceleratedCompositingEnabled(flag);
+    protect(toImpl(preferencesRef))->setAcceleratedCompositingEnabled(flag);
 }
 
 bool WKPreferencesGetAcceleratedCompositingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->acceleratedCompositingEnabled();
+    return protect(toImpl(preferencesRef))->acceleratedCompositingEnabled();
 }
 
 void WKPreferencesSetCompositingBordersVisible(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setCompositingBordersVisible(flag);
+    protect(toImpl(preferencesRef))->setCompositingBordersVisible(flag);
 }
 
 bool WKPreferencesGetCompositingBordersVisible(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->compositingBordersVisible();
+    return protect(toImpl(preferencesRef))->compositingBordersVisible();
 }
 
 void WKPreferencesSetCompositingRepaintCountersVisible(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setCompositingRepaintCountersVisible(flag);
+    protect(toImpl(preferencesRef))->setCompositingRepaintCountersVisible(flag);
 }
 
 bool WKPreferencesGetCompositingRepaintCountersVisible(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->compositingRepaintCountersVisible();
+    return protect(toImpl(preferencesRef))->compositingRepaintCountersVisible();
 }
 
 void WKPreferencesSetTiledScrollingIndicatorVisible(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setTiledScrollingIndicatorVisible(flag);
+    protect(toImpl(preferencesRef))->setTiledScrollingIndicatorVisible(flag);
 }
 
 bool WKPreferencesGetTiledScrollingIndicatorVisible(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->tiledScrollingIndicatorVisible();
+    return protect(toImpl(preferencesRef))->tiledScrollingIndicatorVisible();
 }
 
 void WKPreferencesSetWebGLEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setWebGLEnabled(flag);
+    protect(toImpl(preferencesRef))->setWebGLEnabled(flag);
 }
 
 bool WKPreferencesGetWebGLEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webGLEnabled();
+    return protect(toImpl(preferencesRef))->webGLEnabled();
 }
 
 void WKPreferencesSetNeedsSiteSpecificQuirks(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setNeedsSiteSpecificQuirks(flag);
+    protect(toImpl(preferencesRef))->setNeedsSiteSpecificQuirks(flag);
 }
 
 bool WKPreferencesGetNeedsSiteSpecificQuirks(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->needsSiteSpecificQuirks();
+    return protect(toImpl(preferencesRef))->needsSiteSpecificQuirks();
 }
 
 void WKPreferencesSetForceFTPDirectoryListings(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setForceFTPDirectoryListings(flag);
+    protect(toImpl(preferencesRef))->setForceFTPDirectoryListings(flag);
 }
 
 bool WKPreferencesGetForceFTPDirectoryListings(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->forceFTPDirectoryListings();
+    return protect(toImpl(preferencesRef))->forceFTPDirectoryListings();
 }
 
 void WKPreferencesSetFTPDirectoryTemplatePath(WKPreferencesRef preferencesRef, WKStringRef pathRef)
 {
-    toProtectedImpl(preferencesRef)->setFTPDirectoryTemplatePath(toWTFString(pathRef));
+    protect(toImpl(preferencesRef))->setFTPDirectoryTemplatePath(toWTFString(pathRef));
 }
 
 WKStringRef WKPreferencesCopyFTPDirectoryTemplatePath(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->ftpDirectoryTemplatePath());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->ftpDirectoryTemplatePath());
 }
 
 void WKPreferencesSetTabsToLinks(WKPreferencesRef preferencesRef, bool tabsToLinks)
 {
-    toProtectedImpl(preferencesRef)->setTabsToLinks(tabsToLinks);
+    protect(toImpl(preferencesRef))->setTabsToLinks(tabsToLinks);
 }
 
 bool WKPreferencesGetTabsToLinks(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->tabsToLinks();
+    return protect(toImpl(preferencesRef))->tabsToLinks();
 }
 
 void WKPreferencesSetAuthorAndUserStylesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setAuthorAndUserStylesEnabled(enabled);
+    protect(toImpl(preferencesRef))->setAuthorAndUserStylesEnabled(enabled);
 }
 
 bool WKPreferencesGetAuthorAndUserStylesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->authorAndUserStylesEnabled();
+    return protect(toImpl(preferencesRef))->authorAndUserStylesEnabled();
 }
 
 void WKPreferencesSetShouldPrintBackgrounds(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setShouldPrintBackgrounds(flag);
+    protect(toImpl(preferencesRef))->setShouldPrintBackgrounds(flag);
 }
 
 bool WKPreferencesGetShouldPrintBackgrounds(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldPrintBackgrounds();
+    return protect(toImpl(preferencesRef))->shouldPrintBackgrounds();
 }
 
 void WKPreferencesSetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setDOMTimersThrottlingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setDOMTimersThrottlingEnabled(enabled);
 }
 
 bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->domTimersThrottlingEnabled();
+    return protect(toImpl(preferencesRef))->domTimersThrottlingEnabled();
 }
 
 void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setWebArchiveDebugModeEnabled(enabled);
+    protect(toImpl(preferencesRef))->setWebArchiveDebugModeEnabled(enabled);
 }
 
 bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webArchiveDebugModeEnabled();
+    return protect(toImpl(preferencesRef))->webArchiveDebugModeEnabled();
 }
 
 void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setLocalFileContentSniffingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setLocalFileContentSniffingEnabled(enabled);
 }
 
 bool WKPreferencesGetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->localFileContentSniffingEnabled();
+    return protect(toImpl(preferencesRef))->localFileContentSniffingEnabled();
 }
 
 void WKPreferencesSetPageCacheEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setUsesBackForwardCache(enabled);
+    protect(toImpl(preferencesRef))->setUsesBackForwardCache(enabled);
 }
 
 bool WKPreferencesGetPageCacheEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->usesBackForwardCache();
+    return protect(toImpl(preferencesRef))->usesBackForwardCache();
 }
 
 void WKPreferencesSetDOMPasteAllowed(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setDOMPasteAllowed(enabled);
+    protect(toImpl(preferencesRef))->setDOMPasteAllowed(enabled);
 }
 
 bool WKPreferencesGetDOMPasteAllowed(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->domPasteAllowed();
+    return protect(toImpl(preferencesRef))->domPasteAllowed();
 }
 
 void WKPreferencesSetJavaScriptCanAccessClipboard(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setJavaScriptCanAccessClipboard(enabled);
+    protect(toImpl(preferencesRef))->setJavaScriptCanAccessClipboard(enabled);
 }
 
 bool WKPreferencesGetJavaScriptCanAccessClipboard(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->javaScriptCanAccessClipboard();
+    return protect(toImpl(preferencesRef))->javaScriptCanAccessClipboard();
 }
 
 void WKPreferencesSetFullScreenEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setFullScreenEnabled(enabled);
+    protect(toImpl(preferencesRef))->setFullScreenEnabled(enabled);
 }
 
 bool WKPreferencesGetFullScreenEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->fullScreenEnabled();
+    return protect(toImpl(preferencesRef))->fullScreenEnabled();
 }
 
 void WKPreferencesSetAsynchronousSpellCheckingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setAsynchronousSpellCheckingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setAsynchronousSpellCheckingEnabled(enabled);
 }
 
 bool WKPreferencesGetAsynchronousSpellCheckingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->asynchronousSpellCheckingEnabled();
+    return protect(toImpl(preferencesRef))->asynchronousSpellCheckingEnabled();
 }
 
 void WKPreferencesSetAVFoundationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setAVFoundationEnabled(enabled);
+    protect(toImpl(preferencesRef))->setAVFoundationEnabled(enabled);
 }
 
 bool WKPreferencesGetAVFoundationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->isAVFoundationEnabled();
+    return protect(toImpl(preferencesRef))->isAVFoundationEnabled();
 }
 
 void WKPreferencesSetWebSecurityEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setWebSecurityEnabled(enabled);
+    protect(toImpl(preferencesRef))->setWebSecurityEnabled(enabled);
 }
 
 bool WKPreferencesGetWebSecurityEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webSecurityEnabled();
+    return protect(toImpl(preferencesRef))->webSecurityEnabled();
 }
 
 void WKPreferencesSetUniversalAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    toProtectedImpl(preferencesRef)->setAllowUniversalAccessFromFileURLs(allowed);
+    protect(toImpl(preferencesRef))->setAllowUniversalAccessFromFileURLs(allowed);
 }
 
 bool WKPreferencesGetUniversalAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowUniversalAccessFromFileURLs();
+    return protect(toImpl(preferencesRef))->allowUniversalAccessFromFileURLs();
 }
 
 void WKPreferencesSetFileAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    toProtectedImpl(preferencesRef)->setAllowFileAccessFromFileURLs(allowed);
+    protect(toImpl(preferencesRef))->setAllowFileAccessFromFileURLs(allowed);
 }
 
 bool WKPreferencesGetFileAccessFromFileURLsAllowed(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowFileAccessFromFileURLs();
+    return protect(toImpl(preferencesRef))->allowFileAccessFromFileURLs();
 }
 
 void WKPreferencesSetTopNavigationToDataURLsAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    toProtectedImpl(preferencesRef)->setAllowTopNavigationToDataURLs(allowed);
+    protect(toImpl(preferencesRef))->setAllowTopNavigationToDataURLs(allowed);
 }
 
 bool WKPreferencesGetTopNavigationToDataURLsAllowed(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowTopNavigationToDataURLs();
+    return protect(toImpl(preferencesRef))->allowTopNavigationToDataURLs();
 }
 
 void WKPreferencesSetNeedsStorageAccessFromFileURLsQuirk(WKPreferencesRef preferencesRef, bool needsQuirk)
 {
-    toProtectedImpl(preferencesRef)->setNeedsStorageAccessFromFileURLsQuirk(needsQuirk);
+    protect(toImpl(preferencesRef))->setNeedsStorageAccessFromFileURLsQuirk(needsQuirk);
 }
 
 bool WKPreferencesGetNeedsStorageAccessFromFileURLsQuirk(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->needsStorageAccessFromFileURLsQuirk();
+    return protect(toImpl(preferencesRef))->needsStorageAccessFromFileURLsQuirk();
 }
 
 void WKPreferencesSetMediaPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setRequiresUserGestureForMediaPlayback(flag);
+    protect(toImpl(preferencesRef))->setRequiresUserGestureForMediaPlayback(flag);
 }
 
 bool WKPreferencesGetMediaPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->requiresUserGestureForMediaPlayback();
+    return protect(toImpl(preferencesRef))->requiresUserGestureForMediaPlayback();
 }
 
 void WKPreferencesSetVideoPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setRequiresUserGestureForVideoPlayback(flag);
+    protect(toImpl(preferencesRef))->setRequiresUserGestureForVideoPlayback(flag);
 }
 
 bool WKPreferencesGetVideoPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->requiresUserGestureForVideoPlayback();
+    return protect(toImpl(preferencesRef))->requiresUserGestureForVideoPlayback();
 }
 
 void WKPreferencesSetAudioPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setRequiresUserGestureForAudioPlayback(flag);
+    protect(toImpl(preferencesRef))->setRequiresUserGestureForAudioPlayback(flag);
 }
 
 bool WKPreferencesGetAudioPlaybackRequiresUserGesture(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->requiresUserGestureForAudioPlayback();
+    return protect(toImpl(preferencesRef))->requiresUserGestureForAudioPlayback();
 }
 
 void WKPreferencesSetMainContentUserGestureOverrideEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setMainContentUserGestureOverrideEnabled(flag);
+    protect(toImpl(preferencesRef))->setMainContentUserGestureOverrideEnabled(flag);
 }
 
 bool WKPreferencesGetMainContentUserGestureOverrideEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mainContentUserGestureOverrideEnabled();
+    return protect(toImpl(preferencesRef))->mainContentUserGestureOverrideEnabled();
 }
 
 bool WKPreferencesGetVerifyUserGestureInUIProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->verifyWindowOpenUserGestureFromUIProcess();
+    return protect(toImpl(preferencesRef))->verifyWindowOpenUserGestureFromUIProcess();
 }
 
 void WKPreferencesSetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef, double threshold)
 {
-    toProtectedImpl(preferencesRef)->setManagedMediaSourceLowThreshold(threshold);
+    protect(toImpl(preferencesRef))->setManagedMediaSourceLowThreshold(threshold);
 }
 
 double WKPreferencesGetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->managedMediaSourceLowThreshold();
+    return protect(toImpl(preferencesRef))->managedMediaSourceLowThreshold();
 }
 
 void WKPreferencesSetManagedMediaSourceHighThreshold(WKPreferencesRef preferencesRef, double threshold)
 {
-    toProtectedImpl(preferencesRef)->setManagedMediaSourceHighThreshold(threshold);
+    protect(toImpl(preferencesRef))->setManagedMediaSourceHighThreshold(threshold);
 }
 
 double WKPreferencesGetManagedMediaSourceHighThreshold(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->managedMediaSourceHighThreshold();
+    return protect(toImpl(preferencesRef))->managedMediaSourceHighThreshold();
 }
 
 void WKPreferencesSetMediaPlaybackAllowsInline(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setAllowsInlineMediaPlayback(flag);
+    protect(toImpl(preferencesRef))->setAllowsInlineMediaPlayback(flag);
 }
 
 bool WKPreferencesGetMediaPlaybackAllowsInline(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowsInlineMediaPlayback();
+    return protect(toImpl(preferencesRef))->allowsInlineMediaPlayback();
 }
 
 void WKPreferencesSetInlineMediaPlaybackRequiresPlaysInlineAttribute(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setInlineMediaPlaybackRequiresPlaysInlineAttribute(flag);
+    protect(toImpl(preferencesRef))->setInlineMediaPlaybackRequiresPlaysInlineAttribute(flag);
 }
 
 bool WKPreferencesGetInlineMediaPlaybackRequiresPlaysInlineAttribute(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->inlineMediaPlaybackRequiresPlaysInlineAttribute();
+    return protect(toImpl(preferencesRef))->inlineMediaPlaybackRequiresPlaysInlineAttribute();
 }
 
 void WKPreferencesSetBeaconAPIEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setBeaconAPIEnabled(flag);
+    protect(toImpl(preferencesRef))->setBeaconAPIEnabled(flag);
 }
 
 bool WKPreferencesGetBeaconAPIEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->beaconAPIEnabled();
+    return protect(toImpl(preferencesRef))->beaconAPIEnabled();
 }
 
 void WKPreferencesSetDirectoryUploadEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setDirectoryUploadEnabled(flag);
+    protect(toImpl(preferencesRef))->setDirectoryUploadEnabled(flag);
 }
 
 bool WKPreferencesGetDirectoryUploadEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->directoryUploadEnabled();
+    return protect(toImpl(preferencesRef))->directoryUploadEnabled();
 }
 
 void WKPreferencesSetMediaControlsScaleWithPageZoom(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setMediaControlsScaleWithPageZoom(flag);
+    protect(toImpl(preferencesRef))->setMediaControlsScaleWithPageZoom(flag);
 }
 
 bool WKPreferencesGetMediaControlsScaleWithPageZoom(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaControlsScaleWithPageZoom();
+    return protect(toImpl(preferencesRef))->mediaControlsScaleWithPageZoom();
 }
 
 void WKPreferencesSetWebAuthenticationEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setWebAuthenticationEnabled(flag);
+    protect(toImpl(preferencesRef))->setWebAuthenticationEnabled(flag);
 }
 
 bool WKPreferencesGetWebAuthenticationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webAuthenticationEnabled();
+    return protect(toImpl(preferencesRef))->webAuthenticationEnabled();
 }
 
 void WKPreferencesSetDigitalCredentialsEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setDigitalCredentialsEnabled(flag);
+    protect(toImpl(preferencesRef))->setDigitalCredentialsEnabled(flag);
 }
 
 bool WKPreferencesGetDigitalCredentialsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->digitalCredentialsEnabled();
+    return protect(toImpl(preferencesRef))->digitalCredentialsEnabled();
 }
 
 void WKPreferencesSetInvisibleMediaAutoplayPermitted(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setInvisibleAutoplayNotPermitted(!flag);
+    protect(toImpl(preferencesRef))->setInvisibleAutoplayNotPermitted(!flag);
 }
 
 bool WKPreferencesGetInvisibleMediaAutoplayPermitted(WKPreferencesRef preferencesRef)
 {
-    return !toProtectedImpl(preferencesRef)->invisibleAutoplayNotPermitted();
+    return !protect(toImpl(preferencesRef))->invisibleAutoplayNotPermitted();
 }
 
 void WKPreferencesSetShowsToolTipOverTruncatedText(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setShowsToolTipOverTruncatedText(flag);
+    protect(toImpl(preferencesRef))->setShowsToolTipOverTruncatedText(flag);
 }
 
 bool WKPreferencesGetShowsToolTipOverTruncatedText(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->showsToolTipOverTruncatedText();
+    return protect(toImpl(preferencesRef))->showsToolTipOverTruncatedText();
 }
 
 void WKPreferencesSetMockScrollbarsEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setMockScrollbarsEnabled(flag);
+    protect(toImpl(preferencesRef))->setMockScrollbarsEnabled(flag);
 }
 
 bool WKPreferencesGetMockScrollbarsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mockScrollbarsEnabled();
+    return protect(toImpl(preferencesRef))->mockScrollbarsEnabled();
 }
 
 void WKPreferencesSetAttachmentElementEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setAttachmentElementEnabled(flag);
+    protect(toImpl(preferencesRef))->setAttachmentElementEnabled(flag);
 }
 
 bool WKPreferencesGetAttachmentElementEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->attachmentElementEnabled();
+    return protect(toImpl(preferencesRef))->attachmentElementEnabled();
 }
 
 void WKPreferencesSetWebAudioEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setWebAudioEnabled(enabled);
+    protect(toImpl(preferencesRef))->setWebAudioEnabled(enabled);
 }
 
 bool WKPreferencesGetWebAudioEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webAudioEnabled();
+    return protect(toImpl(preferencesRef))->webAudioEnabled();
 }
 
 void WKPreferencesSetSuppressesIncrementalRendering(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setSuppressesIncrementalRendering(enabled);
+    protect(toImpl(preferencesRef))->setSuppressesIncrementalRendering(enabled);
 }
 
 bool WKPreferencesGetSuppressesIncrementalRendering(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->suppressesIncrementalRendering();
+    return protect(toImpl(preferencesRef))->suppressesIncrementalRendering();
 }
 
 void WKPreferencesSetBackspaceKeyNavigationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setBackspaceKeyNavigationEnabled(enabled);
+    protect(toImpl(preferencesRef))->setBackspaceKeyNavigationEnabled(enabled);
 }
 
 bool WKPreferencesGetBackspaceKeyNavigationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->backspaceKeyNavigationEnabled();
+    return protect(toImpl(preferencesRef))->backspaceKeyNavigationEnabled();
 }
 
 void WKPreferencesSetCaretBrowsingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setCaretBrowsingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setCaretBrowsingEnabled(enabled);
 }
 
 bool WKPreferencesGetCaretBrowsingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->caretBrowsingEnabled();
+    return protect(toImpl(preferencesRef))->caretBrowsingEnabled();
 }
 
 void WKPreferencesSetShouldDisplaySubtitles(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setShouldDisplaySubtitles(enabled);
+    protect(toImpl(preferencesRef))->setShouldDisplaySubtitles(enabled);
 }
 
 bool WKPreferencesGetShouldDisplaySubtitles(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldDisplaySubtitles();
+    return protect(toImpl(preferencesRef))->shouldDisplaySubtitles();
 }
 
 void WKPreferencesSetShouldDisplayCaptions(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setShouldDisplayCaptions(enabled);
+    protect(toImpl(preferencesRef))->setShouldDisplayCaptions(enabled);
 }
 
 bool WKPreferencesGetShouldDisplayCaptions(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldDisplayCaptions();
+    return protect(toImpl(preferencesRef))->shouldDisplayCaptions();
 }
 
 void WKPreferencesSetShouldDisplayTextDescriptions(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setShouldDisplayTextDescriptions(enabled);
+    protect(toImpl(preferencesRef))->setShouldDisplayTextDescriptions(enabled);
 }
 
 bool WKPreferencesGetShouldDisplayTextDescriptions(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldDisplayTextDescriptions();
+    return protect(toImpl(preferencesRef))->shouldDisplayTextDescriptions();
 }
 
 void WKPreferencesSetNotificationsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setNotificationsEnabled(enabled);
+    protect(toImpl(preferencesRef))->setNotificationsEnabled(enabled);
 }
 
 bool WKPreferencesGetNotificationsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->notificationsEnabled();
+    return protect(toImpl(preferencesRef))->notificationsEnabled();
 }
 
 void WKPreferencesSetShouldRespectImageOrientation(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setShouldRespectImageOrientation(enabled);
+    protect(toImpl(preferencesRef))->setShouldRespectImageOrientation(enabled);
 }
 
 bool WKPreferencesGetShouldRespectImageOrientation(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldRespectImageOrientation();
+    return protect(toImpl(preferencesRef))->shouldRespectImageOrientation();
 }
 
 void WKPreferencesSetStorageBlockingPolicy(WKPreferencesRef preferencesRef, WKStorageBlockingPolicy policy)
 {
-    toProtectedImpl(preferencesRef)->setStorageBlockingPolicy(static_cast<uint32_t>(toStorageBlockingPolicy(policy)));
+    protect(toImpl(preferencesRef))->setStorageBlockingPolicy(static_cast<uint32_t>(toStorageBlockingPolicy(policy)));
 }
 
 WKStorageBlockingPolicy WKPreferencesGetStorageBlockingPolicy(WKPreferencesRef preferencesRef)
 {
-    return toAPI(static_cast<WebCore::StorageBlockingPolicy>(toProtectedImpl(preferencesRef)->storageBlockingPolicy()));
+    return toAPI(static_cast<WebCore::StorageBlockingPolicy>(protect(toImpl(preferencesRef))->storageBlockingPolicy()));
 }
 
 void WKPreferencesSetDiagnosticLoggingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setDiagnosticLoggingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setDiagnosticLoggingEnabled(enabled);
 }
 
 bool WKPreferencesGetDiagnosticLoggingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->diagnosticLoggingEnabled();
+    return protect(toImpl(preferencesRef))->diagnosticLoggingEnabled();
 }
 
 void WKPreferencesSetInteractiveFormValidationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setInteractiveFormValidationEnabled(enabled);
+    protect(toImpl(preferencesRef))->setInteractiveFormValidationEnabled(enabled);
 }
 
 bool WKPreferencesGetInteractiveFormValidationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->interactiveFormValidationEnabled();
+    return protect(toImpl(preferencesRef))->interactiveFormValidationEnabled();
 }
 
 void WKPreferencesSetScrollingPerformanceLoggingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setScrollingPerformanceTestingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setScrollingPerformanceTestingEnabled(enabled);
 }
 
 bool WKPreferencesGetScrollingPerformanceLoggingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->scrollingPerformanceTestingEnabled();
+    return protect(toImpl(preferencesRef))->scrollingPerformanceTestingEnabled();
 }
 
 void WKPreferencesSetPDFPluginEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setPDFPluginEnabled(enabled);
+    protect(toImpl(preferencesRef))->setPDFPluginEnabled(enabled);
 }
 
 bool WKPreferencesGetPDFPluginEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->pdfPluginEnabled();
+    return protect(toImpl(preferencesRef))->pdfPluginEnabled();
 }
 
 void WKPreferencesSetEncodingDetectorEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setUsesEncodingDetector(enabled);
+    protect(toImpl(preferencesRef))->setUsesEncodingDetector(enabled);
 }
 
 bool WKPreferencesGetEncodingDetectorEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->usesEncodingDetector();
+    return protect(toImpl(preferencesRef))->usesEncodingDetector();
 }
 
 void WKPreferencesSetTextAutosizingEnabled(WKPreferencesRef preferencesRef, bool textAutosizingEnabled)
 {
-    toProtectedImpl(preferencesRef)->setTextAutosizingEnabled(textAutosizingEnabled);
+    protect(toImpl(preferencesRef))->setTextAutosizingEnabled(textAutosizingEnabled);
 }
 
 bool WKPreferencesGetTextAutosizingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->textAutosizingEnabled();
+    return protect(toImpl(preferencesRef))->textAutosizingEnabled();
 }
 
 void WKPreferencesSetTextAutosizingUsesIdempotentMode(WKPreferencesRef preferencesRef, bool textAutosizingUsesIdempotentModeEnabled)
 {
-    toProtectedImpl(preferencesRef)->setTextAutosizingUsesIdempotentMode(textAutosizingUsesIdempotentModeEnabled);
+    protect(toImpl(preferencesRef))->setTextAutosizingUsesIdempotentMode(textAutosizingUsesIdempotentModeEnabled);
 }
 
 bool WKPreferencesGetTextAutosizingUsesIdempotentMode(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->textAutosizingUsesIdempotentMode();
+    return protect(toImpl(preferencesRef))->textAutosizingUsesIdempotentMode();
 }
 
 void WKPreferencesSetAggressiveTileRetentionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setAggressiveTileRetentionEnabled(enabled);
+    protect(toImpl(preferencesRef))->setAggressiveTileRetentionEnabled(enabled);
 }
 
 bool WKPreferencesGetAggressiveTileRetentionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->aggressiveTileRetentionEnabled();
+    return protect(toImpl(preferencesRef))->aggressiveTileRetentionEnabled();
 }
 
 void WKPreferencesSetLogsPageMessagesToSystemConsoleEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setLogsPageMessagesToSystemConsoleEnabled(enabled);
+    protect(toImpl(preferencesRef))->setLogsPageMessagesToSystemConsoleEnabled(enabled);
 }
 
 bool WKPreferencesGetLogsPageMessagesToSystemConsoleEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->logsPageMessagesToSystemConsoleEnabled();
+    return protect(toImpl(preferencesRef))->logsPageMessagesToSystemConsoleEnabled();
 }
 
 void WKPreferencesSetPageVisibilityBasedProcessSuppressionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setPageVisibilityBasedProcessSuppressionEnabled(enabled);
+    protect(toImpl(preferencesRef))->setPageVisibilityBasedProcessSuppressionEnabled(enabled);
 }
 
 bool WKPreferencesGetPageVisibilityBasedProcessSuppressionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->pageVisibilityBasedProcessSuppressionEnabled();
+    return protect(toImpl(preferencesRef))->pageVisibilityBasedProcessSuppressionEnabled();
 }
 
 void WKPreferencesSetSmartInsertDeleteEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setSmartInsertDeleteEnabled(enabled);
+    protect(toImpl(preferencesRef))->setSmartInsertDeleteEnabled(enabled);
 }
 
 bool WKPreferencesGetSmartInsertDeleteEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->smartInsertDeleteEnabled();
+    return protect(toImpl(preferencesRef))->smartInsertDeleteEnabled();
 }
 
 void WKPreferencesSetSelectTrailingWhitespaceEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setSelectTrailingWhitespaceEnabled(enabled);
+    protect(toImpl(preferencesRef))->setSelectTrailingWhitespaceEnabled(enabled);
 }
 
 bool WKPreferencesGetSelectTrailingWhitespaceEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->selectTrailingWhitespaceEnabled();
+    return protect(toImpl(preferencesRef))->selectTrailingWhitespaceEnabled();
 }
 
 void WKPreferencesSetShowsURLsInToolTipsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setShowsURLsInToolTipsEnabled(enabled);
+    protect(toImpl(preferencesRef))->setShowsURLsInToolTipsEnabled(enabled);
 }
 
 bool WKPreferencesGetShowsURLsInToolTipsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->showsURLsInToolTipsEnabled();
+    return protect(toImpl(preferencesRef))->showsURLsInToolTipsEnabled();
 }
 
 void WKPreferencesSetHiddenPageDOMTimerThrottlingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setHiddenPageDOMTimerThrottlingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setHiddenPageDOMTimerThrottlingEnabled(enabled);
 }
 
 void WKPreferencesSetHiddenPageDOMTimerThrottlingAutoIncreases(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setHiddenPageDOMTimerThrottlingAutoIncreases(enabled);
+    protect(toImpl(preferencesRef))->setHiddenPageDOMTimerThrottlingAutoIncreases(enabled);
 }
 
 bool WKPreferencesGetHiddenPageDOMTimerThrottlingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->hiddenPageDOMTimerThrottlingEnabled();
+    return protect(toImpl(preferencesRef))->hiddenPageDOMTimerThrottlingEnabled();
 }
 
 bool WKPreferencesGetHiddenPageDOMTimerThrottlingAutoIncreases(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->hiddenPageDOMTimerThrottlingAutoIncreases();
+    return protect(toImpl(preferencesRef))->hiddenPageDOMTimerThrottlingAutoIncreases();
 }
 
 void WKPreferencesSetHiddenPageCSSAnimationSuspensionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setHiddenPageCSSAnimationSuspensionEnabled(enabled);
+    protect(toImpl(preferencesRef))->setHiddenPageCSSAnimationSuspensionEnabled(enabled);
 }
 
 bool WKPreferencesGetHiddenPageCSSAnimationSuspensionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->hiddenPageCSSAnimationSuspensionEnabled();
+    return protect(toImpl(preferencesRef))->hiddenPageCSSAnimationSuspensionEnabled();
 }
 
 void WKPreferencesSetIncrementalRenderingSuppressionTimeout(WKPreferencesRef preferencesRef, double timeout)
 {
-    toProtectedImpl(preferencesRef)->setIncrementalRenderingSuppressionTimeout(timeout);
+    protect(toImpl(preferencesRef))->setIncrementalRenderingSuppressionTimeout(timeout);
 }
 
 double WKPreferencesGetIncrementalRenderingSuppressionTimeout(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->incrementalRenderingSuppressionTimeout();
+    return protect(toImpl(preferencesRef))->incrementalRenderingSuppressionTimeout();
 }
 
 void WKPreferencesSetThreadedScrollingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setThreadedScrollingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setThreadedScrollingEnabled(enabled);
 }
 
 bool WKPreferencesGetThreadedScrollingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->threadedScrollingEnabled();
+    return protect(toImpl(preferencesRef))->threadedScrollingEnabled();
 }
 
 void WKPreferencesSetLegacyLineLayoutVisualCoverageEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setLegacyLineLayoutVisualCoverageEnabled(flag);
+    protect(toImpl(preferencesRef))->setLegacyLineLayoutVisualCoverageEnabled(flag);
 }
 
 bool WKPreferencesGetLegacyLineLayoutVisualCoverageEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->legacyLineLayoutVisualCoverageEnabled();
+    return protect(toImpl(preferencesRef))->legacyLineLayoutVisualCoverageEnabled();
 }
 
 void WKPreferencesSetContentChangeObserverEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setContentChangeObserverEnabled(flag);
+    protect(toImpl(preferencesRef))->setContentChangeObserverEnabled(flag);
 }
 
 bool WKPreferencesGetContentChangeObserverEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->contentChangeObserverEnabled();
+    return protect(toImpl(preferencesRef))->contentChangeObserverEnabled();
 }
 
 void WKPreferencesSetUseGiantTiles(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setUseGiantTiles(flag);
+    protect(toImpl(preferencesRef))->setUseGiantTiles(flag);
 }
 
 bool WKPreferencesGetUseGiantTiles(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->useGiantTiles();
+    return protect(toImpl(preferencesRef))->useGiantTiles();
 }
 
 void WKPreferencesSetMediaDevicesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setMediaDevicesEnabled(enabled);
+    protect(toImpl(preferencesRef))->setMediaDevicesEnabled(enabled);
 }
 
 bool WKPreferencesGetMediaDevicesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaDevicesEnabled();
+    return protect(toImpl(preferencesRef))->mediaDevicesEnabled();
 }
 
 void WKPreferencesSetPeerConnectionEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setPeerConnectionEnabled(enabled);
+    protect(toImpl(preferencesRef))->setPeerConnectionEnabled(enabled);
 }
 
 bool WKPreferencesGetPeerConnectionEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->peerConnectionEnabled();
+    return protect(toImpl(preferencesRef))->peerConnectionEnabled();
 }
 
 void WKPreferencesSetSpatialNavigationEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setSpatialNavigationEnabled(enabled);
+    protect(toImpl(preferencesRef))->setSpatialNavigationEnabled(enabled);
 }
 
 bool WKPreferencesGetSpatialNavigationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->spatialNavigationEnabled();
+    return protect(toImpl(preferencesRef))->spatialNavigationEnabled();
 }
 
 void WKPreferencesSetMediaSourceEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setMediaSourceEnabled(enabled);
+    protect(toImpl(preferencesRef))->setMediaSourceEnabled(enabled);
 }
 
 bool WKPreferencesGetMediaSourceEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaSourceEnabled();
+    return protect(toImpl(preferencesRef))->mediaSourceEnabled();
 }
 
 void WKPreferencesSetSourceBufferChangeTypeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setSourceBufferChangeTypeEnabled(enabled);
+    protect(toImpl(preferencesRef))->setSourceBufferChangeTypeEnabled(enabled);
 }
 
 bool WKPreferencesGetSourceBufferChangeTypeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->sourceBufferChangeTypeEnabled();
+    return protect(toImpl(preferencesRef))->sourceBufferChangeTypeEnabled();
 }
 
 void WKPreferencesSetViewGestureDebuggingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setViewGestureDebuggingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setViewGestureDebuggingEnabled(enabled);
 }
 
 bool WKPreferencesGetViewGestureDebuggingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->viewGestureDebuggingEnabled();
+    return protect(toImpl(preferencesRef))->viewGestureDebuggingEnabled();
 }
 
 void WKPreferencesSetShouldConvertPositionStyleOnCopy(WKPreferencesRef preferencesRef, bool convert)
 {
-    toProtectedImpl(preferencesRef)->setShouldConvertPositionStyleOnCopy(convert);
+    protect(toImpl(preferencesRef))->setShouldConvertPositionStyleOnCopy(convert);
 }
 
 bool WKPreferencesGetShouldConvertPositionStyleOnCopy(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldConvertPositionStyleOnCopy();
+    return protect(toImpl(preferencesRef))->shouldConvertPositionStyleOnCopy();
 }
 
 void WKPreferencesSetTelephoneNumberParsingEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setTelephoneNumberParsingEnabled(enabled);
+    protect(toImpl(preferencesRef))->setTelephoneNumberParsingEnabled(enabled);
 }
 
 bool WKPreferencesGetTelephoneNumberParsingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->telephoneNumberParsingEnabled();
+    return protect(toImpl(preferencesRef))->telephoneNumberParsingEnabled();
 }
 
 void WKPreferencesSetEnableInheritURIQueryComponent(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setEnableInheritURIQueryComponent(enabled);
+    protect(toImpl(preferencesRef))->setEnableInheritURIQueryComponent(enabled);
 }
 
 bool WKPreferencesGetEnableInheritURIQueryComponent(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->enableInheritURIQueryComponent();
+    return protect(toImpl(preferencesRef))->enableInheritURIQueryComponent();
 }
 
 void WKPreferencesSetServiceControlsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setServiceControlsEnabled(enabled);
+    protect(toImpl(preferencesRef))->setServiceControlsEnabled(enabled);
 }
 
 bool WKPreferencesGetServiceControlsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->serviceControlsEnabled();
+    return protect(toImpl(preferencesRef))->serviceControlsEnabled();
 }
 
 void WKPreferencesSetImageControlsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setImageControlsEnabled(enabled);
+    protect(toImpl(preferencesRef))->setImageControlsEnabled(enabled);
 }
 
 bool WKPreferencesGetImageControlsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->imageControlsEnabled();
+    return protect(toImpl(preferencesRef))->imageControlsEnabled();
 }
 
 void WKPreferencesSetGamepadsEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setGamepadsEnabled(enabled);
+    protect(toImpl(preferencesRef))->setGamepadsEnabled(enabled);
 }
 
 bool WKPreferencesGetGamepadsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->gamepadsEnabled();
+    return protect(toImpl(preferencesRef))->gamepadsEnabled();
 }
 
 void WKPreferencesSetMinimumZoomFontSize(WKPreferencesRef preferencesRef, double size)
 {
-    toProtectedImpl(preferencesRef)->setMinimumZoomFontSize(size);
+    protect(toImpl(preferencesRef))->setMinimumZoomFontSize(size);
 }
 
 double WKPreferencesGetMinimumZoomFontSize(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->minimumZoomFontSize();
+    return protect(toImpl(preferencesRef))->minimumZoomFontSize();
 }
 
 void WKPreferencesSetVisibleDebugOverlayRegions(WKPreferencesRef preferencesRef, WKDebugOverlayRegions visibleRegions)
 {
-    toProtectedImpl(preferencesRef)->setVisibleDebugOverlayRegions(visibleRegions);
+    protect(toImpl(preferencesRef))->setVisibleDebugOverlayRegions(visibleRegions);
 }
 
 WKDebugOverlayRegions WKPreferencesGetVisibleDebugOverlayRegions(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->visibleDebugOverlayRegions();
+    return protect(toImpl(preferencesRef))->visibleDebugOverlayRegions();
 }
 
 void WKPreferencesSetMetaRefreshEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setHTTPEquivEnabled(enabled);
+    protect(toImpl(preferencesRef))->setHTTPEquivEnabled(enabled);
 }
 
 bool WKPreferencesGetMetaRefreshEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->httpEquivEnabled();
+    return protect(toImpl(preferencesRef))->httpEquivEnabled();
 }
 
 void WKPreferencesSetHTTPEquivEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setHTTPEquivEnabled(enabled);
+    protect(toImpl(preferencesRef))->setHTTPEquivEnabled(enabled);
 }
 
 bool WKPreferencesGetHTTPEquivEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->httpEquivEnabled();
+    return protect(toImpl(preferencesRef))->httpEquivEnabled();
 }
 
 void WKPreferencesSetAllowsAirPlayForMediaPlayback(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setAllowsAirPlayForMediaPlayback(enabled);
+    protect(toImpl(preferencesRef))->setAllowsAirPlayForMediaPlayback(enabled);
 }
 
 bool WKPreferencesGetAllowsAirPlayForMediaPlayback(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowsAirPlayForMediaPlayback();
+    return protect(toImpl(preferencesRef))->allowsAirPlayForMediaPlayback();
 }
 
 void WKPreferencesSetUserInterfaceDirectionPolicy(WKPreferencesRef preferencesRef, _WKUserInterfaceDirectionPolicy userInterfaceDirectionPolicy)
 {
-    toProtectedImpl(preferencesRef)->setUserInterfaceDirectionPolicy(userInterfaceDirectionPolicy);
+    protect(toImpl(preferencesRef))->setUserInterfaceDirectionPolicy(userInterfaceDirectionPolicy);
 }
 
 _WKUserInterfaceDirectionPolicy WKPreferencesGetUserInterfaceDirectionPolicy(WKPreferencesRef preferencesRef)
 {
-    return static_cast<_WKUserInterfaceDirectionPolicy>(toProtectedImpl(preferencesRef)->userInterfaceDirectionPolicy());
+    return static_cast<_WKUserInterfaceDirectionPolicy>(protect(toImpl(preferencesRef))->userInterfaceDirectionPolicy());
 }
 
 void WKPreferencesSetResourceUsageOverlayVisible(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setResourceUsageOverlayVisible(enabled);
+    protect(toImpl(preferencesRef))->setResourceUsageOverlayVisible(enabled);
 }
 
 bool WKPreferencesGetResourceUsageOverlayVisible(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->resourceUsageOverlayVisible();
+    return protect(toImpl(preferencesRef))->resourceUsageOverlayVisible();
 }
 
 void WKPreferencesSetMockCaptureDevicesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setMockCaptureDevicesEnabled(enabled);
+    protect(toImpl(preferencesRef))->setMockCaptureDevicesEnabled(enabled);
 }
 
 bool WKPreferencesGetMockCaptureDevicesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mockCaptureDevicesEnabled();
+    return protect(toImpl(preferencesRef))->mockCaptureDevicesEnabled();
 }
 
 void WKPreferencesSetGetUserMediaRequiresFocus(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setGetUserMediaRequiresFocus(enabled);
+    protect(toImpl(preferencesRef))->setGetUserMediaRequiresFocus(enabled);
 }
 
 bool WKPreferencesGetGetUserMediaRequiresFocus(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->getUserMediaRequiresFocus();
+    return protect(toImpl(preferencesRef))->getUserMediaRequiresFocus();
 }
 
 void WKPreferencesSetICECandidateFilteringEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setICECandidateFilteringEnabled(enabled);
+    protect(toImpl(preferencesRef))->setICECandidateFilteringEnabled(enabled);
 }
 
 bool WKPreferencesGetICECandidateFilteringEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->iceCandidateFilteringEnabled();
+    return protect(toImpl(preferencesRef))->iceCandidateFilteringEnabled();
 }
 
 void WKPreferencesSetEnumeratingAllNetworkInterfacesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setEnumeratingAllNetworkInterfacesEnabled(enabled);
+    protect(toImpl(preferencesRef))->setEnumeratingAllNetworkInterfacesEnabled(enabled);
 }
 
 bool WKPreferencesGetEnumeratingAllNetworkInterfacesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->enumeratingAllNetworkInterfacesEnabled();
+    return protect(toImpl(preferencesRef))->enumeratingAllNetworkInterfacesEnabled();
 }
 
 void WKPreferencesSetMediaCaptureRequiresSecureConnection(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setMediaCaptureRequiresSecureConnection(enabled);
+    protect(toImpl(preferencesRef))->setMediaCaptureRequiresSecureConnection(enabled);
 }
 
 bool WKPreferencesGetMediaCaptureRequiresSecureConnection(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaCaptureRequiresSecureConnection();
+    return protect(toImpl(preferencesRef))->mediaCaptureRequiresSecureConnection();
 }
 
 void WKPreferencesSetInactiveMediaCaptureStreamRepromptIntervalInMinutes(WKPreferencesRef preferencesRef, double interval)
 {
-    toProtectedImpl(preferencesRef)->setInactiveMediaCaptureStreamRepromptIntervalInMinutes(interval);
+    protect(toImpl(preferencesRef))->setInactiveMediaCaptureStreamRepromptIntervalInMinutes(interval);
 }
 
 double WKPreferencesGetInactiveMediaCaptureStreamRepromptIntervalInMinutes(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->inactiveMediaCaptureStreamRepromptIntervalInMinutes();
+    return protect(toImpl(preferencesRef))->inactiveMediaCaptureStreamRepromptIntervalInMinutes();
 }
 
 void WKPreferencesSetDataTransferItemsEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setDataTransferItemsEnabled(flag);
+    protect(toImpl(preferencesRef))->setDataTransferItemsEnabled(flag);
 }
 
 bool WKPreferencesGetDataTransferItemsEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->dataTransferItemsEnabled();
+    return protect(toImpl(preferencesRef))->dataTransferItemsEnabled();
 }
 
 void WKPreferencesSetCustomPasteboardDataEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setCustomPasteboardDataEnabled(flag);
+    protect(toImpl(preferencesRef))->setCustomPasteboardDataEnabled(flag);
 }
 
 bool WKPreferencesGetCustomPasteboardDataEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->customPasteboardDataEnabled();
+    return protect(toImpl(preferencesRef))->customPasteboardDataEnabled();
 }
 
 void WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setWriteRichTextDataWhenCopyingOrDragging(flag);
+    protect(toImpl(preferencesRef))->setWriteRichTextDataWhenCopyingOrDragging(flag);
 }
 
 bool WKPreferencesGetWriteRichTextDataWhenCopyingOrDragging(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->writeRichTextDataWhenCopyingOrDragging();
+    return protect(toImpl(preferencesRef))->writeRichTextDataWhenCopyingOrDragging();
 }
 
 void WKPreferencesSetWebShareEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setWebShareEnabled(flag);
+    protect(toImpl(preferencesRef))->setWebShareEnabled(flag);
 }
 
 bool WKPreferencesGetWebShareEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webShareEnabled();
+    return protect(toImpl(preferencesRef))->webShareEnabled();
 }
 
 void WKPreferencesSetDownloadAttributeEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setDownloadAttributeEnabled(flag);
+    protect(toImpl(preferencesRef))->setDownloadAttributeEnabled(flag);
 }
 
 bool WKPreferencesGetDownloadAttributeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->downloadAttributeEnabled();
+    return protect(toImpl(preferencesRef))->downloadAttributeEnabled();
 }
 
 void WKPreferencesSetWebRTCPlatformCodecsInGPUProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setWebRTCPlatformCodecsInGPUProcessEnabled(flag);
+    protect(toImpl(preferencesRef))->setWebRTCPlatformCodecsInGPUProcessEnabled(flag);
 }
 
 bool WKPreferencesGetWebRTCPlatformCodecsInGPUProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->webRTCPlatformCodecsInGPUProcessEnabled();
+    return protect(toImpl(preferencesRef))->webRTCPlatformCodecsInGPUProcessEnabled();
 }
 
 WK_EXPORT void WKPreferencesSetIsAccessibilityIsolatedTreeEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setIsAccessibilityIsolatedTreeEnabled(flag);
+    protect(toImpl(preferencesRef))->setIsAccessibilityIsolatedTreeEnabled(flag);
 }
 
 WK_EXPORT bool WKPreferencesGetIsAccessibilityIsolatedTreeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->isAccessibilityIsolatedTreeEnabled();
+    return protect(toImpl(preferencesRef))->isAccessibilityIsolatedTreeEnabled();
 }
 
 void WKPreferencesSetAllowsPictureInPictureMediaPlayback(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setAllowsPictureInPictureMediaPlayback(enabled);
+    protect(toImpl(preferencesRef))->setAllowsPictureInPictureMediaPlayback(enabled);
 }
 
 bool WKPreferencesGetAllowsPictureInPictureMediaPlayback(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowsPictureInPictureMediaPlayback();
+    return protect(toImpl(preferencesRef))->allowsPictureInPictureMediaPlayback();
 }
 
 WK_EXPORT bool WKPreferencesGetApplePayEnabled(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toProtectedImpl(preferencesRef)->applePayEnabled();
+    return protect(WebKit::toImpl(preferencesRef))->applePayEnabled();
 }
 
 void WKPreferencesSetApplePayEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toProtectedImpl(preferencesRef)->setApplePayEnabled(enabled);
+    protect(WebKit::toImpl(preferencesRef))->setApplePayEnabled(enabled);
 }
 
 bool WKPreferencesGetCSSTransformStyleSeparatedEnabled(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toProtectedImpl(preferencesRef)->cssTransformStyleSeparatedEnabled();
+    return protect(WebKit::toImpl(preferencesRef))->cssTransformStyleSeparatedEnabled();
 }
 
 void WKPreferencesSetCSSTransformStyleSeparatedEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toProtectedImpl(preferencesRef)->setCSSTransformStyleSeparatedEnabled(enabled);
+    protect(WebKit::toImpl(preferencesRef))->setCSSTransformStyleSeparatedEnabled(enabled);
 }
 
 bool WKPreferencesGetApplePayCapabilityDisclosureAllowed(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toProtectedImpl(preferencesRef)->applePayCapabilityDisclosureAllowed();
+    return protect(WebKit::toImpl(preferencesRef))->applePayCapabilityDisclosureAllowed();
 }
 
 void WKPreferencesSetApplePayCapabilityDisclosureAllowed(WKPreferencesRef preferencesRef, bool allowed)
 {
-    WebKit::toProtectedImpl(preferencesRef)->setApplePayCapabilityDisclosureAllowed(allowed);
+    protect(WebKit::toImpl(preferencesRef))->setApplePayCapabilityDisclosureAllowed(allowed);
 }
 
 void WKPreferencesSetLinkPreloadEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setLinkPreloadEnabled(flag);
+    protect(toImpl(preferencesRef))->setLinkPreloadEnabled(flag);
 }
 
 bool WKPreferencesGetLinkPreloadEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->linkPreloadEnabled();
+    return protect(toImpl(preferencesRef))->linkPreloadEnabled();
 }
 
 void WKPreferencesSetMediaPreloadingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setMediaPreloadingEnabled(flag);
+    protect(toImpl(preferencesRef))->setMediaPreloadingEnabled(flag);
 }
 
 bool WKPreferencesGetMediaPreloadingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaPreloadingEnabled();
+    return protect(toImpl(preferencesRef))->mediaPreloadingEnabled();
 }
 
 void WKPreferencesSetExposeSpeakersEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setExposeSpeakersEnabled(flag);
+    protect(toImpl(preferencesRef))->setExposeSpeakersEnabled(flag);
 }
 
 bool WKPreferencesGetExposeSpeakersEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->exposeSpeakersEnabled();
+    return protect(toImpl(preferencesRef))->exposeSpeakersEnabled();
 }
 
 void WKPreferencesSetLargeImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setLargeImageAsyncDecodingEnabled(flag);
+    protect(toImpl(preferencesRef))->setLargeImageAsyncDecodingEnabled(flag);
 }
 
 bool WKPreferencesGetLargeImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->largeImageAsyncDecodingEnabled();
+    return protect(toImpl(preferencesRef))->largeImageAsyncDecodingEnabled();
 }
 
 void WKPreferencesSetAnimatedImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setAnimatedImageAsyncDecodingEnabled(flag);
+    protect(toImpl(preferencesRef))->setAnimatedImageAsyncDecodingEnabled(flag);
 }
 
 bool WKPreferencesGetAnimatedImageAsyncDecodingEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->animatedImageAsyncDecodingEnabled();
+    return protect(toImpl(preferencesRef))->animatedImageAsyncDecodingEnabled();
 }
 
 void WKPreferencesSetShouldSuppressKeyboardInputDuringProvisionalNavigation(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(flag);
+    protect(toImpl(preferencesRef))->setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(flag);
 }
 
 bool WKPreferencesGetShouldSuppressKeyboardInputDuringProvisionalNavigation(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldSuppressTextInputFromEditingDuringProvisionalNavigation();
+    return protect(toImpl(preferencesRef))->shouldSuppressTextInputFromEditingDuringProvisionalNavigation();
 }
 
 void WKPreferencesSetMediaUserGestureInheritsFromDocument(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setMediaUserGestureInheritsFromDocument(flag);
+    protect(toImpl(preferencesRef))->setMediaUserGestureInheritsFromDocument(flag);
 }
 
 bool WKPreferencesGetMediaUserGestureInheritsFromDocument(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaUserGestureInheritsFromDocument();
+    return protect(toImpl(preferencesRef))->mediaUserGestureInheritsFromDocument();
 }
 
 void WKPreferencesSetMediaContentTypesRequiringHardwareSupport(WKPreferencesRef preferencesRef, WKStringRef codecs)
 {
-    toProtectedImpl(preferencesRef)->setMediaContentTypesRequiringHardwareSupport(toWTFString(codecs));
+    protect(toImpl(preferencesRef))->setMediaContentTypesRequiringHardwareSupport(toWTFString(codecs));
 }
 
 WKStringRef WKPreferencesCopyMediaContentTypesRequiringHardwareSupport(WKPreferencesRef preferencesRef)
 {
-    return toCopiedAPI(toProtectedImpl(preferencesRef)->mediaContentTypesRequiringHardwareSupport());
+    return toCopiedAPI(protect(toImpl(preferencesRef))->mediaContentTypesRequiringHardwareSupport());
 }
 
 bool WKPreferencesGetLegacyEncryptedMediaAPIEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->legacyEncryptedMediaAPIEnabled();
+    return protect(toImpl(preferencesRef))->legacyEncryptedMediaAPIEnabled();
 }
 
 void WKPreferencesSetLegacyEncryptedMediaAPIEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    return toProtectedImpl(preferencesRef)->setLegacyEncryptedMediaAPIEnabled(enabled);
+    return protect(toImpl(preferencesRef))->setLegacyEncryptedMediaAPIEnabled(enabled);
 }
 
 bool WKPreferencesGetAllowMediaContentTypesRequiringHardwareSupportAsFallback(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->allowMediaContentTypesRequiringHardwareSupportAsFallback();
+    return protect(toImpl(preferencesRef))->allowMediaContentTypesRequiringHardwareSupportAsFallback();
 }
 
 void WKPreferencesSetAllowMediaContentTypesRequiringHardwareSupportAsFallback(WKPreferencesRef preferencesRef, bool allow)
 {
-    return toProtectedImpl(preferencesRef)->setAllowMediaContentTypesRequiringHardwareSupportAsFallback(allow);
+    return protect(toImpl(preferencesRef))->setAllowMediaContentTypesRequiringHardwareSupportAsFallback(allow);
 }
 
 void WKPreferencesSetShouldAllowUserInstalledFonts(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setShouldAllowUserInstalledFonts(flag);
+    protect(toImpl(preferencesRef))->setShouldAllowUserInstalledFonts(flag);
 }
 
 bool WKPreferencesGetShouldAllowUserInstalledFonts(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->shouldAllowUserInstalledFonts();
+    return protect(toImpl(preferencesRef))->shouldAllowUserInstalledFonts();
 }
 
 void WKPreferencesSetMediaCapabilitiesEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setMediaCapabilitiesEnabled(enabled);
+    protect(toImpl(preferencesRef))->setMediaCapabilitiesEnabled(enabled);
 }
 
 bool WKPreferencesGetMediaCapabilitiesEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->mediaCapabilitiesEnabled();
+    return protect(toImpl(preferencesRef))->mediaCapabilitiesEnabled();
 }
 
 void WKPreferencesSetColorFilterEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setColorFilterEnabled(flag);
+    protect(toImpl(preferencesRef))->setColorFilterEnabled(flag);
 }
 
 bool WKPreferencesGetColorFilterEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->colorFilterEnabled();
+    return protect(toImpl(preferencesRef))->colorFilterEnabled();
 }
 
 void WKPreferencesSetProcessSwapOnNavigationEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setProcessSwapOnCrossSiteNavigationEnabled(flag);
+    protect(toImpl(preferencesRef))->setProcessSwapOnCrossSiteNavigationEnabled(flag);
 }
 
 bool WKPreferencesGetProcessSwapOnNavigationEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->processSwapOnCrossSiteNavigationEnabled();
+    return protect(toImpl(preferencesRef))->processSwapOnCrossSiteNavigationEnabled();
 }
 
 void WKPreferencesSetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setPunchOutWhiteBackgroundsInDarkMode(flag);
+    protect(toImpl(preferencesRef))->setPunchOutWhiteBackgroundsInDarkMode(flag);
 }
 
 bool WKPreferencesGetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->punchOutWhiteBackgroundsInDarkMode();
+    return protect(toImpl(preferencesRef))->punchOutWhiteBackgroundsInDarkMode();
 }
 
 void WKPreferencesSetCaptureAudioInUIProcessEnabled(WKPreferencesRef, bool)
@@ -1631,12 +1631,12 @@ bool WKPreferencesGetCaptureAudioInUIProcessEnabled(WKPreferencesRef)
 
 void WKPreferencesSetCaptureAudioInGPUProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setCaptureAudioInGPUProcessEnabled(flag);
+    protect(toImpl(preferencesRef))->setCaptureAudioInGPUProcessEnabled(flag);
 }
 
 bool WKPreferencesGetCaptureAudioInGPUProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->captureAudioInGPUProcessEnabled();
+    return protect(toImpl(preferencesRef))->captureAudioInGPUProcessEnabled();
 }
 
 void WKPreferencesSetCaptureVideoInUIProcessEnabled(WKPreferencesRef, bool)
@@ -1650,52 +1650,52 @@ bool WKPreferencesGetCaptureVideoInUIProcessEnabled(WKPreferencesRef)
 
 void WKPreferencesSetCaptureVideoInGPUProcessEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setCaptureVideoInGPUProcessEnabled(flag);
+    protect(toImpl(preferencesRef))->setCaptureVideoInGPUProcessEnabled(flag);
 }
 
 bool WKPreferencesGetCaptureVideoInGPUProcessEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->captureVideoInGPUProcessEnabled();
+    return protect(toImpl(preferencesRef))->captureVideoInGPUProcessEnabled();
 }
 
 void WKPreferencesSetVP9DecoderEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toProtectedImpl(preferencesRef)->setVP9DecoderEnabled(flag);
+    protect(toImpl(preferencesRef))->setVP9DecoderEnabled(flag);
 }
 
 bool WKPreferencesGetVP9DecoderEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->vp9DecoderEnabled();
+    return protect(toImpl(preferencesRef))->vp9DecoderEnabled();
 }
 
 bool WKPreferencesGetRemotePlaybackEnabled(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toProtectedImpl(preferencesRef)->remotePlaybackEnabled();
+    return protect(WebKit::toImpl(preferencesRef))->remotePlaybackEnabled();
 }
 
 void WKPreferencesSetRemotePlaybackEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toProtectedImpl(preferencesRef)->setRemotePlaybackEnabled(enabled);
+    protect(WebKit::toImpl(preferencesRef))->setRemotePlaybackEnabled(enabled);
 }
 
 bool WKPreferencesGetShouldUseServiceWorkerShortTimeout(WKPreferencesRef preferencesRef)
 {
-    return WebKit::toProtectedImpl(preferencesRef)->shouldUseServiceWorkerShortTimeout();
+    return protect(WebKit::toImpl(preferencesRef))->shouldUseServiceWorkerShortTimeout();
 }
 
 void WKPreferencesSetShouldUseServiceWorkerShortTimeout(WKPreferencesRef preferencesRef, bool enabled)
 {
-    WebKit::toProtectedImpl(preferencesRef)->setShouldUseServiceWorkerShortTimeout(enabled);
+    protect(WebKit::toImpl(preferencesRef))->setShouldUseServiceWorkerShortTimeout(enabled);
 }
 
 void WKPreferencesSetRequestVideoFrameCallbackEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toProtectedImpl(preferencesRef)->setRequestVideoFrameCallbackEnabled(enabled);
+    protect(toImpl(preferencesRef))->setRequestVideoFrameCallbackEnabled(enabled);
 }
 
 bool WKPreferencesGetRequestVideoFrameCallbackEnabled(WKPreferencesRef preferencesRef)
 {
-    return toProtectedImpl(preferencesRef)->requestVideoFrameCallbackEnabled();
+    return protect(toImpl(preferencesRef))->requestVideoFrameCallbackEnabled();
 }
 
 

--- a/Source/WebKit/UIProcess/API/C/WKProtectionSpace.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKProtectionSpace.cpp
@@ -38,35 +38,35 @@ WKTypeID WKProtectionSpaceGetTypeID()
 
 WKStringRef WKProtectionSpaceCopyHost(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toCopiedAPI(toProtectedImpl(protectionSpaceRef)->host());
+    return toCopiedAPI(protect(toImpl(protectionSpaceRef))->host());
 }
 
 int WKProtectionSpaceGetPort(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toProtectedImpl(protectionSpaceRef)->port();
+    return protect(toImpl(protectionSpaceRef))->port();
 }
 
 WKStringRef WKProtectionSpaceCopyRealm(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toCopiedAPI(toProtectedImpl(protectionSpaceRef)->realm());
+    return toCopiedAPI(protect(toImpl(protectionSpaceRef))->realm());
 }
 
 bool WKProtectionSpaceGetIsProxy(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toProtectedImpl(protectionSpaceRef)->isProxy();
+    return protect(toImpl(protectionSpaceRef))->isProxy();
 }
 
 WKProtectionSpaceServerType WKProtectionSpaceGetServerType(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toAPI(toProtectedImpl(protectionSpaceRef)->serverType());
+    return toAPI(protect(toImpl(protectionSpaceRef))->serverType());
 }
 
 bool WKProtectionSpaceGetReceivesCredentialSecurely(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toProtectedImpl(protectionSpaceRef)->receivesCredentialSecurely();
+    return protect(toImpl(protectionSpaceRef))->receivesCredentialSecurely();
 }
 
 WKProtectionSpaceAuthenticationScheme WKProtectionSpaceGetAuthenticationScheme(WKProtectionSpaceRef protectionSpaceRef)
 {
-    return toAPI(toProtectedImpl(protectionSpaceRef)->authenticationScheme());
+    return toAPI(protect(toImpl(protectionSpaceRef))->authenticationScheme());
 }

--- a/Source/WebKit/UIProcess/API/C/WKQueryPermissionResultCallback.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKQueryPermissionResultCallback.cpp
@@ -38,15 +38,15 @@ WKTypeID WKQueryPermissionResultCallbackGetTypeID()
 
 void WKQueryPermissionResultCallbackCompleteWithDenied(WKQueryPermissionResultCallbackRef callback)
 {
-    return toProtectedImpl(callback)->setPermission(WebCore::PermissionState::Denied);
+    return protect(toImpl(callback))->setPermission(WebCore::PermissionState::Denied);
 }
 
 void WKQueryPermissionResultCallbackCompleteWithGranted(WKQueryPermissionResultCallbackRef callback)
 {
-    return toProtectedImpl(callback)->setPermission(WebCore::PermissionState::Granted);
+    return protect(toImpl(callback))->setPermission(WebCore::PermissionState::Granted);
 }
 
 void WKQueryPermissionResultCallbackCompleteWithPrompt(WKQueryPermissionResultCallbackRef callback)
 {
-    return toProtectedImpl(callback)->setPermission(WebCore::PermissionState::Prompt);
+    return protect(toImpl(callback))->setPermission(WebCore::PermissionState::Prompt);
 }

--- a/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
@@ -53,30 +53,30 @@ WKUserContentControllerRef WKUserContentControllerCreate()
 
 WKArrayRef WKUserContentControllerCopyUserScripts(WKUserContentControllerRef userContentControllerRef)
 {
-    return toAPILeakingRef(toProtectedImpl(userContentControllerRef)->userScripts().copy());
+    return toAPILeakingRef(protect(toImpl(userContentControllerRef))->userScripts().copy());
 }
 
 void WKUserContentControllerAddUserScript(WKUserContentControllerRef userContentControllerRef, WKUserScriptRef userScriptRef)
 {
-    toProtectedImpl(userContentControllerRef)->addUserScript(*toProtectedImpl(userScriptRef), InjectUserScriptImmediately::No);
+    protect(toImpl(userContentControllerRef))->addUserScript(*protect(toImpl(userScriptRef)), InjectUserScriptImmediately::No);
 }
 
 void WKUserContentControllerRemoveAllUserScripts(WKUserContentControllerRef userContentControllerRef)
 {
-    toProtectedImpl(userContentControllerRef)->removeAllUserScripts();
+    protect(toImpl(userContentControllerRef))->removeAllUserScripts();
 }
 
 void WKUserContentControllerAddUserContentFilter(WKUserContentControllerRef userContentControllerRef, WKUserContentFilterRef userContentFilterRef)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toProtectedImpl(userContentControllerRef)->addContentRuleList(*toProtectedImpl(userContentFilterRef));
+    protect(toImpl(userContentControllerRef))->addContentRuleList(*protect(toImpl(userContentFilterRef)));
 #endif
 }
 
 void WKUserContentControllerRemoveAllUserContentFilters(WKUserContentControllerRef userContentControllerRef)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toProtectedImpl(userContentControllerRef)->removeAllContentRuleLists();
+    protect(toImpl(userContentControllerRef))->removeAllContentRuleLists();
 #endif
 }
 
@@ -92,7 +92,7 @@ private:
     {
         Ref message = API::ScriptMessage::create(result.toAPI(), page, API::FrameInfo::create(WTF::move(frameInfo)), m_name, API::ContentWorld::pageContentWorldSingleton());
         Ref listener = API::CompletionListener::create([completionHandler = WTF::move(completionHandler)] (WKTypeRef reply) mutable {
-            if (auto result = JavaScriptEvaluationResult::extract(toProtectedImpl(reply).get()))
+            if (auto result = JavaScriptEvaluationResult::extract(protect(toImpl(reply)).get()))
                 return completionHandler(WTF::move(*result));
             completionHandler(makeUnexpected(String()));
         });
@@ -111,10 +111,10 @@ void WKUserContentControllerAddScriptMessageHandler(WKUserContentControllerRef u
     String name = toWTFString(wkName);
 
     auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<WebScriptMessageClient>(name, callback, context), name, API::ContentWorld::pageContentWorldSingleton());
-    toProtectedImpl(userContentController)->addUserScriptMessageHandler(handler);
+    protect(toImpl(userContentController))->addUserScriptMessageHandler(handler);
 }
 
 void WKUserContentControllerRemoveAllUserMessageHandlers(WKUserContentControllerRef userContentController)
 {
-    toProtectedImpl(userContentController)->removeAllUserMessageHandlers();
+    protect(toImpl(userContentController))->removeAllUserMessageHandlers();
 }

--- a/Source/WebKit/UIProcess/API/C/WKUserContentExtensionStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserContentExtensionStoreRef.cpp
@@ -76,7 +76,7 @@ static inline WKUserContentExtensionStoreResult toResult(const std::error_code& 
 void WKUserContentExtensionStoreCompile(WKUserContentExtensionStoreRef store, WKStringRef identifier, WKStringRef jsonSource, void* context, WKUserContentExtensionStoreFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toProtectedImpl(store)->compileContentRuleList(toWTFString(identifier), toWTFString(jsonSource), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    protect(toImpl(store))->compileContentRuleList(toWTFString(identifier), toWTFString(jsonSource), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         callback(error ? nullptr : toAPILeakingRef(WTF::move(contentRuleList)), toResult(error), context);
     });
 #else
@@ -88,7 +88,7 @@ void WKUserContentExtensionStoreCompile(WKUserContentExtensionStoreRef store, WK
 void WKUserContentExtensionStoreLookup(WKUserContentExtensionStoreRef store, WKStringRef identifier, void* context, WKUserContentExtensionStoreFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toProtectedImpl(store)->lookupContentRuleList(toWTFString(identifier), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    protect(toImpl(store))->lookupContentRuleList(toWTFString(identifier), [context, callback](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         callback(error ? nullptr : toAPILeakingRef(WTF::move(contentRuleList)), toResult(error), context);
     });
 #else
@@ -99,7 +99,7 @@ void WKUserContentExtensionStoreLookup(WKUserContentExtensionStoreRef store, WKS
 void WKUserContentExtensionStoreRemove(WKUserContentExtensionStoreRef store, WKStringRef identifier, void* context, WKUserContentExtensionStoreFunction callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    toProtectedImpl(store)->removeContentRuleList(toWTFString(identifier), [context, callback](std::error_code error) {
+    protect(toImpl(store))->removeContentRuleList(toWTFString(identifier), [context, callback](std::error_code error) {
         callback(nullptr, toResult(error), context);
     });
 #else

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp
@@ -46,5 +46,5 @@ WKTypeID WKUserMediaPermissionCheckGetTypeID()
 
 void WKUserMediaPermissionCheckSetUserMediaAccessInfo(WKUserMediaPermissionCheckRef userMediaPermissionRequestRef, WKStringRef, bool allowed)
 {
-    toProtectedImpl(userMediaPermissionRequestRef)->setUserMediaAccessInfo(allowed);
+    protect(toImpl(userMediaPermissionRequestRef))->setUserMediaAccessInfo(allowed);
 }

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp
@@ -36,7 +36,7 @@ WKTypeID WKUserMediaPermissionRequestGetTypeID()
 
 void WKUserMediaPermissionRequestAllow(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef, WKStringRef audioDeviceUID, WKStringRef videoDeviceUID)
 {
-    toProtectedImpl(userMediaPermissionRequestRef)->allow(toWTFString(audioDeviceUID), toWTFString(videoDeviceUID));
+    protect(toImpl(userMediaPermissionRequestRef))->allow(toWTFString(audioDeviceUID), toWTFString(videoDeviceUID));
 }
 
 static UserMediaPermissionRequestProxy::UserMediaAccessDenialReason toWK(UserMediaPermissionRequestDenialReason reason)
@@ -72,14 +72,14 @@ static UserMediaPermissionRequestProxy::UserMediaAccessDenialReason toWK(UserMed
 
 void WKUserMediaPermissionRequestDeny(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef, UserMediaPermissionRequestDenialReason reason)
 {
-    toProtectedImpl(userMediaPermissionRequestRef)->deny(toWK(reason));
+    protect(toImpl(userMediaPermissionRequestRef))->deny(toWK(reason));
 }
 
 WKArrayRef WKUserMediaPermissionRequestVideoDeviceUIDs(WKUserMediaPermissionRequestRef userMediaPermissionRef)
 {
     WKMutableArrayRef array = WKMutableArrayCreate();
 #if ENABLE(MEDIA_STREAM)
-    for (auto& deviceUID : toProtectedImpl(userMediaPermissionRef)->videoDeviceUIDs())
+    for (auto& deviceUID : protect(toImpl(userMediaPermissionRef))->videoDeviceUIDs())
         WKArrayAppendItem(array, toAPI(API::String::create(deviceUID).ptr()));
 #endif
     return array;
@@ -89,7 +89,7 @@ WKArrayRef WKUserMediaPermissionRequestAudioDeviceUIDs(WKUserMediaPermissionRequ
 {
     WKMutableArrayRef array = WKMutableArrayCreate();
 #if ENABLE(MEDIA_STREAM)
-    for (auto& deviceUID : toProtectedImpl(userMediaPermissionRef)->audioDeviceUIDs())
+    for (auto& deviceUID : protect(toImpl(userMediaPermissionRef))->audioDeviceUIDs())
         WKArrayAppendItem(array, toAPI(API::String::create(deviceUID).ptr()));
 #endif
     return array;
@@ -97,15 +97,15 @@ WKArrayRef WKUserMediaPermissionRequestAudioDeviceUIDs(WKUserMediaPermissionRequ
 
 bool WKUserMediaPermissionRequestRequiresCameraCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
 {
-    return toProtectedImpl(userMediaPermissionRequestRef)->requiresVideoCapture();
+    return protect(toImpl(userMediaPermissionRequestRef))->requiresVideoCapture();
 }
 
 bool WKUserMediaPermissionRequestRequiresDisplayCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
 {
-    return toProtectedImpl(userMediaPermissionRequestRef)->requiresDisplayCapture();
+    return protect(toImpl(userMediaPermissionRequestRef))->requiresDisplayCapture();
 }
 
 bool WKUserMediaPermissionRequestRequiresMicrophoneCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
 {
-    return toProtectedImpl(userMediaPermissionRequestRef)->requiresAudioCapture();
+    return protect(toImpl(userMediaPermissionRequestRef))->requiresAudioCapture();
 }

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
@@ -51,7 +51,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyNetworkCacheDirectory(WKWebsiteDa
 
 void WKWebsiteDataStoreConfigurationSetNetworkCacheDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setNetworkCacheDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setNetworkCacheDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyIndexedDBDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -61,7 +61,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyIndexedDBDatabaseDirectory(WKWebs
 
 void WKWebsiteDataStoreConfigurationSetIndexedDBDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setIndexedDBDatabaseDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setIndexedDBDatabaseDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyLocalStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -71,7 +71,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyLocalStorageDirectory(WKWebsiteDa
 
 void WKWebsiteDataStoreConfigurationSetLocalStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setLocalStorageDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setLocalStorageDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyWebSQLDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -81,7 +81,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyWebSQLDatabaseDirectory(WKWebsite
 
 void WKWebsiteDataStoreConfigurationSetWebSQLDatabaseDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setWebSQLDatabaseDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setWebSQLDatabaseDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyCacheStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -91,7 +91,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyCacheStorageDirectory(WKWebsiteDa
 
 void WKWebsiteDataStoreConfigurationSetCacheStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setCacheStorageDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setCacheStorageDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyGeneralStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -101,7 +101,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyGeneralStorageDirectory(WKWebsite
 
 void WKWebsiteDataStoreConfigurationSetGeneralStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setGeneralStorageDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setGeneralStorageDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyMediaKeysStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -111,7 +111,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyMediaKeysStorageDirectory(WKWebsi
 
 void WKWebsiteDataStoreConfigurationSetMediaKeysStorageDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setMediaKeysStorageDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setMediaKeysStorageDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyResourceLoadStatisticsDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -121,7 +121,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyResourceLoadStatisticsDirectory(W
 
 void WKWebsiteDataStoreConfigurationSetResourceLoadStatisticsDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setResourceLoadStatisticsDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setResourceLoadStatisticsDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyServiceWorkerRegistrationDirectory(WKWebsiteDataStoreConfigurationRef configuration)
@@ -131,7 +131,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyServiceWorkerRegistrationDirector
 
 void WKWebsiteDataStoreConfigurationSetServiceWorkerRegistrationDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
-    protect(WebKit::toImpl(configuration))->setServiceWorkerRegistrationDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setServiceWorkerRegistrationDirectory(protect(WebKit::toImpl(directory))->string());
 }
 
 WKStringRef WKWebsiteDataStoreConfigurationCopyCookieStorageFile(WKWebsiteDataStoreConfigurationRef configuration)
@@ -141,7 +141,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyCookieStorageFile(WKWebsiteDataSt
 
 void WKWebsiteDataStoreConfigurationSetCookieStorageFile(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef cookieStorageFile)
 {
-    protect(WebKit::toImpl(configuration))->setCookieStorageFile(WebKit::toProtectedImpl(cookieStorageFile)->string());
+    protect(WebKit::toImpl(configuration))->setCookieStorageFile(protect(WebKit::toImpl(cookieStorageFile))->string());
 }
 
 uint64_t WKWebsiteDataStoreConfigurationGetPerOriginStorageQuota(WKWebsiteDataStoreConfigurationRef configuration)
@@ -191,7 +191,7 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyPCMMachServiceName(WKWebsiteDataS
 
 void WKWebsiteDataStoreConfigurationSetPCMMachServiceName(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef name)
 {
-    protect(WebKit::toImpl(configuration))->setPCMMachServiceName(name ? WebKit::toProtectedImpl(name)->string() : String());
+    protect(WebKit::toImpl(configuration))->setPCMMachServiceName(name ? protect(WebKit::toImpl(name))->string() : String());
 }
 
 bool WKWebsiteDataStoreConfigurationHasOriginQuotaRatio(WKWebsiteDataStoreConfigurationRef configuration)
@@ -226,6 +226,6 @@ WKStringRef WKWebsiteDataStoreConfigurationCopyResourceMonitorThrottlerDirectory
 void WKWebsiteDataStoreConfigurationSetResourceMonitorThrottlerDirectory(WKWebsiteDataStoreConfigurationRef configuration, WKStringRef directory)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protect(WebKit::toImpl(configuration))->setResourceMonitorThrottlerDirectory(WebKit::toProtectedImpl(directory)->string());
+    protect(WebKit::toImpl(configuration))->setResourceMonitorThrottlerDirectory(protect(WebKit::toImpl(directory))->string());
 #endif
 }

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -72,69 +72,69 @@ WKWebsiteDataStoreRef WKWebsiteDataStoreCreateWithConfiguration(WKWebsiteDataSto
 
 void WKWebsiteDataStoreTerminateNetworkProcess(WKWebsiteDataStoreRef dataStore)
 {
-    WebKit::toProtectedImpl(dataStore)->terminateNetworkProcess();
+    protect(WebKit::toImpl(dataStore))->terminateNetworkProcess();
 }
 
 WKProcessID WKWebsiteDataStoreGetNetworkProcessIdentifier(WKWebsiteDataStoreRef dataStore)
 {
-    return WebKit::toProtectedImpl(dataStore)->networkProcess().processID();
+    return protect(WebKit::toImpl(dataStore))->networkProcess().processID();
 }
 
 void WKWebsiteDataStoreRemoveITPDataForDomain(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreRemoveITPDataForDomainFunction callback)
 {
     WebKit::WebsiteDataRecord dataRecord;
     dataRecord.types.add(WebKit::WebsiteDataType::ResourceLoadStatistics);
-    dataRecord.addResourceLoadStatisticsRegistrableDomain(WebCore::RegistrableDomain::uncheckedCreateFromHost(WebKit::toProtectedImpl(host)->string()));
+    dataRecord.addResourceLoadStatisticsRegistrableDomain(WebCore::RegistrableDomain::uncheckedCreateFromHost(protect(WebKit::toImpl(host))->string()));
     Vector<WebKit::WebsiteDataRecord> dataRecords = { WTF::move(dataRecord) };
 
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::ResourceLoadStatistics;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, dataRecords, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, dataRecords, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreDoesStatisticsDomainIDExistInDatabase(WKWebsiteDataStoreRef dataStoreRef, int domainID, void* context, WKWebsiteDataStoreDoesStatisticsDomainIDExistInDatabaseFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->domainIDExistsInDatabase(domainID, [context, callback](bool exists) {
+    protect(WebKit::toImpl(dataStoreRef))->domainIDExistsInDatabase(domainID, [context, callback](bool exists) {
         callback(exists, context);
     });
 }
 
 void WKWebsiteDataStoreSetServiceWorkerFetchTimeoutForTesting(WKWebsiteDataStoreRef dataStore, double seconds)
 {
-    WebKit::toProtectedImpl(dataStore)->setServiceWorkerTimeoutForTesting(Seconds(seconds));
+    protect(WebKit::toImpl(dataStore))->setServiceWorkerTimeoutForTesting(Seconds(seconds));
 }
 
 void WKWebsiteDataStoreResetServiceWorkerFetchTimeoutForTesting(WKWebsiteDataStoreRef dataStore)
 {
-    WebKit::toProtectedImpl(dataStore)->resetServiceWorkerTimeoutForTesting();
+    protect(WebKit::toImpl(dataStore))->resetServiceWorkerTimeoutForTesting();
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enable)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setTrackingPreventionEnabled(enable);
+    protect(WebKit::toImpl(dataStoreRef))->setTrackingPreventionEnabled(enable);
 }
 
 void WKWebsiteDataStoreIsStatisticsEphemeral(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsEphemeralFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isResourceLoadStatisticsEphemeral([context, completionHandler](bool isEphemeral) {
+    protect(WebKit::toImpl(dataStoreRef))->isResourceLoadStatisticsEphemeral([context, completionHandler](bool isEphemeral) {
         completionHandler(isEphemeral, context);
     });
 }
 
 bool WKWebsiteDataStoreGetResourceLoadStatisticsEnabled(WKWebsiteDataStoreRef dataStoreRef)
 {
-    return WebKit::toProtectedImpl(dataStoreRef)->trackingPreventionEnabled();
+    return protect(WebKit::toImpl(dataStoreRef))->trackingPreventionEnabled();
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsDebugMode(WKWebsiteDataStoreRef dataStoreRef, bool enable)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsDebugMode(enable);
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsDebugMode(enable);
 }
 
 void WKWebsiteDataStoreSyncLocalStorage(WKWebsiteDataStoreRef dataStore, void* context, WKWebsiteDataStoreSyncLocalStorageCallback callback)
 {
-    WebKit::toProtectedImpl(dataStore)->syncLocalStorage([context, callback] {
+    protect(WebKit::toImpl(dataStore))->syncLocalStorage([context, callback] {
         if (callback)
             callback(context);
     });
@@ -142,7 +142,7 @@ void WKWebsiteDataStoreSyncLocalStorage(WKWebsiteDataStoreRef dataStore, void* c
 
 WKHTTPCookieStoreRef WKWebsiteDataStoreGetHTTPCookieStore(WKWebsiteDataStoreRef dataStoreRef)
 {
-    return WebKit::toAPI(protect(WebKit::toProtectedImpl(dataStoreRef)->cookieStore()).get());
+    return WebKit::toAPI(protect(protect(WebKit::toImpl(dataStoreRef))->cookieStore()).get());
 }
 
 void WKWebsiteDataStoreSetAllowsAnySSLCertificateForWebSocketTesting(WKWebsiteDataStoreRef, bool)
@@ -151,34 +151,34 @@ void WKWebsiteDataStoreSetAllowsAnySSLCertificateForWebSocketTesting(WKWebsiteDa
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsDebugModeWithCompletionHandler(WKWebsiteDataStoreRef dataStoreRef, bool enable, void* context, WKWebsiteDataStoreStatisticsDebugModeFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsDebugMode(enable, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsDebugMode(enable, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsPrevalentResourceForDebugMode(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreStatisticsDebugModeFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setPrevalentResourceForDebugMode(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setPrevalentResourceForDebugMode(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 void WKWebsiteDataStoreSetStatisticsLastSeen(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, double seconds, void* context, WKWebsiteDataStoreStatisticsLastSeenFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setLastSeen(URL { WebKit::toProtectedImpl(host)->string() }, Seconds { seconds }, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setLastSeen(URL { protect(WebKit::toImpl(host))->string() }, Seconds { seconds }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsMergeStatistic(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef topFrameDomain1, WKStringRef topFrameDomain2, double lastSeen, bool hadUserInteraction, double mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, void* context, WKWebsiteDataStoreStatisticsMergeStatisticFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->mergeStatisticForTesting(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(topFrameDomain1)->string() }, URL { WebKit::toProtectedImpl(topFrameDomain2)->string() }, Seconds { lastSeen }, hadUserInteraction, Seconds { mostRecentUserInteraction }, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->mergeStatisticForTesting(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(topFrameDomain1))->string() }, URL { protect(WebKit::toImpl(topFrameDomain2))->string() }, Seconds { lastSeen }, hadUserInteraction, Seconds { mostRecentUserInteraction }, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsExpiredStatistic(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, void* context, WKWebsiteDataStoreStatisticsMergeStatisticFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->insertExpiredStatisticForTesting(URL { WebKit::toProtectedImpl(host)->string() }, numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->insertExpiredStatisticForTesting(URL { protect(WebKit::toImpl(host))->string() }, numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, [context, completionHandler] {
         completionHandler(context);
     });
 }
@@ -188,11 +188,11 @@ void WKWebsiteDataStoreSetStatisticsPrevalentResource(WKWebsiteDataStoreRef data
     Ref websiteDataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        websiteDataStore->setPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->setPrevalentResource(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        websiteDataStore->clearPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->clearPrevalentResource(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
@@ -202,204 +202,204 @@ void WKWebsiteDataStoreSetStatisticsVeryPrevalentResource(WKWebsiteDataStoreRef 
     Ref websiteDataStore = *WebKit::toImpl(dataStoreRef);
 
     if (value)
-        websiteDataStore->setVeryPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->setVeryPrevalentResource(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        websiteDataStore->clearPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+        websiteDataStore->clearPrevalentResource(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
 
 void WKWebsiteDataStoreDumpResourceLoadStatistics(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreDumpResourceLoadStatisticsFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->dumpResourceLoadStatistics([context, callback] (const String& resourceLoadStatistics) {
+    protect(WebKit::toImpl(dataStoreRef))->dumpResourceLoadStatistics([context, callback] (const String& resourceLoadStatistics) {
         callback(WebKit::toAPI(resourceLoadStatistics.impl()), context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsPrevalentResource(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsPrevalentResourceFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool isPrevalentResource) {
+    protect(WebKit::toImpl(dataStoreRef))->isPrevalentResource(URL { protect(WebKit::toImpl(host))->string() }, [context, callback](bool isPrevalentResource) {
         callback(isPrevalentResource, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsVeryPrevalentResource(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsPrevalentResourceFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isVeryPrevalentResource(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool isVeryPrevalentResource) {
+    protect(WebKit::toImpl(dataStoreRef))->isVeryPrevalentResource(URL { protect(WebKit::toImpl(host))->string() }, [context, callback](bool isVeryPrevalentResource) {
         callback(isVeryPrevalentResource, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsRegisteredAsSubresourceUnder(WKWebsiteDataStoreRef dataStoreRef, WKStringRef subresourceHost, WKStringRef topFrameHost, void* context, WKWebsiteDataStoreIsStatisticsRegisteredAsSubresourceUnderFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isRegisteredAsSubresourceUnder(URL { WebKit::toProtectedImpl(subresourceHost)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [context, callback](bool isRegisteredAsSubresourceUnder) {
+    protect(WebKit::toImpl(dataStoreRef))->isRegisteredAsSubresourceUnder(URL { protect(WebKit::toImpl(subresourceHost))->string() }, URL { protect(WebKit::toImpl(topFrameHost))->string() }, [context, callback](bool isRegisteredAsSubresourceUnder) {
         callback(isRegisteredAsSubresourceUnder, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsRegisteredAsSubFrameUnder(WKWebsiteDataStoreRef dataStoreRef, WKStringRef subFrameHost, WKStringRef topFrameHost, void* context, WKWebsiteDataStoreIsStatisticsRegisteredAsSubFrameUnderFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isRegisteredAsSubFrameUnder(URL { WebKit::toProtectedImpl(subFrameHost)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [context, callback](bool isRegisteredAsSubFrameUnder) {
+    protect(WebKit::toImpl(dataStoreRef))->isRegisteredAsSubFrameUnder(URL { protect(WebKit::toImpl(subFrameHost))->string() }, URL { protect(WebKit::toImpl(topFrameHost))->string() }, [context, callback](bool isRegisteredAsSubFrameUnder) {
         callback(isRegisteredAsSubFrameUnder, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsRegisteredAsRedirectingTo(WKWebsiteDataStoreRef dataStoreRef, WKStringRef hostRedirectedFrom, WKStringRef hostRedirectedTo, void* context, WKWebsiteDataStoreIsStatisticsRegisteredAsRedirectingToFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isRegisteredAsRedirectingTo(URL { WebKit::toProtectedImpl(hostRedirectedFrom)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedTo)->string() }, [context, callback](bool isRegisteredAsRedirectingTo) {
+    protect(WebKit::toImpl(dataStoreRef))->isRegisteredAsRedirectingTo(URL { protect(WebKit::toImpl(hostRedirectedFrom))->string() }, URL { protect(WebKit::toImpl(hostRedirectedTo))->string() }, [context, callback](bool isRegisteredAsRedirectingTo) {
         callback(isRegisteredAsRedirectingTo, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsHasHadUserInteraction(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value, void* context, WKWebsiteDataStoreStatisticsHasHadUserInteractionFunction completionHandler)
 {
-    Ref dataStore = *WebKit::toProtectedImpl(dataStoreRef);
+    Ref dataStore = *protect(WebKit::toImpl(dataStoreRef));
 
     if (value)
-        dataStore->logUserInteraction(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+        dataStore->logUserInteraction(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
             completionHandler(context);
         });
     else
-        dataStore->clearUserInteraction(URL { WebKit::toProtectedImpl(host)->string() }, [context, completionHandler] {
+        dataStore->clearUserInteraction(URL { protect(WebKit::toImpl(host))->string() }, [context, completionHandler] {
             completionHandler(context);
         });
 }
 
 void WKWebsiteDataStoreIsStatisticsHasHadUserInteraction(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsHasHadUserInteractionFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->hasHadUserInteraction(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool hasHadUserInteraction) {
+    protect(WebKit::toImpl(dataStoreRef))->hasHadUserInteraction(URL { protect(WebKit::toImpl(host))->string() }, [context, callback](bool hasHadUserInteraction) {
         callback(hasHadUserInteraction, context);
     });
 }
 
 void WKWebsiteDataStoreIsStatisticsOnlyInDatabaseOnce(WKWebsiteDataStoreRef dataStoreRef, WKStringRef subHost, WKStringRef topHost, void* context, WKWebsiteDataStoreIsStatisticsOnlyInDatabaseOnceFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isRelationshipOnlyInDatabaseOnce(URL { WebKit::toProtectedImpl(subHost)->string() }, URL { WebKit::toProtectedImpl(topHost)->string() }, [context, callback](bool onlyInDatabaseOnce) {
+    protect(WebKit::toImpl(dataStoreRef))->isRelationshipOnlyInDatabaseOnce(URL { protect(WebKit::toImpl(subHost))->string() }, URL { protect(WebKit::toImpl(topHost))->string() }, [context, callback](bool onlyInDatabaseOnce) {
         callback(onlyInDatabaseOnce, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsGrandfathered(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool value)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setGrandfathered(URL { WebKit::toProtectedImpl(host)->string() }, value, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setGrandfathered(URL { protect(WebKit::toImpl(host))->string() }, value, [] { });
 }
 
 void WKWebsiteDataStoreIsStatisticsGrandfathered(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreIsStatisticsGrandfatheredFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->isGrandfathered(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool isGrandfathered) {
+    protect(WebKit::toImpl(dataStoreRef))->isGrandfathered(URL { protect(WebKit::toImpl(host))->string() }, [context, callback](bool isGrandfathered) {
         callback(isGrandfathered, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubframeUnderTopFrameOrigin(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef topFrameHost)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setSubframeUnderTopFrameDomain(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setSubframeUnderTopFrameDomain(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(topFrameHost))->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubresourceUnderTopFrameOrigin(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef topFrameHost)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setSubresourceUnderTopFrameDomain(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(topFrameHost)->string() }, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setSubresourceUnderTopFrameDomain(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(topFrameHost))->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubresourceUniqueRedirectTo(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedTo)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setSubresourceUniqueRedirectTo(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedTo)->string() }, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setSubresourceUniqueRedirectTo(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(hostRedirectedTo))->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsSubresourceUniqueRedirectFrom(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedFrom)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setSubresourceUniqueRedirectFrom(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedFrom)->string() }, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setSubresourceUniqueRedirectFrom(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(hostRedirectedFrom))->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsTopFrameUniqueRedirectTo(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedTo)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setTopFrameUniqueRedirectTo(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedTo)->string() }, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setTopFrameUniqueRedirectTo(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(hostRedirectedTo))->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsTopFrameUniqueRedirectFrom(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, WKStringRef hostRedirectedFrom)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setTopFrameUniqueRedirectFrom(URL { WebKit::toProtectedImpl(host)->string() }, URL { WebKit::toProtectedImpl(hostRedirectedFrom)->string() }, [] { });
+    protect(WebKit::toImpl(dataStoreRef))->setTopFrameUniqueRedirectFrom(URL { protect(WebKit::toImpl(host))->string() }, URL { protect(WebKit::toImpl(hostRedirectedFrom))->string() }, [] { });
 }
 
 void WKWebsiteDataStoreSetStatisticsCrossSiteLoadWithLinkDecoration(WKWebsiteDataStoreRef dataStoreRef, WKStringRef fromHost, WKStringRef toHost, bool wasFiltered, void* context, WKWebsiteDataStoreSetStatisticsCrossSiteLoadWithLinkDecorationFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setCrossSiteLoadWithLinkDecorationForTesting(URL { WebKit::toProtectedImpl(fromHost)->string() }, URL { WebKit::toProtectedImpl(toHost)->string() }, wasFiltered, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->setCrossSiteLoadWithLinkDecorationForTesting(URL { protect(WebKit::toImpl(fromHost))->string() }, URL { protect(WebKit::toImpl(toHost))->string() }, wasFiltered, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsTimeToLiveUserInteraction(WKWebsiteDataStoreRef dataStoreRef, double seconds, void* context, WKWebsiteDataStoreSetStatisticsTimeToLiveUserInteractionFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setTimeToLiveUserInteraction(Seconds { seconds }, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->setTimeToLiveUserInteraction(Seconds { seconds }, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsProcessStatisticsAndDataRecords(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsProcessStatisticsAndDataRecordsFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->scheduleStatisticsAndDataRecordsProcessing([context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->scheduleStatisticsAndDataRecordsProcessing([context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsUpdateCookieBlocking(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsUpdateCookieBlockingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->scheduleCookieBlockingUpdate([context, completionHandler]() {
+    protect(WebKit::toImpl(dataStoreRef))->scheduleCookieBlockingUpdate([context, completionHandler]() {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsTimeAdvanceForTesting(WKWebsiteDataStoreRef dataStoreRef, double value, void* context, WKWebsiteDataStoreSetStatisticsIsRunningTestFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsTimeAdvanceForTesting(Seconds { value }, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsTimeAdvanceForTesting(Seconds { value }, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsIsRunningTest(WKWebsiteDataStoreRef dataStoreRef, bool value, void* context, WKWebsiteDataStoreSetStatisticsIsRunningTestFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setIsRunningResourceLoadStatisticsTest(value, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->setIsRunningResourceLoadStatisticsTest(value, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(WKWebsiteDataStoreRef dataStoreRef, bool value)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setShouldClassifyResourcesBeforeDataRecordsRemoval(value, []() { });
+    protect(WebKit::toImpl(dataStoreRef))->setShouldClassifyResourcesBeforeDataRecordsRemoval(value, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsMinimumTimeBetweenDataRecordsRemoval(WKWebsiteDataStoreRef dataStoreRef, double seconds)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setMinimumTimeBetweenDataRecordsRemoval(Seconds { seconds }, []() { });
+    protect(WebKit::toImpl(dataStoreRef))->setMinimumTimeBetweenDataRecordsRemoval(Seconds { seconds }, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsGrandfatheringTime(WKWebsiteDataStoreRef dataStoreRef, double seconds)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setGrandfatheringTime(Seconds { seconds }, []() { });
+    protect(WebKit::toImpl(dataStoreRef))->setGrandfatheringTime(Seconds { seconds }, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsMaxStatisticsEntries(WKWebsiteDataStoreRef dataStoreRef, unsigned entries)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setMaxStatisticsEntries(entries, []() { });
+    protect(WebKit::toImpl(dataStoreRef))->setMaxStatisticsEntries(entries, []() { });
 }
 
 void WKWebsiteDataStoreSetStatisticsPruneEntriesDownTo(WKWebsiteDataStoreRef dataStoreRef, unsigned entries)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setPruneEntriesDownTo(entries, []() { });
+    protect(WebKit::toImpl(dataStoreRef))->setPruneEntriesDownTo(entries, []() { });
 }
 
 void WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStore(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->scheduleClearInMemoryAndPersistent(WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
+    protect(WebKit::toImpl(dataStoreRef))->scheduleClearInMemoryAndPersistent(WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHours(WKWebsiteDataStoreRef dataStoreRef, unsigned hours, void* context, WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHoursFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->scheduleClearInMemoryAndPersistent(WallTime::now() - Seconds::fromHours(hours), WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
+    protect(WebKit::toImpl(dataStoreRef))->scheduleClearInMemoryAndPersistent(WallTime::now() - Seconds::fromHours(hours), WebKit::ShouldGrandfatherStatistics::Yes, [context, callback]() {
         callback(context);
     });
 }
@@ -407,35 +407,35 @@ void WKWebsiteDataStoreStatisticsClearInMemoryAndPersistentStoreModifiedSinceHou
 void WKWebsiteDataStoreStatisticsClearThroughWebsiteDataRemoval(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsClearThroughWebsiteDataRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::ResourceLoadStatistics;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsDeleteCookiesForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, bool includeHttpOnlyCookies, void* context, WKWebsiteDataStoreStatisticsDeleteCookiesForTestingFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->deleteCookiesForTesting(URL { WebKit::toProtectedImpl(host)->string() }, includeHttpOnlyCookies, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->deleteCookiesForTesting(URL { protect(WebKit::toImpl(host))->string() }, includeHttpOnlyCookies, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsHasLocalStorage(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreStatisticsHasLocalStorageFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->hasLocalStorageForTesting(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool hasLocalStorage) {
+    protect(WebKit::toImpl(dataStoreRef))->hasLocalStorageForTesting(URL { protect(WebKit::toImpl(host))->string() }, [context, callback](bool hasLocalStorage) {
         callback(hasLocalStorage, context);
     });
 }
 
 void WKWebsiteDataStoreSetStatisticsCacheMaxAgeCap(WKWebsiteDataStoreRef dataStoreRef, double seconds, void* context, WKWebsiteDataStoreSetStatisticsCacheMaxAgeCapFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setCacheMaxAgeCapForPrevalentResources(Seconds { seconds }, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->setCacheMaxAgeCapForPrevalentResources(Seconds { seconds }, [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreStatisticsHasIsolatedSession(WKWebsiteDataStoreRef dataStoreRef, WKStringRef host, void* context, WKWebsiteDataStoreStatisticsHasIsolatedSessionFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->hasIsolatedSessionForTesting(URL { WebKit::toProtectedImpl(host)->string() }, [context, callback](bool hasIsolatedSession) {
+    protect(WebKit::toImpl(dataStoreRef))->hasIsolatedSessionForTesting(URL { protect(WebKit::toImpl(host))->string() }, [context, callback](bool hasIsolatedSession) {
         callback(hasIsolatedSession, context);
     });
 }
@@ -443,7 +443,7 @@ void WKWebsiteDataStoreStatisticsHasIsolatedSession(WKWebsiteDataStoreRef dataSt
 void WKWebsiteDataStoreHasAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreHasAppBoundSessionFunction callback)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    WebKit::toProtectedImpl(dataStoreRef)->hasAppBoundSession([context, callback](bool hasAppBoundSession) {
+    protect(WebKit::toImpl(dataStoreRef))->hasAppBoundSession([context, callback](bool hasAppBoundSession) {
         callback(hasAppBoundSession, context);
     });
 #else
@@ -454,7 +454,7 @@ void WKWebsiteDataStoreHasAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, vo
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsShouldDowngradeReferrerForTesting(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsShouldDowngradeReferrerForTestingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsShouldDowngradeReferrerForTesting(enabled, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsShouldDowngradeReferrerForTesting(enabled, [context, completionHandler] {
         completionHandler(context);
     });
 }
@@ -479,35 +479,35 @@ void WKWebsiteDataStoreSetResourceLoadStatisticsShouldBlockThirdPartyCookiesForT
 
     }
 
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting(enabled, blockingMode, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting(enabled, blockingMode, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTestingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(enabled, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting(enabled, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsToSameSiteStrictCookiesForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef hostName, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsToSameSiteStrictCookiesForTestingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsToSameSiteStrictCookiesForTesting(URL { WebKit::toProtectedImpl(hostName)->string() }, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsToSameSiteStrictCookiesForTesting(URL { protect(WebKit::toImpl(hostName))->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef firstPartyURLString, WKStringRef cnameURLString, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsFirstPartyHostCNAMEDomainForTestingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(URL { WebKit::toProtectedImpl(firstPartyURLString)->string() }, URL { WebKit::toProtectedImpl(cnameURLString)->string() }, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(URL { protect(WebKit::toImpl(firstPartyURLString))->string() }, URL { protect(WebKit::toImpl(cnameURLString))->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(WKWebsiteDataStoreRef dataStoreRef, WKStringRef cnameURLString, void* context, WKWebsiteDataStoreSetResourceLoadStatisticsThirdPartyCNAMEDomainForTestingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(URL { WebKit::toProtectedImpl(cnameURLString)->string() }, [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(URL { protect(WebKit::toImpl(cnameURLString))->string() }, [context, completionHandler] {
         completionHandler(context);
     });
 }
@@ -580,7 +580,7 @@ void WKWebsiteDataStoreStatisticsResetToConsistentState(WKWebsiteDataStoreRef da
 void WKWebsiteDataStoreRemoveAllFetchCaches(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveFetchCacheRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::DOMCache;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
@@ -588,7 +588,7 @@ void WKWebsiteDataStoreRemoveAllFetchCaches(WKWebsiteDataStoreRef dataStoreRef, 
 void WKWebsiteDataStoreRemoveNetworkCache(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveNetworkCacheCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::DiskCache;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
@@ -596,7 +596,7 @@ void WKWebsiteDataStoreRemoveNetworkCache(WKWebsiteDataStoreRef dataStoreRef, vo
 void WKWebsiteDataStoreRemoveMemoryCaches(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveMemoryCachesRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::MemoryCache;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
@@ -608,7 +608,7 @@ void WKWebsiteDataStoreRemoveFetchCacheForOrigin(WKWebsiteDataStoreRef dataStore
     Vector<WebKit::WebsiteDataRecord> dataRecords = { WTF::move(dataRecord) };
 
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::DOMCache;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, dataRecords, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, dataRecords, [context, callback] {
         callback(context);
     });
 }
@@ -616,7 +616,7 @@ void WKWebsiteDataStoreRemoveFetchCacheForOrigin(WKWebsiteDataStoreRef dataStore
 void WKWebsiteDataStoreRemoveAllIndexedDatabases(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveAllIndexedDatabasesCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::IndexedDBDatabases;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
     if (callback)
         callback(context);
     });
@@ -625,7 +625,7 @@ void WKWebsiteDataStoreRemoveAllIndexedDatabases(WKWebsiteDataStoreRef dataStore
 void WKWebsiteDataStoreRemoveLocalStorage(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveLocalStorageCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::LocalStorage;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         if (callback)
             callback(context);
     });
@@ -634,14 +634,14 @@ void WKWebsiteDataStoreRemoveLocalStorage(WKWebsiteDataStoreRef dataStoreRef, vo
 void WKWebsiteDataStoreRemoveAllServiceWorkerRegistrations(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreRemoveAllServiceWorkerRegistrationsCallback callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::ServiceWorkerRegistrations;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreGetFetchCacheOrigins(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreGetFetchCacheOriginsFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->fetchData(WebKit::WebsiteDataType::DOMCache, { }, [context, callback] (auto dataRecords) {
+    protect(WebKit::toImpl(dataStoreRef))->fetchData(WebKit::WebsiteDataType::DOMCache, { }, [context, callback] (auto dataRecords) {
         Vector<RefPtr<API::Object>> securityOrigins;
         for (const auto& dataRecord : dataRecords) {
             for (const auto& origin : dataRecord.origins)
@@ -655,8 +655,8 @@ void WKWebsiteDataStoreGetFetchCacheSizeForOrigin(WKWebsiteDataStoreRef dataStor
 {
     OptionSet<WebKit::WebsiteDataFetchOption> fetchOptions = WebKit::WebsiteDataFetchOption::ComputeSizes;
 
-    WebKit::toProtectedImpl(dataStoreRef)->fetchData(WebKit::WebsiteDataType::DOMCache, fetchOptions, [origin, context, callback] (auto dataRecords) {
-        auto originData = WebCore::SecurityOrigin::createFromString(WebKit::toProtectedImpl(origin)->string())->data();
+    protect(WebKit::toImpl(dataStoreRef))->fetchData(WebKit::WebsiteDataType::DOMCache, fetchOptions, [origin, context, callback] (auto dataRecords) {
+        auto originData = WebCore::SecurityOrigin::createFromString(protect(WebKit::toImpl(origin))->string())->data();
         for (auto& dataRecord : dataRecords) {
             for (const auto& recordOrigin : dataRecord.origins) {
                 if (originData == recordOrigin) {
@@ -677,26 +677,26 @@ void WKWebsiteDataStoreSetPerOriginStorageQuota(WKWebsiteDataStoreRef, uint64_t)
 void WKWebsiteDataStoreClearAllDeviceOrientationPermissions(WKWebsiteDataStoreRef dataStoreRef)
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    protect(WebKit::toProtectedImpl(dataStoreRef)->deviceOrientationAndMotionAccessController())->clearPermissions();
+    protect(protect(WebKit::toImpl(dataStoreRef))->deviceOrientationAndMotionAccessController())->clearPermissions();
 #endif
 }
 
 void WKWebsiteDataStoreClearPrivateClickMeasurementsThroughWebsiteDataRemoval(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearPrivateClickMeasurementsThroughWebsiteDataRemovalFunction callback)
 {
     OptionSet<WebKit::WebsiteDataType> dataTypes = WebKit::WebsiteDataType::PrivateClickMeasurements;
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, WallTime::fromRawSeconds(0), [context, callback] {
         callback(context);
     });
 }
 
 void WKWebsiteDataStoreSetCacheModelSynchronouslyForTesting(WKWebsiteDataStoreRef dataStoreRef, WKCacheModel cacheModel)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setCacheModelSynchronouslyForTesting(WebKit::toCacheModel(cacheModel));
+    protect(WebKit::toImpl(dataStoreRef))->setCacheModelSynchronouslyForTesting(WebKit::toCacheModel(cacheModel));
 }
 
 void WKWebsiteDataStoreResetQuota(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreResetQuotaCallback callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->resetQuota([context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->resetQuota([context, callback] {
         if (callback)
             callback(context);
     });
@@ -704,7 +704,7 @@ void WKWebsiteDataStoreResetQuota(WKWebsiteDataStoreRef dataStoreRef, void* cont
 
 void WKWebsiteDataStoreResetStoragePersistedState(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreResetStoragePersistedStateCallback callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->resetStoragePersistedState([context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->resetStoragePersistedState([context, callback] {
         if (callback)
             callback(context);
     });
@@ -720,7 +720,7 @@ void WKWebsiteDataStoreClearStorage(WKWebsiteDataStoreRef dataStoreRef, void* co
         WebKit::WebsiteDataType::Credentials,
         WebKit::WebsiteDataType::ServiceWorkerRegistrations
     };
-    WebKit::toProtectedImpl(dataStoreRef)->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->removeData(dataTypes, -WallTime::infinity(), [context, callback] {
         if (callback)
             callback(context);
     });
@@ -728,7 +728,7 @@ void WKWebsiteDataStoreClearStorage(WKWebsiteDataStoreRef dataStoreRef, void* co
 
 void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreResetQuotaCallback callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setOriginQuotaRatioEnabledForTesting(enabled, [context, callback] {
+    protect(WebKit::toImpl(dataStoreRef))->setOriginQuotaRatioEnabledForTesting(enabled, [context, callback] {
         if (callback)
             callback(context);
     });
@@ -737,7 +737,7 @@ void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStor
 void WKWebsiteDataStoreClearAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearAppBoundSessionFunction completionHandler)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    WebKit::toProtectedImpl(dataStoreRef)->clearAppBoundSession([context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->clearAppBoundSession([context, completionHandler] {
         completionHandler(context);
     });
 #else
@@ -749,7 +749,7 @@ void WKWebsiteDataStoreClearAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, 
 void WKWebsiteDataStoreReinitializeAppBoundDomains(WKWebsiteDataStoreRef dataStoreRef)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    WebKit::toProtectedImpl(dataStoreRef)->reinitializeAppBoundDomains();
+    protect(WebKit::toImpl(dataStoreRef))->reinitializeAppBoundDomains();
 #else
     UNUSED_PARAM(dataStoreRef);
 #endif
@@ -757,21 +757,21 @@ void WKWebsiteDataStoreReinitializeAppBoundDomains(WKWebsiteDataStoreRef dataSto
 
 void WKWebsiteDataStoreUpdateBundleIdentifierInNetworkProcess(WKWebsiteDataStoreRef dataStoreRef, const WKStringRef bundleIdentifier, void* context, WKWebsiteDataStoreUpdateBundleIdentifierInNetworkProcessFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->updateBundleIdentifierInNetworkProcess(WebKit::toProtectedImpl(bundleIdentifier)->string(), [context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->updateBundleIdentifierInNetworkProcess(protect(WebKit::toImpl(bundleIdentifier))->string(), [context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreClearBundleIdentifierInNetworkProcess(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearBundleIdentifierInNetworkProcessFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->clearBundleIdentifierInNetworkProcess([context, completionHandler] {
+    protect(WebKit::toImpl(dataStoreRef))->clearBundleIdentifierInNetworkProcess([context, completionHandler] {
         completionHandler(context);
     });
 }
 
 void WKWebsiteDataStoreGetAllStorageAccessEntries(WKWebsiteDataStoreRef dataStoreRef, WKPageRef pageRef, void* context, WKWebsiteDataStoreGetAllStorageAccessEntriesFunction callback)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->getAllStorageAccessEntries(WebKit::toImpl(pageRef)->identifier(), [context, callback] (Vector<String>&& domains) {
+    protect(WebKit::toImpl(dataStoreRef))->getAllStorageAccessEntries(WebKit::toImpl(pageRef)->identifier(), [context, callback] (Vector<String>&& domains) {
         auto domainArrayRef = WKMutableArrayCreate();
         for (auto domain : domains)
             WKArrayAppendItem(domainArrayRef, adoptWK(WKStringCreateWithUTF8CString(domain.utf8().data())).get());
@@ -783,7 +783,7 @@ void WKWebsiteDataStoreGetAllStorageAccessEntries(WKWebsiteDataStoreRef dataStor
 void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataStoreRef, void* context, KWebsiteDataStoreResetResourceMonitorThrottler callback)
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    WebKit::toProtectedImpl(dataStoreRef)->resetResourceMonitorThrottlerForTesting([context, callback] () {
+    protect(WebKit::toImpl(dataStoreRef))->resetResourceMonitorThrottlerForTesting([context, callback] () {
         if (callback)
             callback(context);
     });
@@ -803,7 +803,7 @@ void WKWebsiteDataStoreSetStorageAccessPermissionForTesting(WKWebsiteDataStoreRe
     Ref store = *WebKit::toImpl(dataStoreRef);
     if (!granted)
         store->clearResourceLoadStatisticsInWebProcesses([callbackAggregator] { });
-    store->setStorageAccessPermissionForTesting(granted, WebKit::toImpl(pageRef)->identifier(), WebKit::toProtectedImpl(topFrame)->string(), WebKit::toProtectedImpl(subFrame)->string(), [callbackAggregator] { });
+    store->setStorageAccessPermissionForTesting(granted, WebKit::toImpl(pageRef)->identifier(), protect(WebKit::toImpl(topFrame))->string(), protect(WebKit::toImpl(subFrame))->string(), [callbackAggregator] { });
 }
 
 void WKWebsiteDataStoreSetStorageAccessForTesting(WKWebsiteDataStoreRef dataStoreRef, bool blocked, void* context, WKWebsiteDataStoreSetStorageAccessForTestingFunction completionHandler)

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -50,12 +50,12 @@ WKWebsitePoliciesRef WKWebsitePoliciesCreate()
 void WKWebsitePoliciesSetContentBlockersEnabled(WKWebsitePoliciesRef websitePolicies, bool enabled)
 {
     auto defaultEnablement = enabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
-    toProtectedImpl(websitePolicies)->setContentExtensionEnablement({ defaultEnablement, { } });
+    protect(toImpl(websitePolicies))->setContentExtensionEnablement({ defaultEnablement, { } });
 }
 
 bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef websitePolicies)
 {
-    return toProtectedImpl(websitePolicies)->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
+    return protect(toImpl(websitePolicies))->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
 }
 
 WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef)
@@ -82,13 +82,13 @@ void WKWebsitePoliciesSetAllowedAutoplayQuirks(WKWebsitePoliciesRef websitePolic
     if (allowedQuirks & kWKWebsiteAutoplayQuirkPerDocumentAutoplayBehavior)
         quirks.add(WebsiteAutoplayQuirk::PerDocumentAutoplayBehavior);
 
-    toProtectedImpl(websitePolicies)->setAllowedAutoplayQuirks(quirks);
+    protect(toImpl(websitePolicies))->setAllowedAutoplayQuirks(quirks);
 }
 
 WKWebsiteAutoplayQuirk WKWebsitePoliciesGetAllowedAutoplayQuirks(WKWebsitePoliciesRef websitePolicies)
 {
     WKWebsiteAutoplayQuirk quirks = 0;
-    auto allowedQuirks = toProtectedImpl(websitePolicies)->allowedAutoplayQuirks();
+    auto allowedQuirks = protect(toImpl(websitePolicies))->allowedAutoplayQuirks();
 
     if (allowedQuirks.contains(WebsiteAutoplayQuirk::SynthesizedPauseEvents))
         quirks |= kWKWebsiteAutoplayQuirkSynthesizedPauseEvents;
@@ -107,7 +107,7 @@ WKWebsiteAutoplayQuirk WKWebsitePoliciesGetAllowedAutoplayQuirks(WKWebsitePolici
 
 WKWebsiteAutoplayPolicy WKWebsitePoliciesGetAutoplayPolicy(WKWebsitePoliciesRef websitePolicies)
 {
-    switch (toProtectedImpl(websitePolicies)->autoplayPolicy()) {
+    switch (protect(toImpl(websitePolicies))->autoplayPolicy()) {
     case WebKit::WebsiteAutoplayPolicy::Default:
         return kWKWebsiteAutoplayPolicyDefault;
     case WebsiteAutoplayPolicy::Allow:
@@ -125,16 +125,16 @@ void WKWebsitePoliciesSetAutoplayPolicy(WKWebsitePoliciesRef websitePolicies, WK
 {
     switch (policy) {
     case kWKWebsiteAutoplayPolicyDefault:
-        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Default);
+        protect(toImpl(websitePolicies))->setAutoplayPolicy(WebsiteAutoplayPolicy::Default);
         return;
     case kWKWebsiteAutoplayPolicyAllow:
-        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Allow);
+        protect(toImpl(websitePolicies))->setAutoplayPolicy(WebsiteAutoplayPolicy::Allow);
         return;
     case kWKWebsiteAutoplayPolicyAllowWithoutSound:
-        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::AllowWithoutSound);
+        protect(toImpl(websitePolicies))->setAutoplayPolicy(WebsiteAutoplayPolicy::AllowWithoutSound);
         return;
     case kWKWebsiteAutoplayPolicyDeny:
-        toProtectedImpl(websitePolicies)->setAutoplayPolicy(WebsiteAutoplayPolicy::Deny);
+        protect(toImpl(websitePolicies))->setAutoplayPolicy(WebsiteAutoplayPolicy::Deny);
         return;
     }
     ASSERT_NOT_REACHED();
@@ -142,7 +142,7 @@ void WKWebsitePoliciesSetAutoplayPolicy(WKWebsitePoliciesRef websitePolicies, WK
 
 WKWebsitePopUpPolicy WKWebsitePoliciesGetPopUpPolicy(WKWebsitePoliciesRef websitePolicies)
 {
-    switch (toProtectedImpl(websitePolicies)->popUpPolicy()) {
+    switch (protect(toImpl(websitePolicies))->popUpPolicy()) {
     case WebsitePopUpPolicy::Default:
         return kWKWebsitePopUpPolicyDefault;
     case WebsitePopUpPolicy::Allow:
@@ -158,13 +158,13 @@ void WKWebsitePoliciesSetPopUpPolicy(WKWebsitePoliciesRef websitePolicies, WKWeb
 {
     switch (policy) {
     case kWKWebsitePopUpPolicyDefault:
-        toProtectedImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Default);
+        protect(toImpl(websitePolicies))->setPopUpPolicy(WebsitePopUpPolicy::Default);
         return;
     case kWKWebsitePopUpPolicyAllow:
-        toProtectedImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Allow);
+        protect(toImpl(websitePolicies))->setPopUpPolicy(WebsitePopUpPolicy::Allow);
         return;
     case kWKWebsitePopUpPolicyBlock:
-        toProtectedImpl(websitePolicies)->setPopUpPolicy(WebsitePopUpPolicy::Block);
+        protect(toImpl(websitePolicies))->setPopUpPolicy(WebsitePopUpPolicy::Block);
         return;
     }
     ASSERT_NOT_REACHED();
@@ -172,20 +172,20 @@ void WKWebsitePoliciesSetPopUpPolicy(WKWebsitePoliciesRef websitePolicies, WKWeb
 
 WKWebsiteDataStoreRef WKWebsitePoliciesGetDataStore(WKWebsitePoliciesRef websitePolicies)
 {
-    return toAPI(protect(toProtectedImpl(websitePolicies)->websiteDataStore()).get());
+    return toAPI(protect(protect(toImpl(websitePolicies))->websiteDataStore()).get());
 }
 
 void WKWebsitePoliciesSetDataStore(WKWebsitePoliciesRef websitePolicies, WKWebsiteDataStoreRef websiteDataStore)
 {
-    toProtectedImpl(websitePolicies)->setWebsiteDataStore(toProtectedImpl(websiteDataStore));
+    protect(toImpl(websitePolicies))->setWebsiteDataStore(protect(toImpl(websiteDataStore)));
 }
 
 bool WKWebsitePoliciesGetAllowsJSHandleCreationInPageWorld(WKWebsitePoliciesRef websitePolicies)
 {
-    return toProtectedImpl(websitePolicies)->allowsJSHandleCreationInPageWorld();
+    return protect(toImpl(websitePolicies))->allowsJSHandleCreationInPageWorld();
 }
 
 void WKWebsitePoliciesSetAllowsJSHandleCreationInPageWorld(WKWebsitePoliciesRef websitePolicies, bool allows)
 {
-    toProtectedImpl(websitePolicies)->setAllowsJSHandleCreationInPageWorld(allows);
+    protect(toImpl(websitePolicies))->setAllowsJSHandleCreationInPageWorld(allows);
 }

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -124,7 +124,7 @@ id <_WKObservablePageState> WKPageCreateObservableState(WKPageRef pageRef)
 _WKRemoteObjectRegistry *WKPageGetObjectRegistry(WKPageRef pageRef)
 {
 #if PLATFORM(MAC)
-    return WebKit::toProtectedImpl(pageRef)->remoteObjectRegistry();
+    return protect(WebKit::toImpl(pageRef))->remoteObjectRegistry();
 #else
     return nil;
 #endif
@@ -132,29 +132,29 @@ _WKRemoteObjectRegistry *WKPageGetObjectRegistry(WKPageRef pageRef)
 
 bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url)
 {
-    return protect(WebKit::toProtectedImpl(page)->configuration().processPool())->isURLKnownHSTSHost(WebKit::toImpl(url)->string());
+    return protect(protect(WebKit::toImpl(page))->configuration().processPool())->isURLKnownHSTSHost(WebKit::toImpl(url)->string());
 }
 
 WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef pageRef, WKURLRequestRef urlRequestRef)
 {
     auto resourceRequest = WebKit::toImpl(urlRequestRef)->resourceRequest();
-    return WebKit::wrapper(WebKit::toProtectedImpl(pageRef)->loadRequest(WTF::move(resourceRequest))).autorelease();
+    return WebKit::wrapper(protect(WebKit::toImpl(pageRef))->loadRequest(WTF::move(resourceRequest))).autorelease();
 }
 
 WKNavigation *WKPageLoadFileReturningNavigation(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL)
 {
-    return WebKit::wrapper(WebKit::toProtectedImpl(pageRef)->loadFile(WebKit::toWTFString(fileURL), WebKit::toWTFString(resourceDirectoryURL))).autorelease();
+    return WebKit::wrapper(protect(WebKit::toImpl(pageRef))->loadFile(WebKit::toWTFString(fileURL), WebKit::toWTFString(resourceDirectoryURL))).autorelease();
 }
 
 WKWebView *WKPageGetWebView(WKPageRef page)
 {
-    return page ? WebKit::toProtectedImpl(page)->cocoaView().autorelease() : nil;
+    return page ? protect(WebKit::toImpl(page))->cocoaView().autorelease() : nil;
 }
 
 #if PLATFORM(MAC)
 bool WKPageIsPlayingVideoInPictureInPicture(WKPageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->isPlayingVideoInPictureInPicture();
+    return protect(WebKit::toImpl(pageRef))->isPlayingVideoInPictureInPicture();
 }
 #endif
 
@@ -177,7 +177,7 @@ id <_WKFullscreenDelegate> WKPageGetFullscreenDelegate(WKPageRef page)
 NSDictionary *WKPageGetAccessibilityWebProcessDebugInfo(WKPageRef pageRef)
 {
 #if PLATFORM(MAC)
-    return WebKit::toProtectedImpl(pageRef)->getAccessibilityWebProcessDebugInfo();
+    return protect(WebKit::toImpl(pageRef))->getAccessibilityWebProcessDebugInfo();
 #else
     return nil;
 #endif
@@ -186,7 +186,7 @@ NSDictionary *WKPageGetAccessibilityWebProcessDebugInfo(WKPageRef pageRef)
 NSArray *WKPageGetAccessibilityWebProcessDebugInfoForAllProcesses(WKPageRef pageRef)
 {
 #if PLATFORM(MAC)
-    return WebKit::toProtectedImpl(pageRef)->getAccessibilityWebProcessDebugInfoForAllProcesses();
+    return protect(WebKit::toImpl(pageRef))->getAccessibilityWebProcessDebugInfoForAllProcesses();
 #else
     return nil;
 #endif
@@ -195,6 +195,6 @@ NSArray *WKPageGetAccessibilityWebProcessDebugInfoForAllProcesses(WKPageRef page
 void WKPageAccessibilityClearIsolatedTree(WKPageRef pageRef)
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    WebKit::toProtectedImpl(pageRef)->clearAccessibilityIsolatedTree();
+    protect(WebKit::toImpl(pageRef))->clearAccessibilityIsolatedTree();
 #endif
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -55,65 +55,65 @@ WKTypeID WKBundleGetTypeID()
 
 void WKBundleSetClient(WKBundleRef bundleRef, WKBundleClientBase *wkClient)
 {
-    WebKit::toProtectedImpl(bundleRef)->setClient(makeUnique<WebKit::InjectedBundleClient>(wkClient));
+    protect(WebKit::toImpl(bundleRef))->setClient(makeUnique<WebKit::InjectedBundleClient>(wkClient));
 }
 
 void WKBundleSetServiceWorkerProxyCreationCallback(WKBundleRef bundleRef, void (*callback)(uint64_t))
 {
-    WebKit::toProtectedImpl(bundleRef)->setServiceWorkerProxyCreationCallback(callback);
+    protect(WebKit::toImpl(bundleRef))->setServiceWorkerProxyCreationCallback(callback);
 }
 
 void WKBundlePostMessage(WKBundleRef bundleRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toProtectedImpl(bundleRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
+    protect(WebKit::toImpl(bundleRef))->postMessage(WebKit::toWTFString(messageNameRef), protect(WebKit::toImpl(messageBodyRef)).get());
 }
 
 void WKBundlePostSynchronousMessage(WKBundleRef bundleRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef, WKTypeRef* returnRetainedDataRef)
 {
     RefPtr<API::Object> returnData;
-    WebKit::toProtectedImpl(bundleRef)->postSynchronousMessage(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get(), returnData);
+    protect(WebKit::toImpl(bundleRef))->postSynchronousMessage(WebKit::toWTFString(messageNameRef), protect(WebKit::toImpl(messageBodyRef)).get(), returnData);
     if (returnRetainedDataRef)
         *returnRetainedDataRef = WebKit::toAPILeakingRef(WTF::move(returnData));
 }
 
 void WKBundleGarbageCollectJavaScriptObjects(WKBundleRef bundleRef)
 {
-    WebKit::toProtectedImpl(bundleRef)->garbageCollectJavaScriptObjects();
+    protect(WebKit::toImpl(bundleRef))->garbageCollectJavaScriptObjects();
 }
 
 void WKBundleGarbageCollectJavaScriptObjectsOnAlternateThreadForDebugging(WKBundleRef bundleRef, bool waitUntilDone)
 {
-    WebKit::toProtectedImpl(bundleRef)->garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging(waitUntilDone);
+    protect(WebKit::toImpl(bundleRef))->garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging(waitUntilDone);
 }
 
 size_t WKBundleGetJavaScriptObjectsCount(WKBundleRef bundleRef)
 {
-    return WebKit::toProtectedImpl(bundleRef)->javaScriptObjectsCount();
+    return protect(WebKit::toImpl(bundleRef))->javaScriptObjectsCount();
 }
 
 void WKBundleAddOriginAccessAllowListEntry(WKBundleRef bundleRef, WKStringRef sourceOrigin, WKStringRef destinationProtocol, WKStringRef destinationHost, bool allowDestinationSubdomains)
 {
-    WebKit::toProtectedImpl(bundleRef)->addOriginAccessAllowListEntry(WebKit::toWTFString(sourceOrigin), WebKit::toWTFString(destinationProtocol), WebKit::toWTFString(destinationHost), allowDestinationSubdomains);
+    protect(WebKit::toImpl(bundleRef))->addOriginAccessAllowListEntry(WebKit::toWTFString(sourceOrigin), WebKit::toWTFString(destinationProtocol), WebKit::toWTFString(destinationHost), allowDestinationSubdomains);
 }
 
 void WKBundleRemoveOriginAccessAllowListEntry(WKBundleRef bundleRef, WKStringRef sourceOrigin, WKStringRef destinationProtocol, WKStringRef destinationHost, bool allowDestinationSubdomains)
 {
-    WebKit::toProtectedImpl(bundleRef)->removeOriginAccessAllowListEntry(WebKit::toWTFString(sourceOrigin), WebKit::toWTFString(destinationProtocol), WebKit::toWTFString(destinationHost), allowDestinationSubdomains);
+    protect(WebKit::toImpl(bundleRef))->removeOriginAccessAllowListEntry(WebKit::toWTFString(sourceOrigin), WebKit::toWTFString(destinationProtocol), WebKit::toWTFString(destinationHost), allowDestinationSubdomains);
 }
 
 void WKBundleResetOriginAccessAllowLists(WKBundleRef bundleRef)
 {
-    WebKit::toProtectedImpl(bundleRef)->resetOriginAccessAllowLists();
+    protect(WebKit::toImpl(bundleRef))->resetOriginAccessAllowLists();
 }
 
 void WKBundleSetAsynchronousSpellCheckingEnabledForTesting(WKBundleRef bundleRef, bool enabled)
 {
-    WebKit::toProtectedImpl(bundleRef)->setAsynchronousSpellCheckingEnabled(enabled);
+    protect(WebKit::toImpl(bundleRef))->setAsynchronousSpellCheckingEnabled(enabled);
 }
 
 WKArrayRef WKBundleGetLiveDocumentURLsForTesting(WKBundleRef bundleRef, bool excludeDocumentsInPageGroupPages)
 {
-    auto liveDocuments = WebKit::toProtectedImpl(bundleRef)->liveDocumentURLs(excludeDocumentsInPageGroupPages);
+    auto liveDocuments = protect(WebKit::toImpl(bundleRef))->liveDocumentURLs(excludeDocumentsInPageGroupPages);
 
     auto liveURLs = adoptWK(WKMutableArrayCreate());
 
@@ -153,27 +153,27 @@ void WKBundleReleaseMemory(WKBundleRef)
 
 WKDataRef WKBundleCreateWKDataFromUInt8Array(WKBundleRef bundle, JSContextRef context, JSValueRef data)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(bundle)->createWebDataFromUint8Array(context, data));
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(bundle))->createWebDataFromUint8Array(context, data));
 }
 
 int WKBundleNumberOfPages(WKBundleRef bundleRef, WKBundleFrameRef frameRef, double pageWidthInPixels, double pageHeightInPixels)
 {
-    return WebKit::toProtectedImpl(bundleRef)->numberOfPages(WebKit::toProtectedImpl(frameRef).get(), pageWidthInPixels, pageHeightInPixels);
+    return protect(WebKit::toImpl(bundleRef))->numberOfPages(protect(WebKit::toImpl(frameRef)).get(), pageWidthInPixels, pageHeightInPixels);
 }
 
 int WKBundlePageNumberForElementById(WKBundleRef bundleRef, WKBundleFrameRef frameRef, WKStringRef idRef, double pageWidthInPixels, double pageHeightInPixels)
 {
-    return WebKit::toProtectedImpl(bundleRef)->pageNumberForElementById(WebKit::toProtectedImpl(frameRef).get(), WebKit::toWTFString(idRef), pageWidthInPixels, pageHeightInPixels);
+    return protect(WebKit::toImpl(bundleRef))->pageNumberForElementById(protect(WebKit::toImpl(frameRef)).get(), WebKit::toWTFString(idRef), pageWidthInPixels, pageHeightInPixels);
 }
 
 WKStringRef WKBundlePageSizeAndMarginsInPixels(WKBundleRef bundleRef, WKBundleFrameRef frameRef, int pageIndex, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(bundleRef)->pageSizeAndMarginsInPixels(WebKit::toProtectedImpl(frameRef).get(), pageIndex, width, height, marginTop, marginRight, marginBottom, marginLeft));
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(bundleRef))->pageSizeAndMarginsInPixels(protect(WebKit::toImpl(frameRef)).get(), pageIndex, width, height, marginTop, marginRight, marginBottom, marginLeft));
 }
 
 bool WKBundleIsPageBoxVisible(WKBundleRef bundleRef, WKBundleFrameRef frameRef, int pageIndex)
 {
-    return WebKit::toProtectedImpl(bundleRef)->isPageBoxVisible(WebKit::toProtectedImpl(frameRef).get(), pageIndex);
+    return protect(WebKit::toImpl(bundleRef))->isPageBoxVisible(protect(WebKit::toImpl(frameRef)).get(), pageIndex);
 }
 
 bool WKBundleIsProcessingUserGesture(WKBundleRef)
@@ -183,17 +183,17 @@ bool WKBundleIsProcessingUserGesture(WKBundleRef)
 
 void WKBundleSetUserStyleSheetLocationForTesting(WKBundleRef bundleRef, WKStringRef location)
 {
-    WebKit::toProtectedImpl(bundleRef)->setUserStyleSheetLocation(WebKit::toWTFString(location));
+    protect(WebKit::toImpl(bundleRef))->setUserStyleSheetLocation(WebKit::toWTFString(location));
 }
 
 void WKBundleRemoveAllWebNotificationPermissions(WKBundleRef bundleRef, WKBundlePageRef pageRef)
 {
-    WebKit::toProtectedImpl(bundleRef)->removeAllWebNotificationPermissions(WebKit::toProtectedImpl(pageRef).get());
+    protect(WebKit::toImpl(bundleRef))->removeAllWebNotificationPermissions(protect(WebKit::toImpl(pageRef)).get());
 }
 
 WKDataRef WKBundleCopyWebNotificationID(WKBundleRef bundleRef, JSContextRef context, JSValueRef notification)
 {
-    auto identifier = WebKit::toProtectedImpl(bundleRef)->webNotificationID(context, notification);
+    auto identifier = protect(WebKit::toImpl(bundleRef))->webNotificationID(context, notification);
     if (!identifier)
         return nullptr;
 
@@ -203,7 +203,7 @@ WKDataRef WKBundleCopyWebNotificationID(WKBundleRef bundleRef, JSContextRef cont
 
 void WKBundleSetTabKeyCyclesThroughElements(WKBundleRef bundleRef, WKBundlePageRef pageRef, bool enabled)
 {
-    WebKit::toProtectedImpl(bundleRef)->setTabKeyCyclesThroughElements(WebKit::toProtectedImpl(pageRef).get(), enabled);
+    protect(WebKit::toImpl(bundleRef))->setTabKeyCyclesThroughElements(protect(WebKit::toImpl(pageRef)).get(), enabled);
 }
 
 void WKBundleClearResourceLoadStatistics(WKBundleRef)
@@ -228,6 +228,6 @@ void WKBundleExtendClassesForParameterCoder(WKBundleRef bundle, WKArrayRef class
     if (!classList)
         return;
 
-    WebKit::toProtectedImpl(bundle)->extendClassesForParameterCoder(*classList);
+    protect(WebKit::toImpl(bundle))->extendClassesForParameterCoder(*classList);
 #endif
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
@@ -39,16 +39,16 @@ WKTypeID WKBundleDOMWindowExtensionGetTypeID()
 
 WKBundleDOMWindowExtensionRef WKBundleDOMWindowExtensionCreate(WKBundleFrameRef frame, WKBundleScriptWorldRef world)
 {
-    RefPtr<WebKit::InjectedBundleDOMWindowExtension> extension = WebKit::InjectedBundleDOMWindowExtension::create(WebKit::toProtectedImpl(frame).get(), WebKit::toProtectedImpl(world).get());
+    RefPtr<WebKit::InjectedBundleDOMWindowExtension> extension = WebKit::InjectedBundleDOMWindowExtension::create(protect(WebKit::toImpl(frame)).get(), protect(WebKit::toImpl(world)).get());
     return toAPILeakingRef(WTF::move(extension));
 }
 
 WKBundleFrameRef WKBundleDOMWindowExtensionGetFrame(WKBundleDOMWindowExtensionRef extension)
 {
-    return toAPI(WebKit::toProtectedImpl(extension)->frame().get());
+    return toAPI(protect(WebKit::toImpl(extension))->frame().get());
 }
 
 WKBundleScriptWorldRef WKBundleDOMWindowExtensionGetScriptWorld(WKBundleDOMWindowExtensionRef extension)
 {
-    return toAPI(RefPtr { WebKit::toProtectedImpl(extension)->world() }.get());
+    return toAPI(RefPtr { protect(WebKit::toImpl(extension))->world() }.get());
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -56,27 +56,27 @@ WKTypeID WKBundleFrameGetTypeID()
 
 bool WKBundleFrameIsMainFrame(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->isMainFrame();
+    return protect(WebKit::toImpl(frameRef))->isMainFrame();
 }
 
 WKBundleFrameRef WKBundleFrameGetParentFrame(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toProtectedImpl(frameRef)->parentFrame().get());
+    return toAPI(protect(WebKit::toImpl(frameRef))->parentFrame().get());
 }
 
 WKURLRef WKBundleFrameCopyURL(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(frameRef)->url());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(frameRef))->url());
 }
 
 WKURLRef WKBundleFrameCopyProvisionalURL(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(frameRef)->provisionalURL());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(frameRef))->provisionalURL());
 }
 
 WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = protect(WebKit::toImpl(frameRef))->coreLocalFrame();
     if (!coreFrame)
         return kWKFrameLoadStateFinished;
 
@@ -95,12 +95,12 @@ WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 
 WKArrayRef WKBundleFrameCopyChildFrames(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(frameRef)->childFrames());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(frameRef))->childFrames());
 }
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContext(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->jsContext();
+    return protect(WebKit::toImpl(frameRef))->jsContext();
 }
 
 WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
@@ -110,22 +110,22 @@ WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContextForWorld(WKBundleFrameRef frameRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->jsContextForWorld(WebKit::toProtectedImpl(worldRef).get());
+    return protect(WebKit::toImpl(frameRef))->jsContextForWorld(protect(WebKit::toImpl(worldRef)).get());
 }
 
 JSValueRef WKBundleFrameGetJavaScriptWrapperForNodeForWorld(WKBundleFrameRef frameRef, WKBundleNodeHandleRef nodeHandleRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->jsWrapperForWorld(WebKit::toProtectedImpl(nodeHandleRef).get(), WebKit::toProtectedImpl(worldRef).get());
+    return protect(WebKit::toImpl(frameRef))->jsWrapperForWorld(protect(WebKit::toImpl(nodeHandleRef)).get(), protect(WebKit::toImpl(worldRef)).get());
 }
 
 JSValueRef WKBundleFrameGetJavaScriptWrapperForRangeForWorld(WKBundleFrameRef frameRef, WKBundleRangeHandleRef rangeHandleRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->jsWrapperForWorld(WebKit::toProtectedImpl(rangeHandleRef).get(), WebKit::toProtectedImpl(worldRef).get());
+    return protect(WebKit::toImpl(frameRef))->jsWrapperForWorld(protect(WebKit::toImpl(rangeHandleRef)).get(), protect(WebKit::toImpl(worldRef)).get());
 }
 
 WKStringRef WKBundleFrameCopyName(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->name());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(frameRef))->name());
 }
 
 WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frameRef, JSObjectRef element)
@@ -135,27 +135,27 @@ WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frameRef, JSObjectRef
 
 unsigned WKBundleFrameGetPendingUnloadCount(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->pendingUnloadCount();
+    return protect(WebKit::toImpl(frameRef))->pendingUnloadCount();
 }
 
 WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 {
-    return toAPI(protect(WebKit::toProtectedImpl(frameRef)->page()).get());
+    return toAPI(protect(protect(WebKit::toImpl(frameRef))->page()).get());
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)
 {
-    WebKit::toProtectedImpl(frameRef)->stopLoading();
+    protect(WebKit::toImpl(frameRef))->stopLoading();
 }
 
 WKStringRef WKBundleFrameCopyLayerTreeAsText(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->layerTreeAsText());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(frameRef))->layerTreeAsText());
 }
 
 bool WKBundleFrameAllowsFollowingLink(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->allowsFollowingLink(URL { WebKit::toWTFString(urlRef) });
+    return protect(WebKit::toImpl(frameRef))->allowsFollowingLink(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef)
@@ -166,57 +166,57 @@ bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef)
 
 WKRect WKBundleFrameGetContentBounds(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->contentBounds());
+    return WebKit::toAPI(protect(WebKit::toImpl(frameRef))->contentBounds());
 }
 
 WKRect WKBundleFrameGetVisibleContentBounds(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->visibleContentBounds());
+    return WebKit::toAPI(protect(WebKit::toImpl(frameRef))->visibleContentBounds());
 }
 
 WKRect WKBundleFrameGetVisibleContentBoundsExcludingScrollbars(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->visibleContentBoundsExcludingScrollbars());
+    return WebKit::toAPI(protect(WebKit::toImpl(frameRef))->visibleContentBoundsExcludingScrollbars());
 }
 
 WKSize WKBundleFrameGetScrollOffset(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->scrollOffset());
+    return WebKit::toAPI(protect(WebKit::toImpl(frameRef))->scrollOffset());
 }
 
 bool WKBundleFrameHasHorizontalScrollbar(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->hasHorizontalScrollbar();
+    return protect(WebKit::toImpl(frameRef))->hasHorizontalScrollbar();
 }
 
 bool WKBundleFrameHasVerticalScrollbar(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->hasVerticalScrollbar();
+    return protect(WebKit::toImpl(frameRef))->hasVerticalScrollbar();
 }
 
 bool WKBundleFrameGetDocumentBackgroundColor(WKBundleFrameRef frameRef, double* red, double* green, double* blue, double* alpha)
 {
-    return WebKit::toProtectedImpl(frameRef)->getDocumentBackgroundColor(red, green, blue, alpha);
+    return protect(WebKit::toImpl(frameRef))->getDocumentBackgroundColor(red, green, blue, alpha);
 }
 
 WKStringRef WKBundleFrameCopySuggestedFilenameForResourceWithURL(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->suggestedFilenameForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(frameRef))->suggestedFilenameForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
 }
 
 WKStringRef WKBundleFrameCopyMIMETypeForResourceWithURL(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->mimeTypeForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(frameRef))->mimeTypeForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
 }
 
 bool WKBundleFrameContainsAnyFormElements(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->containsAnyFormElements();
+    return protect(WebKit::toImpl(frameRef))->containsAnyFormElements();
 }
 
 bool WKBundleFrameContainsAnyFormControls(WKBundleFrameRef frameRef)
 {
-    return WebKit::toProtectedImpl(frameRef)->containsAnyFormControls();
+    return protect(WebKit::toImpl(frameRef))->containsAnyFormControls();
 }
 
 void WKBundleFrameSetTextDirection(WKBundleFrameRef frameRef, WKStringRef directionRef)
@@ -224,7 +224,7 @@ void WKBundleFrameSetTextDirection(WKBundleFrameRef frameRef, WKStringRef direct
     if (!frameRef)
         return;
 
-    WebKit::toProtectedImpl(frameRef)->setTextDirection(WebKit::toWTFString(directionRef));
+    protect(WebKit::toImpl(frameRef))->setTextDirection(WebKit::toWTFString(directionRef));
 }
 
 void WKBundleFrameSetAccessibleName(WKBundleFrameRef frameRef, WKStringRef accessibleNameRef)
@@ -232,7 +232,7 @@ void WKBundleFrameSetAccessibleName(WKBundleFrameRef frameRef, WKStringRef acces
     if (!frameRef)
         return;
 
-    WebKit::toProtectedImpl(frameRef)->setAccessibleName(AtomString { WebKit::toWTFString(accessibleNameRef) });
+    protect(WebKit::toImpl(frameRef))->setAccessibleName(AtomString { WebKit::toWTFString(accessibleNameRef) });
 }
 
 WKDataRef WKBundleFrameCopyWebArchive(WKBundleFrameRef frameRef)
@@ -243,7 +243,7 @@ WKDataRef WKBundleFrameCopyWebArchive(WKBundleFrameRef frameRef)
 WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRef, WKBundleFrameFrameFilterCallback frameFilterCallback, void* context)
 {
 #if PLATFORM(COCOA)
-    RetainPtr<CFDataRef> data = WebKit::toProtectedImpl(frameRef)->webArchiveData(frameFilterCallback, context);
+    RetainPtr<CFDataRef> data = protect(WebKit::toImpl(frameRef))->webArchiveData(frameFilterCallback, context);
     if (data)
         return WKDataCreate(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()));
 #else
@@ -260,7 +260,7 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
     if (!frameRef)
         return true;
 
-    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = protect(WebKit::toImpl(frameRef))->coreLocalFrame();
     if (!coreFrame)
         return true;
 
@@ -270,12 +270,12 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
 WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frameRef, WKPoint point)
 {
     ASSERT(frameRef);
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(frameRef)->hitTest(WebKit::toIntPoint(point)));
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(frameRef))->hitTest(WebKit::toIntPoint(point)));
 }
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = protect(WebKit::toImpl(frameRef))->coreLocalFrame();
     if (!coreFrame)
         return 0;
 
@@ -284,7 +284,7 @@ WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 
 void WKBundleFrameFocus(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = protect(WebKit::toImpl(frameRef))->coreLocalFrame();
     if (!coreFrame)
         return;
 
@@ -296,7 +296,7 @@ void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef mes
     if (!frameRef)
         return;
 
-    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = protect(WebKit::toImpl(frameRef))->coreLocalFrame();
     if (!coreFrame)
         return;
 
@@ -312,7 +312,7 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
     auto getAXObjectCache = [&frameRef] () -> CheckedPtr<WebCore::AXObjectCache> {
         WebCore::AXObjectCache::enableAccessibility();
 
-        RefPtr frame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
+        RefPtr frame = protect(WebKit::toImpl(frameRef))->coreLocalFrame();
         RefPtr document = frame ? frame->rootFrame().document() : nullptr;
         return document ? document->axObjectCache() : nullptr;
     };
@@ -320,7 +320,7 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
     // Notify the UI process that accessibility is enabled so that any new processes
     // (e.g., for site-isolated iframes) will also have accessibility enabled.
     if (!WebCore::AXObjectCache::accessibilityEnabled()) {
-        if (RefPtr page = WebKit::toProtectedImpl(frameRef)->page())
+        if (RefPtr page = protect(WebKit::toImpl(frameRef))->page())
             page->enableAccessibilityForAllProcesses();
     }
 
@@ -345,6 +345,6 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     CheckedPtr cache = getAXObjectCache();
-    RefPtr root = cache ? cache->rootObjectForFrame(*protect(WebKit::toProtectedImpl(frameRef)->coreLocalFrame())) : nullptr;
+    RefPtr root = cache ? cache->rootObjectForFrame(*protect(protect(WebKit::toImpl(frameRef))->coreLocalFrame())) : nullptr;
     return root ? root->wrapper() : nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
@@ -41,13 +41,13 @@ WKTypeID WKBundleHitTestResultGetTypeID()
 
 WKBundleNodeHandleRef WKBundleHitTestResultCopyNodeHandle(WKBundleHitTestResultRef hitTestResultRef)
 {
-    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toProtectedImpl(hitTestResultRef)->nodeHandle();
+    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = protect(WebKit::toImpl(hitTestResultRef))->nodeHandle();
     return toAPILeakingRef(WTF::move(nodeHandle));
 }
 
 WKBundleNodeHandleRef WKBundleHitTestResultCopyURLElementHandle(WKBundleHitTestResultRef hitTestResultRef)
 {
-    RefPtr<WebKit::InjectedBundleNodeHandle> urlElementNodeHandle = WebKit::toProtectedImpl(hitTestResultRef)->urlElementHandle();
+    RefPtr<WebKit::InjectedBundleNodeHandle> urlElementNodeHandle = protect(WebKit::toImpl(hitTestResultRef))->urlElementHandle();
     return toAPILeakingRef(WTF::move(urlElementNodeHandle));
 }
 
@@ -63,47 +63,47 @@ WKBundleFrameRef WKBundleHitTestResultGetTargetFrame(WKBundleHitTestResultRef)
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteImageURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absoluteImageURL());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(hitTestResultRef))->absoluteImageURL());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsolutePDFURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absolutePDFURL());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(hitTestResultRef))->absolutePDFURL());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteLinkURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absoluteLinkURL());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(hitTestResultRef))->absoluteLinkURL());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteMediaURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absoluteMediaURL());
+    return WebKit::toCopiedURLAPI(protect(WebKit::toImpl(hitTestResultRef))->absoluteMediaURL());
 }
 
 bool WKBundleHitTestResultMediaIsInFullscreen(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toProtectedImpl(hitTestResultRef)->mediaIsInFullscreen();
+    return protect(WebKit::toImpl(hitTestResultRef))->mediaIsInFullscreen();
 }
 
 bool WKBundleHitTestResultMediaHasAudio(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toProtectedImpl(hitTestResultRef)->mediaHasAudio();
+    return protect(WebKit::toImpl(hitTestResultRef))->mediaHasAudio();
 }
 
 bool WKBundleHitTestResultIsDownloadableMedia(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toProtectedImpl(hitTestResultRef)->isDownloadableMedia();
+    return protect(WebKit::toImpl(hitTestResultRef))->isDownloadableMedia();
 }
 
 WKBundleHitTestResultMediaType WKBundleHitTestResultGetMediaType(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return toAPI(WebKit::toProtectedImpl(hitTestResultRef)->mediaType());
+    return toAPI(protect(WebKit::toImpl(hitTestResultRef))->mediaType());
 }
 
 WKRect WKBundleHitTestResultGetImageRect(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(hitTestResultRef)->imageRect());
+    return WebKit::toAPI(protect(WebKit::toImpl(hitTestResultRef))->imageRect());
 }
 
 WKImageRef WKBundleHitTestResultCopyImage(WKBundleHitTestResultRef)
@@ -113,20 +113,20 @@ WKImageRef WKBundleHitTestResultCopyImage(WKBundleHitTestResultRef)
 
 bool WKBundleHitTestResultGetIsSelected(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toProtectedImpl(hitTestResultRef)->isSelected();
+    return protect(WebKit::toImpl(hitTestResultRef))->isSelected();
 }
 
 WKStringRef WKBundleHitTestResultCopyLinkLabel(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(hitTestResultRef)->linkLabel());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(hitTestResultRef))->linkLabel());
 }
 
 WKStringRef WKBundleHitTestResultCopyLinkTitle(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(hitTestResultRef)->linkTitle());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(hitTestResultRef))->linkTitle());
 }
 
 WKStringRef WKBundleHitTestResultCopyLinkSuggestedFilename(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(hitTestResultRef)->linkSuggestedFilename());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(hitTestResultRef))->linkSuggestedFilename());
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
@@ -87,7 +87,7 @@ WKBundleNodeHandleRef WKBundleNodeHandleCreate(JSContextRef contextRef, JSObject
 
 WKBundleNodeHandleRef WKBundleNodeHandleCopyDocument(WKBundleNodeHandleRef nodeHandleRef)
 {
-    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toProtectedImpl(nodeHandleRef)->document();
+    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = protect(WebKit::toImpl(nodeHandleRef))->document();
     return toAPILeakingRef(WTF::move(nodeHandle));
 }
 
@@ -99,7 +99,7 @@ WKRect WKBundleNodeHandleGetRenderRect(WKBundleNodeHandleRef nodeHandleRef, bool
 
 WKImageRef WKBundleNodeHandleCopySnapshotWithOptions(WKBundleNodeHandleRef nodeHandleRef, WKSnapshotOptions options)
 {
-    RefPtr<WebKit::WebImage> image = WebKit::toProtectedImpl(nodeHandleRef)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow);
+    RefPtr<WebKit::WebImage> image = protect(WebKit::toImpl(nodeHandleRef))->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow);
     return toAPILeakingRef(WTF::move(image));
 }
 
@@ -111,17 +111,17 @@ WKBundleRangeHandleRef WKBundleNodeHandleCopyVisibleRange(WKBundleNodeHandleRef)
 
 WKRect WKBundleNodeHandleGetElementBounds(WKBundleNodeHandleRef elementHandleRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(elementHandleRef)->elementBounds());
+    return WebKit::toAPI(protect(WebKit::toImpl(elementHandleRef))->elementBounds());
 }
 
 void WKBundleNodeHandleSetHTMLInputElementValueForUser(WKBundleNodeHandleRef htmlInputElementHandleRef, WKStringRef valueRef)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementValueForUser(WebKit::toWTFString(valueRef));
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setHTMLInputElementValueForUser(WebKit::toWTFString(valueRef));
 }
 
 void WKBundleNodeHandleSetHTMLInputElementSpellcheckEnabled(WKBundleNodeHandleRef htmlInputElementHandleRef, bool enabled)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementSpellcheckEnabled(enabled);
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setHTMLInputElementSpellcheckEnabled(enabled);
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutoFilled(WKBundleNodeHandleRef)
@@ -132,17 +132,17 @@ bool WKBundleNodeHandleGetHTMLInputElementAutoFilled(WKBundleNodeHandleRef)
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFilled(WKBundleNodeHandleRef htmlInputElementHandleRef, bool filled)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilled(filled);
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setHTMLInputElementAutoFilled(filled);
 }
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFilledAndViewable(WKBundleNodeHandleRef htmlInputElementHandleRef, bool autoFilledAndViewable)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilledAndViewable(autoFilledAndViewable);
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setHTMLInputElementAutoFilledAndViewable(autoFilledAndViewable);
 }
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFilledAndObscured(WKBundleNodeHandleRef htmlInputElementHandleRef, bool autoFilledAndObscured)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFilledAndObscured(autoFilledAndObscured);
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setHTMLInputElementAutoFilledAndObscured(autoFilledAndObscured);
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHandleRef)
@@ -153,17 +153,17 @@ bool WKBundleNodeHandleGetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHand
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFillButtonEnabledWithButtonType(WKBundleNodeHandleRef htmlInputElementHandleRef, WKAutoFillButtonType autoFillButtonType)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
 }
 
 WKAutoFillButtonType WKBundleNodeHandleGetHTMLInputElementAutoFillButtonType(WKBundleNodeHandleRef htmlInputElementHandleRef)
 {
-    return toWKAutoFillButtonType(WebKit::toProtectedImpl(htmlInputElementHandleRef)->htmlInputElementAutoFillButtonType());
+    return toWKAutoFillButtonType(protect(WebKit::toImpl(htmlInputElementHandleRef))->htmlInputElementAutoFillButtonType());
 }
 
 WKAutoFillButtonType WKBundleNodeHandleGetHTMLInputElementLastAutoFillButtonType(WKBundleNodeHandleRef htmlInputElementHandleRef)
 {
-    return toWKAutoFillButtonType(WebKit::toProtectedImpl(htmlInputElementHandleRef)->htmlInputElementLastAutoFillButtonType());
+    return toWKAutoFillButtonType(protect(WebKit::toImpl(htmlInputElementHandleRef))->htmlInputElementLastAutoFillButtonType());
 }
 
 bool WKBundleNodeHandleGetHTMLInputElementAutoFillAvailable(WKBundleNodeHandleRef)
@@ -174,7 +174,7 @@ bool WKBundleNodeHandleGetHTMLInputElementAutoFillAvailable(WKBundleNodeHandleRe
 
 void WKBundleNodeHandleSetHTMLInputElementAutoFillAvailable(WKBundleNodeHandleRef htmlInputElementHandleRef, bool autoFillAvailable)
 {
-    WebKit::toProtectedImpl(htmlInputElementHandleRef)->setAutoFillAvailable(autoFillAvailable);
+    protect(WebKit::toImpl(htmlInputElementHandleRef))->setAutoFillAvailable(autoFillAvailable);
 }
 
 WKRect WKBundleNodeHandleGetHTMLInputElementAutoFillButtonBounds(WKBundleNodeHandleRef)
@@ -185,12 +185,12 @@ WKRect WKBundleNodeHandleGetHTMLInputElementAutoFillButtonBounds(WKBundleNodeHan
 
 bool WKBundleNodeHandleGetHTMLInputElementLastChangeWasUserEdit(WKBundleNodeHandleRef htmlInputElementHandleRef)
 {
-    return WebKit::toProtectedImpl(htmlInputElementHandleRef)->htmlInputElementLastChangeWasUserEdit();
+    return protect(WebKit::toImpl(htmlInputElementHandleRef))->htmlInputElementLastChangeWasUserEdit();
 }
 
 bool WKBundleNodeHandleGetHTMLTextAreaElementLastChangeWasUserEdit(WKBundleNodeHandleRef htmlTextAreaElementHandleRef)
 {
-    return WebKit::toProtectedImpl(htmlTextAreaElementHandleRef)->htmlTextAreaElementLastChangeWasUserEdit();
+    return protect(WebKit::toImpl(htmlTextAreaElementHandleRef))->htmlTextAreaElementLastChangeWasUserEdit();
 }
 
 WKBundleNodeHandleRef WKBundleNodeHandleCopyHTMLTableCellElementCellAbove(WKBundleNodeHandleRef)
@@ -201,7 +201,7 @@ WKBundleNodeHandleRef WKBundleNodeHandleCopyHTMLTableCellElementCellAbove(WKBund
 
 WKBundleFrameRef WKBundleNodeHandleCopyDocumentFrame(WKBundleNodeHandleRef documentHandleRef)
 {
-    RefPtr<WebKit::WebFrame> frame = WebKit::toProtectedImpl(documentHandleRef)->documentFrame();
+    RefPtr<WebKit::WebFrame> frame = protect(WebKit::toImpl(documentHandleRef))->documentFrame();
     return toAPILeakingRef(WTF::move(frame));
 }
 
@@ -213,7 +213,7 @@ WKBundleFrameRef WKBundleNodeHandleCopyHTMLFrameElementContentFrame(WKBundleNode
 
 WKBundleFrameRef WKBundleNodeHandleCopyHTMLIFrameElementContentFrame(WKBundleNodeHandleRef htmlIFrameElementHandleRef)
 {
-    RefPtr<WebKit::WebFrame> frame = WebKit::toProtectedImpl(htmlIFrameElementHandleRef)->htmlIFrameElementContentFrame();
+    RefPtr<WebKit::WebFrame> frame = protect(WebKit::toImpl(htmlIFrameElementHandleRef))->htmlIFrameElementContentFrame();
     return toAPILeakingRef(WTF::move(frame));
 }
 
@@ -235,7 +235,7 @@ void WKBundleNodeHandleSetHTMLInputElementAutoFillButtonEnabled(WKBundleNodeHand
 
 WKBundleFrameRef WKBundleNodeHandleCopyOwningDocumentFrame(WKBundleNodeHandleRef documentHandleRef)
 {
-    if (RefPtr document = WebKit::toProtectedImpl(documentHandleRef)->document())
+    if (RefPtr document = protect(WebKit::toImpl(documentHandleRef))->document())
         return toAPILeakingRef(document->documentFrame());
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -85,7 +85,7 @@ WKTypeID WKBundlePageGetTypeID()
 void WKBundlePageSetContextMenuClient(WKBundlePageRef pageRef, WKBundlePageContextMenuClientBase* wkClient)
 {
 #if ENABLE(CONTEXT_MENUS)
-    WebKit::toProtectedImpl(pageRef)->setInjectedBundleContextMenuClient(makeUnique<WebKit::InjectedBundlePageContextMenuClient>(wkClient));
+    protect(WebKit::toImpl(pageRef))->setInjectedBundleContextMenuClient(makeUnique<WebKit::InjectedBundlePageContextMenuClient>(wkClient));
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(wkClient);
@@ -94,22 +94,22 @@ void WKBundlePageSetContextMenuClient(WKBundlePageRef pageRef, WKBundlePageConte
 
 void WKBundlePageSetEditorClient(WKBundlePageRef pageRef, WKBundlePageEditorClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(pageRef)->setInjectedBundleEditorClient(wkClient ? makeUnique<WebKit::InjectedBundlePageEditorClient>(*wkClient) : makeUnique<API::InjectedBundle::EditorClient>());
+    protect(WebKit::toImpl(pageRef))->setInjectedBundleEditorClient(wkClient ? makeUnique<WebKit::InjectedBundlePageEditorClient>(*wkClient) : makeUnique<API::InjectedBundle::EditorClient>());
 }
 
 void WKBundlePageSetFormClient(WKBundlePageRef pageRef, WKBundlePageFormClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(pageRef)->setInjectedBundleFormClient(makeUnique<WebKit::InjectedBundlePageFormClient>(wkClient));
+    protect(WebKit::toImpl(pageRef))->setInjectedBundleFormClient(makeUnique<WebKit::InjectedBundlePageFormClient>(wkClient));
 }
 
 void WKBundlePageSetPageLoaderClient(WKBundlePageRef pageRef, WKBundlePageLoaderClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(pageRef)->setInjectedBundlePageLoaderClient(makeUnique<WebKit::InjectedBundlePageLoaderClient>(wkClient));
+    protect(WebKit::toImpl(pageRef))->setInjectedBundlePageLoaderClient(makeUnique<WebKit::InjectedBundlePageLoaderClient>(wkClient));
 }
 
 void WKBundlePageSetResourceLoadClient(WKBundlePageRef pageRef, WKBundlePageResourceLoadClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(pageRef)->setInjectedBundleResourceLoadClient(makeUnique<WebKit::InjectedBundlePageResourceLoadClient>(wkClient));
+    protect(WebKit::toImpl(pageRef))->setInjectedBundleResourceLoadClient(makeUnique<WebKit::InjectedBundlePageResourceLoadClient>(wkClient));
 }
 
 void WKBundlePageSetPolicyClient(WKBundlePageRef, WKBundlePagePolicyClientBase*)
@@ -118,7 +118,7 @@ void WKBundlePageSetPolicyClient(WKBundlePageRef, WKBundlePagePolicyClientBase*)
 
 void WKBundlePageSetUIClient(WKBundlePageRef pageRef, WKBundlePageUIClientBase* wkClient)
 {
-    WebKit::toProtectedImpl(pageRef)->setInjectedBundleUIClient(makeUnique<WebKit::InjectedBundlePageUIClient>(wkClient));
+    protect(WebKit::toImpl(pageRef))->setInjectedBundleUIClient(makeUnique<WebKit::InjectedBundlePageUIClient>(wkClient));
 }
 
 WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef pageRef)
@@ -134,7 +134,7 @@ WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef bundleFrameRef)
 void WKBundlePageClickMenuItem(WKBundlePageRef pageRef, WKContextMenuItemRef item)
 {
 #if ENABLE(CONTEXT_MENUS)
-    protect(WebKit::toProtectedImpl(pageRef)->contextMenu())->itemSelected(WebKit::toImpl(item)->data());
+    protect(protect(WebKit::toImpl(pageRef))->contextMenu())->itemSelected(WebKit::toImpl(item)->data());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(item);
@@ -154,7 +154,7 @@ static Ref<API::Array> contextMenuItems(const WebKit::WebContextMenu& contextMen
 WKArrayRef WKBundlePageCopyContextMenuItems(WKBundlePageRef pageRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    Ref contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenu();
+    Ref contextMenu = protect(WebKit::toImpl(pageRef))->contextMenu();
     return WebKit::toAPILeakingRef(contextMenuItems(contextMenu.get()));
 #else
     UNUSED_PARAM(pageRef);
@@ -169,7 +169,7 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
     if (!page)
         return nullptr;
 
-    RefPtr contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toDoublePoint(point));
+    RefPtr contextMenu = protect(WebKit::toImpl(pageRef))->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toDoublePoint(point));
     if (!contextMenu)
         return nullptr;
 
@@ -183,7 +183,7 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
 
 void WKBundlePageInsertNewlineInQuotedContent(WKBundlePageRef pageRef)
 {
-    WebKit::toProtectedImpl(pageRef)->insertNewlineInQuotedContent();
+    protect(WebKit::toImpl(pageRef))->insertNewlineInQuotedContent();
 }
 
 void WKAccessibilityTestingInjectPreference(WKBundlePageRef pageRef, WKStringRef domain, WKStringRef key, WKStringRef encodedValue)
@@ -291,37 +291,37 @@ void WKBundlePageSetDefersLoading(WKBundlePageRef, bool)
 WKStringRef WKBundlePageCopyRenderTreeExternalRepresentation(WKBundlePageRef pageRef, RenderTreeExternalRepresentationBehavior options)
 {
     // Convert to webcore options.
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(pageRef)->renderTreeExternalRepresentation(options));
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(pageRef))->renderTreeExternalRepresentation(options));
 }
 
 WKStringRef WKBundlePageCopyRenderTreeExternalRepresentationForPrinting(WKBundlePageRef pageRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(pageRef)->renderTreeExternalRepresentationForPrinting());
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(pageRef))->renderTreeExternalRepresentationForPrinting());
 }
 
 void WKBundlePageClose(WKBundlePageRef pageRef)
 {
-    WebKit::toProtectedImpl(pageRef)->sendClose();
+    protect(WebKit::toImpl(pageRef))->sendClose();
 }
 
 bool WKBundlePageIsClosed(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->isClosed();
+    return protect(WebKit::toImpl(pageRef))->isClosed();
 }
 
 double WKBundlePageGetTextZoomFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->textZoomFactor();
+    return protect(WebKit::toImpl(pageRef))->textZoomFactor();
 }
 
 double WKBundlePageGetPageZoomFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->pageZoomFactor();
+    return protect(WebKit::toImpl(pageRef))->pageZoomFactor();
 }
 
 WKStringRef WKBundlePageDumpHistoryForTesting(WKBundlePageRef page, WKStringRef directory)
 {
-    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));
+    return WebKit::toCopiedAPI(protect(WebKit::toImpl(page))->dumpHistoryForTesting(WebKit::toWTFString(directory)));
 }
 
 WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRef)
@@ -356,7 +356,7 @@ void WKBundlePageUninstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBu
 void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)
 {
 #if PLATFORM(MAC)
-    WebKit::toProtectedImpl(pageRef)->setTopOverhangImage(WebKit::toProtectedImpl(imageRef).get());
+    protect(WebKit::toImpl(pageRef))->setTopOverhangImage(protect(WebKit::toImpl(imageRef)).get());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(imageRef);
@@ -366,7 +366,7 @@ void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRe
 void WKBundlePageSetBottomOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)
 {
 #if PLATFORM(MAC)
-    WebKit::toProtectedImpl(pageRef)->setBottomOverhangImage(WebKit::toProtectedImpl(imageRef).get());
+    protect(WebKit::toImpl(pageRef))->setBottomOverhangImage(protect(WebKit::toImpl(imageRef)).get());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(imageRef);
@@ -376,12 +376,12 @@ void WKBundlePageSetBottomOverhangImage(WKBundlePageRef pageRef, WKImageRef imag
 #if !PLATFORM(IOS_FAMILY)
 void WKBundlePageSetHeaderBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef bannerRef)
 {
-    WebKit::toProtectedImpl(pageRef)->setHeaderPageBanner(WebKit::toProtectedImpl(bannerRef).get());
+    protect(WebKit::toImpl(pageRef))->setHeaderPageBanner(protect(WebKit::toImpl(bannerRef)).get());
 }
 
 void WKBundlePageSetFooterBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef bannerRef)
 {
-    WebKit::toProtectedImpl(pageRef)->setFooterPageBanner(WebKit::toProtectedImpl(bannerRef).get());
+    protect(WebKit::toImpl(pageRef))->setFooterPageBanner(protect(WebKit::toImpl(bannerRef)).get());
 }
 #endif // !PLATFORM(IOS_FAMILY)
 
@@ -410,12 +410,12 @@ void WKBundlePageReplaceStringMatches(WKBundlePageRef pageRef, WKArrayRef matchI
         if (RefPtr indexAsObject = matchIndices->at<API::UInt64>(i))
             indices.append(indexAsObject->value());
     }
-    WebKit::toProtectedImpl(pageRef)->replaceStringMatchesFromInjectedBundle(indices, WebKit::toWTFString(replacementText), selectionOnly);
+    protect(WebKit::toImpl(pageRef))->replaceStringMatchesFromInjectedBundle(indices, WebKit::toWTFString(replacementText), selectionOnly);
 }
 
 WKImageRef WKBundlePageCreateSnapshotWithOptions(WKBundlePageRef pageRef, WKRect rect, WKSnapshotOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
+    RefPtr<WebKit::WebImage> webImage = protect(WebKit::toImpl(pageRef))->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
     return toAPILeakingRef(WTF::move(webImage));
 }
 
@@ -423,55 +423,55 @@ WKImageRef WKBundlePageCreateSnapshotInViewCoordinates(WKBundlePageRef pageRef, 
 {
     auto snapshotOptions = WebKit::snapshotOptionsFromImageOptions(options);
     snapshotOptions.add(WebKit::SnapshotOption::InViewCoordinates);
-    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
+    RefPtr<WebKit::WebImage> webImage = protect(WebKit::toImpl(pageRef))->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
     return toAPILeakingRef(WTF::move(webImage));
 }
 
 WKImageRef WKBundlePageCreateSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
+    RefPtr<WebKit::WebImage> webImage = protect(WebKit::toImpl(pageRef))->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
     return toAPILeakingRef(WTF::move(webImage));
 }
 
 WKImageRef WKBundlePageCreateScaledSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, double scaleFactor, WKImageOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
+    RefPtr<WebKit::WebImage> webImage = protect(WebKit::toImpl(pageRef))->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
     return toAPILeakingRef(WTF::move(webImage));
 }
 
 double WKBundlePageGetBackingScaleFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->deviceScaleFactor();
+    return protect(WebKit::toImpl(pageRef))->deviceScaleFactor();
 }
 
 void WKBundlePageListenForLayoutMilestones(WKBundlePageRef pageRef, WKLayoutMilestones milestones)
 {
-    WebKit::toProtectedImpl(pageRef)->listenForLayoutMilestones(WebKit::toLayoutMilestones(milestones));
+    protect(WebKit::toImpl(pageRef))->listenForLayoutMilestones(WebKit::toLayoutMilestones(milestones));
 }
 
 void WKBundlePageCloseInspectorForTest(WKBundlePageRef page)
 {
-    protect(WebKit::toProtectedImpl(page)->inspector())->close();
+    protect(protect(WebKit::toImpl(page))->inspector())->close();
 }
 
 void WKBundlePageEvaluateScriptInInspectorForTest(WKBundlePageRef page, WKStringRef script)
 {
-    protect(WebKit::toProtectedImpl(page)->inspector())->evaluateScriptForTest(WebKit::toWTFString(script));
+    protect(protect(WebKit::toImpl(page))->inspector())->evaluateScriptForTest(WebKit::toWTFString(script));
 }
 
 void WKBundlePageForceRepaint(WKBundlePageRef page)
 {
-    WebKit::toProtectedImpl(page)->updateRenderingWithForcedRepaintWithoutCallback();
+    protect(WebKit::toImpl(page))->updateRenderingWithForcedRepaintWithoutCallback();
 }
 
 void WKBundlePageFlushPendingEditorStateUpdate(WKBundlePageRef page)
 {
-    WebKit::toProtectedImpl(page)->flushPendingEditorStateUpdate();
+    protect(WebKit::toImpl(page))->flushPendingEditorStateUpdate();
 }
 
 uint64_t WKBundlePageGetRenderTreeSize(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->renderTreeSize();
+    return protect(WebKit::toImpl(pageRef))->renderTreeSize();
 }
 
 // This function should be kept around for compatibility with SafariForWebKitDevelopment.
@@ -492,12 +492,12 @@ void WKBundlePageSetPaintedObjectsCounterThreshold(WKBundlePageRef, uint64_t)
 
 bool WKBundlePageIsTrackingRepaints(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->isTrackingRepaints();
+    return protect(WebKit::toImpl(pageRef))->isTrackingRepaints();
 }
 
 WKArrayRef WKBundlePageCopyTrackedRepaintRects(WKBundlePageRef pageRef)
 {
-    return WebKit::toAPILeakingRef(WebKit::toProtectedImpl(pageRef)->trackedRepaintRects());
+    return WebKit::toAPILeakingRef(protect(WebKit::toImpl(pageRef))->trackedRepaintRects());
 }
 
 void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData, WKArrayRef annotationData)
@@ -544,22 +544,22 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
         }
     }
 
-    WebKit::toProtectedImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
+    protect(WebKit::toImpl(pageRef))->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
 }
 
 bool WKBundlePageHasComposition(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->hasCompositionForTesting();
+    return protect(WebKit::toImpl(pageRef))->hasCompositionForTesting();
 }
 
 void WKBundlePageConfirmComposition(WKBundlePageRef pageRef)
 {
-    WebKit::toProtectedImpl(pageRef)->confirmCompositionForTesting(String());
+    protect(WebKit::toImpl(pageRef))->confirmCompositionForTesting(String());
 }
 
 void WKBundlePageConfirmCompositionWithText(WKBundlePageRef pageRef, WKStringRef text)
 {
-    WebKit::toProtectedImpl(pageRef)->confirmCompositionForTesting(WebKit::toWTFString(text));
+    protect(WebKit::toImpl(pageRef))->confirmCompositionForTesting(WebKit::toWTFString(text));
 }
 
 void WKBundlePageSetUseDarkAppearance(WKBundlePageRef pageRef, bool useDarkAppearance)
@@ -579,27 +579,27 @@ bool WKBundlePageIsUsingDarkAppearance(WKBundlePageRef pageRef)
 
 bool WKBundlePageCanShowMIMEType(WKBundlePageRef pageRef, WKStringRef mimeTypeRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->canShowMIMEType(WebKit::toWTFString(mimeTypeRef));
+    return protect(WebKit::toImpl(pageRef))->canShowMIMEType(WebKit::toWTFString(mimeTypeRef));
 }
 
 WKRenderingSuppressionToken WKBundlePageExtendIncrementalRenderingSuppression(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->extendIncrementalRenderingSuppression();
+    return protect(WebKit::toImpl(pageRef))->extendIncrementalRenderingSuppression();
 }
 
 void WKBundlePageStopExtendingIncrementalRenderingSuppression(WKBundlePageRef pageRef, WKRenderingSuppressionToken token)
 {
-    WebKit::toProtectedImpl(pageRef)->stopExtendingIncrementalRenderingSuppression(token);
+    protect(WebKit::toImpl(pageRef))->stopExtendingIncrementalRenderingSuppression(token);
 }
 
 bool WKBundlePageIsUsingEphemeralSession(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->usesEphemeralSession();
+    return protect(WebKit::toImpl(pageRef))->usesEphemeralSession();
 }
 
 bool WKBundlePageIsControlledByAutomation(WKBundlePageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->isControlledByAutomation();
+    return protect(WebKit::toImpl(pageRef))->isControlledByAutomation();
 }
 
 #if TARGET_OS_IPHONE
@@ -665,23 +665,23 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
 
 void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page)
 {
-    WebKit::toProtectedImpl(page)->flushDeferredDidReceiveMouseEvent();
+    protect(WebKit::toImpl(page))->flushDeferredDidReceiveMouseEvent();
 }
 
 void WKBundlePagePostMessage(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toProtectedImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
+    protect(WebKit::toImpl(pageRef))->postMessage(WebKit::toWTFString(messageNameRef), protect(WebKit::toImpl(messageBodyRef)).get());
 }
 
 void WKBundlePagePostMessageIgnoringFullySynchronousMode(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toProtectedImpl(pageRef)->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
+    protect(WebKit::toImpl(pageRef))->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), protect(WebKit::toImpl(messageBodyRef)).get());
 }
 
 void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef, WKTypeRef* returnRetainedDataRef)
 {
     RefPtr<API::Object> returnData;
-    WebKit::toProtectedImpl(pageRef)->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get(), returnData);
+    protect(WebKit::toImpl(pageRef))->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), protect(WebKit::toImpl(messageBodyRef)).get(), returnData);
     if (returnRetainedDataRef)
         *returnRetainedDataRef = WebKit::toAPILeakingRef(WTF::move(returnData));
 }
@@ -693,22 +693,22 @@ bool WKBundlePageIsSuspended(WKBundlePageRef pageRef)
 
 void WKBundlePageAddUserScript(WKBundlePageRef pageRef, WKStringRef source, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toProtectedImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    protect(WebKit::toImpl(pageRef))->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserScriptInWorld(WKBundlePageRef page, WKStringRef source, WKBundleScriptWorldRef scriptWorld, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toProtectedImpl(page)->addUserScript(WebKit::toWTFString(source), *WebKit::toProtectedImpl(scriptWorld), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    protect(WebKit::toImpl(page))->addUserScript(WebKit::toWTFString(source), *protect(WebKit::toImpl(scriptWorld)), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserStyleSheet(WKBundlePageRef pageRef, WKStringRef source, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toProtectedImpl(pageRef)->addUserStyleSheet(WebKit::toWTFString(source), WebKit::toUserContentInjectedFrames(injectedFrames));
+    protect(WebKit::toImpl(pageRef))->addUserStyleSheet(WebKit::toWTFString(source), WebKit::toUserContentInjectedFrames(injectedFrames));
 }
 
 void WKBundlePageRemoveAllUserContent(WKBundlePageRef pageRef)
 {
-    WebKit::toProtectedImpl(pageRef)->removeAllUserContent();
+    protect(WebKit::toImpl(pageRef))->removeAllUserContent();
 }
 
 WKStringRef WKBundlePageCopyGroupIdentifier(WKBundlePageRef pageRef)
@@ -748,7 +748,7 @@ WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPrefere
 
 void WKBundlePageLayoutIfNeeded(WKBundlePageRef page)
 {
-    WebKit::toProtectedImpl(page)->layoutIfNeeded();
+    protect(WebKit::toImpl(page))->layoutIfNeeded();
 }
 
 void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, bool skip)
@@ -758,5 +758,5 @@ void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, 
 
 WKStringRef WKBundlePageCopyFrameTextForTesting(WKBundlePageRef page, bool includeSubframes)
 {
-    return WebKit::toAPILeakingRef(API::String::create(WebKit::toProtectedImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)));
+    return WebKit::toAPILeakingRef(API::String::create(protect(WebKit::toImpl(page))->frameTextForTestingIncludingSubframes(includeSubframes)));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -184,7 +184,7 @@ private:
         if (!m_accessibilityClient.client().copyAccessibilityAttributeValue)
             return false;
         auto wkType = m_accessibilityClient.client().copyAccessibilityAttributeValue(toAPI(&pageOverlay), WebKit::toCopiedAPI(attribute), WKPointCreate(WKPointMake(parameter.x(), parameter.y())), m_accessibilityClient.client().base.clientInfo);
-        if (WebKit::toProtectedImpl(wkType)->type() != API::String::APIType)
+        if (protect(WebKit::toImpl(wkType))->type() != API::String::APIType)
             return false;
         value = WebKit::toWTFString(static_cast<WKStringRef>(wkType));
         return true;
@@ -195,7 +195,7 @@ private:
         if (!m_accessibilityClient.client().copyAccessibilityAttributeValue)
             return false;
         auto wkType = m_accessibilityClient.client().copyAccessibilityAttributeValue(toAPI(&pageOverlay), WebKit::toCopiedAPI(attribute), WKPointCreate(WKPointMake(parameter.x(), parameter.y())), m_accessibilityClient.client().base.clientInfo);
-        if (WebKit::toProtectedImpl(wkType)->type() != API::Boolean::APIType)
+        if (protect(WebKit::toImpl(wkType))->type() != API::Boolean::APIType)
             return false;
         value = WKBooleanGetValue(static_cast<WKBooleanRef>(wkType));
         return true;
@@ -212,7 +212,7 @@ private:
         names.reserveInitialCapacity(count);
         for (size_t k = 0; k < count; k++) {
             WKTypeRef item = WKArrayGetItemAtIndex(wkNames, k);
-            if (WebKit::toProtectedImpl(item)->type() == API::String::APIType)
+            if (protect(WebKit::toImpl(item))->type() == API::String::APIType)
                 names.append(WebKit::toWTFString(static_cast<WKStringRef>(item)));
         }
         names.shrinkToFit();
@@ -245,7 +245,7 @@ void WKBundlePageOverlaySetAccessibilityClient(WKBundlePageOverlayRef bundlePage
 
 void WKBundlePageOverlaySetNeedsDisplay(WKBundlePageOverlayRef bundlePageOverlayRef, WKRect rect)
 {
-    WebKit::toProtectedImpl(bundlePageOverlayRef)->setNeedsDisplay(enclosingIntRect(WebKit::toFloatRect(rect)));
+    protect(WebKit::toImpl(bundlePageOverlayRef))->setNeedsDisplay(enclosingIntRect(WebKit::toFloatRect(rect)));
 }
 
 float WKBundlePageOverlayFractionFadedIn(WKBundlePageOverlayRef)
@@ -259,5 +259,5 @@ float WKBundlePageOverlayFractionFadedIn(WKBundlePageOverlayRef)
 
 void WKBundlePageOverlayClear(WKBundlePageOverlayRef bundlePageOverlayRef)
 {
-    WebKit::toProtectedImpl(bundlePageOverlayRef)->clear();
+    protect(WebKit::toImpl(bundlePageOverlayRef))->clear();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
@@ -48,18 +48,18 @@ WKBundleRangeHandleRef WKBundleRangeHandleCreate(JSContextRef contextRef, JSObje
 
 WKRect WKBundleRangeHandleGetBoundingRectInWindowCoordinates(WKBundleRangeHandleRef rangeHandleRef)
 {
-    WebCore::IntRect boundingRect = WebKit::toProtectedImpl(rangeHandleRef)->boundingRectInWindowCoordinates();
+    WebCore::IntRect boundingRect = protect(WebKit::toImpl(rangeHandleRef))->boundingRectInWindowCoordinates();
     return WKRectMake(boundingRect.x(), boundingRect.y(), boundingRect.width(), boundingRect.height());
 }
 
 WKImageRef WKBundleRangeHandleCopySnapshotWithOptions(WKBundleRangeHandleRef rangeHandleRef, WKSnapshotOptions options)
 {
-    RefPtr<WebKit::WebImage> image = WebKit::toProtectedImpl(rangeHandleRef)->renderedImage(WebKit::toSnapshotOptions(options));
+    RefPtr<WebKit::WebImage> image = protect(WebKit::toImpl(rangeHandleRef))->renderedImage(WebKit::toSnapshotOptions(options));
     return toAPILeakingRef(WTF::move(image));
 }
 
 WKBundleFrameRef WKBundleRangeHandleCopyDocumentFrame(WKBundleRangeHandleRef rangeHandleRef)
 {
-    RefPtr frame = WebKit::toProtectedImpl(rangeHandleRef)->document()->documentFrame();
+    RefPtr frame = protect(WebKit::toImpl(rangeHandleRef))->document()->documentFrame();
     return toAPILeakingRef(WTF::move(frame));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
@@ -48,27 +48,27 @@ WKBundleScriptWorldRef WKBundleScriptWorldNormalWorld()
 
 void WKBundleScriptWorldClearWrappers(WKBundleScriptWorldRef scriptWorldRef)
 {
-    WebKit::toProtectedImpl(scriptWorldRef)->clearWrappers();
+    protect(WebKit::toImpl(scriptWorldRef))->clearWrappers();
 }
 
 void WKBundleScriptWorldMakeAllShadowRootsOpen(WKBundleScriptWorldRef scriptWorldRef)
 {
-    WebKit::toProtectedImpl(scriptWorldRef)->makeAllShadowRootsOpen();
+    protect(WebKit::toImpl(scriptWorldRef))->makeAllShadowRootsOpen();
 }
 
 void WKBundleScriptWorldExposeClosedShadowRootsForExtensions(WKBundleScriptWorldRef scriptWorldRef)
 {
-    WebKit::toProtectedImpl(scriptWorldRef)->exposeClosedShadowRootsForExtensions();
+    protect(WebKit::toImpl(scriptWorldRef))->exposeClosedShadowRootsForExtensions();
 }
 
 void WKBundleScriptWorldDisableOverrideBuiltinsBehavior(WKBundleScriptWorldRef scriptWorldRef)
 {
-    WebKit::toProtectedImpl(scriptWorldRef)->disableOverrideBuiltinsBehavior();
+    protect(WebKit::toImpl(scriptWorldRef))->disableOverrideBuiltinsBehavior();
 }
 
 void WKBundleScriptWorldSetAllowElementUserInfo(WKBundleScriptWorldRef scriptWorldRef)
 {
-    WebKit::toProtectedImpl(scriptWorldRef)->setAllowElementUserInfo();
+    protect(WebKit::toImpl(scriptWorldRef))->setAllowElementUserInfo();
 }
 
 WKStringRef WKBundleScriptWorldCopyName(WKBundleScriptWorldRef scriptWorldRef)
@@ -78,5 +78,5 @@ WKStringRef WKBundleScriptWorldCopyName(WKBundleScriptWorldRef scriptWorldRef)
 
 void WKBundleScriptWorldSetAllowJSHandleCreation(WKBundleScriptWorldRef scriptWorldRef)
 {
-    WebKit::toProtectedImpl(scriptWorldRef)->setAllowJSHandleCreation();
+    protect(WebKit::toImpl(scriptWorldRef))->setAllowJSHandleCreation();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
@@ -31,5 +31,5 @@
 
 id WKBundleGetParameters(WKBundleRef bundle)
 {
-    return WebKit::toProtectedImpl(bundle)->bundleParameters();
+    return protect(WebKit::toImpl(bundle))->bundleParameters();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
@@ -104,7 +104,7 @@ WKBundlePageBannerRef WKBundlePageBannerCreateBannerWithCALayer(CALayer *layer, 
 
 CALayer *WKBundlePageBannerGetLayer(WKBundlePageBannerRef pageBanner)
 {
-    return WebKit::toProtectedImpl(pageBanner)->layer();
+    return protect(WebKit::toImpl(pageBanner))->layer();
 }
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
@@ -58,7 +58,7 @@ static void didCreatePage(WKBundleRef bundle, WKBundlePageRef page, const void* 
     RetainPtr principalClassInstance = plugInController->_principalClassInstance.get();
 
     if ([principalClassInstance respondsToSelector:@selector(webProcessPlugIn:didCreateBrowserContextController:)])
-        [principalClassInstance webProcessPlugIn:plugInController didCreateBrowserContextController:protect(wrapper(*WebKit::toProtectedImpl(page))).get()];
+        [principalClassInstance webProcessPlugIn:plugInController didCreateBrowserContextController:protect(wrapper(*protect(WebKit::toImpl(page)))).get()];
 }
 
 static void willDestroyPage(WKBundleRef bundle, WKBundlePageRef page, const void* clientInfo)
@@ -67,7 +67,7 @@ static void willDestroyPage(WKBundleRef bundle, WKBundlePageRef page, const void
     RetainPtr principalClassInstance = plugInController->_principalClassInstance.get();
 
     if ([principalClassInstance respondsToSelector:@selector(webProcessPlugIn:willDestroyBrowserContextController:)])
-        [principalClassInstance webProcessPlugIn:plugInController willDestroyBrowserContextController:protect(wrapper(*WebKit::toProtectedImpl(page))).get()];
+        [principalClassInstance webProcessPlugIn:plugInController willDestroyBrowserContextController:protect(wrapper(*protect(WebKit::toImpl(page)))).get()];
 }
 
 static void setUpBundleClient(WKWebProcessPlugInController *plugInController, WebKit::InjectedBundle& bundle)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -89,7 +89,7 @@ static void didStartProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameR
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didStartProvisionalLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didStartProvisionalLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didStartProvisionalLoadForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didReceiveServerRedirectForProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef *userDataRef, const void *clientInfo)
@@ -98,7 +98,7 @@ static void didReceiveServerRedirectForProvisionalLoadForFrame(WKBundlePageRef p
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didReceiveServerRedirectForProvisionalLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didReceiveServerRedirectForProvisionalLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didReceiveServerRedirectForProvisionalLoadForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -107,7 +107,7 @@ static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFinishLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishLoadForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didClearWindowObjectForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -116,7 +116,7 @@ static void didClearWindowObjectForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
     
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didClearWindowObjectForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didClearWindowObjectForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didClearWindowObjectForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() inScriptWorld:protect(wrapper(*protect(WebKit::toImpl(scriptWorld)))).get()];
 }
 
 static void globalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -125,7 +125,7 @@ static void globalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameR
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:globalObjectIsAvailableForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController globalObjectIsAvailableForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController globalObjectIsAvailableForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() inScriptWorld:protect(wrapper(*protect(WebKit::toImpl(scriptWorld)))).get()];
 }
 
 static void serviceWorkerGlobalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -134,7 +134,7 @@ static void serviceWorkerGlobalObjectIsAvailableForFrame(WKBundlePageRef page, W
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:serviceWorkerGlobalObjectIsAvailableForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController serviceWorkerGlobalObjectIsAvailableForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController serviceWorkerGlobalObjectIsAvailableForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() inScriptWorld:protect(wrapper(*protect(WebKit::toImpl(scriptWorld)))).get()];
 }
 
 static void willInjectUserScriptForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -143,7 +143,7 @@ static void willInjectUserScriptForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:willInjectUserScriptForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController willInjectUserScriptForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController willInjectUserScriptForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() inScriptWorld:protect(wrapper(*protect(WebKit::toImpl(scriptWorld)))).get()];
 }
 
 static void didRemoveFrameFromHierarchy(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void* clientInfo)
@@ -152,7 +152,7 @@ static void didRemoveFrameFromHierarchy(WKBundlePageRef page, WKBundleFrameRef f
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didRemoveFrameFromHierarchy:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didRemoveFrameFromHierarchy:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didRemoveFrameFromHierarchy:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didCommitLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -161,7 +161,7 @@ static void didCommitLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didCommitLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didCommitLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didCommitLoadForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didFinishDocumentLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -170,7 +170,7 @@ static void didFinishDocumentLoadForFrame(WKBundlePageRef page, WKBundleFrameRef
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFinishDocumentLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishDocumentLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishDocumentLoadForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didFailProvisionalLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKErrorRef wkError, WKTypeRef* userData, const void *clientInfo)
@@ -179,7 +179,7 @@ static void didFailProvisionalLoadWithErrorForFrame(WKBundlePageRef page, WKBund
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFailProvisionalLoadWithErrorForFrame:error:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailProvisionalLoadWithErrorForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() error:protect(wrapper(*WebKit::toProtectedImpl(wkError))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailProvisionalLoadWithErrorForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() error:protect(wrapper(*protect(WebKit::toImpl(wkError)))).get()];
 }
 
 static void didFailLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKErrorRef wkError, WKTypeRef* userData, const void *clientInfo)
@@ -188,7 +188,7 @@ static void didFailLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFailLoadWithErrorForFrame:error:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailLoadWithErrorForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() error:protect(wrapper(*WebKit::toProtectedImpl(wkError))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailLoadWithErrorForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() error:protect(wrapper(*protect(WebKit::toImpl(wkError)))).get()];
 }
 
 static void didSameDocumentNavigationForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKSameDocumentNavigationType type, WKTypeRef* userData, const void *clientInfo)
@@ -197,11 +197,11 @@ static void didSameDocumentNavigationForFrame(WKBundlePageRef page, WKBundleFram
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didSameDocumentNavigation:forFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigation:toWKSameDocumentNavigationType(WebKit::toSameDocumentNavigationType(type)) forFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigation:toWKSameDocumentNavigationType(WebKit::toSameDocumentNavigationType(type)) forFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
     else {
         // FIXME: Remove this once clients switch to implementing the above delegate method.
         if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didSameDocumentNavigationForFrame:)])
-            [(NSObject *)loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigationForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+            [(NSObject *)loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigationForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
     }
 }
 
@@ -211,7 +211,7 @@ static void didLayoutForFrame(WKBundlePageRef page, WKBundleFrameRef frame, cons
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didLayoutForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didLayoutForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didLayoutForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didReachLayoutMilestone(WKBundlePageRef page, WKLayoutMilestones milestones, WKTypeRef* userData, const void *clientInfo)
@@ -241,7 +241,7 @@ static void didFirstVisuallyNonEmptyLayoutForFrame(WKBundlePageRef page, WKBundl
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFirstVisuallyNonEmptyLayoutForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFirstVisuallyNonEmptyLayoutForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFirstVisuallyNonEmptyLayoutForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef frame, const void* clientInfo)
@@ -250,7 +250,7 @@ static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didHandleOnloadEventsForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didHandleOnloadEventsForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didHandleOnloadEventsForFrame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get()];
 }
 
 static void setUpPageLoaderClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
@@ -290,14 +290,14 @@ static WKURLRequestRef willSendRequestForFrame(WKBundlePageRef, WKBundleFrameRef
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequestForResource:request:redirectResponse:)]) {
         RetainPtr originalRequest = wrapper(*protect(WebKit::toImpl(request)));
-        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() willSendRequestForResource:resourceIdentifier
+        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() willSendRequestForResource:resourceIdentifier
             request:originalRequest.get() redirectResponse:protect(WebKit::toImpl(redirectResponse)->resourceResponse().nsURLResponse()).get()];
 
         if (substituteRequest != originalRequest.get())
             return substituteRequest ? WKURLRequestCreateWithNSURLRequest(substituteRequest.get()) : nullptr;
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequest:redirectResponse:)]) {
         RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
-        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() willSendRequest:originalRequest.get()
+        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() willSendRequest:originalRequest.get()
             redirectResponse:protect(WebKit::toImpl(redirectResponse)->resourceResponse().nsURLResponse()).get()];
 
         if (substituteRequest != originalRequest.get())
@@ -314,10 +314,10 @@ static void didInitiateLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didInitiateLoadForResource:request:pageIsProvisionallyLoading:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didInitiateLoadForResource:resourceIdentifier request:protect(wrapper(*WebKit::toProtectedImpl(request))).get()
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() didInitiateLoadForResource:resourceIdentifier request:protect(wrapper(*protect(WebKit::toImpl(request)))).get()
             pageIsProvisionallyLoading:pageIsProvisionallyLoading];
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didInitiateLoadForResource:request:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didInitiateLoadForResource:resourceIdentifier request:protect(wrapper(*WebKit::toProtectedImpl(request))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() didInitiateLoadForResource:resourceIdentifier request:protect(wrapper(*protect(WebKit::toImpl(request)))).get()];
     }
 }
 
@@ -327,7 +327,7 @@ static void didReceiveResponseForResource(WKBundlePageRef, WKBundleFrameRef fram
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didReceiveResponse:forResource:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didReceiveResponse:protect(WebKit::toImpl(response)->resourceResponse().nsURLResponse()).get() forResource:resourceIdentifier];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() didReceiveResponse:protect(WebKit::toImpl(response)->resourceResponse().nsURLResponse()).get() forResource:resourceIdentifier];
 }
 
 static void didFinishLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint64_t resourceIdentifier, const void* clientInfo)
@@ -336,7 +336,7 @@ static void didFinishLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, ui
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didFinishLoadForResource:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didFinishLoadForResource:resourceIdentifier];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() didFinishLoadForResource:resourceIdentifier];
     }
 }
 
@@ -346,7 +346,7 @@ static void didFailLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didFailLoadForResource:error:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didFailLoadForResource:resourceIdentifier error:protect(wrapper(*WebKit::toProtectedImpl(error))).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*protect(WebKit::toImpl(frame)))).get() didFailLoadForResource:resourceIdentifier error:protect(wrapper(*protect(WebKit::toImpl(error)))).get()];
     }
 }
 


### PR DESCRIPTION
#### 8b578347a19a59cb11c78a5254977f9ffa1e2218
<pre>
Remove toProtectedImpl() method
<a href="https://bugs.webkit.org/show_bug.cgi?id=308727">https://bugs.webkit.org/show_bug.cgi?id=308727</a>

Reviewed by Chris Dumez.

Replace with a protect() wrapper.

Canonical link: <a href="https://commits.webkit.org/308283@main">https://commits.webkit.org/308283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed112a1ed969df0fe8dd065f64ecfb7c8d16cf95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155671 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a4d8719-8192-4f79-9b03-ec1960cabe60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113262 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a02f62f7-6917-4906-ac53-2a6fa8290608) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94019 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9715aa17-60fc-47b3-a8e2-6fadd261cbcc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14720 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3113 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124305 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158002 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121287 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131737 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8564 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82841 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->