### PR TITLE
REGRESSION(307450@main): [iOS] webgl/lose-context-after-context-lost.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8475,8 +8475,6 @@ media/caption-display-settings/caption-display-settings-default-anchorBounds.htm
 
 webkit.org/b/307582 compositing/overflow/rtl-scrollbar-layer-positioning.html [ Failure ]
 
-webkit.org/b/307882 webgl/lose-context-after-context-lost.html [ Failure ]
-
 webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-unrelated-gesture-scroll.html [ Skip ]

--- a/LayoutTests/webgl/lose-context-after-context-lost.html
+++ b/LayoutTests/webgl/lose-context-after-context-lost.html
@@ -51,8 +51,9 @@ async function runTest(subcase)
     } else if (subcase.loseMethod == "manyContexts") {
         // This causes the older contexts to be lost, including the first one we created
         // for testing.
+        let contexts = [];
         for (let i = 0; i < 50; ++i)
-            document.createElement("canvas").getContext("webgl");
+            contexts.push(document.createElement("canvas").getContext("webgl"));
     }
 
     try {


### PR DESCRIPTION
#### 586c879d099eaa2dd8a3f469a20f39d3229322df
<pre>
REGRESSION(307450@main): [iOS] webgl/lose-context-after-context-lost.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=307882">https://bugs.webkit.org/show_bug.cgi?id=307882</a>
<a href="https://rdar.apple.com/170363832">rdar://170363832</a>

Reviewed by Cameron McCormack.

The test tried to create excessive amount of contexts to test webgl
context loss for the early contexts. It did not retain the contexts
it created.

307450@main added better memory accounting for WebGL contexts, so GC
collected the temporary elements and thus the context count never
exceeded the threshold for context loss triggering.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/webgl/lose-context-after-context-lost.html:

Canonical link: <a href="https://commits.webkit.org/308319@main">https://commits.webkit.org/308319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e841cc284497d643ec573fa23ab5f014656162c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100408 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56017297-4144-4065-b77d-e42e52927a0c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113269 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80828 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78af0e9c-8e40-4eb9-b6c9-547aa295ba4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdb5e767-3d2a-4cec-b2a9-f0ac92aab4da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14725 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12502 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158007 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121293 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31150 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75444 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17058 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8567 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19091 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18972 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->