### PR TITLE
[JSC] Move MicrotaskQueue enqueue code from WebCore to JSC

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -42,7 +42,6 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         nullptr, // moduleLoaderImportModule
         nullptr, // moduleLoaderResolve

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -62,7 +62,6 @@ const GlobalObjectMethodTable* JSAPIGlobalObject::globalObjectMethodTable()
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
@@ -220,7 +219,7 @@ JSInternalPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
         if (Identifier::fromString(vm, oldModuleKey) != moduleKey) [[unlikely]]
             return rejectPromise(makeString("The same JSScript was provided for two different identifiers, previously: "_s, oldModuleKey, " and now: "_s, moduleKey.string()));
 
-        strongPromise.get()->resolve(globalObject, source);
+        strongPromise.get()->resolve(globalObject, vm, source);
         return encodedJSUndefined();
     });
 
@@ -293,7 +292,7 @@ JSValue JSAPIGlobalObject::loadAndEvaluateJSScriptModule(const JSLockHolder&, JS
     JSInternalPromise* promise = importModule(this, key, jsUndefined(), jsUndefined(), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
     auto* result = JSPromise::create(vm, this->promiseStructure());
-    result->resolve(this, promise);
+    result->resolve(this, vm, promise);
     RETURN_IF_EXCEPTION(scope, { });
     return result;
 }

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1065,6 +1065,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/ConstructData.h
     runtime/ConstructorKind.h
     runtime/ControlFlowProfiler.h
+    runtime/CrossTaskToken.h
     runtime/CustomGetterSetter.h
     runtime/DOMAnnotation.h
     runtime/DataView.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1986,6 +1986,7 @@
 		E323116924A1DC3500693DA5 /* IntlNumberFormatInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E323116824A1DC2F00693DA5 /* IntlNumberFormatInlines.h */; };
 		E325956421FDA2C9008EDC9C /* RegExpGlobalDataInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E325956321FDA2C8008EDC9C /* RegExpGlobalDataInlines.h */; };
 		E325A36022211590007349A1 /* StringPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E325A35F2221158A007349A1 /* StringPrototypeInlines.h */; };
+		E325AB002F504878009DA19F /* CrossTaskToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E325AAFE2F504878009DA19F /* CrossTaskToken.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3282BBB1FE930AF00EDAF71 /* YarrErrorCode.h in Headers */ = {isa = PBXBuildFile; fileRef = E3282BBA1FE930A400EDAF71 /* YarrErrorCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E328C6C71DA4304500D255FD /* MaxFrameExtentForSlowPathCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 65860177185A8F5E00030EEE /* MaxFrameExtentForSlowPathCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E328C6C81DA4306100D255FD /* RegisterAtOffsetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 6540C79D1B82D99D000F6B79 /* RegisterAtOffsetList.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5830,6 +5831,8 @@
 		E323116824A1DC2F00693DA5 /* IntlNumberFormatInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlNumberFormatInlines.h; sourceTree = "<group>"; };
 		E325956321FDA2C8008EDC9C /* RegExpGlobalDataInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegExpGlobalDataInlines.h; sourceTree = "<group>"; };
 		E325A35F2221158A007349A1 /* StringPrototypeInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringPrototypeInlines.h; sourceTree = "<group>"; };
+		E325AAFE2F504878009DA19F /* CrossTaskToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrossTaskToken.h; sourceTree = "<group>"; };
+		E325AAFF2F504878009DA19F /* CrossTaskToken.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CrossTaskToken.cpp; sourceTree = "<group>"; };
 		E326C4961ECBEF5700A9A905 /* ClassInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClassInfo.cpp; sourceTree = "<group>"; };
 		E3282BB91FE930A300EDAF71 /* YarrErrorCode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = YarrErrorCode.cpp; path = yarr/YarrErrorCode.cpp; sourceTree = "<group>"; };
 		E3282BBA1FE930A400EDAF71 /* YarrErrorCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YarrErrorCode.h; path = yarr/YarrErrorCode.h; sourceTree = "<group>"; };
@@ -8507,6 +8510,8 @@
 				E3FCCB632310A90D00238E72 /* ConstructorKind.h */,
 				52B717B41A0597E1007AF4F3 /* ControlFlowProfiler.cpp */,
 				52678F901A04177C006A306D /* ControlFlowProfiler.h */,
+				E325AAFF2F504878009DA19F /* CrossTaskToken.cpp */,
+				E325AAFE2F504878009DA19F /* CrossTaskToken.h */,
 				2A111243192FCE79005EE18D /* CustomGetterSetter.cpp */,
 				2A111244192FCE79005EE18D /* CustomGetterSetter.h */,
 				278D26052A70CF20007F5BC3 /* CustomGetterSetterInlines.h */,
@@ -11152,6 +11157,7 @@
 				FE37C5282A99A372003EE733 /* CPUInlines.h in Headers */,
 				5DE6E5B30E1728EC00180407 /* create_hash_table in Headers */,
 				535C24611F78928E006EC40E /* create_regex_tables in Headers */,
+				E325AB002F504878009DA19F /* CrossTaskToken.h in Headers */,
 				9959E92B1BD17FA4001AA413 /* cssmin.py in Headers */,
 				2A111246192FCE79005EE18D /* CustomGetterSetter.h in Headers */,
 				278D26082A70CF21007F5BC3 /* CustomGetterSetterInlines.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -791,6 +791,7 @@ runtime/ConsoleObject.cpp
 runtime/ConstantMode.cpp
 runtime/ConstructData.cpp
 runtime/ControlFlowProfiler.cpp
+runtime/CrossTaskToken.cpp
 runtime/CustomGetterSetter.cpp
 runtime/DOMAttributeGetterSetter.cpp
 runtime/DataView.cpp

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1635,7 +1635,7 @@ JSC_DEFINE_JIT_OPERATION(operationResolvePromiseFirstResolving, void, (JSGlobalO
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue argument = JSValue::decode(encodedArgument);
-    promise->resolve(globalObject, argument);
+    promise->resolve(globalObject, vm, argument);
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -961,7 +961,6 @@ const GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     &shellSupportsRichSourceInfo,
     &shouldInterruptScript,
     &javaScriptRuntimeFlags,
-    &queueMicrotaskToEventLoop,
     &shouldInterruptScriptBeforeTimeout,
     &moduleLoaderImportModule,
     &moduleLoaderResolve,
@@ -1496,7 +1495,7 @@ JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
         auto source = SourceCode(WebAssemblySourceProvider::create(WTF::move(buffer), SourceOrigin { moduleURL }, WTF::move(moduleKey)));
         auto sourceCode = JSSourceCode::create(vm, WTF::move(source));
         scope.release();
-        promise->resolve(globalObject, sourceCode);
+        promise->resolve(globalObject, vm, sourceCode);
         return promise;
     }
 #endif
@@ -1505,13 +1504,13 @@ JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
         auto source = SourceCode(StringSourceProvider::create(stringFromUTF(buffer), SourceOrigin { moduleURL }, WTF::move(moduleKey), SourceTaintedOrigin::Untainted, TextPosition(), SourceProviderSourceType::JSON));
         auto sourceCode = JSSourceCode::create(vm, WTF::move(source));
         scope.release();
-        promise->resolve(globalObject, sourceCode);
+        promise->resolve(globalObject, vm, sourceCode);
         return promise;
     }
 
     auto sourceCode = JSSourceCode::create(vm, jscSource(stringFromUTF(buffer), SourceOrigin { moduleURL }, WTF::move(moduleKey), TextPosition(), SourceProviderSourceType::Module));
     scope.release();
-    promise->resolve(globalObject, sourceCode);
+    promise->resolve(globalObject, vm, sourceCode);
     return promise;
 }
 

--- a/Source/JavaScriptCore/runtime/CrossTaskToken.cpp
+++ b/Source/JavaScriptCore/runtime/CrossTaskToken.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CrossTaskToken.h"
+
+#include "MicrotaskQueue.h"
+
+namespace JSC {
+
+CrossTaskToken::CrossTaskToken() = default;
+CrossTaskToken::~CrossTaskToken() = default;
+
+RefPtr<MicrotaskDispatcher> CrossTaskToken::createMicrotaskDispatcher(VM&, JSGlobalObject*)
+{
+    return nullptr;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/CrossTaskToken.h
+++ b/Source/JavaScriptCore/runtime/CrossTaskToken.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSExportMacros.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+
+namespace JSC {
+
+class JSGlobalObject;
+class MicrotaskDispatcher;
+class VM;
+
+class CrossTaskToken : public RefCountedAndCanMakeWeakPtr<CrossTaskToken> {
+public:
+    JS_EXPORT_PRIVATE CrossTaskToken();
+    JS_EXPORT_PRIVATE virtual ~CrossTaskToken();
+
+    bool shouldPropagateToMicroTask() const { return m_shouldPropagateToMicroTask; }
+    void setShouldPropagateToMicroTask(bool value) { m_shouldPropagateToMicroTask = value; }
+    void resetShouldPropagateToMicroTask() { m_shouldPropagateToMicroTask = false; }
+    JS_EXPORT_PRIVATE virtual RefPtr<MicrotaskDispatcher> createMicrotaskDispatcher(VM&, JSGlobalObject*);
+
+private:
+    bool m_shouldPropagateToMicroTask { false };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -57,7 +57,6 @@ struct GlobalObjectMethodTable {
     bool (*supportsRichSourceInfo)(const JSGlobalObject*);
     bool (*shouldInterruptScript)(const JSGlobalObject*);
     RuntimeFlags (*javaScriptRuntimeFlags)(const JSGlobalObject*);
-    void (*queueMicrotaskToEventLoop)(JSGlobalObject&, QueuedTask&&);
     bool (*shouldInterruptScriptBeforeTimeout)(const JSGlobalObject*);
 
     JSInternalPromise* (*moduleLoaderImportModule)(JSGlobalObject*, JSModuleLoader*, JSString*, JSValue, const SourceOrigin&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -63,6 +63,7 @@
 #include "CodeBlockSetInlines.h"
 #include "ConsoleClient.h"
 #include "ConsoleObjectInlines.h"
+#include "CrossTaskToken.h"
 #include "DateConstructorInlines.h"
 #include "DateInstanceInlines.h"
 #include "DatePrototypeInlines.h"
@@ -217,6 +218,7 @@
 #include "MarkedSpaceInlines.h"
 #include "MathObjectInlines.h"
 #include "Microtask.h"
+#include "MicrotaskQueueInlines.h"
 #include "NativeErrorConstructorInlines.h"
 #include "NativeErrorPrototypeInlines.h"
 #include "NullGetterFunctionInlines.h"
@@ -666,7 +668,6 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         nullptr, // moduleLoaderImportModule
         nullptr, // moduleLoaderResolve
@@ -745,7 +746,7 @@ JSC_DEFINE_HOST_FUNCTION(resolvePromise, (JSGlobalObject* globalObject, CallFram
 {
     auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
-    promise->resolvePromise(globalObject, argument);
+    promise->resolvePromise(globalObject, globalObject->vm(), argument);
     return encodedJSUndefined();
 }
 
@@ -769,7 +770,7 @@ JSC_DEFINE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck, (JSG
 {
     auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
-    promise->resolve(globalObject, argument);
+    promise->resolve(globalObject, globalObject->vm(), argument);
     return encodedJSUndefined();
 }
 
@@ -791,18 +792,20 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck, (JSG
 
 JSC_DEFINE_HOST_FUNCTION(resolveWithInternalMicrotaskForAsyncAwait, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
     JSValue resolution = callFrame->uncheckedArgument(0);
     auto task = static_cast<InternalMicrotask>(callFrame->uncheckedArgument(1).asUInt32AsAnyInt());
     JSValue context = callFrame->uncheckedArgument(2);
-    JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, resolution, task, context);
+    JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, resolution, task, context);
     return encodedJSUndefined();
 }
 
 JSC_DEFINE_HOST_FUNCTION(driveAsyncFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
     JSValue resolution = callFrame->uncheckedArgument(0);
     JSValue context = callFrame->uncheckedArgument(1);
-    JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, resolution, InternalMicrotask::AsyncFunctionResume, context);
+    JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, resolution, InternalMicrotask::AsyncFunctionResume, context);
     return encodedJSUndefined();
 }
 
@@ -884,7 +887,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueDequeueResolve, (JSGlobalObject* glo
 
     auto [value, resumeMode, promise] = generator->dequeue(vm);
 
-    promise->resolve(globalObject, resolution);
+    promise->resolve(globalObject, vm, resolution);
 
     return JSValue::encode(jsNumber(generator->resumeMode()));
 }
@@ -908,6 +911,7 @@ JS_GLOBAL_OBJECT_ADDITIONS_2;
 JSGlobalObject::JSGlobalObject(VM& vm, Structure* structure, const GlobalObjectMethodTable* globalObjectMethodTable)
     : Base(vm, structure, nullptr)
     , m_vm(&vm)
+    , m_microtaskQueue(vm.defaultMicrotaskQueue())
     , m_linkTimeConstants(numberOfLinkTimeConstants)
     , m_structureCache(vm)
     , m_masqueradesAsUndefinedWatchpointSet(WatchpointSet::create(IsWatched))
@@ -3589,15 +3593,35 @@ void JSGlobalObject::bumpGlobalLexicalBindingEpoch(VM& vm)
 
 void JSGlobalObject::queueMicrotaskToEventLoop(JSC::JSGlobalObject& globalObject, JSC::QueuedTask&& task)
 {
-    if (globalObject.debugger()) [[unlikely]]
-        task.setDispatcher(JSMicrotaskDispatcher::create(globalObject.vm(), DebuggableMicrotaskDispatcher::create(), &globalObject));
-    globalObject.vm().queueMicrotask(WTF::move(task));
+    globalObject.queueMicrotask(globalObject.vm(), WTF::move(task));
 }
 
-void JSGlobalObject::queueMicrotask(InternalMicrotask job, uint8_t payload, JSValue argument0, JSValue argument1, JSValue argument2)
+void JSGlobalObject::queueMicrotask(VM& vm, QueuedTask&& task)
 {
-    QueuedTask task { nullptr, job, payload, this, argument0, argument1, argument2 };
-    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, WTF::move(task));
+    ([&] ALWAYS_INLINE_LAMBDA {
+        if (auto* crossTaskToken = vm.crossTaskToken(); crossTaskToken && crossTaskToken->shouldPropagateToMicroTask()) [[unlikely]] {
+            if (auto dispatcher = crossTaskToken->createMicrotaskDispatcher(vm, this)) {
+                task.setDispatcher(JSMicrotaskDispatcher::create(vm, dispatcher.releaseNonNull(), this));
+                return;
+            }
+        }
+
+        if (debugger()) [[unlikely]] {
+            task.setDispatcher(JSMicrotaskDispatcher::create(vm, DebuggableMicrotaskDispatcher::create(), this));
+            return;
+        }
+    }());
+    microtaskQueue().enqueue(WTF::move(task));
+}
+
+void JSGlobalObject::queueMicrotask(VM& vm, InternalMicrotask job, uint8_t payload, JSValue argument0, JSValue argument1, JSValue argument2)
+{
+    queueMicrotask(vm, QueuedTask { nullptr, job, payload, this, argument0, argument1, argument2 });
+}
+
+void JSGlobalObject::setMicrotaskQueue(Ref<MicrotaskQueue>&& queue)
+{
+    m_microtaskQueue = WTF::move(queue);
 }
 
 void JSGlobalObject::promiseRejectionTracker(JSGlobalObject* globalObject, JSPromise* promise, JSPromiseRejectionOperation operation)
@@ -3613,9 +3637,8 @@ void JSGlobalObject::promiseRejectionTracker(JSGlobalObject* globalObject, JSPro
     }
 }
 
-void JSGlobalObject::reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception* exception)
+void JSGlobalObject::reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception*)
 {
-    dataLogLn("Uncaught Exception at run loop: ", exception->value());
 }
 
 void JSGlobalObject::setConsoleClient(WeakPtr<ConsoleClient>&& consoleClient)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -105,6 +105,7 @@ class JSTypedArrayViewPrototype;
 class MapIteratorPrototype;
 class MapPrototype;
 class Microtask;
+class MicrotaskQueue;
 class NullGetterFunction;
 class NullSetterFunction;
 class ObjectAdaptiveStructureWatchpoint;
@@ -230,6 +231,7 @@ private:
     VM* const m_vm;
     Debugger* m_debugger { nullptr };
     QueuedTaskResult m_microtaskRunnability { QueuedTaskResult::Executed };
+    Ref<MicrotaskQueue> m_microtaskQueue;
 
 // Our hashtable code-generator tries to access these properties, so we make them public.
 // However, we'd like it better if they could be protected.
@@ -1173,7 +1175,8 @@ public:
             m_trustedTypesEnforcement = enforcement;
     }
 
-    void queueMicrotask(InternalMicrotask, uint8_t, JSValue, JSValue, JSValue);
+    void queueMicrotask(VM&, QueuedTask&&);
+    void queueMicrotask(VM&, InternalMicrotask, uint8_t, JSValue, JSValue, JSValue);
 
 #if ASSERT_ENABLED
     const JSGlobalObject* globalObjectAtDebuggerEntry() const { return m_globalObjectAtDebuggerEntry; }
@@ -1231,6 +1234,9 @@ public:
 
     QueuedTaskResult microtaskRunnability() const { return m_microtaskRunnability; }
     void setMicrotaskRunnability(QueuedTaskResult runnability) { m_microtaskRunnability = runnability; }
+
+    MicrotaskQueue& microtaskQueue() const { return m_microtaskQueue.get(); }
+    JS_EXPORT_PRIVATE void setMicrotaskQueue(Ref<MicrotaskQueue>&&);
 
 protected:
     enum class HasSpeciesProperty : bool { No, Yes };

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -819,7 +819,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncImportModule, (JSGlobalObject* globalObject, 
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
 
     scope.release();
-    promise->resolve(globalObject, internalPromise);
+    promise->resolve(globalObject, vm, internalPromise);
     return JSValue::encode(promise);
 }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -289,7 +289,7 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
     case JSPromise::Status::Fulfilled: {
         auto* resultObject = createIteratorResultObject(globalObject, result, done);
         scope.release();
-        jsCast<JSPromise*>(promise)->resolve(globalObject, resultObject);
+        jsCast<JSPromise*>(promise)->resolve(globalObject, vm, resultObject);
         break;
     }
     }
@@ -309,7 +309,7 @@ static void promiseRaceResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromis
     }
     case JSPromise::Status::Fulfilled: {
         scope.release();
-        promise->resolve(globalObject, resolution);
+        promise->resolve(globalObject, vm, resolution);
         break;
     }
     case JSPromise::Status::Rejected: {
@@ -344,7 +344,7 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         globalContext->setRemainingElementsCount(vm, jsNumber(count));
         if (!count) {
             scope.release();
-            promise->resolve(globalObject, values);
+            promise->resolve(globalObject, vm, values);
         }
         break;
     }
@@ -430,7 +430,7 @@ static void promiseAllSettledResolveJob(JSGlobalObject* globalObject, VM& vm, JS
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
         scope.release();
-        promise->resolve(globalObject, values);
+        promise->resolve(globalObject, vm, values);
     }
 }
 
@@ -447,7 +447,7 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
     }
     case JSPromise::Status::Fulfilled: {
         scope.release();
-        promise->resolve(globalObject, resolution);
+        promise->resolve(globalObject, vm, resolution);
         break;
     }
     case JSPromise::Status::Rejected: {
@@ -504,7 +504,7 @@ static void asyncGeneratorResolve(JSGlobalObject* globalObject, JSAsyncGenerator
 
     auto* iteratorResult = createIteratorResultObject(globalObject, value, done);
 
-    promise->resolve(globalObject, iteratorResult);
+    promise->resolve(globalObject, vm, iteratorResult);
     RETURN_IF_EXCEPTION(scope, void());
 
     if constexpr (status == IterationStatus::Continue)
@@ -520,7 +520,7 @@ static bool asyncGeneratorBodyCall(JSGlobalObject* globalObject, JSAsyncGenerato
     if (resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode) && isSuspendYieldState(state)) {
         state = (state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await);
         generator->setState(state);
-        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, resumeValue, InternalMicrotask::AsyncGeneratorBodyCallReturn, generator);
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, resumeValue, InternalMicrotask::AsyncGeneratorBodyCallReturn, generator);
         return false;
     }
 
@@ -557,13 +557,13 @@ static bool asyncGeneratorBodyCall(JSGlobalObject* globalObject, JSAsyncGenerato
 
     if (state > 0) {
         if ((state & JSAsyncGenerator::reasonMask) == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await)) {
-            JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, value, InternalMicrotask::AsyncGeneratorBodyCallNormal, generator);
+            JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncGeneratorBodyCallNormal, generator);
             return false;
         }
 
         state = (state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await);
         generator->setState(state);
-        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, value, InternalMicrotask::AsyncGeneratorYieldAwaited, generator);
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncGeneratorYieldAwaited, generator);
         return false;
     }
 
@@ -603,7 +603,7 @@ static void asyncGeneratorResumeNext(JSGlobalObject* globalObject, JSAsyncGenera
             if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
                 if (resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode)) {
                     generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::AwaitingReturn));
-                    RELEASE_AND_RETURN(scope, JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, nextValue, InternalMicrotask::AsyncGeneratorResumeNext, generator));
+                    RELEASE_AND_RETURN(scope, JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, nextValue, InternalMicrotask::AsyncGeneratorResumeNext, generator));
                 }
 
                 ASSERT(resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
@@ -702,7 +702,7 @@ static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue
     }
 
     if (wasFulfilled)
-        resultPromise->resolvePromise(globalObject, originalValue);
+        resultPromise->resolvePromise(globalObject, vm, originalValue);
     else
         resultPromise->rejectPromise(vm, globalObject, originalValue);
 }
@@ -786,9 +786,8 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     promiseResolveThenableJob(globalObject, resolutionObject, then, resolve, reject);
 }
 
-void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments)
+void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments)
 {
-    VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     switch (task) {
@@ -822,11 +821,11 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         case JSPromise::Status::Rejected: {
             if (!promise->isHandled())
                 globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, promise, JSPromiseRejectionOperation::Handle);
-            JSPromise::rejectWithInternalMicrotask(globalObject, promise->reactionsOrResult(), task, context);
+            JSPromise::rejectWithInternalMicrotask(vm, globalObject, promise->reactionsOrResult(), task, context);
             break;
         }
         case JSPromise::Status::Fulfilled: {
-            JSPromise::fulfillWithInternalMicrotask(globalObject, promise->reactionsOrResult(), task, context);
+            JSPromise::fulfillWithInternalMicrotask(vm, globalObject, promise->reactionsOrResult(), task, context);
             break;
         }
         }
@@ -862,7 +861,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         }
         case JSPromise::Status::Fulfilled: {
             scope.release();
-            promise->resolvePromise(globalObject, resolution);
+            promise->resolvePromise(globalObject, vm, resolution);
             break;
         }
         case JSPromise::Status::Rejected: {
@@ -932,7 +931,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         }
 
         if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
-            RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, result));
+            RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, vm, result));
 
         JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);
         RETURN_IF_EXCEPTION(scope, void());
@@ -1001,12 +1000,12 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         if (generator->state() == static_cast<int32_t>(JSGenerator::State::Executing)) {
             auto* promise = jsCast<JSPromise*>(generator->context());
             scope.release();
-            promise->resolve(globalObject, value);
+            promise->resolve(globalObject, vm, value);
             return;
         }
 
         scope.release();
-        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, value, InternalMicrotask::AsyncFunctionResume, generator);
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncFunctionResume, generator);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -31,6 +31,6 @@
 
 namespace JSC {
 
-JS_EXPORT_PRIVATE void runInternalMicrotask(JSGlobalObject*, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>);
+void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/JSCell.h>
 #include <JavaScriptCore/MicrotaskQueue.h>
+#include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/WriteBarrier.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -361,7 +361,7 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
         auto* moduleRecord = SyntheticModuleRecord::parseJSONModule(globalObject, moduleKey, WTF::move(sourceCode));
         RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
         scope.release();
-        promise->resolve(globalObject, moduleRecord);
+        promise->resolve(globalObject, vm, moduleRecord);
         return JSValue::encode(promise);
     }
 
@@ -383,7 +383,7 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
     }
 
     scope.release();
-    promise->resolve(globalObject, result.value());
+    promise->resolve(globalObject, vm, result.value());
     return JSValue::encode(promise);
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -179,14 +179,13 @@ JSPromise* JSPromise::rejectedPromise(JSGlobalObject* globalObject, JSValue valu
     return promise;
 }
 
-void JSPromise::resolve(JSGlobalObject* globalObject, JSValue value)
+void JSPromise::resolve(JSGlobalObject* globalObject, VM& vm, JSValue value)
 {
-    VM& vm = globalObject->vm();
     uint32_t flags = this->flags();
     ASSERT(!value.inherits<Exception>());
     if (!(flags & isFirstResolvingFunctionCalledFlag)) {
         internalField(Field::Flags).set(vm, this, jsNumber(flags | isFirstResolvingFunctionCalledFlag));
-        resolvePromise(globalObject, value);
+        resolvePromise(globalObject, vm, value);
     }
 }
 
@@ -263,11 +262,11 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     case JSPromise::Status::Rejected: {
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Rejected), promiseOrCapability, onRejected, reactionsOrResult);
+        globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Rejected), promiseOrCapability, onRejected, reactionsOrResult);
         break;
     }
     case JSPromise::Status::Fulfilled: {
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Fulfilled), promiseOrCapability, onFulfilled, reactionsOrResult);
+        globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Fulfilled), promiseOrCapability, onFulfilled, reactionsOrResult);
         break;
     }
     }
@@ -287,11 +286,11 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
     case JSPromise::Status::Rejected: {
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
-        globalObject->queueMicrotask(task, static_cast<uint8_t>(Status::Rejected), promise, reactionsOrResult, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), promise, reactionsOrResult, context);
         break;
     }
     case JSPromise::Status::Fulfilled: {
-        globalObject->queueMicrotask(task, static_cast<uint8_t>(Status::Fulfilled), promise, reactionsOrResult, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), promise, reactionsOrResult, context);
         break;
     }
     }
@@ -347,10 +346,8 @@ void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue arg
     triggerPromiseReactions(vm, globalObject, Status::Fulfilled, reactions, argument);
 }
 
-void JSPromise::resolvePromise(JSGlobalObject* globalObject, JSValue resolution)
+void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue resolution)
 {
-    VM& vm = globalObject->vm();
-
     if (resolution == this) [[unlikely]] {
         Structure* errorStructure = globalObject->errorStructure(ErrorType::TypeError);
         auto* error = ErrorInstance::create(vm, errorStructure, "Cannot resolve a promise with itself"_s, jsUndefined(), nullptr, TypeNothing, ErrorType::TypeError, false);
@@ -364,7 +361,7 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, JSValue resolution)
     if (resolutionObject->inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
-            return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJobFast, 0, resolutionObject, this, jsUndefined());
+            return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobFast, 0, resolutionObject, this, jsUndefined());
     }
 
     if (isDefinitelyNonThenable(resolutionObject, globalObject))
@@ -387,7 +384,7 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, JSValue resolution)
     if (!then.isCallable()) [[likely]]
         return fulfillPromise(vm, globalObject, resolutionObject);
 
-    return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJob, 0, resolutionObject, then, this);
+    return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJob, 0, resolutionObject, then, this);
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -405,7 +402,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolve, (JSGlobalObject* globa
     auto* promise = jsCast<JSPromise*>(callee->getField(JSFunctionWithFields::Field::ResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
-    promise->resolvePromise(globalObject, argument);
+    promise->resolvePromise(globalObject, vm, argument);
     return JSValue::encode(jsUndefined());
 }
 
@@ -434,7 +431,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseFirstResolvingFunctionResolve, (JSGlobalObject* 
     auto* promise = jsCast<JSPromise*>(callee->getField(JSFunctionWithFields::Field::FirstResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
-    promise->resolve(globalObject, argument);
+    promise->resolve(globalObject, globalObject->vm(), argument);
     return JSValue::encode(jsUndefined());
 }
 
@@ -463,7 +460,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolveWithInternalMicrotask, (
     auto* context = jsCast<JSPromiseCombinatorsGlobalContext*>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
     JSValue argument = callFrame->argument(0);
     JSValue onFulfilled = context->promise();
-    JSPromise::resolveWithInternalMicrotask(globalObject, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
+    JSPromise::resolveWithInternalMicrotask(globalObject, vm, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
     return JSValue::encode(jsUndefined());
 }
 
@@ -482,7 +479,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionRejectWithInternalMicrotask, (J
     auto* context = jsCast<JSPromiseCombinatorsGlobalContext*>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
     JSValue argument = callFrame->argument(0);
     JSValue onFulfilled = context->promise();
-    JSPromise::rejectWithInternalMicrotask(globalObject, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
+    JSPromise::rejectWithInternalMicrotask(vm, globalObject, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
     return JSValue::encode(jsUndefined());
 }
 
@@ -577,18 +574,16 @@ void JSPromise::triggerPromiseReactions(VM& vm, JSGlobalObject* globalObject, St
 
         if (handler.isInt32()) {
             auto task = static_cast<InternalMicrotask>(handler.asInt32());
-            globalObject->queueMicrotask(task, static_cast<uint8_t>(status), promise, argument, context);
+            globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(status), promise, argument, context);
             continue;
         }
         ASSERT(context.isUndefinedOrNull());
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(status), promise, handler, argument);
+        globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(status), promise, handler, argument);
     }
 }
 
-void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* globalObject, JSValue resolution, InternalMicrotask task, JSValue context)
+void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* globalObject, VM& vm, JSValue resolution, InternalMicrotask task, JSValue context)
 {
-    VM& vm = globalObject->vm();
-
     if (resolution.inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(resolution);
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
@@ -611,7 +606,7 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
                 error,
                 context,
             } };
-            runInternalMicrotask(globalObject, task, static_cast<uint8_t>(JSPromise::Status::Rejected), arguments);
+            runInternalMicrotask(globalObject, vm, task, static_cast<uint8_t>(JSPromise::Status::Rejected), arguments);
             return;
         }
 
@@ -619,25 +614,23 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
             return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
     }
 
-    resolveWithInternalMicrotask(globalObject, resolution, task, context);
+    resolveWithInternalMicrotask(globalObject, vm, resolution, task, context);
 }
 
-void JSPromise::resolveWithInternalMicrotask(JSGlobalObject* globalObject, JSValue resolution, InternalMicrotask task, JSValue context)
+void JSPromise::resolveWithInternalMicrotask(JSGlobalObject* globalObject, VM& vm, JSValue resolution, InternalMicrotask task, JSValue context)
 {
-    VM& vm = globalObject->vm();
-
     if (!resolution.isObject())
-        return fulfillWithInternalMicrotask(globalObject, resolution, task, context);
+        return fulfillWithInternalMicrotask(vm, globalObject, resolution, task, context);
 
     auto* resolutionObject = asObject(resolution);
     if (resolutionObject->inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
-            return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotaskFast, static_cast<uint8_t>(task), resolutionObject, context, jsUndefined());
+            return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotaskFast, static_cast<uint8_t>(task), resolutionObject, context, jsUndefined());
     }
 
     if (isDefinitelyNonThenable(resolutionObject, globalObject))
-        return fulfillWithInternalMicrotask(globalObject, resolution, task, context);
+        return fulfillWithInternalMicrotask(vm, globalObject, resolution, task, context);
 
     JSValue then;
     JSValue error;
@@ -651,22 +644,22 @@ void JSPromise::resolveWithInternalMicrotask(JSGlobalObject* globalObject, JSVal
         }
     }
     if (error) [[unlikely]]
-        return rejectWithInternalMicrotask(globalObject, error, task, context);
+        return rejectWithInternalMicrotask(vm, globalObject, error, task, context);
 
     if (!then.isCallable()) [[likely]]
-        return fulfillWithInternalMicrotask(globalObject, resolution, task, context);
+        return fulfillWithInternalMicrotask(vm, globalObject, resolution, task, context);
 
-    return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotask, static_cast<uint8_t>(task), resolutionObject, then, context);
+    return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotask, static_cast<uint8_t>(task), resolutionObject, then, context);
 }
 
-void JSPromise::rejectWithInternalMicrotask(JSGlobalObject* globalObject, JSValue argument, InternalMicrotask task, JSValue context)
+void JSPromise::rejectWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, JSValue argument, InternalMicrotask task, JSValue context)
 {
-    globalObject->queueMicrotask(task, static_cast<uint8_t>(Status::Rejected), jsUndefined(), argument, context);
+    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), jsUndefined(), argument, context);
 }
 
-void JSPromise::fulfillWithInternalMicrotask(JSGlobalObject* globalObject, JSValue argument, InternalMicrotask task, JSValue context)
+void JSPromise::fulfillWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, JSValue argument, InternalMicrotask task, JSValue context)
 {
-    globalObject->queueMicrotask(task, static_cast<uint8_t>(Status::Fulfilled), jsUndefined(), argument, context);
+    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), jsUndefined(), argument, context);
 }
 
 bool JSPromise::isThenFastAndNonObservable()
@@ -791,7 +784,7 @@ JSObject* JSPromise::promiseResolve(JSGlobalObject* globalObject, JSObject* cons
     if (constructor == globalObject->promiseConstructor()) [[likely]] {
         JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
         scope.release();
-        promise->resolve(globalObject, argument);
+        promise->resolve(globalObject, vm, argument);
         return promise;
     }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -96,7 +96,7 @@ public:
     JS_EXPORT_PRIVATE static JSPromise* resolvedPromise(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE static JSPromise* rejectedPromise(JSGlobalObject*, JSValue);
 
-    JS_EXPORT_PRIVATE void resolve(JSGlobalObject*, JSValue);
+    JS_EXPORT_PRIVATE void resolve(JSGlobalObject*, VM&, JSValue);
     JS_EXPORT_PRIVATE void reject(VM&, JSGlobalObject*, JSValue);
     void fulfill(VM&, JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE void rejectAsHandled(VM&, JSGlobalObject*, JSValue);
@@ -132,12 +132,12 @@ public:
     void performPromiseThen(VM&, JSGlobalObject*, JSValue onFulfilled, JSValue onRejected, JSValue);
     void rejectPromise(VM&, JSGlobalObject*, JSValue);
     void fulfillPromise(VM&, JSGlobalObject*, JSValue);
-    void resolvePromise(JSGlobalObject*, JSValue);
+    void resolvePromise(JSGlobalObject*, VM&, JSValue);
 
-    static void resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject*, JSValue resolution, InternalMicrotask, JSValue context);
-    static void resolveWithInternalMicrotask(JSGlobalObject*, JSValue resolution, InternalMicrotask, JSValue context);
-    static void rejectWithInternalMicrotask(JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
-    static void fulfillWithInternalMicrotask(JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
+    static void resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject*, VM&, JSValue resolution, InternalMicrotask, JSValue context);
+    static void resolveWithInternalMicrotask(JSGlobalObject*, VM&, JSValue resolution, InternalMicrotask, JSValue context);
+    static void rejectWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
+    static void fulfillWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
 
     void performPromiseThenWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSValue promise, JSValue context);
 

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -534,7 +534,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
         scope.release();
-        promise->resolve(globalObject, values);
+        promise->resolve(globalObject, vm, values);
         if (scope.exception()) [[unlikely]] {
             callReject();
             return JSValue::encode(promise);
@@ -573,7 +573,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllFulfillFunction, (JSGlobalObject* globalObjec
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
         scope.release();
-        promise->resolve(globalObject, values);
+        promise->resolve(globalObject, vm, values);
     }
 
     return JSValue::encode(jsUndefined());
@@ -861,7 +861,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
         scope.release();
-        promise->resolve(globalObject, values);
+        promise->resolve(globalObject, vm, values);
         if (scope.exception()) [[unlikely]] {
             callReject();
             return JSValue::encode(promise);
@@ -909,7 +909,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledFulfillFunction, (JSGlobalObject* glob
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
         scope.release();
-        promise->resolve(globalObject, values);
+        promise->resolve(globalObject, vm, values);
     }
 
     return JSValue::encode(jsUndefined());
@@ -953,7 +953,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledRejectFunction, (JSGlobalObject* globa
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
         scope.release();
-        promise->resolve(globalObject, values);
+        promise->resolve(globalObject, vm, values);
     }
 
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -28,12 +28,14 @@
 
 #include "Debugger.h"
 #include "DeferTermination.h"
+#include "GlobalObjectMethodTable.h"
 #include "JSCJSValueInlines.h"
 #include "JSGlobalObject.h"
 #include "JSMicrotask.h"
 #include "JSMicrotaskDispatcher.h"
 #include "JSObject.h"
 #include "MicrotaskQueueInlines.h"
+#include "ScriptProfilingScope.h"
 #include "SlotVisitorInlines.h"
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -53,10 +55,20 @@ bool QueuedTask::isRunnable() const
     return jsCast<JSGlobalObject*>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
 }
 
-QueuedTaskResult DebuggableMicrotaskDispatcher::run(QueuedTask& task)
+void runMicrotask(JSGlobalObject* globalObject, VM& vm, QueuedTask& task)
 {
-    auto* globalObject = task.globalObject();
-    VM& vm = globalObject->vm();
+    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    runInternalMicrotask(globalObject, vm, task.job(), task.payload(), task.arguments());
+    if (auto* exception = catchScope.exception()) [[unlikely]] {
+        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+            return;
+        globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        catchScope.clearExceptionExceptTermination();
+    }
+}
+
+void runMicrotaskWithDebugger(JSGlobalObject* globalObject, VM& vm, QueuedTask& task)
+{
     auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto identifier = task.identifier();
 
@@ -64,20 +76,24 @@ QueuedTaskResult DebuggableMicrotaskDispatcher::run(QueuedTask& task)
         DeferTerminationForAWhile deferTerminationForAWhile(vm);
         debugger->willRunMicrotask(globalObject, identifier.value());
         if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
-            return QueuedTask::Result::Executed;
+            return;
     }
 
-    runInternalMicrotask(globalObject, task.job(), task.payload(), task.arguments());
+    runMicrotask(globalObject, vm, task);
     if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
-        return QueuedTask::Result::Executed;
+        return;
 
     if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]] {
         DeferTerminationForAWhile deferTerminationForAWhile(vm);
         debugger->didRunMicrotask(globalObject, identifier.value());
-        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
-            return QueuedTask::Result::Executed;
+        catchScope.clearExceptionExceptTermination();
     }
+}
 
+QueuedTaskResult DebuggableMicrotaskDispatcher::run(QueuedTask& task)
+{
+    auto* globalObject = task.globalObject();
+    runMicrotaskWithDebugger(globalObject, globalObject->vm(), task);
     return QueuedTask::Result::Executed;
 }
 
@@ -89,6 +105,11 @@ bool DebuggableMicrotaskDispatcher::isRunnable() const
 MicrotaskQueue::MicrotaskQueue(VM& vm)
 {
     vm.m_microtaskQueues.append(this);
+}
+
+Ref<MicrotaskQueue> MicrotaskQueue::create(VM& vm)
+{
+    return adoptRef(*new MicrotaskQueue(vm));
 }
 
 MicrotaskQueue::~MicrotaskQueue()
@@ -114,6 +135,8 @@ void MicrotaskQueue::enqueueSlow(QueuedTask&& task)
         if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]]
             debugger->didQueueMicrotask(globalObject, identifier.value());
     }
+    if (!m_isScheduledToRun) [[unlikely]]
+        scheduleToRunIfNeeded();
 }
 
 bool MarkedMicrotaskDeque::hasMicrotasksForFullyActiveDocument() const
@@ -144,6 +167,68 @@ void MarkedMicrotaskDeque::visitAggregateImpl(Visitor& visitor)
     m_markedBefore = m_queue.size();
 }
 DEFINE_VISIT_AGGREGATE(MarkedMicrotaskDeque);
+
+std::pair<JSGlobalObject*, bool> MicrotaskQueue::drain(bool useCallOnEachMicrotask, JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
+{
+    while (!m_queue.isEmpty()) {
+        auto& front = m_queue.front();
+
+        if (!front.isJSMicrotaskDispatcher()) [[likely]] {
+            auto* globalObject = jsCast<JSGlobalObject*>(front.dispatcher());
+            auto result = globalObject->microtaskRunnability();
+            if (result != QueuedTask::Result::Executed) [[unlikely]] {
+                auto task = m_queue.dequeue();
+                if (result == QueuedTask::Result::Suspended)
+                    m_toKeep.enqueue(WTF::move(task));
+                continue;
+            }
+
+            if (globalObject != currentGlobalObject) [[unlikely]]
+                return { globalObject, false };
+
+            auto task = m_queue.dequeue();
+            runMicrotask(globalObject, vm, task);
+        } else {
+            auto* jsMicrotaskDispatcher = jsCast<JSMicrotaskDispatcher*>(front.dispatcher());
+            auto* globalObject = front.globalObject();
+
+            if (globalObject != currentGlobalObject) [[unlikely]]
+                return { globalObject, false };
+
+            auto task = m_queue.dequeue();
+            QueuedTask::Result result;
+            {
+                ScriptProfilingScope profilingScope(globalObject, ProfilingReason::Microtask);
+                result = jsMicrotaskDispatcher->dispatcher()->run(task);
+            }
+
+            switch (result) {
+            case QueuedTask::Result::Executed:
+                break;
+            case QueuedTask::Result::Discard:
+                break;
+            case QueuedTask::Result::Suspended:
+                m_toKeep.enqueue(WTF::move(task));
+                break;
+            }
+        }
+
+        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+            clear();
+            return { nullptr, true };
+        }
+
+        if (useCallOnEachMicrotask) {
+            vm.callOnEachMicrotaskTick();
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                clear();
+                return { nullptr, true };
+            }
+        }
+    }
+
+    return { nullptr, true };
+}
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -31,6 +31,8 @@
 #include <wtf/CompactPointerTuple.h>
 #include <wtf/Compiler.h>
 #include <wtf/Deque.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 #include <wtf/SentinelLinkedList.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/VectorTraits.h>
@@ -50,6 +52,7 @@ class MarkedMicrotaskDeque;
 class MicrotaskDispatcher;
 class MicrotaskQueue;
 class QueuedTask;
+class TopExceptionScope;
 class VM;
 
 class MicrotaskDispatcher : public RefCounted<MicrotaskDispatcher> {
@@ -59,8 +62,6 @@ public:
         None,
         JSCDebuggable,
         // WebCoreMicrotaskDispatcher starts from here.
-        WebCoreJS,
-        WebCoreJSDebuggable,
         WebCoreUserGestureIndicator,
         WebCoreFunction,
     };
@@ -73,7 +74,7 @@ public:
     virtual QueuedTaskResult run(QueuedTask&) = 0;
     virtual bool isRunnable() const = 0;
     Type type() const { return m_type; }
-    bool isWebCoreMicrotaskDispatcher() const { return static_cast<uint8_t>(m_type) >= static_cast<uint8_t>(Type::WebCoreJS); }
+    bool isWebCoreMicrotaskDispatcher() const { return static_cast<uint8_t>(m_type) >= static_cast<uint8_t>(Type::WebCoreUserGestureIndicator); }
 
 private:
     Type m_type { Type::None };
@@ -126,10 +127,10 @@ public:
     bool isRunnable() const;
 
     // Defined in MicrotaskQueueInlines.h (requires JSType knowledge).
-    inline JSCell* dispatcher() const;
-    inline JSGlobalObject* globalObject() const;
-    inline JSMicrotaskDispatcher* jsMicrotaskDispatcher() const;
-    inline std::optional<MicrotaskIdentifier> identifier() const;
+    JSCell* dispatcher() const;
+    JSGlobalObject* globalObject() const;
+    JSMicrotaskDispatcher* jsMicrotaskDispatcher() const;
+    std::optional<MicrotaskIdentifier> identifier() const;
     InternalMicrotask job() const { return static_cast<InternalMicrotask>(static_cast<uint8_t>(m_dispatcher.type())); }
     // Task-specific metadata stored in upper 8 bits of type field.
     // Typically holds JSPromise::Status or a nested InternalMicrotask value.
@@ -154,6 +155,8 @@ public:
     friend class MicrotaskQueue;
 
     MarkedMicrotaskDeque() = default;
+
+    const QueuedTask& front() const { return m_queue.first(); }
 
     QueuedTask dequeue()
     {
@@ -200,12 +203,12 @@ private:
     size_t m_markedBefore { 0 };
 };
 
-class MicrotaskQueue final : public BasicRawSentinelNode<MicrotaskQueue> {
+class MicrotaskQueue : public BasicRawSentinelNode<MicrotaskQueue>, public RefCounted<MicrotaskQueue> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MicrotaskQueue, JS_EXPORT_PRIVATE);
     WTF_MAKE_NONCOPYABLE(MicrotaskQueue);
 public:
-    JS_EXPORT_PRIVATE MicrotaskQueue(VM&);
-    JS_EXPORT_PRIVATE ~MicrotaskQueue();
+    JS_EXPORT_PRIVATE static Ref<MicrotaskQueue> create(VM&);
+    JS_EXPORT_PRIVATE virtual ~MicrotaskQueue();
 
     inline void enqueue(QueuedTask&&);
     JS_EXPORT_PRIVATE void enqueueSlow(QueuedTask&&);
@@ -232,17 +235,33 @@ public:
     DECLARE_VISIT_AGGREGATE;
 
     template<bool useCallOnEachMicrotask>
-    inline void performMicrotaskCheckpoint(VM&, NOESCAPE const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor);
+    inline void performMicrotaskCheckpoint(VM&, NOESCAPE const Invocable<void(JSGlobalObject*, JSGlobalObject*)> auto& globalObjectSwitchCallback);
 
     bool hasMicrotasksForFullyActiveDocument() const
     {
         return m_queue.hasMicrotasksForFullyActiveDocument();
     }
 
+    bool isScheduledToRun() const { return m_isScheduledToRun; }
+    void setIsScheduledToRun(bool value) { m_isScheduledToRun = value; }
+
+protected:
+    JS_EXPORT_PRIVATE MicrotaskQueue(VM&);
+    virtual void scheduleToRunIfNeeded()
+    {
+        setIsScheduledToRun(true);
+    }
+    bool m_isScheduledToRun { false };
+
 private:
+    JS_EXPORT_PRIVATE std::pair<JSGlobalObject*, bool> drain(bool useCallOnEachMicrotask, JSGlobalObject* currentGlobalObject, VM&, TopExceptionScope&);
+
     MarkedMicrotaskDeque m_queue;
     MarkedMicrotaskDeque m_toKeep;
 };
+
+void runMicrotask(JSGlobalObject*, VM&, QueuedTask&);
+JS_EXPORT_PRIVATE void runMicrotaskWithDebugger(JSGlobalObject*, VM&, QueuedTask&);
 
 } // namespace JSC
 namespace WTF {

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/JSMicrotaskDispatcher.h>
 #include <JavaScriptCore/MicrotaskQueue.h>
 #include <JavaScriptCore/TopExceptionScope.h>
+#include <JavaScriptCore/VMEntryScopeInlines.h>
 
 namespace JSC {
 
@@ -67,10 +68,12 @@ inline void MicrotaskQueue::enqueue(QueuedTask&& task)
         return;
     }
     m_queue.enqueue(WTF::move(task));
+    if (!m_isScheduledToRun) [[unlikely]]
+        scheduleToRunIfNeeded();
 }
 
 template<bool useCallOnEachMicrotask>
-inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor)
+inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const Invocable<void(JSGlobalObject*, JSGlobalObject*)> auto& globalObjectSwitchCallback)
 {
     auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (vm.executionForbidden()) [[unlikely]]
@@ -81,34 +84,27 @@ inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const In
             return;
         }
 
-        while (!m_queue.isEmpty()) {
-            auto task = m_queue.dequeue();
-            auto result = functor(task);
-            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
-                clear();
-                break;
-            }
+        std::optional<VMEntryScope> entryScope;
+        JSGlobalObject* currentGlobalObject = nullptr;
 
-            if constexpr (useCallOnEachMicrotask) {
-                vm.callOnEachMicrotaskTick();
-                if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
-                    clear();
-                    break;
-                }
-            }
+        while (true) {
+            auto [nextGlobalObject, done] = drain(useCallOnEachMicrotask, currentGlobalObject, vm, catchScope);
+            if (done)
+                break;
 
-            switch (result) {
-            case QueuedTask::Result::Executed:
-                break;
-            case QueuedTask::Result::Discard:
-                // Let this task go away.
-                break;
-            case QueuedTask::Result::Suspended: {
-                m_toKeep.enqueue(WTF::move(task));
-                break;
-            }
-            }
+            globalObjectSwitchCallback(currentGlobalObject, nextGlobalObject);
+
+            if (nextGlobalObject) {
+                if (!entryScope)
+                    entryScope.emplace(vm, nextGlobalObject);
+                else
+                    entryScope->setGlobalObject(nextGlobalObject);
+            } else
+                entryScope = std::nullopt;
+
+            currentGlobalObject = nextGlobalObject;
         }
+
         vm.didEnterVM = true;
     }
     m_queue.swap(m_toKeep);

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -252,7 +252,7 @@ UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* contex
     JSPromise* resultPromise = pinball->resultPromise();
     if (!scope.exception()) {
         JSValue arg = JSValue::decode(context->arguments[0]);
-        resultPromise->resolve(context->globalObject, arg);
+        resultPromise->resolve(context->globalObject, vm, arg);
     } else {
         resultPromise->reject(vm, context->globalObject, scope.exception());
         scope.clearException();
@@ -292,7 +292,7 @@ void pinballHandlerFinishReject(PinballHandlerContext* context)
 
     if (!scope.exception()) {
         JSValue arg = JSValue::decode(context->arguments[0]);
-        resultPromise->resolve(context->globalObject, arg);
+        resultPromise->resolve(context->globalObject, vm, arg);
     } else {
         resultPromise->reject(vm, context->globalObject, scope.exception());
         scope.clearException();

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(importInRealm, (JSGlobalObject* globalObject, CallFrame
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(realmGlobalObject, scope)));
 
     scope.release();
-    promise->resolve(globalObject, internalPromise);
+    promise->resolve(globalObject, vm, internalPromise);
     return JSValue::encode(promise);
 }
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -40,6 +40,7 @@
 #include "CodeCache.h"
 #include "CommonIdentifiers.h"
 #include "ControlFlowProfiler.h"
+#include "CrossTaskToken.h"
 #include "CustomGetterSetterInlines.h"
 #include "DOMAttributeGetterSetterInlines.h"
 #include "Debugger.h"
@@ -272,7 +273,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , m_codeCache(makeUnique<CodeCache>())
     , m_intlCache(makeUnique<IntlCache>())
     , m_builtinExecutables(makeUnique<BuiltinExecutables>(*this))
-    , m_defaultMicrotaskQueue(*this)
+    , m_defaultMicrotaskQueue(MicrotaskQueue::create(*this))
     , m_syncWaiter(adoptRef(*new Waiter(this)))
 {
     if (vmCreationShouldCrash || g_jscConfig.vmCreationDisallowed) [[unlikely]]
@@ -521,6 +522,11 @@ static ReadWriteLock s_destructionLock;
 void waitForVMDestruction()
 {
     Locker locker { s_destructionLock.write() };
+}
+
+void VM::setCrossTaskToken(RefPtr<CrossTaskToken>&& token)
+{
+    m_crossTaskToken = WTF::move(token);
 }
 
 VM::~VM()
@@ -1369,11 +1375,6 @@ void VM::dumpTypeProfilerData()
     typeProfiler()->dumpTypeProfilerData(*this);
 }
 
-void VM::queueMicrotask(QueuedTask&& task)
-{
-    m_defaultMicrotaskQueue.enqueue(WTF::move(task));
-}
-
 void VM::callPromiseRejectionCallback(Strong<JSPromise>& promise)
 {
     JSObject* callback = promise->globalObject()->unhandledRejectionCallback();
@@ -1419,35 +1420,23 @@ void VM::drainMicrotasks()
         return;
 
     if (executionForbidden()) [[unlikely]]
-        m_defaultMicrotaskQueue.clear();
+        m_defaultMicrotaskQueue->clear();
     else {
         std::optional<VMEntryScope> entryScope;
-        if (!m_defaultMicrotaskQueue.isEmpty())
+        if (!m_defaultMicrotaskQueue->isEmpty())
             entryScope.emplace(*this, nullptr);
         while (true) {
-            m_defaultMicrotaskQueue.performMicrotaskCheckpoint</* useCallOnEachMicrotask */ true>(*this,
-                [&](QueuedTask& task) ALWAYS_INLINE_LAMBDA {
-                    auto* dispatcher = task.dispatcher();
-                    if (dispatcher->type() == JSMicrotaskDispatcherType) [[unlikely]] {
-                        auto* jsMicrotaskDispatcher = jsCast<JSMicrotaskDispatcher*>(dispatcher);
-                        auto* globalObject = jsMicrotaskDispatcher->globalObject();
-                        entryScope->setGlobalObject(globalObject);
-                        return jsMicrotaskDispatcher->dispatcher()->run(task);
-                    }
-
-                    auto* globalObject = jsCast<JSGlobalObject*>(dispatcher);
-                    entryScope->setGlobalObject(globalObject);
-                    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(*this);
-                    runInternalMicrotask(globalObject, task.job(), task.payload(), task.arguments());
-                    catchScope.clearExceptionExceptTermination();
-                    return QueuedTask::Result::Executed;
+            m_defaultMicrotaskQueue->performMicrotaskCheckpoint</* useCallOnEachMicrotask */ true>(*this,
+                [&](JSGlobalObject*, JSGlobalObject* nextGlobalObject) {
+                    if (entryScope && nextGlobalObject)
+                        entryScope->setGlobalObject(nextGlobalObject);
                 });
             if (hasPendingTerminationException()) [[unlikely]]
                 return;
             didExhaustMicrotaskQueue();
             if (hasPendingTerminationException()) [[unlikely]]
                 return;
-            if (m_defaultMicrotaskQueue.isEmpty())
+            if (m_defaultMicrotaskQueue->isEmpty())
                 break;
             if (!entryScope)
                 entryScope.emplace(*this, nullptr);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -124,6 +124,7 @@ class CommonIdentifiers;
 class CompactTDZEnvironmentMap;
 class ConservativeRoots;
 class ControlFlowProfiler;
+class CrossTaskToken;
 class EvacuatedStackSlice;
 class Exception;
 class ExceptionScope;
@@ -442,6 +443,7 @@ public:
 
 private:
     bool m_isInService { false };
+    RefPtr<CrossTaskToken> m_crossTaskToken;
     VMIdentifier m_identifier;
     const Ref<JSLock> m_apiLock;
     VMThreadContext m_threadContext;
@@ -994,6 +996,8 @@ public:
 
     std::unique_ptr<Profiler::Database> m_perBytecodeProfiler;
     RefPtr<TypedArrayController> m_typedArrayController;
+    CrossTaskToken* crossTaskToken() const { return m_crossTaskToken.get(); }
+    JS_EXPORT_PRIVATE void setCrossTaskToken(RefPtr<CrossTaskToken>&&);
     std::unique_ptr<RegExpCache> m_regExpCache;
     BumpPointerAllocator m_regExpAllocator;
     ConcurrentJSLock m_regExpAllocatorLock;
@@ -1085,8 +1089,9 @@ public:
         RefPtr<VM> m_vm;
     };
 
+    MicrotaskQueue& defaultMicrotaskQueue() { return m_defaultMicrotaskQueue.get(); }
+
     DrainMicrotaskDelayScope drainMicrotaskDelayScope() { return DrainMicrotaskDelayScope { *this }; }
-    void queueMicrotask(QueuedTask&&);
     JS_EXPORT_PRIVATE void drainMicrotasks();
     void setOnEachMicrotaskTick(WTF::Function<void(VM&)>&& func) { m_onEachMicrotaskTick = WTF::move(func); }
     void callOnEachMicrotaskTick()
@@ -1340,7 +1345,7 @@ private:
     Lock m_loopHintExecutionCountLock;
     UncheckedKeyHashMap<const JSInstruction*, std::pair<unsigned, std::unique_ptr<uintptr_t>>> m_loopHintExecutionCounts;
 
-    MicrotaskQueue m_defaultMicrotaskQueue;
+    const Ref<MicrotaskQueue> m_defaultMicrotaskQueue;
     const Ref<Waiter> m_syncWaiter;
 
     std::atomic<int64_t> m_numberOfActiveJITPlans { 0 };

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -209,7 +209,7 @@ void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<W
             JSGlobalObject* globalObject = promise->globalObject();
             VM& vm = promise->vm();
             JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
-            promise->resolve(globalObject, result);
+            promise->resolve(globalObject, vm, result);
         });
         return;
     }

--- a/Source/JavaScriptCore/runtime/WeakGCMap.h
+++ b/Source/JavaScriptCore/runtime/WeakGCMap.h
@@ -37,6 +37,7 @@ namespace JSC {
 template<typename KeyArg, typename ValueArg, typename HashArg = DefaultHash<KeyArg>, typename KeyTraitsArg = HashTraits<KeyArg>>
 class WeakGCMap final : public WeakGCHashTable {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WeakGCMap);
+    WTF_MAKE_NONCOPYABLE(WeakGCMap);
     typedef Weak<ValueArg> ValueType;
     typedef UncheckedKeyHashMap<KeyArg, ValueType, HashArg, KeyTraitsArg> HashMapType;
 

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -59,7 +59,8 @@ struct WeakGCSetHash {
 // FIXME: This doesn't currently accept WeakHandleOwners by default... it's probably not hard to add but it's not exactly clear how to handle multiple different handle owners for the same value.
 template<typename ValueArg, typename HashArg = WeakGCSetHash<ValueArg>, typename TraitsArg = WeakGCSetHashTraits<ValueArg>>
 class WeakGCSet final : public WeakGCHashTable {
-    WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(WeakGCSet);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WeakGCSet);
+    WTF_MAKE_NONCOPYABLE(WeakGCSet);
     using ValueType = Weak<ValueArg>;
     using HashSetType = UncheckedKeyHashSet<ValueType, HashArg, TraitsArg>;
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -170,7 +170,7 @@ void StreamingCompiler::didComplete()
             JSWebAssemblyModule* module = JSWebAssemblyModule::create(vm, globalObject->webAssemblyModuleStructure(), WTF::move(result.value()));
 
             scope.release();
-            promise->resolve(globalObject, module);
+            promise->resolve(globalObject, vm, module);
         });
         return;
     }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -203,7 +203,7 @@ void JSWebAssembly::webAssemblyModuleValidateAsync(JSGlobalObject* globalObject,
             JSValue module = JSWebAssemblyModule::create(vm, globalObject->webAssemblyModuleStructure(), WTF::move(result.value()));
 
             scope.release();
-            promise->resolve(globalObject, module);
+            promise->resolve(globalObject, vm, module);
         });
     }));
 }
@@ -246,21 +246,21 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
             scope.release();
             switch (resolveKind) {
             case Resolve::WithInstance: {
-                promise->resolve(globalObject, instance);
+                promise->resolve(globalObject, vm, instance);
                 break;
             }
             case Resolve::WithModuleRecord: {
                 auto* moduleRecord = instance->moduleRecord();
                 if (Options::dumpModuleRecord()) [[unlikely]]
                     moduleRecord->dump();
-                promise->resolve(globalObject, moduleRecord);
+                promise->resolve(globalObject, vm, moduleRecord);
                 break;
             }
             case Resolve::WithModuleAndInstance: {
                 JSObject* result = constructEmptyObject(globalObject);
                 result->putDirect(vm, Identifier::fromString(vm, "module"_s), module);
                 result->putDirect(vm, Identifier::fromString(vm, "instance"_s), instance);
-                promise->resolve(globalObject, result);
+                promise->resolve(globalObject, vm, result);
                 break;
             }
             }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
@@ -78,7 +78,7 @@ JSC_DEFINE_HOST_FUNCTION(runWebAssemblyPromisingFunction, (JSGlobalObject* globa
         resultPromise->reject(vm, globalObject, exceptionValue);
     } else if (!context.completion) [[likely]] {
         // The call returned without suspending, result is the returned value
-        resultPromise->resolve(globalObject, result);
+        resultPromise->resolve(globalObject, vm, result);
     }
     // If neither of the the above conditions are true, the call was suspended
     // and all the promises involved are fully hooked up to do the right thing.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -139,7 +139,7 @@ void* runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* 
     if (!promise) {
         // The spec requires us to suspend even if the wrapped function returned a real value.
         promise = JSPromise::create(vm, globalObject->promiseStructure());
-        promise->resolve(globalObject, result);
+        promise->resolve(globalObject, vm, result);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
@@ -142,7 +142,7 @@ void ReadableStreamToSharedBufferSink::enqueue(const Ref<JSC::Uint8Array>& buffe
     if (!context)
         return;
 
-    protect(context->eventLoop())->queueMicrotask([weakThis = WeakPtr { *this }] {
+    protect(context->eventLoop())->queueMicrotask(context->vm(), [weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis)
             protectedThis->keepReading();
     });

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -165,7 +165,7 @@ public:
             return;
 
         auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
-        protect(context->eventLoop())->queueMicrotask([task = WTF::move(task), value = JSC::Strong<JSC::Unknown> { globalObject.vm(), value }] {
+        protect(context->eventLoop())->queueMicrotask(globalObject.vm(), [task = WTF::move(task), value = JSC::Strong<JSC::Unknown> { globalObject.vm(), value }] {
             task(value.get());
         });
     }

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -60,7 +60,6 @@ bindings/js/JSNodeCustom.cpp
 bindings/js/JSPluginElementFunctions.cpp
 bindings/js/JSSVGViewSpecCustom.cpp
 bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
-bindings/js/JSWorkerGlobalScopeBase.cpp
 bindings/js/JSWorkletGlobalScopeBase.cpp
 bindings/js/ScheduledAction.cpp
 bindings/js/ScriptController.cpp

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -214,7 +214,8 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
     }
 
     // 3. Perform a microtask checkpoint.
-    protect(protect(document())->eventLoop())->performMicrotaskCheckpoint();
+    Ref document = this->document();
+    protect(document->eventLoop())->performMicrotaskCheckpoint(document->vm());
 
     if (RefPtr documentTimeline = m_document->existingTimeline()) {
         // FIXME: pending animation events should be owned by this controller rather

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2282,7 +2282,7 @@ void KeyframeEffect::wasRemovedFromEffectStack()
             // to allow the finished promise callback to observe the final animation state (e.g., layer tree).
             // Only immediately stop animations removed mid-flight.
             if (RefPtr context = animation->scriptExecutionContext()) {
-                context->eventLoop().queueMicrotask([protectedThis = Ref { *this }] {
+                context->eventLoop().queueMicrotask(context->vm(), [protectedThis = Ref { *this }] {
                     protectedThis->applyPendingAcceleratedActions();
                 });
             }

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -849,7 +849,7 @@ void WebAnimation::cancel(Silently silently)
         // 2. Reject the current finished promise with a DOMException named "AbortError".
         // 3. Set the [[PromiseIsHandled]] internal slot of the current finished promise to true.
         if (RefPtr context = scriptExecutionContext(); context && !m_finishedPromise->isFulfilled()) {
-            context->eventLoop().queueMicrotask([finishedPromise = WTF::move(m_finishedPromise)]() mutable {
+            context->eventLoop().queueMicrotask(context->vm(), [finishedPromise = WTF::move(m_finishedPromise)]() mutable {
                 finishedPromise->reject(Exception { ExceptionCode::AbortError }, RejectAsHandled::Yes);
             });
         }
@@ -970,7 +970,7 @@ void WebAnimation::resetPendingTasks()
     // 5. Reject animation's current ready promise with a DOMException named "AbortError".
     // 6. Set the [[PromiseIsHandled]] internal slot of animation’s current ready promise to true.
     if (RefPtr context = scriptExecutionContext()) {
-        context->eventLoop().queueMicrotask([readyPromise = WTF::move(m_readyPromise)]() mutable {
+        context->eventLoop().queueMicrotask(context->vm(), [readyPromise = WTF::move(m_readyPromise)]() mutable {
             if (!readyPromise->isFulfilled())
                 readyPromise->reject(Exception { ExceptionCode::AbortError }, RejectAsHandled::Yes);
         });
@@ -1119,7 +1119,7 @@ void WebAnimation::updateFinishedState(DidSeek didSeek, SynchronouslyNotify sync
             // is already a microtask queued to run those steps for animation.
             m_finishNotificationStepsMicrotaskPending = true;
             if (RefPtr context = scriptExecutionContext()) {
-                context->eventLoop().queueMicrotask([this, protectedThis = Ref { *this }] {
+                context->eventLoop().queueMicrotask(context->vm(), [this, protectedThis = Ref { *this }] {
                     if (m_finishNotificationStepsMicrotaskPending) {
                         m_finishNotificationStepsMicrotaskPending = false;
                         finishNotificationSteps();

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -163,7 +163,7 @@ static RefPtr<Element> constructCustomElementSynchronously(Document& document, V
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     if (parserConstructElementWithEmptyStack == ParserConstructElementWithEmptyStack::Yes)
-        document.eventLoop().performMicrotaskCheckpoint();
+        document.eventLoop().performMicrotaskCheckpoint(vm);
 
     ASSERT(!newElement.isEmpty());
     RefPtr wrappedElement = JSHTMLElement::toWrapped(vm, newElement);

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -258,7 +258,7 @@ JSC::JSPromise* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::runNextSteps(
     RETURN_IF_EXCEPTION(scope, { });
 
     if (m_isFinished.get()) {
-        promise->resolve(&globalObject, JSC::createIteratorResultObject(&globalObject, JSC::jsUndefined(), true));
+        promise->resolve(&globalObject, vm, JSC::createIteratorResultObject(&globalObject, JSC::jsUndefined(), true));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
         return promise;
@@ -457,7 +457,7 @@ JSC::JSPromise* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::runReturnStep
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     if (m_isFinished.get()) {
-        returnPromise->resolve(&globalObject, JSC::createIteratorResultObject(&globalObject, value, true));
+        returnPromise->resolve(&globalObject, vm, JSC::createIteratorResultObject(&globalObject, value, true));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
         return returnPromise;

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -776,6 +776,8 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
     proxy->setTarget(vm, wrapper);
 
     wrapper->setConsoleClient(domGlobalObject->consoleClient().get());
+    if (context && !is<WorkletGlobalScope>(context.get()))
+        context->addMicrotaskGlobalObject(wrapper);
 
     return wrapper;
 }

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -92,7 +92,7 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
             if (shouldSetCurrentState)
                 data.setCurrentState(&lexicalGlobalObject);
 
-            deferred()->resolve(&lexicalGlobalObject, resolution);
+            deferred()->resolve(&lexicalGlobalObject, vm, resolution);
 
             if (shouldSetCurrentState)
                 data.setCurrentState(nullptr);

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -88,7 +88,6 @@ const GlobalObjectMethodTable* JSDOMWindowBase::globalObjectMethodTable()
         supportsRichSourceInfo,
         shouldInterruptScript,
         javaScriptRuntimeFlags,
-        queueMicrotaskToEventLoop,
         shouldInterruptScriptBeforeTimeout,
         moduleLoaderImportModule,
         moduleLoaderResolve,
@@ -245,63 +244,6 @@ RuntimeFlags JSDOMWindowBase::javaScriptRuntimeFlags(const JSGlobalObject* objec
     if (!frame)
         return RuntimeFlags();
     return frame->settings().javaScriptRuntimeFlags();
-}
-
-class UserGestureInitiatedMicrotaskDispatcher final : public WebCoreMicrotaskDispatcher {
-    WTF_MAKE_COMPACT_TZONE_ALLOCATED(UserGestureInitiatedMicrotaskDispatcher);
-public:
-
-    UserGestureInitiatedMicrotaskDispatcher(EventLoopTaskGroup& group, Ref<UserGestureToken>&& userGestureToken)
-        : WebCoreMicrotaskDispatcher(Type::WebCoreUserGestureIndicator, group)
-        , m_userGestureToken(WTF::move(userGestureToken))
-    {
-    }
-
-    ~UserGestureInitiatedMicrotaskDispatcher() final = default;
-
-    JSC::QueuedTask::Result run(JSC::QueuedTask& task) final
-    {
-        auto runnability = currentRunnability();
-        if (runnability == JSC::QueuedTask::Result::Executed) {
-            UserGestureIndicator gestureIndicator(m_userGestureToken.ptr(), m_userGestureToken->scope(), UserGestureToken::ShouldPropagateToMicroTask::Yes);
-            JSExecState::runTaskWithDebugger(task.globalObject(), task);
-        }
-        return runnability;
-    }
-
-    static Ref<UserGestureInitiatedMicrotaskDispatcher> create(EventLoopTaskGroup& group, Ref<UserGestureToken>&& userGestureToken)
-    {
-        return adoptRef(*new UserGestureInitiatedMicrotaskDispatcher(group, WTF::move(userGestureToken)));
-    }
-
-private:
-    const Ref<UserGestureToken> m_userGestureToken;
-};
-
-WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(UserGestureInitiatedMicrotaskDispatcher);
-
-
-void JSDOMWindowBase::queueMicrotaskToEventLoop(JSGlobalObject& object, QueuedTask&& task)
-{
-    auto& thisObject = *jsCast<JSDOMWindowBase*>(&object);
-
-    CheckedPtr objectScriptExecutionContext = thisObject.scriptExecutionContext();
-    CheckedRef eventLoop = objectScriptExecutionContext->eventLoop();
-    // Propagating media only user gesture for Fetch API's promise chain.
-    auto userGestureToken = UserGestureIndicator::currentUserGestureForMainThread();
-    if (userGestureToken && (!userGestureToken->shouldPropagateToMicroTask() || !objectScriptExecutionContext->settingsValues().userGesturePromisePropagationEnabled))
-        userGestureToken = nullptr;
-
-    if (!userGestureToken) {
-        if (object.debugger()) [[unlikely]]
-            task.setDispatcher(eventLoop->jsMicrotaskDispatcherForDebugger(object.vm(), &object));
-    } else {
-        auto& vm = object.vm();
-        JSC::JSLockHolder locker(vm);
-        task.setDispatcher(JSC::JSMicrotaskDispatcher::create(vm, UserGestureInitiatedMicrotaskDispatcher::create(eventLoop.get(), Ref { *userGestureToken }), &object));
-    }
-
-    eventLoop->queueMicrotask(WTF::move(task));
 }
 
 JSC::JSObject* JSDOMWindowBase::currentScriptExecutionOwner(JSGlobalObject* object)

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -77,7 +77,6 @@ public:
     static bool shouldInterruptScript(const JSC::JSGlobalObject*);
     static bool shouldInterruptScriptBeforeTimeout(const JSC::JSGlobalObject*);
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
-    static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, JSC::QueuedTask&&);
     static JSC::JSObject* currentScriptExecutionOwner(JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -604,7 +604,7 @@ JSValue JSDOMWindow::queueMicrotask(JSGlobalObject& lexicalGlobalObject, CallFra
     auto* globalObject = asObject(functionValue)->globalObject();
 
     scope.release();
-    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, JSC::InternalMicrotask::InvokeFunctionJob, 0, globalObject, functionValue });
+    queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, JSC::InternalMicrotask::InvokeFunctionJob, 0, globalObject, functionValue });
     return jsUndefined();
 }
 

--- a/Source/WebCore/bindings/js/JSExecState.cpp
+++ b/Source/WebCore/bindings/js/JSExecState.cpp
@@ -28,10 +28,10 @@
 
 #include "EventLoop.h"
 #include "JSDOMExceptionHandling.h"
-#include "Microtasks.h"
 #include "RejectedPromiseTracker.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerGlobalScope.h"
+#include <JavaScriptCore/MicrotaskQueue.h>
 #include <JavaScriptCore/ScriptProfilingScope.h>
 #include <JavaScriptCore/VMEntryScopeInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
@@ -43,7 +43,7 @@ void JSExecState::didLeaveScriptContext(JSC::JSGlobalObject* lexicalGlobalObject
     RefPtr context = executionContext(lexicalGlobalObject);
     if (!context)
         return;
-    context->eventLoop().performMicrotaskCheckpoint();
+    context->eventLoop().performMicrotaskCheckpoint(lexicalGlobalObject->vm());
 }
 
 JSC::JSValue functionCallHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>& returnedException)
@@ -54,23 +54,6 @@ JSC::JSValue functionCallHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobal
 JSC::JSValue evaluateHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobalObject, const JSC::SourceCode& source, JSC::JSValue thisValue, NakedPtr<JSC::Exception>& returnedException)
 {
     return JSExecState::evaluate(lexicalGlobalObject, source, thisValue, returnedException);
-}
-
-void JSExecState::runTask(JSC::JSGlobalObject* globalObject, JSC::QueuedTask& task)
-{
-    JSC::VM& vm = globalObject->vm();
-    JSExecState currentState(globalObject);
-    JSC::VMEntryScope entryScope(vm, globalObject);
-    MicrotaskQueue::runJSMicrotask(globalObject, vm, task);
-}
-
-void JSExecState::runTaskWithDebugger(JSC::JSGlobalObject* globalObject, JSC::QueuedTask& task)
-{
-    JSC::VM& vm = globalObject->vm();
-    JSExecState currentState(globalObject);
-    JSC::VMEntryScope entryScope(vm, globalObject);
-    JSC::ScriptProfilingScope profilingScope(globalObject, JSC::ProfilingReason::Microtask);
-    MicrotaskQueue::runJSMicrotaskWithDebugger(globalObject, vm, task);
 }
 
 ScriptExecutionContext* executionContext(JSC::JSGlobalObject* globalObject)

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -114,9 +114,6 @@ public:
         return profiledEvaluate(lexicalGlobalObject, reason, source, thisValue, unused);
     }
 
-    static void runTask(JSC::JSGlobalObject*, JSC::QueuedTask&);
-    static void runTaskWithDebugger(JSC::JSGlobalObject*, JSC::QueuedTask&);
-
     static JSC::JSInternalPromise* loadModule(JSC::JSGlobalObject& lexicalGlobalObject, const URL& topLevelModuleURL, JSC::JSValue parameters, JSC::JSValue scriptFetcher)
     {
         JSExecState currentState(&lexicalGlobalObject);
@@ -155,7 +152,7 @@ private:
         , m_lock(lexicalGlobalObject)
     {
         setCurrentState(lexicalGlobalObject);
-    };
+    }
 
     ~JSExecState()
     {

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp
@@ -49,7 +49,6 @@ const GlobalObjectMethodTable* JSShadowRealmGlobalScopeBase::globalObjectMethodT
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,
@@ -154,12 +153,6 @@ void JSShadowRealmGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObj
 {
     auto incubating = jsCast<JSShadowRealmGlobalScopeBase*>(globalObject)->incubatingRealm();
     incubating->globalObjectMethodTable()->reportViolationForUnsafeEval(incubating, msg);
-}
-
-void JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, QueuedTask&& task)
-{
-    auto incubating = jsCast<JSShadowRealmGlobalScopeBase*>(&object)->incubatingRealm();
-    incubating->globalObjectMethodTable()->queueMicrotaskToEventLoop(*incubating, WTF::move(task));
 }
 
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, ShadowRealmGlobalScope& realmGlobalScope)

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -55,7 +55,6 @@ private:
     static bool shouldInterruptScriptBeforeTimeout(const JSC::JSGlobalObject*);
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
-    static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, JSC::QueuedTask&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
 protected:

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -56,7 +56,6 @@ const GlobalObjectMethodTable* JSWorkerGlobalScopeBase::globalObjectMethodTable(
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,
@@ -145,15 +144,6 @@ JSC::ScriptExecutionStatus JSWorkerGlobalScopeBase::scriptExecutionStatus(JSC::J
 void JSWorkerGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* globalObject, const String& source)
 {
     return JSGlobalObject::reportViolationForUnsafeEval(globalObject, source);
-}
-
-void JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, JSC::QueuedTask&& task)
-{
-    auto& thisObject = *jsCast<JSWorkerGlobalScopeBase*>(&object);
-    CheckedRef context = thisObject.wrapped();
-    if (object.debugger()) [[unlikely]]
-        task.setDispatcher(context->eventLoop().jsMicrotaskDispatcherForDebugger(object.vm(), &object));
-    context->eventLoop().queueMicrotask(WTF::move(task));
 }
 
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, WorkerGlobalScope& workerGlobalScope)

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -57,7 +57,6 @@ public:
     static bool shouldInterruptScriptBeforeTimeout(const JSC::JSGlobalObject*);
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
-    static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, JSC::QueuedTask&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
 protected:

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
@@ -71,7 +71,7 @@ JSValue JSWorkerGlobalScope::queueMicrotask(JSGlobalObject& lexicalGlobalObject,
     auto* globalObject = asObject(functionValue)->globalObject();
 
     scope.release();
-    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, JSC::InternalMicrotask::InvokeFunctionJob, 0, globalObject, functionValue });
+    queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, JSC::InternalMicrotask::InvokeFunctionJob, 0, globalObject, functionValue });
     return jsUndefined();
 }
 

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp
@@ -48,7 +48,6 @@ const GlobalObjectMethodTable* JSWorkletGlobalScopeBase::globalObjectMethodTable
         &supportsRichSourceInfo,
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
-        &queueMicrotaskToEventLoop,
         &shouldInterruptScriptBeforeTimeout,
         &moduleLoaderImportModule,
         &moduleLoaderResolve,
@@ -137,11 +136,6 @@ RuntimeFlags JSWorkletGlobalScopeBase::javaScriptRuntimeFlags(const JSGlobalObje
 {
     auto* thisObject = jsCast<const JSWorkletGlobalScopeBase*>(object);
     return thisObject->m_wrapped->jsRuntimeFlags();
-}
-
-void JSWorkletGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, JSC::QueuedTask&& task)
-{
-    return Base::queueMicrotaskToEventLoop(object, WTF::move(task));
 }
 
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, WorkletGlobalScope& workletGlobalScope)

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -58,7 +58,6 @@ public:
     static bool shouldInterruptScriptBeforeTimeout(const JSC::JSGlobalObject*);
     static JSC::RuntimeFlags javaScriptRuntimeFlags(const JSC::JSGlobalObject*);
     static JSC::ScriptExecutionStatus scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject*);
-    static void queueMicrotaskToEventLoop(JSC::JSGlobalObject&, JSC::QueuedTask&&);
     static void reportViolationForUnsafeEval(JSC::JSGlobalObject*, const String&);
 
 protected:

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -327,8 +327,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
 
     if (RefPtr document = m_frame->document()) {
         protect(document->contentSecurityPolicy())->didCreateWindowProxy(windowProxy);
-        if (world->isNormal())
-            document->setMicrotaskGlobalObject(windowProxy.window());
+        document->addMicrotaskGlobalObject(windowProxy.window());
     }
 
     if (RefPtr page = m_frame->page()) {
@@ -498,9 +497,12 @@ bool ScriptController::canAccessFromCurrentOrigin(Frame* frame, Document& access
 
 void ScriptController::updateDocument()
 {
+    RefPtr document = m_frame->document();
     for (auto& jsWindowProxy : protect(windowProxy())->jsWindowProxiesAsVector()) {
         JSLockHolder lock(jsWindowProxy->world().vm());
         jsCast<JSDOMWindow*>(jsWindowProxy->window())->updateDocument();
+        if (document)
+            document->addMicrotaskGlobalObject(jsWindowProxy->window());
     }
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -982,7 +982,7 @@ void Document::removedLastRef()
 void Document::commonTeardown()
 {
     stopActiveDOMObjects();
-    clearMicrotaskGlobalObject();
+    clearMicrotaskGlobalObjects();
 
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr fullscreen = m_fullscreen.get())
@@ -4814,7 +4814,7 @@ void Document::considerSpeculationRules()
     // 3. Set document's consider speculative loads microtask queued to true.
     m_speculationRulesConsiderationScheduled = true;
     // 4. Queue a microtask given document to run the following steps:
-    eventLoop().queueMicrotask([weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }] {
+    eventLoop().queueMicrotask(vm(), [weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -8315,7 +8315,7 @@ void Document::finishedParsing()
     RefPtr documentLoader = loader();
     bool isInMiddleOfInitializingIframe = documentLoader && documentLoader->isInFinishedLoadingOfEmptyDocument();
     if (!isInMiddleOfInitializingIframe)
-        eventLoop().performMicrotaskCheckpoint();
+        eventLoop().performMicrotaskCheckpoint(vm());
 
     dispatchEvent(Event::create(eventNames().DOMContentLoadedEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 
@@ -8999,7 +8999,7 @@ void Document::reveal()
         inboundTransition->activateViewTransition();
 
         // FIXME: Clean up after running script given document.
-        eventLoop().performMicrotaskCheckpoint();
+        eventLoop().performMicrotaskCheckpoint(vm());
     }
 }
 

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -253,7 +253,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
 
         Ref document = protectedThis->m_document.get();
         if (shouldPreserveUserGesture) {
-            protect(document->eventLoop())->queueMicrotask([weakThis] {
+            protect(document->eventLoop())->queueMicrotask(document->vm(), [weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->enableTemporaryTimeUserGesture();
             });
@@ -278,7 +278,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
         }
 
         if (shouldPreserveUserGesture) {
-            protect(document->eventLoop())->queueMicrotask([weakThis] {
+            protect(document->eventLoop())->queueMicrotask(document->vm(), [weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->consumeTemporaryTimeUserGesture();
             });
@@ -350,11 +350,13 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         if (!protectedThis)
             return;
 
+        Ref document = protectedThis->m_document;
+
         // Consume the user gesture only if the user explicitly denied access.
         bool shouldPreserveUserGesture = result.wasGranted == StorageAccessWasGranted::Yes || result.promptWasShown == StorageAccessPromptWasShown::No;
 
         if (shouldPreserveUserGesture) {
-            protect(protect(protectedThis->m_document)->eventLoop())->queueMicrotask([weakThis] {
+            protect(document->eventLoop())->queueMicrotask(document->vm(), [weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->enableTemporaryTimeUserGesture();
             });
@@ -372,7 +374,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         }
 
         if (shouldPreserveUserGesture) {
-            protect(protect(protectedThis->m_document)->eventLoop())->queueMicrotask([weakThis] {
+            protect(document->eventLoop())->queueMicrotask(document->vm(), [weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->consumeTemporaryTimeUserGesture();
             });

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -119,18 +119,18 @@ private:
             return adoptRef(*new EmptyEventLoop(vm));
         }
 
-        MicrotaskQueue& microtaskQueue() final { return m_queue; }
+        MicrotaskQueue& microtaskQueue() final { return m_queue.get(); }
 
     private:
         explicit EmptyEventLoop(JSC::VM& vm)
-            : m_queue(MicrotaskQueue(vm, *this))
+            : m_queue(MicrotaskQueue::create(vm, *this))
         {
         }
 
         void scheduleToRun() final { ASSERT_NOT_REACHED(); }
         bool isContextThread() const final { return true; }
 
-        MicrotaskQueue m_queue;
+        Ref<MicrotaskQueue> m_queue;
     };
 
     const Ref<JSC::VM> m_vm;

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -26,9 +26,8 @@
 #include "config.h"
 #include "EventLoop.h"
 
-#include "JSExecState.h"
 #include "Microtasks.h"
-#include "ScriptExecutionContext.h"
+#include "ScriptExecutionContextInlines.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSMicrotaskDispatcher.h>
 #include <JavaScriptCore/MicrotaskQueueInlines.h>
@@ -255,13 +254,15 @@ void EventLoop::removeRepeatingTimer(EventLoopTimer& timer)
 
 void EventLoop::queueMicrotask(JSC::QueuedTask&& microtask)
 {
-    microtaskQueue().append(WTF::move(microtask));
+    SUPPRESS_UNCOUNTED_LOCAL auto& microtaskQueue = this->microtaskQueue();
+    microtaskQueue.enqueue(WTF::move(microtask));
     scheduleToRunIfNeeded(); // FIXME: Remove this once everything is integrated with the event loop.
 }
 
-void EventLoop::performMicrotaskCheckpoint()
+void EventLoop::performMicrotaskCheckpoint(JSC::VM& vm)
 {
-    microtaskQueue().performMicrotaskCheckpoint();
+    SUPPRESS_UNCOUNTED_LOCAL auto& microtaskQueue = this->microtaskQueue();
+    microtaskQueue.performMicrotaskCheckpoint(vm);
 }
 
 void EventLoop::resumeGroup(EventLoopTaskGroup& group)
@@ -307,15 +308,15 @@ void EventLoop::stopGroup(EventLoopTaskGroup& group)
 
 void EventLoop::scheduleToRunIfNeeded()
 {
-    if (m_isScheduledToRun)
+    if (microtaskQueue().isScheduledToRun())
         return;
-    m_isScheduledToRun = true;
+    microtaskQueue().setIsScheduledToRun(true);
     scheduleToRun();
 }
 
-void EventLoop::run(std::optional<ApproximateTime> deadline)
+void EventLoop::run(JSC::VM& vm, std::optional<ApproximateTime> deadline)
 {
-    m_isScheduledToRun = false;
+    microtaskQueue().setIsScheduledToRun(false);
     bool didPerformMicrotaskCheckpoint = false;
 
     if (!m_tasks.isEmpty()) {
@@ -339,7 +340,7 @@ void EventLoop::run(std::optional<ApproximateTime> deadline)
 
             task->execute();
             didPerformMicrotaskCheckpoint = true;
-            performMicrotaskCheckpoint();
+            performMicrotaskCheckpoint(vm);
         }
         for (auto& task : m_tasks)
             remainingTasks.append(WTF::move(task));
@@ -351,7 +352,7 @@ void EventLoop::run(std::optional<ApproximateTime> deadline)
 
     // FIXME: Remove this once everything is integrated with the event loop.
     if (!didPerformMicrotaskCheckpoint)
-        performMicrotaskCheckpoint();
+        performMicrotaskCheckpoint(vm);
 }
 
 void EventLoop::clearAllTasks()
@@ -411,32 +412,6 @@ Markable<MonotonicTime> EventLoop::nextTimerFireTime() const
     return m_nextTimerFireTimeCache;
 }
 
-class WebCoreJSDebuggableMicrotaskDispatcher final : public WebCoreMicrotaskDispatcher {
-    WTF_MAKE_COMPACT_TZONE_ALLOCATED(WebCoreJSDebuggableMicrotaskDispatcher);
-public:
-    WebCoreJSDebuggableMicrotaskDispatcher(EventLoopTaskGroup& group)
-        : WebCoreMicrotaskDispatcher(Type::WebCoreJSDebuggable, group)
-    {
-    }
-
-    ~WebCoreJSDebuggableMicrotaskDispatcher() final = default;
-
-    JSC::QueuedTask::Result run(JSC::QueuedTask& task) final
-    {
-        auto runnability = currentRunnability();
-        if (runnability == JSC::QueuedTask::Result::Executed)
-            JSExecState::runTaskWithDebugger(task.globalObject(), task);
-        return runnability;
-    }
-
-    static Ref<WebCoreJSDebuggableMicrotaskDispatcher> create(EventLoopTaskGroup& group)
-    {
-        return adoptRef(*new WebCoreJSDebuggableMicrotaskDispatcher(group));
-    }
-};
-
-WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WebCoreJSDebuggableMicrotaskDispatcher);
-
 EventLoopTaskGroup::EventLoopTaskGroup(EventLoop& eventLoop)
     : m_eventLoop(eventLoop)
 {
@@ -449,12 +424,6 @@ EventLoopTaskGroup::~EventLoopTaskGroup()
         eventLoop->unregisterGroup(*this);
 }
 
-JSC::JSMicrotaskDispatcher* EventLoopTaskGroup::jsMicrotaskDispatcherForDebugger(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
-{
-    JSC::JSLockHolder locker(vm);
-    return JSC::JSMicrotaskDispatcher::create(vm, WebCoreJSDebuggableMicrotaskDispatcher::create(*this), globalObject);
-}
-
 void EventLoopTaskGroup::setScriptExecutionContext(ScriptExecutionContext& context)
 {
     m_context = context;
@@ -465,8 +434,9 @@ void EventLoopTaskGroup::stopAndDiscardAllTasks()
     ASSERT(isReadyToStop());
     m_state = State::Stopped;
     if (RefPtr context = m_context.get()) {
-        if (auto* globalObject = context->microtaskGlobalObject())
-            globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Discard);
+        context->forEachMicrotaskGlobalObject([](auto& globalObject) {
+            globalObject.setMicrotaskRunnability(JSC::QueuedTaskResult::Discard);
+        });
     }
     if (RefPtr eventLoop = m_eventLoop.get())
         eventLoop->stopGroup(*this);
@@ -579,9 +549,8 @@ private:
 
 WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(EventLoopFunctionMicrotaskDispatcher);
 
-void EventLoopTaskGroup::queueMicrotask(EventLoop::TaskFunction&& function)
+void EventLoopTaskGroup::queueMicrotask(JSC::VM& vm, EventLoop::TaskFunction&& function)
 {
-    auto& vm = microtaskQueue().vm();
     JSC::JSLockHolder locker(vm);
     auto* cell = JSC::JSMicrotaskDispatcher::create(vm, EventLoopFunctionMicrotaskDispatcher::create(*this, WTF::move(function)));
     queueMicrotask(JSC::QueuedTask { cell });
@@ -595,10 +564,10 @@ void EventLoopTaskGroup::queueMicrotask(JSC::QueuedTask&& task)
     protect(m_eventLoop)->queueMicrotask(WTF::move(task));
 }
 
-void EventLoopTaskGroup::performMicrotaskCheckpoint()
+void EventLoopTaskGroup::performMicrotaskCheckpoint(JSC::VM& vm)
 {
     if (RefPtr eventLoop = m_eventLoop.get())
-        eventLoop->performMicrotaskCheckpoint();
+        eventLoop->performMicrotaskCheckpoint(vm);
 }
 
 void EventLoopTaskGroup::runAtEndOfMicrotaskCheckpoint(EventLoop::TaskFunction&& function)
@@ -606,7 +575,8 @@ void EventLoopTaskGroup::runAtEndOfMicrotaskCheckpoint(EventLoop::TaskFunction&&
     if (m_state == State::Stopped || !m_eventLoop)
         return;
 
-    microtaskQueue().addCheckpointTask(makeUnique<EventLoopFunctionDispatchTask>(TaskSource::IndexedDB, *this, WTF::move(function)));
+    SUPPRESS_UNCOUNTED_LOCAL auto& microtaskQueue = this->microtaskQueue();
+    microtaskQueue.addCheckpointTask(makeUnique<EventLoopFunctionDispatchTask>(TaskSource::IndexedDB, *this, WTF::move(function)));
 }
 
 EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TaskSource source, EventLoop::TaskFunction&& function)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -123,7 +123,7 @@ public:
     void queueMicrotask(JSC::QueuedTask&&);
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
-    void performMicrotaskCheckpoint();
+    void performMicrotaskCheckpoint(JSC::VM&);
     virtual MicrotaskQueue& microtaskQueue() = 0;
 
     void resumeGroup(EventLoopTaskGroup&);
@@ -141,10 +141,11 @@ public:
     void invalidateNextTimerFireTimeCache() { m_nextTimerFireTimeCache = std::nullopt; }
     Markable<MonotonicTime> nextTimerFireTime() const;
 
+    void scheduleToRunIfNeeded();
+
 protected:
     EventLoop();
-    void scheduleToRunIfNeeded();
-    void run(std::optional<ApproximateTime> deadline = std::nullopt);
+    void run(JSC::VM&, std::optional<ApproximateTime> deadline = std::nullopt);
     void clearAllTasks();
 
     bool hasTasksForFullyActiveDocument() const;
@@ -160,7 +161,6 @@ private:
     WeakHashSet<EventLoopTaskGroup> m_associatedGroups;
     WeakHashSet<EventLoopTaskGroup> m_groupsWithSuspendedTasks;
     WeakHashSet<ScriptExecutionContext> m_associatedContexts;
-    bool m_isScheduledToRun { false };
     mutable Markable<MonotonicTime> m_nextTimerFireTimeCache;
 };
 
@@ -202,12 +202,12 @@ public:
     WEBCORE_EXPORT void queueTask(TaskSource, EventLoop::TaskFunction&&);
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
-    WEBCORE_EXPORT void queueMicrotask(EventLoop::TaskFunction&&);
+    WEBCORE_EXPORT void queueMicrotask(JSC::VM&, EventLoop::TaskFunction&&);
     WEBCORE_EXPORT void queueMicrotask(JSC::QueuedTask&&);
     MicrotaskQueue& microtaskQueue() { return protect(m_eventLoop)->microtaskQueue(); }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
-    void performMicrotaskCheckpoint();
+    void performMicrotaskCheckpoint(JSC::VM&);
 
     void runAtEndOfMicrotaskCheckpoint(EventLoop::TaskFunction&&);
 
@@ -227,8 +227,6 @@ public:
 
     void didAddTimer(EventLoopTimer&);
     void didRemoveTimer(EventLoopTimer&);
-
-    JSC::JSMicrotaskDispatcher* jsMicrotaskDispatcherForDebugger(JSC::VM&, JSC::JSGlobalObject*);
 
     void setScriptExecutionContext(ScriptExecutionContext&);
 

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -25,17 +25,13 @@
 
 #include "CommonVM.h"
 #include "EventLoop.h"
-#include "JSDOMExceptionHandling.h"
 #include "JSExecState.h"
 #include "RejectedPromiseTracker.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerGlobalScope.h"
 #include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/JSMicrotaskDispatcher.h>
 #include <JavaScriptCore/MicrotaskQueueInlines.h>
-#include <JavaScriptCore/ScriptProfilingScope.h>
 #include <JavaScriptCore/TopExceptionScope.h>
-#include <JavaScriptCore/VMEntryScopeInlines.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
@@ -57,102 +53,39 @@ JSC::QueuedTask::Result WebCoreMicrotaskDispatcher::currentRunnability() const
     return JSC::QueuedTask::Result::Executed;
 }
 
+Ref<MicrotaskQueue> MicrotaskQueue::create(JSC::VM& vm, EventLoop& eventLoop)
+{
+    return adoptRef(*new MicrotaskQueue(vm, eventLoop));
+}
+
 MicrotaskQueue::MicrotaskQueue(JSC::VM& vm, EventLoop& eventLoop)
-    : m_vm(vm)
+    : JSC::MicrotaskQueue(vm)
     , m_eventLoop(eventLoop)
-    , m_microtaskQueue(vm)
 {
 }
 
 MicrotaskQueue::~MicrotaskQueue() = default;
 
-void MicrotaskQueue::append(JSC::QueuedTask&& task)
-{
-    m_microtaskQueue.enqueue(WTF::move(task));
-}
-
-void MicrotaskQueue::runJSMicrotaskWithDebugger(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::QueuedTask& task)
-{
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-
-    auto identifier = task.identifier();
-    if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]] {
-        JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
-        debugger->willRunMicrotask(globalObject, identifier.value());
-        if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-            return;
-    }
-
-    runJSMicrotask(globalObject, vm, task);
-    if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-        return;
-
-    if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]] {
-        JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
-        debugger->didRunMicrotask(globalObject, identifier.value());
-        if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-            return;
-    }
-}
-
-void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::QueuedTask& task)
-{
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    JSC::runInternalMicrotask(globalObject, task.job(), task.payload(), task.arguments());
-    if (scope.exception()) [[unlikely]] {
-        auto* exception = scope.exception();
-        if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-            return;
-        reportException(globalObject, exception);
-        if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-            return;
-    }
-}
-
-void MicrotaskQueue::performMicrotaskCheckpoint()
+void MicrotaskQueue::performMicrotaskCheckpoint(JSC::VM& vm)
 {
     if (m_performingMicrotaskCheckpoint)
         return;
 
     SetForScope change(m_performingMicrotaskCheckpoint, true);
-    Ref vm = this->vm();
     JSC::JSLockHolder locker(vm);
     auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     {
         SUPPRESS_UNCOUNTED_ARG auto& data = threadGlobalDataSingleton();
         auto* previousState = data.currentState();
-        std::optional<JSC::VMEntryScope> entryScope;
-        JSC::JSGlobalObject* currentGlobalObject = nullptr;
-        m_microtaskQueue.performMicrotaskCheckpoint</* useCallOnEachMicrotask */ false>(vm,
-            [&](JSC::QueuedTask& task) ALWAYS_INLINE_LAMBDA {
-                auto* dispatcher = task.dispatcher();
-                if (dispatcher->type() != JSC::JSMicrotaskDispatcherType) [[likely]] {
-                    auto* globalObject = JSC::jsCast<JSC::JSGlobalObject*>(dispatcher);
-                    auto result = globalObject->microtaskRunnability();
-                    if (result == JSC::QueuedTask::Result::Executed) [[likely]] {
-                        data.setCurrentState(globalObject);
-                        if (currentGlobalObject != globalObject) {
-                            if (!entryScope)
-                                entryScope.emplace(vm, globalObject);
-                            else
-                                entryScope->setGlobalObject(globalObject);
-                            currentGlobalObject = globalObject;
-                        }
-                        runJSMicrotask(globalObject, vm, task);
-                    }
-                    return result;
-                }
-
-                entryScope = std::nullopt;
-                currentGlobalObject = nullptr;
-                data.setCurrentState(previousState);
-                return JSC::jsCast<JSC::JSMicrotaskDispatcher*>(dispatcher)->dispatcher()->run(task);
+        JSC::MicrotaskQueue::performMicrotaskCheckpoint</* useCallOnEachMicrotask */ false>(vm,
+            [&](JSC::JSGlobalObject*, JSC::JSGlobalObject* nextGlobalObject) ALWAYS_INLINE_LAMBDA {
+                data.setCurrentState(nextGlobalObject ? nextGlobalObject : previousState);
             });
         data.setCurrentState(previousState);
     }
-    vm->finalizeSynchronousJSExecution();
+    vm.finalizeSynchronousJSExecution();
 
-    if (!vm->executionForbidden()) {
+    if (!vm.executionForbidden()) {
         auto checkpointTasks = std::exchange(m_checkpointTasks, { });
         for (auto& checkpointTask : checkpointTasks) {
             CheckedPtr group = checkpointTask->group();
@@ -171,8 +104,8 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
     }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint (step 4).
-    Ref { *m_eventLoop }->forEachAssociatedContext([vm = vm.copyRef()](auto& context) {
-        if (vm->executionForbidden()) [[unlikely]]
+    Ref { *m_eventLoop }->forEachAssociatedContext([&vm](auto& context) {
+        if (vm.executionForbidden()) [[unlikely]]
             return;
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         if (CheckedPtr tracker = context.rejectedPromiseTracker())
@@ -189,9 +122,10 @@ void MicrotaskQueue::addCheckpointTask(std::unique_ptr<EventLoopTask>&& task)
     m_checkpointTasks.append(WTF::move(task));
 }
 
-bool MicrotaskQueue::hasMicrotasksForFullyActiveDocument() const
+void MicrotaskQueue::scheduleToRunIfNeeded()
 {
-    return m_microtaskQueue.hasMicrotasksForFullyActiveDocument();
+    if (RefPtr eventLoop = m_eventLoop.get())
+        eventLoop->scheduleToRunIfNeeded();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -55,33 +55,25 @@ private:
     WeakPtr<EventLoopTaskGroup> m_group;
 };
 
-class MicrotaskQueue final {
+class MicrotaskQueue final : public JSC::MicrotaskQueue {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MicrotaskQueue, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT MicrotaskQueue(JSC::VM&, EventLoop&);
+    WEBCORE_EXPORT static Ref<MicrotaskQueue> create(JSC::VM&, EventLoop&);
     WEBCORE_EXPORT ~MicrotaskQueue();
 
-    WEBCORE_EXPORT void append(JSC::QueuedTask&&);
-    WEBCORE_EXPORT void performMicrotaskCheckpoint();
+    WEBCORE_EXPORT void performMicrotaskCheckpoint(JSC::VM&);
 
     WEBCORE_EXPORT void addCheckpointTask(std::unique_ptr<EventLoopTask>&&);
 
-    bool isEmpty() const { return m_microtaskQueue.isEmpty(); }
-    bool hasMicrotasksForFullyActiveDocument() const;
     bool isPerformingCheckpoint() const { return m_performingMicrotaskCheckpoint; }
 
-    static void runJSMicrotask(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
-    static void runJSMicrotaskWithDebugger(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
-
-    JSC::VM& vm() const { return m_vm.get(); }
-
 private:
+    WEBCORE_EXPORT MicrotaskQueue(JSC::VM&, EventLoop&);
+
+    void scheduleToRunIfNeeded() override;
 
     bool m_performingMicrotaskCheckpoint { false };
-    // For the main thread the VM lives forever. For workers it's lifetime is tied to our owning WorkerGlobalScope. Regardless, we retain the VM here to be safe.
-    const Ref<JSC::VM> m_vm;
     WeakPtr<EventLoop> m_eventLoop;
-    JSC::MicrotaskQueue m_microtaskQueue;
 
     EventLoop::TaskVector m_checkpointTasks;
 };

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -51,6 +51,7 @@
 #include "LegacySchemeRegistry.h"
 #include "LocalDOMWindow.h"
 #include "MessagePort.h"
+#include "Microtasks.h"
 #include "Navigator.h"
 #include "OriginAccessPatterns.h"
 #include "Page.h"
@@ -92,6 +93,7 @@
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/WeakGCSetInlines.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
@@ -350,11 +352,15 @@ URL ScriptExecutionContext::currentSourceURL(CallStackPosition position) const
     return sourceURL;
 }
 
-void ScriptExecutionContext::setMicrotaskGlobalObject(JSC::JSGlobalObject* globalObject)
+void ScriptExecutionContext::addMicrotaskGlobalObject(JSC::JSGlobalObject* globalObject)
 {
-    m_microtaskGlobalObject = JSC::Weak<JSC::JSGlobalObject>(globalObject);
     if (!globalObject)
         return;
+    if (!m_microtaskGlobalObjects)
+        m_microtaskGlobalObjects = makeUnique<JSC::WeakGCSet<JSC::JSGlobalObject>>(vm());
+    m_microtaskGlobalObjects->add(globalObject);
+    Ref microtaskQueue = protect(eventLoop())->microtaskQueue();
+    globalObject->setMicrotaskQueue(WTF::move(microtaskQueue));
     if (isEventLoopGroupStoppedPermanently())
         globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Discard);
     else if (activeDOMObjectsAreSuspended())
@@ -363,14 +369,9 @@ void ScriptExecutionContext::setMicrotaskGlobalObject(JSC::JSGlobalObject* globa
         globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Executed);
 }
 
-JSC::JSGlobalObject* ScriptExecutionContext::microtaskGlobalObject() const
+void ScriptExecutionContext::clearMicrotaskGlobalObjects()
 {
-    return m_microtaskGlobalObject.get();
-}
-
-void ScriptExecutionContext::clearMicrotaskGlobalObject()
-{
-    m_microtaskGlobalObject.clear();
+    m_microtaskGlobalObjects = nullptr;
 }
 
 void ScriptExecutionContext::suspendActiveDOMObjects(ReasonForSuspension why)
@@ -387,8 +388,9 @@ void ScriptExecutionContext::suspendActiveDOMObjects(ReasonForSuspension why)
 
     m_activeDOMObjectsAreSuspended = true;
 
-    if (auto* globalObject = microtaskGlobalObject())
-        globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Suspended);
+    forEachMicrotaskGlobalObject([](auto& globalObject) {
+        globalObject.setMicrotaskRunnability(JSC::QueuedTaskResult::Suspended);
+    });
 
     forEachActiveDOMObject([why](auto& activeDOMObject) {
         activeDOMObject.suspend(why);
@@ -414,8 +416,9 @@ void ScriptExecutionContext::resumeActiveDOMObjects(ReasonForSuspension why)
 
     m_activeDOMObjectsAreSuspended = false;
 
-    if (auto* globalObject = microtaskGlobalObject())
-        globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Executed);
+    forEachMicrotaskGlobalObject([](auto& globalObject) {
+        globalObject.setMicrotaskRunnability(JSC::QueuedTaskResult::Executed);
+    });
 
     // In case there were pending messages at the time the script execution context entered the BackForwardCache,
     // make sure those get dispatched shortly after restoring from the BackForwardCache.

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/Weak.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/SecurityContext.h>
 #include <WebCore/ServiceWorkerIdentifier.h>
@@ -56,6 +55,9 @@ class Exception;
 class JSGlobalObject;
 class JSPromise;
 class VM;
+template<typename> struct WeakGCSetHash;
+template<typename> struct WeakGCSetHashTraits;
+template<typename, typename, typename> class WeakGCSet;
 enum class MessageLevel : uint8_t;
 enum class MessageSource : uint8_t;
 enum class MessageType : uint8_t;
@@ -388,9 +390,10 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
-    void setMicrotaskGlobalObject(JSC::JSGlobalObject*);
-    JSC::JSGlobalObject* microtaskGlobalObject() const;
-    void clearMicrotaskGlobalObject();
+    void addMicrotaskGlobalObject(JSC::JSGlobalObject*);
+    template<typename Functor>
+    void forEachMicrotaskGlobalObject(const Functor&);
+    void clearMicrotaskGlobalObjects();
     virtual bool isEventLoopGroupStoppedPermanently() const { return false; }
 
 protected:
@@ -473,7 +476,7 @@ private:
 
     const RefPtr<GuaranteedSerialFunctionDispatcher> m_nativePromiseDispatcher;
     WeakHashSet<NativePromiseRequest> m_nativePromiseRequests;
-    JSC::Weak<JSC::JSGlobalObject> m_microtaskGlobalObject;
+    std::unique_ptr<JSC::WeakGCSet<JSC::JSGlobalObject, JSC::WeakGCSetHash<JSC::JSGlobalObject>, JSC::WeakGCSetHashTraits<JSC::JSGlobalObject>>> m_microtaskGlobalObjects;
 };
 
 WebCoreOpaqueRoot NODELETE root(ScriptExecutionContext*);

--- a/Source/WebCore/dom/ScriptExecutionContextInlines.h
+++ b/Source/WebCore/dom/ScriptExecutionContextInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/WeakGCSet.h>
 #include <WebCore/DOMTimer.h>
 #include <WebCore/EventLoop.h>
 #include <WebCore/ScriptExecutionContext.h>
@@ -95,6 +96,17 @@ inline ScriptExecutionContext::AddConsoleMessageTask::AddConsoleMessageTask(Mess
         context.addConsoleMessage(source, level, message);
     })
 {
+}
+
+template<typename Functor>
+void ScriptExecutionContext::forEachMicrotaskGlobalObject(const Functor& functor)
+{
+    if (!m_microtaskGlobalObjects)
+        return;
+    for (auto& weak : *m_microtaskGlobalObjects) {
+        if (SUPPRESS_FORWARD_DECL_ARG auto* globalObject = weak.get())
+            functor(*globalObject);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -26,27 +26,41 @@
 #include "config.h"
 #include "UserGestureIndicator.h"
 
+#include "CommonVM.h"
 #include "DocumentPage.h"
+#include "DocumentSettingsValues.h"
+#include "EventLoop.h"
 #include "FrameDestructionObserverInlines.h"
+#include "JSDOMGlobalObject.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "Logging.h"
+#include "Microtasks.h"
 #include "ResourceLoadObserver.h"
 #include "SecurityOrigin.h"
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/Microtask.h>
+#include <JavaScriptCore/MicrotaskQueueInlines.h>
+#include <JavaScriptCore/ScriptProfilingScope.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/MainThread.h>
-#include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UserGestureIndicator);
 
-static RefPtr<UserGestureToken>& NODELETE currentToken()
+static UserGestureToken* currentToken(JSC::VM& vm)
 {
     ASSERT(isMainThread());
-    static NeverDestroyed<RefPtr<UserGestureToken>> token;
-    return token;
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<UserGestureToken*>(vm.crossTaskToken());
+}
+
+static void setCurrentToken(JSC::VM& vm, RefPtr<UserGestureToken>&& token)
+{
+    ASSERT(isMainThread());
+    vm.setCrossTaskToken(WTF::move(token));
 }
 
 UserGestureToken::UserGestureToken(IsProcessingUserGesture isProcessingUserGesture, UserGestureType gestureType, Document* document, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
@@ -113,16 +127,63 @@ void UserGestureToken::forEachImpactedDocument(Function<void(Document&)>&& funct
     m_documentsImpactedByUserGesture.forEach(function);
 }
 
+class UserGestureInitiatedMicrotaskDispatcher final : public WebCoreMicrotaskDispatcher {
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(UserGestureInitiatedMicrotaskDispatcher);
+public:
+
+    UserGestureInitiatedMicrotaskDispatcher(EventLoopTaskGroup& group, Ref<UserGestureToken>&& userGestureToken)
+        : WebCoreMicrotaskDispatcher(Type::WebCoreUserGestureIndicator, group)
+        , m_userGestureToken(WTF::move(userGestureToken))
+    {
+    }
+
+    ~UserGestureInitiatedMicrotaskDispatcher() final = default;
+
+    JSC::QueuedTask::Result run(JSC::QueuedTask& task) final
+    {
+        auto runnability = currentRunnability();
+        if (runnability == JSC::QueuedTask::Result::Executed) {
+            auto* globalObject = task.globalObject();
+            UserGestureIndicator gestureIndicator(m_userGestureToken.ptr(), m_userGestureToken->scope(), UserGestureToken::ShouldPropagateToMicroTask::Yes);
+            JSC::runMicrotaskWithDebugger(globalObject, globalObject->vm(), task);
+        }
+        return runnability;
+    }
+
+    static Ref<UserGestureInitiatedMicrotaskDispatcher> create(EventLoopTaskGroup& group, Ref<UserGestureToken>&& userGestureToken)
+    {
+        return adoptRef(*new UserGestureInitiatedMicrotaskDispatcher(group, WTF::move(userGestureToken)));
+    }
+
+private:
+    const Ref<UserGestureToken> m_userGestureToken;
+};
+
+WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(UserGestureInitiatedMicrotaskDispatcher);
+
+RefPtr<JSC::MicrotaskDispatcher> UserGestureToken::createMicrotaskDispatcher(JSC::VM&, JSC::JSGlobalObject* globalObject)
+{
+    auto* domGlobalObject = JSC::jsCast<JSDOMGlobalObject*>(globalObject);
+    RefPtr context = domGlobalObject->scriptExecutionContext();
+    if (!context) [[unlikely]]
+        return nullptr;
+    if (!context->settingsValues().userGesturePromisePropagationEnabled)
+        return nullptr;
+    return UserGestureInitiatedMicrotaskDispatcher::create(protect(context->eventLoop()), Ref { *this });
+}
+
 UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture> isProcessingUserGesture, Document* document, UserGestureType gestureType, ProcessInteractionStyle processInteractionStyle, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
-    : m_previousToken { currentToken() }
 {
     ASSERT(isMainThread());
 
-    if (isProcessingUserGesture)
-        currentToken() = UserGestureToken::create(isProcessingUserGesture.value(), gestureType, document, authorizationToken, canRequestDOMPaste);
+    auto& vm = commonVM();
+    m_previousToken = currentToken(vm);
 
-    if (isProcessingUserGesture && document && currentToken()->processingUserGesture()) {
-        document->updateLastHandledUserGestureTimestamp(currentToken()->startTime());
+    if (isProcessingUserGesture)
+        setCurrentToken(vm, UserGestureToken::create(isProcessingUserGesture.value(), gestureType, document, authorizationToken, canRequestDOMPaste));
+
+    if (isProcessingUserGesture && document && currentToken(vm)->processingUserGesture()) {
+        document->updateLastHandledUserGestureTimestamp(currentToken(vm)->startTime());
         if (processInteractionStyle == ProcessInteractionStyle::Immediate) {
             RefPtr mainFrameDocument = document->mainFrameDocument();
             if (mainFrameDocument)
@@ -137,7 +198,7 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
                 if (RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor)) {
                     localAncestor->setHasHadUserInteraction();
                     if (RefPtr ancestorDocument = localAncestor->document())
-                        ancestorDocument->updateLastHandledUserGestureTimestamp(currentToken()->startTime());
+                        ancestorDocument->updateLastHandledUserGestureTimestamp(currentToken(vm)->startTime());
                 }
             }
         }
@@ -147,7 +208,7 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
         // NOTE: Only activate the relevent DOMWindow when the gestureType is an ActivationTriggering one
         RefPtr window = document->window();
         if (window && gestureType == UserGestureType::ActivationTriggering)
-            window->notifyActivated(currentToken()->startTime());
+            window->notifyActivated(currentToken(vm)->startTime());
     }
 }
 
@@ -158,12 +219,13 @@ UserGestureIndicator::UserGestureIndicator(RefPtr<UserGestureToken> token, UserG
         return;
 
     // It is only safe to use currentToken() on the main thread.
-    m_previousToken = currentToken();
+    auto& vm = commonVM();
+    m_previousToken = currentToken(vm);
 
     if (token) {
         token->setScope(scope);
         token->setShouldPropagateToMicroTask(shouldPropagateToMicroTask);
-        currentToken() = token;
+        setCurrentToken(vm, WTF::move(token));
     }
 }
 
@@ -171,19 +233,15 @@ UserGestureIndicator::~UserGestureIndicator()
 {
     if (!isMainThread())
         return;
-    
-    if (auto token = currentToken()) {
+
+    auto& vm = commonVM();
+    if (auto* token = currentToken(vm)) {
         token->resetDOMPasteAccess();
         token->resetScope();
         token->resetShouldPropagateToMicroTask();
     }
 
-    currentToken() = m_previousToken;
-}
-
-RefPtr<UserGestureToken> UserGestureIndicator::currentUserGestureForMainThread()
-{
-    return currentToken();
+    setCurrentToken(vm, WTF::move(m_previousToken));
 }
 
 RefPtr<UserGestureToken> UserGestureIndicator::currentUserGesture()
@@ -191,7 +249,7 @@ RefPtr<UserGestureToken> UserGestureIndicator::currentUserGesture()
     if (!isMainThread())
         return nullptr;
 
-    return currentToken();
+    return currentToken(commonVM());
 }
 
 bool UserGestureIndicator::processingUserGesture(const Document* document)
@@ -199,7 +257,7 @@ bool UserGestureIndicator::processingUserGesture(const Document* document)
     if (!isMainThread())
         return false;
 
-    RefPtr token = currentToken();
+    RefPtr token = currentToken(commonVM());
     if (!token || !token->processingUserGesture())
         return false;
 
@@ -211,7 +269,7 @@ bool UserGestureIndicator::processingUserGestureForMedia()
     if (!isMainThread())
         return false;
 
-    RefPtr token = currentToken();
+    RefPtr token = currentToken(commonVM());
     return token ? token->processingUserGestureForMedia() : false;
 }
 
@@ -220,7 +278,7 @@ std::optional<WTF::UUID> UserGestureIndicator::authorizationToken() const
     if (!isMainThread())
         return std::nullopt;
 
-    RefPtr token = currentToken();
+    RefPtr token = currentToken(commonVM());
     return token ? token->authorizationToken() : std::nullopt;
 }
 

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -25,17 +25,21 @@
 
 #pragma once
 
+#include <JavaScriptCore/CrossTaskToken.h>
 #include <WebCore/DOMPasteAccess.h>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/Function.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
+namespace JSC {
+class VM;
+}
 namespace WebCore {
 
 class Document;
@@ -46,7 +50,7 @@ enum class IsProcessingUserGesture : uint8_t { No, Yes, Potentially };
 enum class CanRequestDOMPaste : bool { No, Yes };
 enum class UserGestureType : uint8_t { EscapeKey, ActivationTriggering, Other };
 
-class UserGestureToken : public RefCountedAndCanMakeWeakPtr<UserGestureToken> {
+class UserGestureToken : public JSC::CrossTaskToken {
 public:
     static constexpr Seconds maximumIntervalForUserGestureForwarding { 1_s }; // One second matches Gecko.
     static const Seconds& NODELETE maximumIntervalForUserGestureForwardingForFetch();
@@ -92,9 +96,7 @@ public:
 
     // Expand the following methods if more propagation sources are added later.
     enum class ShouldPropagateToMicroTask : bool { No, Yes };
-    void setShouldPropagateToMicroTask(ShouldPropagateToMicroTask is) { m_shouldPropagateToMicroTask = is; }
-    void resetShouldPropagateToMicroTask() { m_shouldPropagateToMicroTask = ShouldPropagateToMicroTask::No; }
-    bool shouldPropagateToMicroTask() const { return m_shouldPropagateToMicroTask == ShouldPropagateToMicroTask::Yes; }
+    void setShouldPropagateToMicroTask(ShouldPropagateToMicroTask is) { CrossTaskToken::setShouldPropagateToMicroTask(is == ShouldPropagateToMicroTask::Yes); }
 
     bool hasExpired(Seconds expirationInterval) const
     {
@@ -111,6 +113,8 @@ public:
 
     void forEachImpactedDocument(Function<void(Document&)>&&);
 
+    RefPtr<JSC::MicrotaskDispatcher> createMicrotaskDispatcher(JSC::VM&, JSC::JSGlobalObject*) override;
+
 private:
     UserGestureToken(IsProcessingUserGesture, UserGestureType, Document*, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste);
 
@@ -122,7 +126,6 @@ private:
     DOMPasteAccessPolicy m_domPasteAccessPolicy { DOMPasteAccessPolicy::NotRequestedYet };
     GestureScope m_scope { GestureScope::All };
     MonotonicTime m_startTime { MonotonicTime::now() };
-    ShouldPropagateToMicroTask m_shouldPropagateToMicroTask { ShouldPropagateToMicroTask::No };
     std::optional<WTF::UUID> m_authorizationToken;
 };
 
@@ -130,8 +133,7 @@ class UserGestureIndicator {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(UserGestureIndicator, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(UserGestureIndicator);
 public:
-    WEBCORE_EXPORT static RefPtr<UserGestureToken> NODELETE currentUserGesture();
-    static RefPtr<UserGestureToken> NODELETE currentUserGestureForMainThread();
+    WEBCORE_EXPORT static RefPtr<UserGestureToken> currentUserGesture();
 
     WEBCORE_EXPORT static bool processingUserGesture(const Document* = nullptr);
     WEBCORE_EXPORT static bool processingUserGestureForMedia();

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -119,7 +119,7 @@ bool WindowEventLoop::isContextThread() const
 MicrotaskQueue& WindowEventLoop::microtaskQueue()
 {
     if (!m_microtaskQueue)
-        m_microtaskQueue = makeUnique<MicrotaskQueue>(commonVM(), *this);
+        m_microtaskQueue = MicrotaskQueue::create(commonVM(), *this);
     return *m_microtaskQueue;
 }
 
@@ -180,7 +180,8 @@ bool WindowEventLoop::shouldEndIdlePeriod()
 {
     if (hasTasksForFullyActiveDocument())
         return true;
-    if (microtaskQueue().hasMicrotasksForFullyActiveDocument())
+    SUPPRESS_UNCOUNTED_LOCAL auto& microtaskQueue = this->microtaskQueue();
+    if (microtaskQueue.hasMicrotasksForFullyActiveDocument())
         return true;
     return false;
 }
@@ -230,7 +231,7 @@ void WindowEventLoop::didReachTimeToRun()
 {
     Ref protectedThis { *this }; // Executing tasks may remove the last reference to this WindowEventLoop.
     auto deadline = ApproximateTime::now() + ThreadTimers::maxDurationOfFiringTimers;
-    run(deadline);
+    run(commonVM(), deadline);
     opportunisticallyRunIdleCallbacks(deadline.approximateMonotonicTime());
 }
 
@@ -245,7 +246,7 @@ void WindowEventLoop::queueMutationObserverCompoundMicrotask()
     if (m_mutationObserverCompoundMicrotaskQueuedFlag)
         return;
     m_mutationObserverCompoundMicrotaskQueuedFlag = true;
-    m_perpetualTaskGroupForSimilarOriginWindowAgents->queueMicrotask([weakThis = WeakPtr { *this }] {
+    m_perpetualTaskGroupForSimilarOriginWindowAgents->queueMicrotask(commonVM(), [weakThis = WeakPtr { *this }] {
         // We can't make a Ref to WindowEventLoop in the lambda capture as that would result in a reference cycle & leak.
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -266,7 +267,7 @@ CustomElementQueue& WindowEventLoop::backupElementQueue()
 {
     if (!m_processingBackupElementQueue) {
         m_processingBackupElementQueue = true;
-        m_perpetualTaskGroupForSimilarOriginWindowAgents->queueMicrotask([weakThis = WeakPtr { *this }] {
+        m_perpetualTaskGroupForSimilarOriginWindowAgents->queueMicrotask(commonVM(), [weakThis = WeakPtr { *this }] {
             // We can't make a Ref to WindowEventLoop in the lambda capture as that would result in a reference cycle & leak.
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -85,8 +85,7 @@ private:
     String m_agentClusterKey;
     Timer m_timer;
     Timer m_idleTimer;
-    std::unique_ptr<MicrotaskQueue> m_microtaskQueue;
-
+    RefPtr<MicrotaskQueue> m_microtaskQueue;
     // Each task scheduled in event loop is associated with a document so that it can be suspened or stopped
     // when the associated document is suspened or stopped. This task group is used to schedule a task
     // which is not scheduled to a specific document, and should only be used when it's absolutely required.

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -159,7 +159,7 @@ void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
     context->graphicsContextGL()->endQueryEXT(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    context->scriptExecutionContext()->eventLoop().queueMicrotask([query = WTF::move(context->m_activeQuery)] {
+    context->scriptExecutionContext()->eventLoop().queueMicrotask(context->scriptExecutionContext()->vm(), [query = WTF::move(context->m_activeQuery)] {
         query->makeResultAvailable();
     });
 }
@@ -190,7 +190,7 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
     context->graphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    context->scriptExecutionContext()->eventLoop().queueMicrotask([&] {
+    context->scriptExecutionContext()->eventLoop().queueMicrotask(context->scriptExecutionContext()->vm(), [&] {
         query.makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -77,7 +77,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
     context->graphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protect(protect(context->scriptExecutionContext())->eventLoop())->queueMicrotask([&] {
+    protect(protect(context->scriptExecutionContext())->eventLoop())->queueMicrotask(protect(context->scriptExecutionContext())->vm(), [&] {
         query.makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1809,7 +1809,7 @@ void WebGL2RenderingContext::endQuery(GCGLenum target)
     graphicsContextGL()->endQuery(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protect(protect(scriptExecutionContext())->eventLoop())->queueMicrotask([query = WTF::move(m_activeQueries[*activeQueryKey])] {
+    protect(protect(scriptExecutionContext())->eventLoop())->queueMicrotask(protect(scriptExecutionContext())->vm(), [query = WTF::move(m_activeQueries[*activeQueryKey])] {
         query->makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -243,7 +243,7 @@ void HTMLDocumentParser::runScriptsForPausedTreeBuilder()
             RefPtr document = this->document();
             ThrowOnDynamicMarkupInsertionCountIncrementer incrementer(*document);
 
-            document->eventLoop().performMicrotaskCheckpoint();
+            document->eventLoop().performMicrotaskCheckpoint(document->vm());
 
             CustomElementReactionStack reactionStack(document->globalObject());
             Ref elementInterface = constructionData->elementInterface.get();

--- a/Source/WebCore/html/parser/HTMLScriptRunner.cpp
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.cpp
@@ -113,7 +113,7 @@ void HTMLScriptRunner::executePendingScriptAndDispatchEvent(PendingScript& pendi
         stopWatchingForLoad(pendingScript);
 
     if (!isExecutingScript() && m_document)
-        m_document->eventLoop().performMicrotaskCheckpoint();
+        m_document->eventLoop().performMicrotaskCheckpoint(m_document->vm());
 
     {
         NestingLevelIncrementer nestingLevelIncrementer(m_scriptNestingLevel);
@@ -248,7 +248,7 @@ void HTMLScriptRunner::runScript(ScriptElement& scriptElement, const TextPositio
     // unfortunately no obvious way to tell if prepareScript is going to
     // execute the script before calling it.
     if (!isExecutingScript() && m_document)
-        m_document->eventLoop().performMicrotaskCheckpoint();
+        m_document->eventLoop().performMicrotaskCheckpoint(m_document->vm());
 
     InsertionPointRecord insertionPointRecord(m_host.inputStream());
     NestingLevelIncrementer nestingLevelIncrementer(m_scriptNestingLevel);

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -535,7 +535,7 @@ void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingC
     // Only enqueue one microtask for all actively recording canvases.
     if (m_recordingCanvasIdentifiers.isEmpty()) {
         if (RefPtr scriptExecutionContext = inspectorCanvas->scriptExecutionContext()) {
-            scriptExecutionContext->eventLoop().queueMicrotask([weakThis = WeakPtr { *this }] {
+            scriptExecutionContext->eventLoop().queueMicrotask(scriptExecutionContext->vm(), [weakThis = WeakPtr { *this }] {
                 if (!weakThis)
                     return;
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -964,7 +964,7 @@ struct AwaitingPromiseData : public RefCounted<AwaitingPromiseData> {
 static void waitForAllPromises(Document& document, const Vector<Ref<DOMPromise>>& promises, Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback)
 {
     if (promises.isEmpty()) {
-        protect(document.eventLoop())->queueMicrotask(WTF::move(fulfilledCallback));
+        protect(document.eventLoop())->queueMicrotask(document.vm(), WTF::move(fulfilledCallback));
         return;
     }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5908,7 +5908,7 @@ void Internals::queueMicroTask(int testNumber)
 
     ScriptExecutionContext* context = document;
     auto& eventLoop = context->eventLoop();
-    eventLoop.queueMicrotask([document = Ref { *document }, testNumber]() {
+    eventLoop.queueMicrotask(document->vm(), [document = Ref { *document }, testNumber]() {
         document->addConsoleMessage(MessageSource::JS, MessageLevel::Debug, makeString("MicroTask #"_s, testNumber, " has run."_s));
     });
 }
@@ -6408,7 +6408,7 @@ ExceptionOr<void> Internals::queueTaskToQueueMicrotask(Document& document, const
     ScriptExecutionContext& context = document; // This avoids unnecessarily exporting Document::eventLoop.
     context.eventLoop().queueTask(*source, [movedCallback = WTF::move(callback), protectedDocument = Ref { document }]() mutable {
         ScriptExecutionContext& context = protectedDocument.get();
-        context.eventLoop().queueMicrotask([callback = WTF::move(movedCallback)] {
+        context.eventLoop().queueMicrotask(context.vm(), [callback = WTF::move(movedCallback)] {
             callback->invoke();
         });
     });

--- a/Source/WebCore/workers/WorkerEventLoop.cpp
+++ b/Source/WebCore/workers/WorkerEventLoop.cpp
@@ -51,10 +51,11 @@ void WorkerEventLoop::scheduleToRun()
 {
     RefPtr globalScope = downcast<WorkerOrWorkletGlobalScope>(scriptExecutionContext());
     ASSERT(globalScope);
+    ASSERT(globalScope->workerOrWorkletThread());
     // Post this task with a special event mode, so that it can be separated from other
     // kinds of tasks so that queued microtasks can run even if other tasks are ignored.
-    globalScope->postTaskForMode([eventLoop = Ref { *this }] (ScriptExecutionContext&) {
-        eventLoop->run();
+    globalScope->postTaskForMode([eventLoop = Ref { *this }] (ScriptExecutionContext& context) {
+        eventLoop->run(context.vm());
     }, WorkerEventLoop::taskMode());
 }
 
@@ -68,7 +69,7 @@ MicrotaskQueue& WorkerEventLoop::microtaskQueue()
     RefPtr context = scriptExecutionContext();
     ASSERT(context);
     if (!m_microtaskQueue)
-        m_microtaskQueue = makeUnique<MicrotaskQueue>(context->vm(), *this);
+        m_microtaskQueue = MicrotaskQueue::create(context->vm(), *this);
     return *m_microtaskQueue;
 }
 

--- a/Source/WebCore/workers/WorkerEventLoop.h
+++ b/Source/WebCore/workers/WorkerEventLoop.h
@@ -53,7 +53,7 @@ private:
     bool isContextThread() const;
     MicrotaskQueue& microtaskQueue() final;
 
-    std::unique_ptr<MicrotaskQueue> m_microtaskQueue;
+    RefPtr<MicrotaskQueue> m_microtaskQueue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -68,7 +68,7 @@ void WorkerOrWorkletGlobalScope::prepareForDestruction()
     }
 
     stopActiveDOMObjects();
-    clearMicrotaskGlobalObject();
+    clearMicrotaskGlobalObjects();
 
     // Event listeners would keep DOMWrapperWorld objects alive for too long. Also, they have references to JS objects,
     // which become dangling once Heap is destroyed.

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -414,7 +414,7 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
     }
 
     RefPtr globalScope = m_globalScope.get();
-    globalScope->eventLoop().performMicrotaskCheckpoint();
+    globalScope->eventLoop().performMicrotaskCheckpoint(*m_vm);
 
     // Drive RunLoop until we get either of "Worker is terminated", "Loading is done", or "Loading is failed".
     WorkerRunLoop& runLoop = globalScope->workerOrWorkletThread()->runLoop();
@@ -433,7 +433,7 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
     while ((!protector->isLoaded() && !protector->wasCanceled()) && success) {
         success = runLoop.runInMode(globalScope.get(), taskMode, allowEventLoopTasks);
         if (success)
-            globalScope->eventLoop().performMicrotaskCheckpoint();
+            globalScope->eventLoop().performMicrotaskCheckpoint(*m_vm);
     }
 
     return success;
@@ -587,7 +587,7 @@ void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL
 
         promise->then(&globalObject, &fulfillHandler, &rejectHandler);
     }
-    globalScope->eventLoop().performMicrotaskCheckpoint();
+    globalScope->eventLoop().performMicrotaskCheckpoint(*m_vm);
 }
 
 template<typename JSGlobalScopePrototype, typename JSGlobalScope, typename GlobalScope>
@@ -624,7 +624,12 @@ void WorkerOrWorkletScriptController::initScriptWithSubclass()
 
     m_consoleClient = makeUnique<WorkerConsoleClient>(*globalScope);
     m_globalScopeWrapper->setConsoleClient(*m_consoleClient);
-    globalScope->setMicrotaskGlobalObject(m_globalScopeWrapper.get());
+    // Worklet global scopes previously routed microtasks to the VM's default queue
+    // We preserve this behavior because AudioWorkletGlobalScope relies on DrainMicrotaskDelayScope to batch
+    // microtask draining between render quanta, which only controls the VM's default
+    // queue, not the event loop's queue.
+    if (!is<WorkletGlobalScope>(m_globalScope))
+        globalScope->addMicrotaskGlobalObject(m_globalScopeWrapper.get());
 }
 
 void WorkerOrWorkletScriptController::initScript()

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -72,7 +72,7 @@ void ExtendableEvent::addExtendLifetimePromise(Ref<DOMPromise>&& promise)
         RefPtr context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
         if (!context)
             return;
-        protect(context->eventLoop())->queueMicrotask([this, protectedThis = WTF::move(protectedThis), weakContext = WeakPtr { *context }]() mutable {
+        protect(context->eventLoop())->queueMicrotask(context->vm(), [this, protectedThis = WTF::move(protectedThis), weakContext = WeakPtr { *context }]() mutable {
             --m_pendingPromiseCount;
 
             // FIXME: Let registration be the context object's relevant global object's associated service worker's containing service worker registration.

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -855,7 +855,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
 
     if (willConstructCustomElement) [[unlikely]] {
         markupInsertionCountIncrementer.emplace(*document);
-        protect(document->eventLoop())->performMicrotaskCheckpoint();
+        protect(document->eventLoop())->performMicrotaskCheckpoint(document->vm());
         customElementReactionStack.emplace(document->globalObject());
     }
 
@@ -954,7 +954,7 @@ void XMLDocumentParser::endElementNs()
     m_requestingScript = true;
 
     Ref document = *this->document();
-    protect(document->eventLoop())->performMicrotaskCheckpoint();
+    protect(document->eventLoop())->performMicrotaskCheckpoint(document->vm());
     if (scriptElement->prepareScript(m_scriptStartPosition)) {
         if (scriptElement->readyToBeParserExecuted()) {
             if (scriptElement->scriptType() == ScriptType::Classic)


### PR DESCRIPTION
#### fa403f3bda25d07f4d04c6a44c7edb36c647aa04
<pre>
[JSC] Move MicrotaskQueue enqueue code from WebCore to JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=308735">https://bugs.webkit.org/show_bug.cgi?id=308735</a>
<a href="https://rdar.apple.com/171259688">rdar://171259688</a>

Reviewed by Yijia Huang.

This patch finally moves MicrotaskQueue implementation completely from
WebCore to JSC, to accelerate its performance by removing
crossing-boundary between WebCore and JSC.

1. Ref&lt;MicrotaskQueue&gt; is held by JSGlobalObject, and WebCore sets its
   custom MicrotaskQueue to its JSGlobalObject (e.g. JSDOMWindow etc.).
   It has scheduleToRunIfNeeded virtual function which allows JSC to
   request scheduling request for MicrotaskQueue draining.
2. MicrotaskQueue::performMicrotaskCheckpoint takes JSGlobalObject
   switching lambda, and moving all of draining code into JSC so we do
   not need to cross WebCore &lt;-&gt; JSC function for each task invocation.
   So, JSC::runMicrotask is no longer exposed to WebCore.
3. JSC::VM holds RefPtr&lt;CrossTaskToken&gt; which is carried between
   multiple tasks. And derived class UserGestureToken is implemented in
   WebCore and setting it to JSC::VM. So JSC side can just do Microtask
   queueing work completely without going to WebCore side.
4. Use reportUncaughtExceptionAtEventLoop so that we can move exception
   reporting to JSC side.
5. Remove queueMicrotaskToEventLoop hook.

* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::globalObjectMethodTable):
(JSC::JSAPIGlobalObject::moduleLoaderFetch):
(JSC::JSAPIGlobalObject::loadAndEvaluateJSScriptModule):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderFetch):
* Source/JavaScriptCore/runtime/CrossTaskToken.cpp: Added.
(JSC::CrossTaskToken::createMicrotaskDispatcher):
* Source/JavaScriptCore/runtime/CrossTaskToken.h: Copied from Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.h.
(JSC::CrossTaskToken::shouldPropagateToMicroTask const):
(JSC::CrossTaskToken::setShouldPropagateToMicroTask):
(JSC::CrossTaskToken::resetShouldPropagateToMicroTask):
* Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::baseGlobalObjectMethodTable):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::JSGlobalObject):
(JSC::JSGlobalObject::queueMicrotaskToEventLoop):
(JSC::JSGlobalObject::queueMicrotask):
(JSC::JSGlobalObject::setMicrotaskQueue):
(JSC::JSGlobalObject::reportUncaughtExceptionAtEventLoop):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::microtaskQueue const):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncFromSyncIteratorContinueOrDone):
(JSC::promiseRaceResolveJob):
(JSC::promiseAllResolveJob):
(JSC::promiseAllSettledResolveJob):
(JSC::promiseAnyResolveJob):
(JSC::asyncGeneratorResolve):
(JSC::asyncGeneratorBodyCall):
(JSC::asyncGeneratorResumeNext):
(JSC::promiseFinallyAwaitJob):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::resolve):
(JSC::JSPromise::performPromiseThen):
(JSC::JSPromise::performPromiseThenWithInternalMicrotask):
(JSC::JSPromise::resolvePromise):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSPromise::triggerPromiseReactions):
(JSC::JSPromise::resolveWithInternalMicrotaskForAsyncAwait):
(JSC::JSPromise::resolveWithInternalMicrotask):
(JSC::JSPromise::rejectWithInternalMicrotask):
(JSC::JSPromise::fulfillWithInternalMicrotask):
(JSC::JSPromise::promiseResolve):
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::runMicrotask):
(JSC::runMicrotaskWithDebugger):
(JSC::DebuggableMicrotaskDispatcher::run):
(JSC::MicrotaskQueue::create):
(JSC::MicrotaskQueue::enqueueSlow):
(JSC::MicrotaskQueue::drain):
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::MicrotaskDispatcher::isWebCoreMicrotaskDispatcher const):
(JSC::MarkedMicrotaskDeque::front const):
(JSC::MicrotaskQueue::isScheduledToRun const):
(JSC::MicrotaskQueue::setIsScheduledToRun):
(JSC::MicrotaskQueue::scheduleToRunIfNeeded):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::MicrotaskQueue::enqueue):
(JSC::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/JavaScriptCore/runtime/PinballCompletion.cpp:
(JSC::pinballHandlerFulfillFunctionContinue):
(JSC::pinballHandlerFinishReject):
* Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::setCrossTaskToken):
(JSC::VM::drainMicrotasks):
(JSC::VM::queueMicrotask): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::crossTaskToken const):
(JSC::VM::defaultMicrotaskQueue):
(JSC::VM::drainMicrotaskDelayScope):
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::notifyWaiterImpl):
* Source/JavaScriptCore/runtime/WeakGCMap.h:
* Source/JavaScriptCore/runtime/WeakGCSet.h:
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::didComplete):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::JSWebAssembly::webAssemblyModuleValidateAsync):
(JSC::instantiate):
* Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp:
(JSC::runWebAssemblySuspendingFunction):
* Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp:
(WebCore::ReadableStreamToSharedBufferSink::enqueue):
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::wasRemovedFromEffectStack):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel):
(WebCore::WebAnimation::resetPendingTasks):
(WebCore::WebAnimation::updateFinishedState):
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::constructCustomElementSynchronously):
* Source/WebCore/bindings/js/JSDOMAsyncIterator.h:
(WebCore::IteratorTraits&gt;::runNextSteps):
(WebCore::IteratorTraits&gt;::runReturnSteps):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::deriveShadowRealmGlobalObject):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::globalObjectMethodTable):
(): Deleted.
(WebCore::JSDOMWindowBase::queueMicrotaskToEventLoop): Deleted.
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::queueMicrotask):
* Source/WebCore/bindings/js/JSExecState.cpp:
(WebCore::JSExecState::didLeaveScriptContext):
(WebCore::JSExecState::runTask): Deleted.
(WebCore::JSExecState::runTaskWithDebugger): Deleted.
* Source/WebCore/bindings/js/JSExecState.h:
(WebCore::JSExecState::JSExecState):
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.cpp:
(WebCore::JSShadowRealmGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSShadowRealmGlobalScopeBase::queueMicrotaskToEventLoop):
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop): Deleted.
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp:
(WebCore::JSWorkerGlobalScope::queueMicrotask):
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.cpp:
(WebCore::JSWorkletGlobalScopeBase::globalObjectMethodTable):
(WebCore::JSWorkletGlobalScopeBase::queueMicrotaskToEventLoop): Deleted.
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::initScriptForWindowProxy):
(WebCore::ScriptController::updateDocument):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
(WebCore::Document::considerSpeculationRules):
(WebCore::Document::finishedParsing):
(WebCore::Document::reveal):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::queueMicrotask):
(WebCore::EventLoop::performMicrotaskCheckpoint):
(WebCore::EventLoop::scheduleToRunIfNeeded):
(WebCore::EventLoop::run):
(WebCore::EventLoopTaskGroup::stopAndDiscardAllTasks):
(WebCore::EventLoopTaskGroup::queueMicrotask):
(WebCore::EventLoopTaskGroup::performMicrotaskCheckpoint):
(WebCore::EventLoopTaskGroup::runAtEndOfMicrotaskCheckpoint):
(WebCore::EventLoopTaskGroup::jsMicrotaskDispatcherForDebugger): Deleted.
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::create):
(WebCore::MicrotaskQueue::MicrotaskQueue):
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
(WebCore::MicrotaskQueue::scheduleToRunIfNeeded):
(WebCore::MicrotaskQueue::append): Deleted.
(WebCore::MicrotaskQueue::runJSMicrotaskWithDebugger): Deleted.
(WebCore::MicrotaskQueue::runJSMicrotask): Deleted.
(WebCore::MicrotaskQueue::hasMicrotasksForFullyActiveDocument const): Deleted.
* Source/WebCore/dom/Microtasks.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::addMicrotaskGlobalObject):
(WebCore::ScriptExecutionContext::clearMicrotaskGlobalObjects):
(WebCore::ScriptExecutionContext::suspendActiveDOMObjects):
(WebCore::ScriptExecutionContext::resumeActiveDOMObjects):
(WebCore::ScriptExecutionContext::setMicrotaskGlobalObject): Deleted.
(WebCore::ScriptExecutionContext::microtaskGlobalObject const): Deleted.
(WebCore::ScriptExecutionContext::clearMicrotaskGlobalObject): Deleted.
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContextInlines.h:
(WebCore::ScriptExecutionContext::forEachMicrotaskGlobalObject):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::currentToken):
(WebCore::setCurrentToken):
(WebCore::UserGestureToken::createMicrotaskDispatcher):
(WebCore::UserGestureIndicator::UserGestureIndicator):
(WebCore::UserGestureIndicator::~UserGestureIndicator):
(WebCore::UserGestureIndicator::currentUserGesture):
(WebCore::UserGestureIndicator::processingUserGesture):
(WebCore::UserGestureIndicator::processingUserGestureForMedia):
(WebCore::UserGestureIndicator::authorizationToken const):
(WebCore::UserGestureIndicator::currentUserGestureForMainThread): Deleted.
* Source/WebCore/dom/UserGestureIndicator.h:
(WebCore::UserGestureToken::setShouldPropagateToMicroTask):
(WebCore::UserGestureToken::resetShouldPropagateToMicroTask): Deleted.
(WebCore::UserGestureToken::shouldPropagateToMicroTask const): Deleted.
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::microtaskQueue):
(WebCore::WindowEventLoop::shouldEndIdlePeriod):
(WebCore::WindowEventLoop::didReachTimeToRun):
(WebCore::WindowEventLoop::queueMutationObserverCompoundMicrotask):
(WebCore::WindowEventLoop::backupElementQueue):
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::endQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::endQuery):
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::runScriptsForPausedTreeBuilder):
* Source/WebCore/html/parser/HTMLScriptRunner.cpp:
(WebCore::HTMLScriptRunner::executePendingScriptAndDispatchEvent):
(WebCore::HTMLScriptRunner::runScript):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::recordAction):
* Source/WebCore/page/Navigation.cpp:
(WebCore::waitForAllPromises):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::queueMicroTask):
(WebCore::Internals::queueTaskToQueueMicrotask):
* Source/WebCore/workers/WorkerEventLoop.cpp:
(WebCore::WorkerEventLoop::scheduleToRun):
(WebCore::WorkerEventLoop::microtaskQueue):
* Source/WebCore/workers/WorkerEventLoop.h:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::prepareForDestruction):
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::loadModuleSynchronously):
(WebCore::WorkerOrWorkletScriptController::loadAndEvaluateModule):
(WebCore::WorkerOrWorkletScriptController::initScriptWithSubclass):
* Source/WebCore/workers/service/ExtendableEvent.cpp:
(WebCore::ExtendableEvent::addExtendLifetimePromise):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):
(WebCore::XMLDocumentParser::endElementNs):

Canonical link: <a href="https://commits.webkit.org/308483@main">https://commits.webkit.org/308483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/158ffea0d2108774ec4dc451283667e031eca7f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20411 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156409 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/113886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150688 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/94646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3849 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139696 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158744 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8514 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22752 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179148 "Failed to checkout and rebase branch from PR 59500") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19826 "Failed to checkout and rebase branch from PR 59500") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/179148 "Failed to checkout and rebase branch from PR 59500") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->