### PR TITLE
Add anonymous block child to RenderMenuList so it properly handles floats

### DIFF
--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -26,7 +26,6 @@
 #include "GraphicsContext.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
-#include "LayoutIntegrationLineLayout.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderChildIterator.h"
@@ -63,41 +62,6 @@ bool RenderButton::canBeSelectionLeaf() const
 bool RenderButton::hasLineIfEmpty() const
 {
     return is<HTMLInputElement>(formControlElement());
-}
-
-void RenderButton::setInnerRenderer(RenderBlock& innerRenderer)
-{
-    ASSERT(!m_inner.get());
-    m_inner = innerRenderer;
-    updateAnonymousChildStyle(m_inner->mutableStyle());
-
-    if (m_inner && m_inner->layoutBox()) {
-        if (auto* inlineFormattingContextRoot = dynamicDowncast<RenderBlockFlow>(*m_inner); inlineFormattingContextRoot && inlineFormattingContextRoot->inlineLayout())
-            inlineFormattingContextRoot->inlineLayout()->rootStyleWillChange(*inlineFormattingContextRoot, inlineFormattingContextRoot->style());
-        if (auto* lineLayout = LayoutIntegration::LineLayout::containing(*m_inner))
-            lineLayout->styleWillChange(*m_inner, m_inner->style(), Style::DifferenceResult::Layout);
-        LayoutIntegration::LineLayout::updateStyle(*m_inner);
-        for (auto& child : childrenOfType<RenderText>(*m_inner))
-            LayoutIntegration::LineLayout::updateStyle(child);
-    }
-}
-
-void RenderButton::updateAnonymousChildStyle(RenderStyle& childStyle) const
-{
-    childStyle.setFlexGrow(1.0f);
-    // min-inline-size: 0; is needed for correct shrinking.
-    // Use margin-block:auto instead of align-items:center to get safe centering, i.e.
-    // when the content overflows, treat it the same as align-items: flex-start.
-    if (isHorizontalWritingMode()) {
-        childStyle.setMinWidth(0_css_px);
-        childStyle.setMarginTop(CSS::Keyword::Auto { });
-        childStyle.setMarginBottom(CSS::Keyword::Auto { });
-    } else {
-        childStyle.setMinHeight(0_css_px);
-        childStyle.setMarginLeft(CSS::Keyword::Auto { });
-        childStyle.setMarginRight(CSS::Keyword::Auto { });
-    }
-    childStyle.setTextBoxTrim(style().textBoxTrim());
 }
 
 void RenderButton::updateFromElement()

--- a/Source/WebCore/rendering/RenderButton.h
+++ b/Source/WebCore/rendering/RenderButton.h
@@ -52,8 +52,6 @@ public:
     bool hasControlClip() const override;
     LayoutRect controlClipRect(const LayoutPoint&) const override;
 
-    void updateAnonymousChildStyle(RenderStyle&) const override;
-
     void setText(const String&);
     String NODELETE text() const;
 
@@ -62,10 +60,6 @@ public:
 #endif
 
     RenderTextFragment* textRenderer() const { return m_buttonText.get(); }
-
-    RenderBlock* innerRenderer() const { return m_inner.get(); }
-    void setInnerRenderer(RenderBlock&);
-
 private:
     void element() const = delete;
 
@@ -76,7 +70,6 @@ private:
     bool isFlexibleBoxImpl() const override { return true; }
 
     SingleThreadWeakPtr<RenderTextFragment> m_buttonText;
-    SingleThreadWeakPtr<RenderBlock> m_inner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -38,6 +38,7 @@
 #include "InspectorInstrumentation.h"
 #include "LayoutIntegrationCoverage.h"
 #include "LayoutIntegrationFlexLayout.h"
+#include "LayoutIntegrationLineLayout.h"
 #include "LayoutRepainter.h"
 #include "LayoutUnit.h"
 #include "RenderBlockInlines.h"
@@ -2961,6 +2962,23 @@ const RenderBox* RenderFlexibleBox::flexItemForLastBaseline() const
     }
     // Logically first (but visually last) item on logically last (but visually first) line.
     return firstBaselineCandidateOnLine(m_orderIterator, m_numberOfFlexItemsOnFirstLine);
+}
+
+void RenderFlexibleBox::setInnerRenderer(RenderBlock& innerRenderer)
+{
+    ASSERT(!m_inner.get());
+    m_inner = innerRenderer;
+    updateAnonymousChildStyle(m_inner->mutableStyle());
+
+    if (m_inner && m_inner->layoutBox()) {
+        if (auto* inlineFormattingContextRoot = dynamicDowncast<RenderBlockFlow>(*m_inner); inlineFormattingContextRoot && inlineFormattingContextRoot->inlineLayout())
+            inlineFormattingContextRoot->inlineLayout()->rootStyleWillChange(*inlineFormattingContextRoot, inlineFormattingContextRoot->style());
+        if (auto* lineLayout = LayoutIntegration::LineLayout::containing(*m_inner))
+            lineLayout->styleWillChange(*m_inner, m_inner->style(), Style::DifferenceResult::Layout);
+        LayoutIntegration::LineLayout::updateStyle(*m_inner);
+        for (auto& child : childrenOfType<RenderText>(*m_inner))
+            LayoutIntegration::LineLayout::updateStyle(child);
+    }
 }
 
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -108,6 +108,10 @@ public:
     bool NODELETE isColumnOrRowReverse() const;
     bool NODELETE isWrapReverse() const;
 
+    RenderBlock* innerRenderer() const { return m_inner.get(); }
+    void setInnerRenderer(RenderBlock&);
+    void updateAnonymousChildStyle(RenderStyle&) const override;
+
 protected:
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
 
@@ -327,6 +331,7 @@ private:
     bool m_shouldResetFlexItemLogicalHeightBeforeLayout { false };
     bool m_isComputingFlexBaseSizes { false };
     std::optional<bool> m_hasFlexFormattingContextLayout;
+    SingleThreadWeakPtr<RenderBlock> m_inner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -104,6 +104,24 @@ void RenderMenuList::updateOptionsWidth()
         setNeedsLayoutAndPreferredWidthsUpdate();
 }
 
+void RenderFlexibleBox::updateAnonymousChildStyle(RenderStyle& childStyle) const
+{
+    childStyle.setFlexGrow(1.0f);
+    // min-inline-size: 0; is needed for correct shrinking.
+    // Use margin-block:auto instead of align-items:center to get safe centering, i.e.
+    // when the content overflows, treat it the same as align-items: flex-start.
+    if (isHorizontalWritingMode()) {
+        childStyle.setMinWidth(0_css_px);
+        childStyle.setMarginTop(CSS::Keyword::Auto { });
+        childStyle.setMarginBottom(CSS::Keyword::Auto { });
+    } else {
+        childStyle.setMinHeight(0_css_px);
+        childStyle.setMarginLeft(CSS::Keyword::Auto { });
+        childStyle.setMarginRight(CSS::Keyword::Auto { });
+    }
+    childStyle.setTextBoxTrim(style().textBoxTrim());
+}
+
 void RenderMenuList::updateFromElement()
 {
     if (m_needsOptionsWidthUpdate) {

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -61,6 +61,8 @@ public:
 
     void updateFromElement() final;
 
+    bool createsAnonymousWrapper() const override { return true; }
+
 private:
     void element() const = delete;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -50,6 +50,7 @@
 #include "RenderLayer.h"
 #include "RenderLineBreak.h"
 #include "RenderMathMLFenced.h"
+#include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
 #include "RenderMultiColumnSpannerPlaceholder.h"
@@ -359,6 +360,11 @@ void RenderTreeBuilder::attachInternal(RenderElement& parent, RenderPtr<RenderOb
         return;
     }
 
+    if (auto* menuList = dynamicDowncast<RenderMenuList>(parent)) {
+        formControlsBuilder().attach(*menuList, WTF::move(child), beforeChild);
+        return;
+    }
+
     if (auto* container = dynamicDowncast<LegacyRenderSVGContainer>(parent)) {
         svgBuilder().attach(*container, WTF::move(child), beforeChild);
         return;
@@ -432,6 +438,9 @@ RenderPtr<RenderObject> RenderTreeBuilder::detach(RenderElement& parent, RenderO
 
     if (auto* button = dynamicDowncast<RenderButton>(parent))
         return formControlsBuilder().detach(*button, child, willBeDestroyed);
+
+    if (auto* menuList = dynamicDowncast<RenderMenuList>(parent))
+        return formControlsBuilder().detach(*menuList, child, willBeDestroyed);
 
     if (auto* grid = dynamicDowncast<RenderGrid>(parent))
         return detachFromRenderGrid(*grid, child, willBeDestroyed);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -29,6 +29,7 @@
 #include "RenderBlockInlines.h"
 #include "RenderButton.h"
 #include "RenderChildIterator.h"
+#include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderObjectInlines.h"
 #include "RenderStyle+GettersInlines.h"
@@ -326,7 +327,7 @@ void RenderTreeBuilder::Block::removeLeftoverAnonymousBlock(RenderBlock& anonymo
         return;
 
     auto* parent = anonymousBlock.parent();
-    if (isAnyOf<RenderButton, RenderTextControl>(*parent))
+    if (isAnyOf<RenderButton, RenderMenuList, RenderTextControl>(*parent))
         return;
 
     m_builder.removeFloatingObjects(anonymousBlock);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -50,13 +50,15 @@ RenderTreeBuilder::FormControls::FormControls(RenderTreeBuilder& builder)
 {
 }
 
-void RenderTreeBuilder::FormControls::attach(RenderButton& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
+void RenderTreeBuilder::FormControls::attach(RenderFlexibleBox& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
 {
+    ASSERT(is<RenderButton>(parent) || is<RenderMenuList>(parent));
     m_builder.blockBuilder().attach(findOrCreateParentForChild(parent), WTF::move(child), beforeChild);
 }
 
-RenderPtr<RenderObject> RenderTreeBuilder::FormControls::detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed willBeDestroyed)
+RenderPtr<RenderObject> RenderTreeBuilder::FormControls::detach(RenderFlexibleBox& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed willBeDestroyed)
 {
+    ASSERT(is<RenderButton>(parent) || is<RenderMenuList>(parent));
     auto* innerRenderer = parent.innerRenderer();
     if (!innerRenderer || &child == innerRenderer || child.parent() == &parent) {
         ASSERT(&child == innerRenderer || !innerRenderer);
@@ -65,8 +67,7 @@ RenderPtr<RenderObject> RenderTreeBuilder::FormControls::detach(RenderButton& pa
     return m_builder.detach(*innerRenderer, child, willBeDestroyed);
 }
 
-
-RenderBlock& RenderTreeBuilder::FormControls::findOrCreateParentForChild(RenderButton& parent)
+RenderBlock& RenderTreeBuilder::FormControls::findOrCreateParentForChild(RenderFlexibleBox& parent)
 {
     auto* innerRenderer = parent.innerRenderer();
     if (innerRenderer)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
@@ -31,21 +31,21 @@
 namespace WebCore {
 
 class RenderBlock;
-class RenderButton;
+class RenderFlexibleBox;
 
 class RenderTreeBuilder::FormControls {
     WTF_MAKE_TZONE_ALLOCATED(FormControls);
 public:
     FormControls(RenderTreeBuilder&);
 
-    void attach(RenderButton& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
+    void attach(RenderFlexibleBox& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    [[nodiscard]] RenderPtr<RenderObject> detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderFlexibleBox& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
     void updateAfterDescendants(RenderElement&);
 
 private:
-    RenderBlock& findOrCreateParentForChild(RenderButton&);
+    RenderBlock& findOrCreateParentForChild(RenderFlexibleBox&);
 
     void updatePseudoElement(PseudoElementType, RenderElement&, StyleAppearance, RenderObject* beforeChild = nullptr);
 


### PR DESCRIPTION
#### 0a7306c4594856e57315cb7f151e9f6569cd5f1c
<pre>
Add anonymous block child to RenderMenuList so it properly handles floats
<a href="https://bugs.webkit.org/show_bug.cgi?id=308734">https://bugs.webkit.org/show_bug.cgi?id=308734</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/RenderButton.cpp:
(WebCore::RenderButton::setInnerRenderer): Deleted.
(WebCore::RenderButton::updateAnonymousChildStyle const): Deleted.
* Source/WebCore/rendering/RenderButton.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::setInnerRenderer):
* Source/WebCore/rendering/RenderFlexibleBox.h:
(WebCore::RenderFlexibleBox::innerRenderer const):
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderFlexibleBox::updateAnonymousChildStyle const):
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachInternal):
(WebCore::RenderTreeBuilder::detach):
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::RenderTreeBuilder::Block::removeLeftoverAnonymousBlock):
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::attach):
(WebCore::RenderTreeBuilder::FormControls::detach):
(WebCore::RenderTreeBuilder::FormControls::findOrCreateParentForChild):
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7306c4594856e57315cb7f151e9f6569cd5f1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148873 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/21586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157559 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150746 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151833 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/15155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5408 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/15155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/15155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/160042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/15155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/15155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->