### PR TITLE
[GTK][WPE] Add Sysprof marks for mouse events

### DIFF
--- a/Source/WebKit/Shared/WebEvent.cpp
+++ b/Source/WebKit/Shared/WebEvent.cpp
@@ -37,11 +37,31 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebEvent);
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+static uintptr_t generateSignpostIdentifier()
+{
+    static std::atomic<uintptr_t> identifier;
+    return ++identifier;
+}
+
+WebEvent::WebEvent(WebEventType type, OptionSet<WebEventModifier> modifiers, MonotonicTime timestamp, WTF::UUID authorizationToken, uintptr_t signpostIdentifier)
+    : m_type(type)
+    , m_modifiers(modifiers)
+    , m_timestamp(timestamp)
+    , m_authorizationToken(authorizationToken)
+    , m_signpostIdentifier(signpostIdentifier)
+{
+}
+#endif
+
 WebEvent::WebEvent(WebEventType type, OptionSet<WebEventModifier> modifiers, MonotonicTime timestamp, WTF::UUID authorizationToken)
     : m_type(type)
     , m_modifiers(modifiers)
     , m_timestamp(timestamp)
     , m_authorizationToken(authorizationToken)
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    , m_signpostIdentifier(generateSignpostIdentifier())
+#endif
 {
 }
 
@@ -50,6 +70,9 @@ WebEvent::WebEvent(WebEventType type, OptionSet<WebEventModifier> modifiers, Mon
     , m_modifiers(modifiers)
     , m_timestamp(timestamp)
     , m_authorizationToken(WTF::UUID::createVersion4())
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    , m_signpostIdentifier(generateSignpostIdentifier())
+#endif
 {
 }
 

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -50,6 +50,9 @@ class WebEvent : public CanMakeThreadSafeCheckedPtr<WebEvent, WTF::DefaultedOper
     WTF_MAKE_TZONE_ALLOCATED(WebEvent);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEvent);
 public:
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    WebEvent(WebEventType, OptionSet<WebEventModifier>, MonotonicTime timestamp, WTF::UUID authorizationToken, uintptr_t signpostIdentifier);
+#endif
     WebEvent(WebEventType, OptionSet<WebEventModifier>, MonotonicTime timestamp, WTF::UUID authorizationToken);
     WebEvent(WebEventType, OptionSet<WebEventModifier>, MonotonicTime timestamp);
 
@@ -70,11 +73,18 @@ public:
     bool NODELETE isActivationTriggeringEvent() const;
     WTF::UUID authorizationToken() const { return m_authorizationToken; }
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    uintptr_t signpostIdentifier() const { return m_signpostIdentifier; }
+#endif
+
 private:
     WebEventType m_type;
     OptionSet<WebEventModifier> m_modifiers;
     MonotonicTime m_timestamp;
     WTF::UUID m_authorizationToken;
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    uintptr_t m_signpostIdentifier;
+#endif
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, WebEventType);

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -33,6 +33,9 @@ class WebKit::WebEvent {
     OptionSet<WebKit::WebEventModifier> modifiers();
     MonotonicTime timestamp();
     WTF::UUID authorizationToken();
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    uintptr_t signpostIdentifier();
+#endif
 };
 
 enum class WebKit::WebEventType : uint32_t {

--- a/Source/WebKit/Shared/WebEventType.h
+++ b/Source/WebKit/Shared/WebEventType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/text/ASCIILiteral.h>
+
 namespace WebKit {
 
 enum class WebEventType : uint32_t {
@@ -59,5 +61,52 @@ enum class WebEventType : uint32_t {
     GestureEnd          = 1 << 17
 #endif
 };
+
+inline ASCIILiteral toString(WebEventType action)
+{
+    switch (action) {
+    case WebEventType::MouseDown:
+        return "MouseDown"_s;
+    case WebEventType::MouseUp:
+        return "MouseUp"_s;
+    case WebEventType::MouseMove:
+        return "MouseMove"_s;
+    case WebEventType::MouseForceChanged:
+        return "MouseForceChanged"_s;
+    case WebEventType::MouseForceDown:
+        return "MouseForceDown"_s;
+    case WebEventType::MouseForceUp:
+        return "MouseForceUp"_s;
+    case WebEventType::Wheel:
+        return "Wheel"_s;
+    case WebEventType::KeyDown:
+        return "KeyDown"_s;
+    case WebEventType::KeyUp:
+        return "KeyUp"_s;
+    case WebEventType::RawKeyDown:
+        return "RawKeyDown"_s;
+    case WebEventType::Char:
+        return "Char"_s;
+#if ENABLE(TOUCH_EVENTS)
+    case WebEventType::TouchStart:
+        return "TouchStart"_s;
+    case WebEventType::TouchMove:
+        return "TouchMove"_s;
+    case WebEventType::TouchEnd:
+        return "TouchEnd"_s;
+    case WebEventType::TouchCancel:
+        return "TouchCancel"_s;
+#endif
+#if ENABLE(MAC_GESTURE_EVENTS)
+    case WebEventType::GestureStart:
+        return "GestureStart"_s;
+    case WebEventType::GestureChange:
+        return "GestureChange"_s;
+    case WebEventType::GestureEnd:
+        return "GestureEnd"_s;
+#endif
+    }
+    return ""_s;
+}
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4139,6 +4139,10 @@ void WebPageProxy::handleMouseEvent(const NativeWebMouseEvent& event)
     if (!m_mainFrame)
         return;
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    WTFBeginSignpost(event.signpostIdentifier(), HandleMouseEvent, "id: %" PRIuPTR ", type: %s", event.signpostIdentifier(), toString(event.type()).characters());
+#endif
+
 #if ENABLE(CONTEXT_MENU_EVENT)
     if (event.button() == WebMouseEventButton::Right && event.type() == WebEventType::MouseDown) {
         ASSERT(m_contextMenuPreventionState != EventPreventionState::Waiting);
@@ -11671,6 +11675,15 @@ void WebPageProxy::mouseEventHandlingCompleted(std::optional<WebEventType> event
         }
 #endif
     }
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    WTFEndSignpost(event.signpostIdentifier(), HandleMouseEvent);
+    for (auto& coalescedEvent : event.coalescedEvents()) {
+        if (coalescedEvent.signpostIdentifier() == event.signpostIdentifier())
+            continue;
+        WTFEndSignpost(coalescedEvent.signpostIdentifier(), HandleMouseEvent);
+    }
+#endif
 
     if (!internals().mouseEventQueue.isEmpty()) {
         LOG(MouseHandling, " UIProcess: handling a queued mouse event from mouseEventHandlingCompleted");

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -33,6 +33,7 @@
 #include "WPEToplevelWaylandPrivate.h"
 #include <linux/input.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 
@@ -99,6 +100,8 @@ const struct wl_pointer_listener WaylandSeat::s_pointerListener = {
     // motion
     [](void* data, struct wl_pointer*, uint32_t time, wl_fixed_t fixedX, wl_fixed_t fixedY)
     {
+        WTFEmitSignpost(wl_pointer, WaylandMotionEvent);
+
         auto& seat = *static_cast<WaylandSeat*>(data);
         if (!seat.m_pointer.toplevel)
             return;
@@ -122,6 +125,8 @@ const struct wl_pointer_listener WaylandSeat::s_pointerListener = {
     // button
     [](void* data, struct wl_pointer*, uint32_t /*serial*/, uint32_t time, uint32_t button, uint32_t state)
     {
+        WTFEmitSignpost(wl_pointer, WaylandButtonEvent);
+
         auto& seat = *static_cast<WaylandSeat*>(data);
         if (!seat.m_pointer.toplevel)
             return;


### PR DESCRIPTION
#### 01d8e1eba767b17f0db868580e16b5bae72ab36d
<pre>
[GTK][WPE] Add Sysprof marks for mouse events
<a href="https://bugs.webkit.org/show_bug.cgi?id=308737">https://bugs.webkit.org/show_bug.cgi?id=308737</a>

Reviewed by Adrian Perez de Castro.

Mouse event processing in the UI process begins in
`WebPageProxy::handleMouseEvent()` and ends in
`WebPageProxy::mouseEventHandlingCompleted()`.

To enable tracking of the time spent handling these events,
corresponding `WTFBeginSignpost()`/`WTFEndSignpost()` calls have been
added to these methods.

To distinguish between multiple mouse events, a unique identifier is now
assigned to each `WebEvent` and included in the signpost name.

Additionally, signposts are emitted for Wayland `motion` and `button`
events in `WPEWaylandSeat` to mark the start of event processing.

* Source/WebKit/Shared/WebEvent.cpp:
(WebKit::generateSignpostIdentifier):
(WebKit::WebEvent::WebEvent):
* Source/WebKit/Shared/WebEvent.h:
(WebKit::WebEvent::signpostIdentifier const):
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventType.h:
(WebKit::toString):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMouseEvent):
(WebKit::WebPageProxy::mouseEventHandlingCompleted):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:

Canonical link: <a href="https://commits.webkit.org/308715@main">https://commits.webkit.org/308715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dfe3a9df3545ce45b759e12f37f6e715bce457a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156950 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114311 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15669 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13470 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125276 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159283 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122344 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122564 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33324 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132859 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76911 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17971 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9598 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84153 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20100 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->