### PR TITLE
Use enum class for SVG Angle Types as suggested in 274778@main

### DIFF
--- a/Source/WebCore/svg/SVGAngle.h
+++ b/Source/WebCore/svg/SVGAngle.h
@@ -55,12 +55,13 @@ public:
         return adoptRef(*new SVGAngle(value.releaseReturnValue()));
     }
 
-    SVGAngleValue::Type unitType() const
+    unsigned short unitType() const
     {
         // Per spec https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__SVG_ANGLETYPE_UNKNOWN
-        if (m_value.unitType() > SVGAngleValue::Type::SVG_ANGLETYPE_GRAD)
-            return SVGAngleValue::Type::SVG_ANGLETYPE_UNKNOWN;
-        return m_value.unitType();
+        auto type = m_value.unitType();
+        if (type > SVGAngleType::Grad)
+            return std::to_underlying(SVGAngleType::Unknown);
+        return std::to_underlying(type);
     }
 
     ExceptionOr<void> setValueForBindings(float value)

--- a/Source/WebCore/svg/SVGAngle.idl
+++ b/Source/WebCore/svg/SVGAngle.idl
@@ -23,15 +23,15 @@
 // https://svgwg.org/svg2-draft/types.html#InterfaceSVGAngle
 
 [
-    ConstantsScope=SVGAngleValue,
+    ConstantsEnum=SVGAngleType,
     Exposed=Window
 ] interface SVGAngle {
     // Angle Unit Types
-    const unsigned short SVG_ANGLETYPE_UNKNOWN = 0;
-    const unsigned short SVG_ANGLETYPE_UNSPECIFIED = 1;
-    const unsigned short SVG_ANGLETYPE_DEG = 2;
-    const unsigned short SVG_ANGLETYPE_RAD = 3;
-    const unsigned short SVG_ANGLETYPE_GRAD = 4;
+    [ImplementedAs=Unknown] const unsigned short SVG_ANGLETYPE_UNKNOWN = 0;
+    [ImplementedAs=Unspecified] const unsigned short SVG_ANGLETYPE_UNSPECIFIED = 1;
+    [ImplementedAs=Deg] const unsigned short SVG_ANGLETYPE_DEG = 2;
+    [ImplementedAs=Rad] const unsigned short SVG_ANGLETYPE_RAD = 3;
+    [ImplementedAs=Grad] const unsigned short SVG_ANGLETYPE_GRAD = 4;
 
     readonly attribute unsigned short unitType;
     [ImplementedAs=valueForBindings] attribute float value;

--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -37,15 +37,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAngleValue);
 float SVGAngleValue::value() const
 {
     switch (m_unitType) {
-    case SVG_ANGLETYPE_GRAD:
+    case Type::Grad:
         return grad2deg(m_valueInSpecifiedUnits);
-    case SVG_ANGLETYPE_RAD:
+    case Type::Rad:
         return rad2deg(m_valueInSpecifiedUnits);
-    case SVG_ANGLETYPE_TURN:
+    case Type::Turn:
         return turn2deg(m_valueInSpecifiedUnits);
-    case SVG_ANGLETYPE_UNSPECIFIED:
-    case SVG_ANGLETYPE_UNKNOWN:
-    case SVG_ANGLETYPE_DEG:
+    case Type::Unspecified:
+    case Type::Unknown:
+    case Type::Deg:
         return m_valueInSpecifiedUnits;
     }
     ASSERT_NOT_REACHED();
@@ -55,18 +55,18 @@ float SVGAngleValue::value() const
 void SVGAngleValue::setValue(float value)
 {
     switch (m_unitType) {
-    case SVG_ANGLETYPE_GRAD:
+    case Type::Grad:
         m_valueInSpecifiedUnits = deg2grad(value);
         return;
-    case SVG_ANGLETYPE_RAD:
+    case Type::Rad:
         m_valueInSpecifiedUnits = deg2rad(value);
         return;
-    case SVG_ANGLETYPE_TURN:
+    case Type::Turn:
         m_valueInSpecifiedUnits = deg2turn(value);
         return;
-    case SVG_ANGLETYPE_UNSPECIFIED:
-    case SVG_ANGLETYPE_UNKNOWN:
-    case SVG_ANGLETYPE_DEG:
+    case Type::Unspecified:
+    case Type::Unknown:
+    case Type::Deg:
         m_valueInSpecifiedUnits = value;
         return;
     }
@@ -76,16 +76,16 @@ void SVGAngleValue::setValue(float value)
 String SVGAngleValue::valueAsString() const
 {
     switch (m_unitType) {
-    case SVG_ANGLETYPE_DEG:
+    case Type::Deg:
         return makeString(m_valueInSpecifiedUnits, "deg"_s);
-    case SVG_ANGLETYPE_RAD:
+    case Type::Rad:
         return makeString(m_valueInSpecifiedUnits, "rad"_s);
-    case SVG_ANGLETYPE_TURN:
+    case Type::Turn:
         return makeString(m_valueInSpecifiedUnits, "turn"_s);
-    case SVG_ANGLETYPE_GRAD:
+    case Type::Grad:
         return makeString(m_valueInSpecifiedUnits, "grad"_s);
-    case SVG_ANGLETYPE_UNSPECIFIED:
-    case SVG_ANGLETYPE_UNKNOWN:
+    case Type::Unspecified:
+    case Type::Unknown:
         return String::number(m_valueInSpecifiedUnits);
     }
 
@@ -97,27 +97,27 @@ template<typename CharacterType> static inline SVGAngleValue::Type NODELETE pars
 {
     switch (buffer.lengthRemaining()) {
     case 0:
-        return SVGAngleValue::SVG_ANGLETYPE_UNSPECIFIED;
+        return SVGAngleValue::Type::Unspecified;
     case 3:
         if (compareCharacters(buffer.position(), 'd', 'e', 'g'))
-            return SVGAngleValue::SVG_ANGLETYPE_DEG;
+            return SVGAngleValue::Type::Deg;
         if (compareCharacters(buffer.position(), 'r', 'a', 'd'))
-            return SVGAngleValue::SVG_ANGLETYPE_RAD;
+            return SVGAngleValue::Type::Rad;
         break;
     case 4:
         if (compareCharacters(buffer.position(), 'g', 'r', 'a', 'd'))
-            return SVGAngleValue::SVG_ANGLETYPE_GRAD;
+            return SVGAngleValue::Type::Grad;
         if (compareCharacters(buffer.position(), 't', 'u', 'r', 'n'))
-            return SVGAngleValue::SVG_ANGLETYPE_TURN;
+            return SVGAngleValue::Type::Turn;
         break;
     }
-    return SVGAngleValue::SVG_ANGLETYPE_UNKNOWN;
+    return SVGAngleValue::Type::Unknown;
 }
 
 ExceptionOr<void> SVGAngleValue::setValueAsString(const String& value)
 {
     if (value.isEmpty()) {
-        m_unitType = SVG_ANGLETYPE_UNSPECIFIED;
+        m_unitType = Type::Unspecified;
         return { };
     }
 
@@ -127,7 +127,7 @@ ExceptionOr<void> SVGAngleValue::setValueAsString(const String& value)
             return Exception { ExceptionCode::SyntaxError };
 
         auto unitType = parseAngleType(buffer);
-        if (unitType == SVGAngleValue::SVG_ANGLETYPE_UNKNOWN)
+        if (unitType == SVGAngleValue::Type::Unknown)
             return Exception { ExceptionCode::SyntaxError };
 
         m_unitType = unitType;
@@ -138,104 +138,106 @@ ExceptionOr<void> SVGAngleValue::setValueAsString(const String& value)
 
 ExceptionOr<void> SVGAngleValue::newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits)
 {
-    if (unitType == SVG_ANGLETYPE_UNKNOWN || unitType > SVG_ANGLETYPE_GRAD)
+    auto type = static_cast<Type>(unitType);
+    if (type == Type::Unknown || type > Type::Grad)
         return Exception { ExceptionCode::NotSupportedError };
 
-    m_unitType = static_cast<Type>(unitType);
+    m_unitType = type;
     m_valueInSpecifiedUnits = valueInSpecifiedUnits;
     return { };
 }
 
 ExceptionOr<void> SVGAngleValue::convertToSpecifiedUnits(unsigned short unitType)
 {
-    if (unitType == SVG_ANGLETYPE_UNKNOWN || m_unitType == SVG_ANGLETYPE_UNKNOWN || unitType > SVG_ANGLETYPE_GRAD)
+    auto targetType = static_cast<Type>(unitType);
+    if (targetType == Type::Unknown || m_unitType == Type::Unknown || targetType > Type::Grad)
         return Exception { ExceptionCode::NotSupportedError };
 
-    if (unitType == m_unitType)
+    if (targetType == m_unitType)
         return { };
 
     switch (m_unitType) {
-    case SVG_ANGLETYPE_TURN:
-        switch (unitType) {
-        case SVG_ANGLETYPE_GRAD:
+    case Type::Turn:
+        switch (targetType) {
+        case Type::Grad:
             m_valueInSpecifiedUnits = turn2grad(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_UNSPECIFIED:
-        case SVG_ANGLETYPE_DEG:
+        case Type::Unspecified:
+        case Type::Deg:
             m_valueInSpecifiedUnits = turn2deg(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_RAD:
+        case Type::Rad:
             m_valueInSpecifiedUnits = deg2rad(turn2deg(m_valueInSpecifiedUnits));
             break;
-        case SVG_ANGLETYPE_TURN:
-        case SVG_ANGLETYPE_UNKNOWN:
+        case Type::Turn:
+        case Type::Unknown:
             ASSERT_NOT_REACHED();
             break;
         }
         break;
-    case SVG_ANGLETYPE_RAD:
-        switch (unitType) {
-        case SVG_ANGLETYPE_GRAD:
+    case Type::Rad:
+        switch (targetType) {
+        case Type::Grad:
             m_valueInSpecifiedUnits = rad2grad(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_UNSPECIFIED:
-        case SVG_ANGLETYPE_DEG:
+        case Type::Unspecified:
+        case Type::Deg:
             m_valueInSpecifiedUnits = rad2deg(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_TURN:
+        case Type::Turn:
             m_valueInSpecifiedUnits = deg2turn(rad2deg(m_valueInSpecifiedUnits));
             break;
-        case SVG_ANGLETYPE_RAD:
-        case SVG_ANGLETYPE_UNKNOWN:
+        case Type::Rad:
+        case Type::Unknown:
             ASSERT_NOT_REACHED();
             break;
         }
         break;
-    case SVG_ANGLETYPE_GRAD:
-        switch (unitType) {
-        case SVG_ANGLETYPE_RAD:
+    case Type::Grad:
+        switch (targetType) {
+        case Type::Rad:
             m_valueInSpecifiedUnits = grad2rad(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_UNSPECIFIED:
-        case SVG_ANGLETYPE_DEG:
+        case Type::Unspecified:
+        case Type::Deg:
             m_valueInSpecifiedUnits = grad2deg(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_TURN:
+        case Type::Turn:
             m_valueInSpecifiedUnits = grad2turn(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_GRAD:
-        case SVG_ANGLETYPE_UNKNOWN:
+        case Type::Grad:
+        case Type::Unknown:
             ASSERT_NOT_REACHED();
             break;
         }
         break;
-    case SVG_ANGLETYPE_UNSPECIFIED:
+    case Type::Unspecified:
         // Spec: For angles, a unitless value is treated the same as if degrees were specified.
-    case SVG_ANGLETYPE_DEG:
-        switch (unitType) {
-        case SVG_ANGLETYPE_RAD:
+    case Type::Deg:
+        switch (targetType) {
+        case Type::Rad:
             m_valueInSpecifiedUnits = deg2rad(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_GRAD:
+        case Type::Grad:
             m_valueInSpecifiedUnits = deg2grad(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_TURN:
+        case Type::Turn:
             m_valueInSpecifiedUnits = deg2turn(m_valueInSpecifiedUnits);
             break;
-        case SVG_ANGLETYPE_UNSPECIFIED:
-        case SVG_ANGLETYPE_DEG:
+        case Type::Unspecified:
+        case Type::Deg:
             break;
-        case SVG_ANGLETYPE_UNKNOWN:
+        case Type::Unknown:
             ASSERT_NOT_REACHED();
             break;
         }
         break;
-    case SVG_ANGLETYPE_UNKNOWN:
+    case Type::Unknown:
         ASSERT_NOT_REACHED();
         break;
     }
 
-    m_unitType = static_cast<Type>(unitType);
+    m_unitType = targetType;
 
     return { };
 }

--- a/Source/WebCore/svg/SVGAngleValue.h
+++ b/Source/WebCore/svg/SVGAngleValue.h
@@ -28,18 +28,19 @@ namespace WebCore {
 
 template<typename> class ExceptionOr;
 
+enum class SVGAngleType : uint8_t {
+    Unknown = 0,
+    Unspecified = 1,
+    Deg = 2,
+    Rad = 3,
+    Grad = 4,
+    Turn = 5
+};
+
 class SVGAngleValue {
     WTF_MAKE_TZONE_ALLOCATED(SVGAngleValue);
 public:
-    enum Type {
-        // FIXME: Change the casing style of the enum type or naming of the Angle Value (webkit.org/b/269429).
-        SVG_ANGLETYPE_UNKNOWN = 0,
-        SVG_ANGLETYPE_UNSPECIFIED = 1,
-        SVG_ANGLETYPE_DEG = 2,
-        SVG_ANGLETYPE_RAD = 3,
-        SVG_ANGLETYPE_GRAD = 4,
-        SVG_ANGLETYPE_TURN = 5
-    };
+    using Type = SVGAngleType;
 
     Type unitType() const { return m_unitType; }
 
@@ -56,7 +57,7 @@ public:
     ExceptionOr<void> convertToSpecifiedUnits(unsigned short unitType);
 
 private:
-    Type m_unitType { SVG_ANGLETYPE_UNSPECIFIED };
+    Type m_unitType { Type::Unspecified };
     float m_valueInSpecifiedUnits { 0 };
 };
 


### PR DESCRIPTION
#### 6d115f74a609e867416af98ad4d82305a65b008d
<pre>
Use enum class for SVG Angle Types as suggested in <a href="https://commits.webkit.org/274778@main">274778@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269429">https://bugs.webkit.org/show_bug.cgi?id=269429</a>
<a href="https://rdar.apple.com/123419968">rdar://123419968</a>

Reviewed by NOBODY (OOPS!).

Convert SVGAngleValue::Type to a namespace-scoped enum class
SVGAngleType following the CSSRule/StyleRuleType pattern. Use
ConstantsEnum and [ImplementedAs=...] in the IDL to map
SVG_ANGLETYPE_* constants directly to the enum class, eliminating
the companion anonymous enum.

* Source/WebCore/svg/SVGAngle.h:
(WebCore::SVGAngle::unitType const):
* Source/WebCore/svg/SVGAngle.idl:
* Source/WebCore/svg/SVGAngleValue.cpp:
(WebCore::SVGAngleValue::newValueSpecifiedUnits):
(WebCore::SVGAngleValue::convertToSpecifiedUnits):
* Source/WebCore/svg/SVGAngleValue.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d115f74a609e867416af98ad4d82305a65b008d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113273 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123330 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86589 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103997 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23076 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15791 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170513 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16266 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131523 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32306 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27146 "Found 1 new test failure: http/tests/security/javascriptURL/xss-ALLOWED-to-javascript-url-from-javscript-url.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131635 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90308 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19372 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31281 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31554 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31436 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->