### PR TITLE
Crash under PC::Connection::sendMessage (MACH_SEND_TOO_LARGE / NetworkStorageManager_CacheStorageRetrieveRecordsReply)

### DIFF
--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -99,6 +99,8 @@ public:
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     UnixFileDescriptor releaseHandle();
+#elif OS(DARWIN)
+    MachSendRight releaseHandle() { return std::exchange(m_handle, MachSendRight { }); }
 #endif
 
 private:

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -555,6 +555,10 @@ public:
     static bool NODELETE shouldCrashOnMessageCheckFailure();
     static void NODELETE setShouldCrashOnMessageCheckFailure(bool);
 
+#if PLATFORM(COCOA)
+    static void setForceUseSharedMemoryForSendingForTesting(bool);
+#endif
+
 #if ENABLE(IPC_TESTING_API)
     bool hasErrorString() const { return !m_errorString.isNull(); }
     void setErrorString(ASCIILiteral error)
@@ -632,7 +636,10 @@ private:
     Error sendMessageImpl(UniqueRef<Encoder>&&, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
 
 #if PLATFORM(COCOA)
-    bool sendMessage(std::unique_ptr<MachMessage>);
+    enum class SendMessageResult : uint8_t { Success, Failure, MessageTooLarge };
+    enum class IsRetryDueToLargeSize : bool { No, Yes };
+    SendMessageResult sendMessage(std::unique_ptr<MachMessage>&, IsRetryDueToLargeSize = IsRetryDueToLargeSize::No);
+    bool retrySendMessageWithSharedMemory(std::unique_ptr<MachMessage> failedMessage, UniqueRef<Encoder>&);
 #endif
     template<typename F>
     void dispatchToClient(F&& clientRunLoopTask) WTF_EXCLUDES_LOCK(m_incomingMessagesLock);

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -36,6 +36,7 @@
 #import "WKCrashReporter.h"
 #import "XPCUtilities.h"
 #import <WebCore/AXObjectCache.h>
+#import <WebCore/SharedMemory.h>
 #import <mach/mach_error.h>
 #import <mach/mach_init.h>
 #import <mach/mach_traps.h>
@@ -60,6 +61,14 @@ static const size_t inlineMessageMaxSize = 4096;
 // Arbitrary message IDs that do not collide with Mach notification messages (used my initials).
 constexpr mach_msg_id_t inlineBodyMessageID = 0xdba0dba;
 constexpr mach_msg_id_t outOfLineBodyMessageID = 0xdba1dba;
+constexpr mach_msg_id_t sharedMemoryBodyMessageID = 0xdba2dba;
+
+static bool s_forceUseSharedMemoryForSending { false };
+
+void Connection::setForceUseSharedMemoryForSendingForTesting(bool force)
+{
+    s_forceUseSharedMemoryForSending = force;
+}
 
 static void requestNoSenderNotifications(mach_port_t port, mach_port_t notify)
 {
@@ -219,7 +228,7 @@ void Connection::platformOpen()
     getAuditToken();
 }
 
-bool Connection::sendMessage(std::unique_ptr<MachMessage> message)
+Connection::SendMessageResult Connection::sendMessage(std::unique_ptr<MachMessage>& message, IsRetryDueToLargeSize isRetryDueToLargeSize)
 {
     ASSERT(message);
     ASSERT(!m_pendingOutgoingMachMessage);
@@ -229,12 +238,13 @@ bool Connection::sendMessage(std::unique_ptr<MachMessage> message)
     case MACH_MSG_SUCCESS:
         // The kernel has already adopted the descriptors.
         message->leakDescriptors();
-        return true;
+        message.reset();
+        return SendMessageResult::Success;
 
     case MACH_SEND_TIMED_OUT:
         // We timed out, stash away the message for later.
         m_pendingOutgoingMachMessage = WTF::move(message);
-        return false;
+        return SendMessageResult::Failure;
 
     case MACH_SEND_INVALID_DEST:
         // The other end has destroyed the receive right to the port we are trying to send to.
@@ -246,12 +256,19 @@ bool Connection::sendMessage(std::unique_ptr<MachMessage> message)
         // Noteworthy special case:
         // InitializeConnection message will hold our send right. If that send fails here, we will destroy
         // the send right inside the `message`that goes out of scope, and thus we get the NO_SENDERS.
-        return false;
+        return SendMessageResult::Failure;
 
-#if ENABLE(IPC_TESTING_API)
     case MACH_SEND_TOO_LARGE:
+#if ENABLE(IPC_TESTING_API)
         RELEASE_LOG_ERROR(Process, "%" PUBLIC_LOG_STRING "Error MACH_SEND_TOO_LARGE", WTF_PRETTY_FUNCTION);
-        return false;
+        return SendMessageResult::Failure;
+#else
+        if (isRetryDueToLargeSize == IsRetryDueToLargeSize::No) {
+            // The message exceeds kernel limits. Leave the message in place so the caller
+            // can extract port descriptors and retry with SharedMemory.
+            return SendMessageResult::MessageTooLarge;
+        }
+        [[fallthrough]];
 #endif
 
     default:
@@ -271,6 +288,35 @@ template<typename descriptorType>
 static descriptorType& popDescriptorAndAdvance(std::span<uint8_t>& data)
 {
     return consumeAndReinterpretCastTo<descriptorType>(data);
+}
+
+static void setPortDescriptor(std::span<uint8_t>& messageSpan, mach_port_t sendRight)
+{
+    auto& descriptor = popDescriptorAndAdvance<mach_msg_port_descriptor_t>(messageSpan);
+    descriptor.name = sendRight;
+    descriptor.disposition = MACH_MSG_TYPE_MOVE_SEND;
+    descriptor.type = MACH_MSG_PORT_DESCRIPTOR;
+}
+
+static Vector<MachSendRight> extractPortDescriptorsFromMessage(MachMessage& message)
+{
+    auto messageSpan = message.span();
+    auto& header = consumeAndReinterpretCastTo<mach_msg_header_t>(messageSpan);
+
+    if (!(header.msgh_bits & MACH_MSGH_BITS_COMPLEX))
+        return { };
+
+    auto& body = consumeAndReinterpretCastTo<mach_msg_body_t>(messageSpan);
+    bool hasOOLDescriptor = (header.msgh_id == outOfLineBodyMessageID);
+    auto portCount = body.msgh_descriptor_count - (hasOOLDescriptor ? 1 : 0);
+
+    Vector<MachSendRight> ports(portCount, [&](size_t) {
+        auto& descriptor = consumeAndReinterpretCastTo<mach_msg_port_descriptor_t>(messageSpan);
+        return MachSendRight::adopt(descriptor.name);
+    });
+
+    message.leakDescriptors();
+    return ports;
 }
 
 bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
@@ -312,12 +358,8 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
         auto& body = consumeAndReinterpretCastTo<mach_msg_body_t>(messageSpan);
         body.msgh_descriptor_count = numberOfPortDescriptors + messageBodyIsOOL;
 
-        for (auto& attachment : attachments) {
-            auto& descriptor = popDescriptorAndAdvance<mach_msg_port_descriptor_t>(messageSpan);
-            descriptor.name = attachment.leakSendRight();
-            descriptor.disposition = MACH_MSG_TYPE_MOVE_SEND;
-            descriptor.type = MACH_MSG_PORT_DESCRIPTOR;
-        }
+        for (auto& attachment : attachments)
+            setPortDescriptor(messageSpan, attachment.leakSendRight());
 
         if (messageBodyIsOOL) {
             auto& descriptor = popDescriptorAndAdvance<mach_msg_ool_descriptor_t>(messageSpan);
@@ -334,7 +376,66 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
     if (!messageBodyIsOOL)
         memcpySpan(messageSpan, encoder->span());
 
-    return sendMessage(WTF::move(message));
+    if (!s_forceUseSharedMemoryForSending) {
+        auto result = sendMessage(message);
+        if (result != SendMessageResult::MessageTooLarge)
+            return result == SendMessageResult::Success;
+
+        RELEASE_LOG_ERROR(IPC, "sendOutgoingMessage: MACH_SEND_TOO_LARGE for message '%" PUBLIC_LOG_STRING "', retrying with SharedMemory", description(encoder->messageName()).characters());
+    }
+
+    return retrySendMessageWithSharedMemory(WTF::move(message), encoder);
+}
+
+bool Connection::retrySendMessageWithSharedMemory(std::unique_ptr<MachMessage> failedMessage, UniqueRef<Encoder>& encoder)
+{
+    // On MACH_SEND_TOO_LARGE the kernel rejects the send without consuming
+    // any descriptors, so the ports in the MachMessage are still valid.
+    auto extractedPorts = extractPortDescriptorsFromMessage(*failedMessage);
+    failedMessage.reset();
+
+    // Create a VM-copy memory entry directly from the encoder's data.
+    auto shmHandle = WebCore::SharedMemoryHandle::createVMCopy(encoder->span(), WebCore::SharedMemoryProtection::ReadOnly);
+    if (!shmHandle) {
+        RELEASE_LOG_ERROR(IPC, "retrySendMessageWithSharedMemory: Failed to create memory entry");
+        CRASH_WITH_INFO(std::to_underlying(encoder->messageName()));
+    }
+    uint64_t shmSize = shmHandle->size();
+    auto shmSendRight = shmHandle->releaseHandle();
+
+    // Build the retry message: extractedPorts + shm port descriptor + uint64_t size inline.
+    size_t newPortCount = extractedPorts.size() + 1;
+    auto newMessageSize = MachMessage::messageSize(sizeof(uint64_t), newPortCount, 0);
+    if (newMessageSize.hasOverflowed()) [[unlikely]]
+        return false;
+
+    size_t safeNewMessageSize = newMessageSize;
+    auto newMessage = MachMessage::create(encoder->messageName(), safeNewMessageSize);
+    if (!newMessage)
+        return false;
+
+    auto newMessageSpan = newMessage->span();
+    auto& newHeader = consumeAndReinterpretCastTo<mach_msg_header_t>(newMessageSpan);
+    newHeader.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0) | MACH_MSGH_BITS_COMPLEX;
+    newHeader.msgh_size = safeNewMessageSize;
+    newHeader.msgh_remote_port = m_sendPort;
+    newHeader.msgh_local_port = MACH_PORT_NULL;
+    newHeader.msgh_id = sharedMemoryBodyMessageID;
+
+    auto& newBody = consumeAndReinterpretCastTo<mach_msg_body_t>(newMessageSpan);
+    newBody.msgh_descriptor_count = newPortCount;
+
+    // Original port descriptors (message attachments).
+    for (auto& sendRight : extractedPorts)
+        setPortDescriptor(newMessageSpan, sendRight.leakSendRight());
+
+    // SharedMemory port descriptor (last).
+    setPortDescriptor(newMessageSpan, shmSendRight.leakSendRight());
+
+    // Inline body: uint64_t shared memory size.
+    memcpySpan(newMessageSpan, asByteSpan(shmSize));
+
+    return sendMessage(newMessage, IsRetryDueToLargeSize::Yes) == SendMessageResult::Success;
 }
 
 void Connection::initializeSendSource()
@@ -373,8 +474,15 @@ void Connection::initializeSendSource()
 
 void Connection::resumeSendSource()
 {
-    if (m_pendingOutgoingMachMessage)
-        sendMessage(WTF::move(m_pendingOutgoingMachMessage));
+    if (m_pendingOutgoingMachMessage) {
+        auto message = std::exchange(m_pendingOutgoingMachMessage, nullptr);
+        auto result = sendMessage(message);
+        if (result == SendMessageResult::MessageTooLarge) {
+            // m_pendingOutgoingMachMessage originates from MACH_SEND_TIMED_OUT, not
+            // expected to hit MACH_SEND_TOO_LARGE on retry. Drop the message.
+            RELEASE_LOG_ERROR(IPC, "resumeSendSource: Unexpected MACH_SEND_TOO_LARGE for pending message");
+        }
+    }
     sendOutgoingMessages();
 }
 
@@ -415,7 +523,10 @@ static std::unique_ptr<Decoder> createMessageDecoder(mach_msg_header_t* header, 
     // If the message body was sent out-of-line, don't treat the last descriptor
     // as an attachment, since it is really the message body.
     bool messageBodyIsOOL = header->msgh_id == outOfLineBodyMessageID;
-    mach_msg_size_t numberOfAttachments = messageBodyIsOOL ? numberOfPortDescriptors - 1 : numberOfPortDescriptors;
+    // If the message body was sent via SharedMemory (retry after MACH_SEND_TOO_LARGE),
+    // the last port descriptor is the SharedMemory send right, not an attachment.
+    bool messageBodyIsSharedMemory = header->msgh_id == sharedMemoryBodyMessageID;
+    mach_msg_size_t numberOfAttachments = (messageBodyIsOOL || messageBodyIsSharedMemory) ? numberOfPortDescriptors - 1 : numberOfPortDescriptors;
 
     // Build attachment list
     Vector<Attachment> attachments(numberOfAttachments);
@@ -445,6 +556,29 @@ static std::unique_ptr<Decoder> createMessageDecoder(mach_msg_header_t* header, 
             // FIXME: <rdar://problem/62086358> bufferDeallocator block ignores mach_msg_ool_descriptor_t->deallocate
             vm_deallocate(mach_task_self(), reinterpret_cast<vm_address_t>(buffer.data()), buffer.size_bytes());
         }, WTF::move(attachments));
+    }
+
+    if (messageBodyIsSharedMemory) {
+        // Last port descriptor is the SharedMemory send right.
+        auto& shmDescriptor = consumeAndReinterpretCastTo<mach_msg_port_descriptor_t>(remaining);
+        ASSERT(shmDescriptor.type == MACH_MSG_PORT_DESCRIPTOR);
+        if (shmDescriptor.type != MACH_MSG_PORT_DESCRIPTOR)
+            return nullptr;
+        auto shmSendRight = MachSendRight::adopt(shmDescriptor.name);
+
+        // Read size from inline body.
+        if (remaining.size() < sizeof(uint64_t))
+            return nullptr;
+        uint64_t shmSize = consumeAndReinterpretCastTo<uint64_t>(remaining);
+
+        // Map the shared memory.
+        WebCore::SharedMemoryHandle shmHandle(WTF::move(shmSendRight), shmSize);
+        shmHandle.takeOwnershipOfMemory(WebCore::MemoryLedger::Default);
+        auto sharedMemory = WebCore::SharedMemory::map(WTF::move(shmHandle), WebCore::SharedMemoryProtection::ReadOnly);
+        if (!sharedMemory)
+            return nullptr;
+
+        return Decoder::create(sharedMemory->span(), [sharedMemory = WTF::move(sharedMemory)](auto) { }, WTF::move(attachments));
     }
 
     ASSERT(std::to_address(message.subspan(sizeWithPortDescriptors.value()).begin()) == std::to_address(remaining.begin()));
@@ -519,6 +653,7 @@ void Connection::receiveSourceEventHandler()
 
     case inlineBodyMessageID:
     case outOfLineBodyMessageID:
+    case sharedMemoryBodyMessageID:
         break;
 
     case MACH_NOTIFY_SEND_ONCE:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -547,6 +547,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     IPC::Connection::setShouldCrashOnMessageCheckFailure(true);
 }
 
++ (void)_forceUseSharedMemoryForSendingForTesting:(BOOL)force
+{
+    IPC::Connection::setForceUseSharedMemoryForSendingForTesting(force);
+}
+
 + (void)_setLinkedOnOrAfterEverything
 {
     enableAllSDKAlignedBehaviors();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -162,6 +162,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 + (void)_forceGameControllerFramework WK_API_AVAILABLE(macos(10.13), ios(11.0));
 + (void)_setLinkedOnOrAfterEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_crashOnMessageCheckFailureForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
++ (void)_forceUseSharedMemoryForSendingForTesting:(BOOL)force WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 + (void)_setLinkedOnOrBeforeEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_setCaptivePortalModeEnabledGloballyForTesting:(BOOL)isEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (void)_clearCaptivePortalModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -153,6 +153,7 @@ Tests/WebKitCocoa/IDBCheckpointWAL.mm @nonARC
 Tests/WebKitCocoa/IDBDeleteRecovery.mm @nonARC
 Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm @nonARC
 Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm @nonARC
+Tests/WebKitCocoa/IPCSharedMemoryFallback.mm @nonARC
 Tests/WebKitCocoa/IPCTestingAPI.mm @nonARC
 Tests/WebKitCocoa/IconLoadingDelegate.mm @nonARC
 Tests/WebKitCocoa/ImageAnalysisTests.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2953,6 +2953,7 @@
 		4612C2B8210A6ABF00B788A6 /* LoadFileThenReload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadFileThenReload.mm; sourceTree = "<group>"; };
 		4628C8E82367ABBC00B073F0 /* WKSecurityOrigin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKSecurityOrigin.cpp; sourceTree = "<group>"; };
 		462B4E7828E7B0AF00653230 /* fragment-navigation-before-load-event.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "fragment-navigation-before-load-event.html"; sourceTree = "<group>"; };
+		4638A0E32F50685100DCCB1E /* IPCSharedMemoryFallback.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = IPCSharedMemoryFallback.mm; sourceTree = "<group>"; };
 		46397B941DC2C850009A78AE /* DOMNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DOMNode.mm; sourceTree = "<group>"; };
 		463F4722255B49B600D9E0CC /* VisibilityState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VisibilityState.mm; sourceTree = "<group>"; };
 		4647B1251EBA3B730041D7EF /* ProcessDidTerminate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessDidTerminate.cpp; sourceTree = "<group>"; };
@@ -5007,6 +5008,7 @@
 				2DB0232E1E4E871800707123 /* InteractionDeadlockAfterCrash.mm */,
 				2D116E1223E0CB3900208900 /* iOSMouseSupport.mm */,
 				950E4CC0252E75230071659F /* iOSStylusSupport.mm */,
+				4638A0E32F50685100DCCB1E /* IPCSharedMemoryFallback.mm */,
 				9B6D9FF8252EFDE500A51640 /* IPCTestingAPI.mm */,
 				5C69BDD41F82A7EB000F4F4B /* JavaScriptDuringNavigation.mm */,
 				5C0160C021A132320077FA32 /* JITEnabled.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCSharedMemoryFallback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCSharedMemoryFallback.mm
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "TestWKWebView.h"
+#import <WebKit/WKProcessPoolPrivate.h>
+
+TEST(IPC, SharedMemoryFallback)
+{
+    [WKProcessPool _forceUseSharedMemoryForSendingForTesting:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+
+    RetainPtr innerHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
+    EXPECT_TRUE([innerHTML containsString:@"Simple HTML file."]);
+
+    [WKProcessPool _forceUseSharedMemoryForSendingForTesting:NO];
+}


### PR DESCRIPTION
#### 18f52512761fb98e775ff460eba8715a9ae26d01
<pre>
Crash under PC::Connection::sendMessage (MACH_SEND_TOO_LARGE / NetworkStorageManager_CacheStorageRetrieveRecordsReply)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308728">https://bugs.webkit.org/show_bug.cgi?id=308728</a>
<a href="https://rdar.apple.com/60344809">rdar://60344809</a>

Reviewed by Ben Nham and Per Arne Vollan.

IPC messages whose encoder body exceeds inlineMessageMaxSize (4096 bytes)
are sent out-of-line (OOL) via mach_msg_ool_descriptor_t. However,
mach_msg() can still fail with MACH_SEND_TOO_LARGE — the kernel imposes
limits on message size that include descriptor counts, OOL memory
regions, and inline data. We are seeing crashes with this error in the
wild on the CacheStorageRetrieveRecords reply path, where many small
cache records with SharedBuffer bodies below the 4096-byte shared memory
threshold produce a large aggregate encoder body.

To fix this, when mach_msg() returns MACH_SEND_TOO_LARGE, we retry by
placing the encoder body into a shared memory entry (via
mach_make_memory_entry_64 with MAP_MEM_VM_COPY) and sending only the
memory entry port plus its size as inline data. The receiver maps the
shared memory to construct the decoder, making the fallback transparent
to message handlers.

Test: IPC.SharedMemoryFallback

* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemoryHandle::releaseHandle):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::setForceUseSharedMemoryForSendingForTesting):
(IPC::Connection::sendMessage):
(IPC::setPortDescriptor):
(IPC::extractPortDescriptorsFromMessage):
(IPC::Connection::sendOutgoingMessage):
(IPC::Connection::retrySendMessageWithSharedMemory):
(IPC::Connection::resumeSendSource):
(IPC::createMessageDecoder):
(IPC::Connection::receiveSourceEventHandler):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _forceUseSharedMemoryForSendingForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCSharedMemoryFallback.mm: Added.
(TEST(IPC, SharedMemoryFallback)):

Canonical link: <a href="https://commits.webkit.org/308536@main">https://commits.webkit.org/308536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f264bb86cd7fe05d718f452e29e66aa9f40d3c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101208 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6745c184-f146-430d-b5e1-3f9db22d9b0c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113936 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81250 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ed03c4c-b8d2-4e99-9425-149f13bcc7e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94696 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec1102e6-cba1-4799-ac97-d3e0653724bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15338 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13125 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158811 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121964 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122166 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31295 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76403 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9212 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83655 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19622 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->