### PR TITLE
[TextureMapper] Make BitmapTexturePool a singleton

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -73,8 +73,6 @@ static bool canPerformAcceleratedRendering()
 SkiaPaintingEngine::SkiaPaintingEngine()
 {
     if (canPerformAcceleratedRendering()) {
-        m_texturePool = makeUnique<BitmapTexturePool>();
-
         if (auto numberOfGPUThreads = numberOfGPUPaintingThreads())
             m_paintingWorkerPool = WorkerPool::create("SkiaGPUWorker"_s, numberOfGPUThreads);
 
@@ -120,8 +118,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode render
         if (!contentsOpaque)
             textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
 
-        ASSERT(m_texturePool);
-        return CoordinatedAcceleratedTileBuffer::create(m_texturePool->acquireTexture(size, textureFlags));
+        return CoordinatedAcceleratedTileBuffer::create(BitmapTexturePool::singleton().acquireTexture(size, textureFlags));
     }
 
     return CoordinatedUnacceleratedTileBuffer::create(size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
@@ -129,9 +126,6 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode render
 
 RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition)
 {
-    if (!m_texturePool)
-        return { };
-
     const auto& atlasSize = layout.atlasSize();
 
     OptionSet<BitmapTexture::Flags> textureFlags { BitmapTexture::Flags::UseBGRALayout, BitmapTexture::Flags::NearestFiltering, BitmapTexture::Flags::SupportsAlpha };
@@ -146,7 +140,7 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
     // Verify the texture actually has DMA-buf backing. BitmapTexture silently
     // falls back to GL if DMA-buf allocation fails, but we must not dispatch
     // GL operations to the upload worker thread (which has no GL context).
-    auto texture = m_texturePool->acquireTexture(atlasSize, textureFlags);
+    auto texture = BitmapTexturePool::singleton().acquireTexture(atlasSize, textureFlags);
     if (!texture->memoryMappedGPUBuffer())
         isDMABufBackedTexture = false;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -34,7 +34,6 @@
 namespace WebCore {
 
 class AtlasUploadCondition;
-class BitmapTexturePool;
 class CoordinatedTileBuffer;
 class GraphicsContext;
 class GraphicsLayer;
@@ -74,8 +73,6 @@ private:
 
     RefPtr<WorkerPool> m_paintingWorkerPool;
     RefPtr<WorkQueue> m_uploadWorkQueue;
-
-    std::unique_ptr<BitmapTexturePool> m_texturePool;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -156,6 +156,16 @@ void BitmapTexture::allocateTexture()
     glTexImage2D(m_renderTarget, 0, GL_RGBA, m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
 }
 
+size_t BitmapTexture::sizeInBytes() const
+{
+    auto size = allocatedSize();
+    if (size.isEmpty())
+        return 0;
+
+    const auto bytesPerRow = CheckedUint32(size.width()) * 4;
+    return CheckedUint32(size.height()) * bytesPerRow;
+}
+
 #if USE(GBM)
 IntSize BitmapTexture::allocatedSize() const
 {

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -80,6 +80,7 @@ public:
     WEBCORE_EXPORT ~BitmapTexture();
 
     const IntSize& size() const { return m_size; };
+    size_t sizeInBytes() const;
     OptionSet<Flags> flags() const { return m_flags; }
     bool isOpaque() const { return !m_flags.contains(Flags::SupportsAlpha); }
 
@@ -94,8 +95,6 @@ public:
 
     void swapTexture(BitmapTexture&);
     void reset(const IntSize&, OptionSet<Flags> = { });
-
-    int numberOfBytes() const { return size().width() * size().height() * 32 >> 3; }
 
     RefPtr<const FilterOperation> filterOperation() const { return m_filterOperation; }
     void setFilterOperation(RefPtr<const FilterOperation>&& filterOperation) { m_filterOperation = WTF::move(filterOperation); }

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
- * Copyright (C) 2015, 2025 Igalia S.L.
+ * Copyright (C) 2015, 2025, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,50 +28,70 @@
 #include "BitmapTexturePool.h"
 
 #if USE(TEXTURE_MAPPER)
+#include "GLContext.h"
+#include "GLContextWrapper.h"
+#include "PlatformDisplay.h"
+#include <wtf/TZoneMallocInlines.h>
+
+#if USE(GLIB)
+#include <wtf/glib/RunLoopSourcePriority.h>
+#endif
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BitmapTexturePool);
+
 #if defined(BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB) && BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB > 0
-static constexpr size_t poolSizeLimit = BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB * MB;
+static constexpr size_t s_poolSizeLimitInBytes = BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB * MB;
 #else
-static constexpr size_t poolSizeLimit = std::numeric_limits<size_t>::max();
+static constexpr size_t s_poolSizeLimitInBytes = std::numeric_limits<size_t>::max();
 #endif
 
-static const Seconds releaseUnusedSecondsTolerance { 3_s };
-static const Seconds releaseUnusedTexturesTimerInterval { 500_ms };
-static const Seconds releaseUnusedSecondsToleranceOnLimitExceeded { 50_ms };
-static const Seconds releaseUnusedTexturesTimerIntervalOnLimitExceeded { 200_ms };
+static constexpr Seconds s_releaseUnusedSecondsTolerance { 3_s };
+static constexpr Seconds s_releaseUnusedTexturesTimerInterval { 500_ms };
+static constexpr Seconds s_releaseUnusedSecondsToleranceOnLimitExceeded { 50_ms };
+static constexpr Seconds s_releaseUnusedTexturesTimerIntervalOnLimitExceeded { 200_ms };
+
+BitmapTexturePool& BitmapTexturePool::singleton()
+{
+    static NeverDestroyed<BitmapTexturePool> pool;
+    return pool;
+}
 
 BitmapTexturePool::BitmapTexturePool()
-    : m_releaseUnusedTexturesTimer(RunLoop::currentSingleton(), "BitmapTexturePool::ReleaseUnusedTexturesTimer"_s, this, &BitmapTexturePool::releaseUnusedTexturesTimerFired)
-    , m_releaseUnusedSecondsTolerance(releaseUnusedSecondsTolerance)
-    , m_releaseUnusedTexturesTimerInterval(releaseUnusedTexturesTimerInterval)
+    : m_releaseUnusedTexturesTimer(RunLoop::mainSingleton(), "BitmapTexturePool::ReleaseUnusedTexturesTimer"_s, this, &BitmapTexturePool::releaseUnusedTexturesTimerFired)
+    , m_releaseUnusedSecondsTolerance(s_releaseUnusedSecondsTolerance)
+    , m_releaseUnusedTexturesTimerInterval(s_releaseUnusedTexturesTimerInterval)
 {
+#if USE(GLIB)
+    m_releaseUnusedTexturesTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
+#endif
 }
 
 Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
 {
-    Entry* selectedEntry = std::find_if(m_textures.begin(), m_textures.end(),
-        [&](Entry& entry) {
-            return entry.m_texture->refCount() == 1
-                && entry.m_texture->size() == size
+    ASSERT(GLContextWrapper::currentContext());
+    Locker locker { m_lock };
+    Entry* selectedEntry = std::find_if(m_textures.begin(), m_textures.end(), [&](Entry& entry) {
+        return entry.texture->refCount() == 1
+            && entry.texture->size() == size
 #if USE(GBM)
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::BackedByDMABuf) == flags.contains(BitmapTexture::Flags::BackedByDMABuf)
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceLinearBuffer) == flags.contains(BitmapTexture::Flags::ForceLinearBuffer)
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer) == flags.contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer)
+            && entry.texture->flags().contains(BitmapTexture::Flags::BackedByDMABuf) == flags.contains(BitmapTexture::Flags::BackedByDMABuf)
+            && entry.texture->flags().contains(BitmapTexture::Flags::ForceLinearBuffer) == flags.contains(BitmapTexture::Flags::ForceLinearBuffer)
+            && entry.texture->flags().contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer) == flags.contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer)
 #endif
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::UseBGRALayout) == flags.contains(BitmapTexture::Flags::UseBGRALayout)
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer)
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::NearestFiltering) == flags.contains(BitmapTexture::Flags::NearestFiltering);
-        });
+            && entry.texture->flags().contains(BitmapTexture::Flags::UseBGRALayout) == flags.contains(BitmapTexture::Flags::UseBGRALayout)
+            && entry.texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer)
+            && entry.texture->flags().contains(BitmapTexture::Flags::NearestFiltering) == flags.contains(BitmapTexture::Flags::NearestFiltering);
+    });
 
     if (selectedEntry == m_textures.end()) {
         m_textures.append(Entry(BitmapTexture::create(size, flags)));
         selectedEntry = &m_textures.last();
-        m_poolSize += size.unclampedArea();
+        m_poolSizeInBytes += selectedEntry->texture->sizeInBytes();
     } else {
-        RELEASE_ASSERT(size == selectedEntry->m_texture->size());
-        selectedEntry->m_texture->reset(size, flags);
+        RELEASE_ASSERT(size == selectedEntry->texture->size());
+        selectedEntry->texture->reset(size, flags);
     }
 
     enterLimitExceededModeIfNeeded();
@@ -79,12 +99,14 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
     scheduleReleaseUnusedTextures();
 
     selectedEntry->markIsInUse();
-    return selectedEntry->m_texture;
+    return selectedEntry->texture;
 }
 
 #if USE(GBM)
 Ref<BitmapTexture> BitmapTexturePool::createTextureForImage(EGLImage image, OptionSet<BitmapTexture::Flags> flags)
 {
+    ASSERT(GLContextWrapper::currentContext());
+    Locker locker { m_lock };
     auto texture = BitmapTexture::create(image, flags);
     m_imageTextures.append(texture.copyRef());
     scheduleReleaseUnusedTextures();
@@ -94,6 +116,7 @@ Ref<BitmapTexture> BitmapTexturePool::createTextureForImage(EGLImage image, Opti
 
 void BitmapTexturePool::scheduleReleaseUnusedTextures()
 {
+    ASSERT(m_lock.isHeld());
     if (m_releaseUnusedTexturesTimer.isActive())
         return;
 
@@ -102,64 +125,90 @@ void BitmapTexturePool::scheduleReleaseUnusedTextures()
 
 void BitmapTexturePool::releaseUnusedTexturesTimerFired()
 {
-    if (!m_textures.isEmpty()) {
-        // Delete entries, which have been unused in releaseUnusedSecondsTolerance.
-        MonotonicTime minUsedTime = MonotonicTime::now() - m_releaseUnusedSecondsTolerance;
+    Locker locker { m_lock };
 
-        m_textures.removeAllMatching([this, &minUsedTime](const Entry& entry) {
-            if (entry.canBeReleased(minUsedTime)) {
-                m_poolSize -= entry.m_texture->size().unclampedArea();
-                return true;
-            }
-            return false;
-        });
+    auto hasTextures = [this] -> bool {
+        if (!m_textures.isEmpty())
+            return true;
+#if USE(GBM)
+        if (!m_imageTextures.isEmpty())
+            return true;
+#endif
+        return false;
+    };
 
-        exitLimitExceededModeIfNeeded();
-    }
+    if (!hasTextures())
+        return;
+
+    auto releaseTexturesIfNeeded = [&] {
+        if (!m_textures.isEmpty()) {
+            // Delete entries, which have been unused in releaseUnusedSecondsTolerance.
+            MonotonicTime minUsedTime = MonotonicTime::now() - m_releaseUnusedSecondsTolerance;
+
+            auto matchCount = m_textures.removeAllMatching([this, &minUsedTime](const Entry& entry) {
+                if (entry.canBeReleased(minUsedTime)) {
+                    m_poolSizeInBytes -= entry.texture->sizeInBytes();
+                    return true;
+                }
+                return false;
+            });
+
+            if (matchCount)
+                exitLimitExceededModeIfNeeded();
+        }
 
 #if USE(GBM)
-    if (!m_imageTextures.isEmpty()) {
-        m_imageTextures.removeAllMatching([](const BitmapTexture& texture) {
-            return texture.refCount() == 1;
-        });
-    }
-
-    if (!m_textures.isEmpty() && !m_imageTextures.isEmpty())
-        scheduleReleaseUnusedTextures();
-#else
-    if (!m_textures.isEmpty())
-        scheduleReleaseUnusedTextures();
+        if (!m_imageTextures.isEmpty()) {
+            m_imageTextures.removeAllMatching([](const BitmapTexture& texture) {
+                return texture.refCount() == 1;
+            });
+        }
 #endif
+    };
+
+    if (GLContextWrapper::currentContext())
+        releaseTexturesIfNeeded();
+#if !PLATFORM(WIN)
+    else if (auto* context = PlatformDisplay::sharedDisplay().sharingGLContext()) {
+        GLContext::ScopedGLContextCurrent scopedCurrent(*context);
+        releaseTexturesIfNeeded();
+    }
+#endif
+
+    if (hasTextures())
+        scheduleReleaseUnusedTextures();
 }
 
 void BitmapTexturePool::enterLimitExceededModeIfNeeded()
 {
+    ASSERT(m_lock.isHeld());
     if (m_onLimitExceededMode)
         return;
 
-    if (m_poolSize > poolSizeLimit) {
+    if (m_poolSizeInBytes > s_poolSizeLimitInBytes) {
         // If we allocated a new texture and this caused that we went over the size limit, enter limit exceeded mode,
         // set values for tolerance and interval for this mode, and trigger an immediate request to release textures.
         // While on limit exceeded mode, we are more aggressive releasing textures, by polling more often and keeping
         // the unused textures in the pool for smaller periods of time.
         m_onLimitExceededMode = true;
-        m_releaseUnusedSecondsTolerance = releaseUnusedSecondsToleranceOnLimitExceeded;
-        m_releaseUnusedTexturesTimerInterval = releaseUnusedTexturesTimerIntervalOnLimitExceeded;
+        m_releaseUnusedSecondsTolerance = s_releaseUnusedSecondsToleranceOnLimitExceeded;
+        m_releaseUnusedTexturesTimerInterval = s_releaseUnusedTexturesTimerIntervalOnLimitExceeded;
         m_releaseUnusedTexturesTimer.startOneShot(0_s);
     }
 }
 
 void BitmapTexturePool::exitLimitExceededModeIfNeeded()
 {
+    ASSERT(m_lock.isHeld());
     if (!m_onLimitExceededMode)
         return;
 
     // If we're in limit exceeded mode and the pool size has become smaller than the limit,
     // exit the limit exceeded mode and set the default values for interval and tolerance again.
-    if (m_poolSize <= poolSizeLimit) {
+    if (m_poolSizeInBytes <= s_poolSizeLimitInBytes) {
         m_onLimitExceededMode = false;
-        m_releaseUnusedSecondsTolerance = releaseUnusedSecondsTolerance;
-        m_releaseUnusedTexturesTimerInterval = releaseUnusedTexturesTimerInterval;
+        m_releaseUnusedSecondsTolerance = s_releaseUnusedSecondsTolerance;
+        m_releaseUnusedTexturesTimerInterval = s_releaseUnusedTexturesTimerInterval;
     }
 }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
- * Copyright (C) 2014 Igalia S.L.
+ * Copyright (C) 2014, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,61 +29,69 @@
 #if USE(TEXTURE_MAPPER)
 
 #include "BitmapTexture.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/Lock.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 
 typedef void *EGLImage;
 
 namespace WebCore {
-class BitmapTexturePool;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::BitmapTexturePool> : std::true_type { };
-}
-
-namespace WebCore {
-
 class IntSize;
 
-class BitmapTexturePool {
-    WTF_MAKE_NONCOPYABLE(BitmapTexturePool);
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(BitmapTexturePool);
+// Thread safe singleton to create textures for any GL context created with the shared PlatformDisplay sharing context.
+// It should be used with a current GL context to be able to create the textures.
+// Unused textures are automatically deleted in the main thread using a timer.
+class BitmapTexturePool final : public CanMakeThreadSafeCheckedPtr<BitmapTexturePool> {
+    WTF_MAKE_TZONE_ALLOCATED(BitmapTexturePool);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BitmapTexturePool);
 public:
-    BitmapTexturePool();
+    WEBCORE_EXPORT static BitmapTexturePool& singleton();
+    ~BitmapTexturePool() = default;
 
-    Ref<BitmapTexture> acquireTexture(const IntSize&, OptionSet<BitmapTexture::Flags>);
+    WEBCORE_EXPORT Ref<BitmapTexture> acquireTexture(const IntSize&, OptionSet<BitmapTexture::Flags>);
 #if USE(GBM)
     Ref<BitmapTexture> createTextureForImage(EGLImage, OptionSet<BitmapTexture::Flags>);
 #endif
-    void releaseUnusedTexturesTimerFired();
+
+#if USE(GRAPHICS_LAYER_WC)
+    void releaseUnusedTexturesNow() { releaseUnusedTexturesTimerFired(); }
+#endif
 
 private:
+    friend class NeverDestroyed<BitmapTexturePool>;
+    BitmapTexturePool();
+
     struct Entry {
         explicit Entry(Ref<BitmapTexture>&& texture)
-            : m_texture(WTF::move(texture))
+            : texture(WTF::move(texture))
         { }
 
-        void markIsInUse() { m_lastUsedTime = MonotonicTime::now(); }
-        bool canBeReleased (MonotonicTime minUsedTime) const { return m_lastUsedTime < minUsedTime && m_texture->refCount() == 1; }
+        void markIsInUse() { lastUsedTime = MonotonicTime::now(); }
+        bool canBeReleased (MonotonicTime minUsedTime) const { return lastUsedTime < minUsedTime && texture->refCount() == 1; }
 
-        const Ref<BitmapTexture> m_texture;
-        MonotonicTime m_lastUsedTime;
+        const Ref<BitmapTexture> texture;
+        MonotonicTime lastUsedTime;
     };
 
     void scheduleReleaseUnusedTextures();
     void enterLimitExceededModeIfNeeded();
     void exitLimitExceededModeIfNeeded();
+    void releaseUnusedTexturesTimerFired();
 
-    Vector<Entry> m_textures;
+    Lock m_lock;
+    Vector<Entry> m_textures WTF_GUARDED_BY_LOCK(m_lock);
 #if USE(GBM)
-    Vector<Ref<BitmapTexture>> m_imageTextures;
+    Vector<Ref<BitmapTexture>> m_imageTextures WTF_GUARDED_BY_LOCK(m_lock);
 #endif
-    RunLoop::Timer m_releaseUnusedTexturesTimer;
-    uint64_t m_poolSize { 0 };
-    bool m_onLimitExceededMode { false };
-    Seconds m_releaseUnusedSecondsTolerance;
-    Seconds m_releaseUnusedTexturesTimerInterval;
+    RunLoop::Timer m_releaseUnusedTexturesTimer WTF_GUARDED_BY_LOCK(m_lock);
+    uint64_t m_poolSizeInBytes WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    bool m_onLimitExceededMode WTF_GUARDED_BY_LOCK(m_lock) { false };
+    Seconds m_releaseUnusedSecondsTolerance WTF_GUARDED_BY_LOCK(m_lock);
+    Seconds m_releaseUnusedTexturesTimerInterval WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -24,7 +24,7 @@
 
 #if USE(TEXTURE_MAPPER)
 
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "ClipPath.h"
 #include "FilterOperations.h"
 #include "FloatPolygon.h"
@@ -217,25 +217,13 @@ TextureMapper::TextureMapper()
 {
 }
 
-Ref<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
-{
-    return m_texturePool.acquireTexture(size, flags);
-}
-
-#if USE(GBM)
-Ref<BitmapTexture> TextureMapper::createTextureForImage(EGLImage image, OptionSet<BitmapTexture::Flags> flags)
-{
-    return m_texturePool.createTextureForImage(image, flags);
-}
-#endif
-
 #if USE(GRAPHICS_LAYER_WC)
 void TextureMapper::releaseUnusedTexturesNow()
 {
     // GraphicsLayerWC runs TextureMapper in the OpenGL thread of the
     // GPU process that doesn't use RunLoop. RunLoop::Timer doesn't
     // work in the thread.
-    m_texturePool.releaseUnusedTexturesTimerFired();
+    BitmapTexturePool::singleton().releaseUnusedTexturesNow();
 }
 #endif
 
@@ -328,7 +316,7 @@ void TextureMapper::drawNumber(int number, const Color& color, const FloatPoint&
     IntRect sourceRect(IntPoint::zero(), size);
     IntRect targetRect(roundedIntPoint(targetPoint), size);
 
-    auto texture = m_texturePool.acquireTexture(size, { BitmapTexture::Flags::SupportsAlpha });
+    auto texture = BitmapTexturePool::singleton().acquireTexture(size, { BitmapTexture::Flags::SupportsAlpha });
     const unsigned char* bits = cairo_image_surface_get_data(surface);
     int stride = cairo_image_surface_get_stride(surface);
     texture->updateContents(bits, sourceRect, IntPoint::zero(), stride, PixelFormat::BGRA8);
@@ -1050,7 +1038,7 @@ RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture>& sour
     if (radiusX < MinBlurRadius && radiusY < MinBlurRadius)
         return sourceTexture;
 
-    RefPtr<BitmapTexture> resultTexture = m_texturePool.acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
+    RefPtr<BitmapTexture> resultTexture = BitmapTexturePool::singleton().acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
     IntSize currentSize = textureSize;
     IntSize targetSize = currentSize;
     Vector<Direction> blurDirections;
@@ -1126,8 +1114,9 @@ RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture>& sour
 RefPtr<BitmapTexture> TextureMapper::applyDropShadowFilter(RefPtr<BitmapTexture>& sourceTexture, const DropShadowFilterOperation& dropShadowFilter)
 {
     const auto& textureSize = sourceTexture->size();
-    RefPtr<BitmapTexture> resultTexture = m_texturePool.acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
-    RefPtr<BitmapTexture> contentTexture = m_texturePool.acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
+    auto& texturePool = BitmapTexturePool::singleton();
+    RefPtr<BitmapTexture> resultTexture = texturePool.acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
+    RefPtr<BitmapTexture> contentTexture = texturePool.acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
     IntSize currentSize = textureSize;
     IntSize targetSize = currentSize;
     float radius = float(dropShadowFilter.stdDeviation());
@@ -1252,7 +1241,7 @@ RefPtr<BitmapTexture> TextureMapper::applySinglePassFilter(RefPtr<BitmapTexture>
         return sourceTexture;
     }
 
-    RefPtr<BitmapTexture> resultTexture = m_texturePool.acquireTexture(sourceTexture->size(), { BitmapTexture::Flags::SupportsAlpha });
+    RefPtr<BitmapTexture> resultTexture = BitmapTexturePool::singleton().acquireTexture(sourceTexture->size(), { BitmapTexture::Flags::SupportsAlpha });
 
     bindSurface(resultTexture.get());
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -21,7 +21,6 @@
 
 #if USE(TEXTURE_MAPPER)
 
-#include "BitmapTexturePool.h"
 #include "ClipStack.h"
 #include "Color.h"
 #include "Damage.h"
@@ -42,7 +41,7 @@
 typedef void *EGLImage;
 
 namespace WebCore {
-
+class BitmapTexture;
 class ClipPath;
 class TextureMapperGLData;
 class TextureMapperGPUBuffer;
@@ -110,11 +109,6 @@ public:
 
     RefPtr<BitmapTexture> applyFilters(RefPtr<BitmapTexture>&, const FilterOperations&, bool defersLastPass);
 
-    WEBCORE_EXPORT Ref<BitmapTexture> acquireTextureFromPool(const IntSize&, OptionSet<BitmapTexture::Flags>);
-#if USE(GBM)
-    WEBCORE_EXPORT Ref<BitmapTexture> createTextureForImage(EGLImage, OptionSet<BitmapTexture::Flags>);
-#endif
-
 #if USE(GRAPHICS_LAYER_WC)
     WEBCORE_EXPORT void releaseUnusedTexturesNow();
 #endif
@@ -153,7 +147,6 @@ private:
 
     void updateProjectionMatrix();
 
-    BitmapTexturePool m_texturePool;
     bool m_isMaskMode { false };
     TransformationMatrix m_patternTransform;
     WrapMode m_wrapMode { WrapMode::Stretch };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -21,7 +21,7 @@
 #include "config.h"
 #include "TextureMapperLayer.h"
 
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "ClipPath.h"
 #include "FloatQuad.h"
 #include "Region.h"
@@ -95,7 +95,7 @@ public:
 
         auto maxTextureSize = options.textureMapper.maxTextureSize();
         forEachTile(maxTextureSize, [&](const IntRect& tileRect) {
-            RefPtr<BitmapTexture> surface = options.textureMapper.acquireTextureFromPool(tileRect.size(), { BitmapTexture::Flags::SupportsAlpha });
+            RefPtr<BitmapTexture> surface = BitmapTexturePool::singleton().acquireTexture(tileRect.size(), { BitmapTexture::Flags::SupportsAlpha });
             {
                 SetForScope scopedSurface(options.surface, surface);
                 SetForScope scopedOffset(options.offset, -toIntSize(tileRect.location()));
@@ -1111,7 +1111,7 @@ static void commitSurface(TextureMapperPaintOptions& options, BitmapTexture& sur
 
 void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
 {
-    auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
+    auto surface = BitmapTexturePool::singleton().acquireTexture(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
         SetForScope scopedSurface(options.surface, surface.ptr());
         SetForScope scopedOffset(options.offset, -toIntSize(rect.location()));
@@ -1127,7 +1127,7 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
 
 void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
 {
-    auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
+    auto surface = BitmapTexturePool::singleton().acquireTexture(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
         SetForScope scopedSurface(options.surface, surface.ptr());
         SetForScope scopedOffset(options.offset, -toIntSize(rect.location()));

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -47,10 +47,10 @@ void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect,
     it->value.addUpdate({ WTF::move(buffer), sourceRect, tileRect, offset });
 }
 
-void CoordinatedBackingStore::processPendingUpdates(TextureMapper& textureMapper)
+void CoordinatedBackingStore::processPendingUpdates()
 {
     for (auto& tile : m_tiles.values())
-        tile.processPendingUpdates(textureMapper);
+        tile.processPendingUpdates();
 }
 
 void CoordinatedBackingStore::resize(const FloatSize& size, float scale)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -43,7 +43,7 @@ public:
     void removeTile(uint32_t tileID);
     void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&, const IntPoint&);
 
-    void processPendingUpdates(TextureMapper&);
+    void processPendingUpdates();
 
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
     void drawBorder(TextureMapper&, const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -22,10 +22,9 @@
 #include "CoordinatedBackingStoreTile.h"
 
 #if USE(COORDINATED_GRAPHICS)
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "CoordinatedTileBuffer.h"
 #include "GraphicsLayer.h"
-#include "TextureMapper.h"
 #include <wtf/SystemTracing.h>
 
 #if USE(SKIA)
@@ -46,7 +45,7 @@ void CoordinatedBackingStoreTile::addUpdate(Update&& update)
     m_updates.append(WTF::move(update));
 }
 
-void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMapper)
+void CoordinatedBackingStoreTile::processPendingUpdates()
 {
     auto updates = WTF::move(m_updates);
     auto updatesCount = updates.size();
@@ -58,9 +57,6 @@ void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMa
         auto& update = updates[updateIndex];
 
         WTFBeginSignpost(this, CoordinatedSwapBuffer, "%u/%zu, rect %ix%i+%i+%i", updateIndex + 1, updatesCount, update.tileRect.x(), update.tileRect.y(), update.tileRect.width(), update.tileRect.height());
-
-        ASSERT(textureMapper.maxTextureSize().width() >= update.tileRect.size().width());
-        ASSERT(textureMapper.maxTextureSize().height() >= update.tileRect.size().height());
 
         FloatRect unscaledTileRect(update.tileRect);
         unscaledTileRect.scale(1. / m_scale);
@@ -82,7 +78,7 @@ void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMa
         WTFBeginSignpost(this, AcquireTexture);
         if (!m_texture || unscaledTileRect != m_rect) {
             m_rect = unscaledTileRect;
-            m_texture = textureMapper.acquireTextureFromPool(update.tileRect.size(), flags);
+            m_texture = BitmapTexturePool::singleton().acquireTexture(update.tileRect.size(), flags);
         } else if (update.buffer->supportsAlpha() == m_texture->isOpaque())
             m_texture->reset(update.tileRect.size(), flags);
         WTFEndSignpost(this, AcquireTexture);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -28,7 +28,6 @@
 namespace WebCore {
 class BitmapTexture;
 class CoordinatedTileBuffer;
-class TextureMapper;
 
 class CoordinatedBackingStoreTile {
 public:
@@ -47,7 +46,7 @@ public:
     };
     void addUpdate(Update&&);
 
-    void processPendingUpdates(TextureMapper&);
+    void processPendingUpdates();
 
     bool canBePainted() const { return !!m_texture; }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -907,7 +907,7 @@ void CoordinatedPlatformLayer::waitUntilPaintingComplete()
         m_backingStoreProxy->waitUntilPaintingComplete();
 }
 
-void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons, TextureMapper& textureMapper)
+void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons)
 {
     ASSERT(!isMainThread());
     Locker locker { m_lock };
@@ -1091,7 +1091,7 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
             for (const auto& tileUpdate : update.tilesToUpdate())
                 m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
 
-            m_backingStore->processPendingUpdates(textureMapper);
+            m_backingStore->processPendingUpdates();
         }
     }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -47,7 +47,6 @@ class CoordinatedPlatformLayerBuffer;
 class CoordinatedTileBuffer;
 class GraphicsLayerCoordinated;
 class NativeImage;
-class TextureMapper;
 class TextureMapperLayer;
 
 #if USE(SKIA)
@@ -184,7 +183,7 @@ public:
     void updateContents(bool affectedByTransformAnimation);
     void updateBackingStore();
 
-    void flushCompositingState(const OptionSet<CompositionReason>&, TextureMapper&);
+    void flushCompositingState(const OptionSet<CompositionReason>&);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
     bool isCompositionRequiredOrOngoing() const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -27,7 +27,7 @@
 #include "CoordinatedPlatformLayerBufferDMABuf.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(GBM)
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayerBufferRGB.h"
 #include "CoordinatedPlatformLayerBufferYUV.h"
 #include "DMABufBuffer.h"
@@ -66,7 +66,7 @@ CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf(Ref<D
 
 CoordinatedPlatformLayerBufferDMABuf::~CoordinatedPlatformLayerBufferDMABuf() = default;
 
-static RefPtr<BitmapTexture> importToTexture(const IntSize& size, const IntSize& subsampling, uint32_t fourcc, const Vector<int>& fds, const Vector<uint32_t>& offsets, const Vector<uint32_t>& strides, uint64_t modifier, OptionSet<BitmapTexture::Flags> textureFlags, TextureMapper& textureMapper)
+static RefPtr<BitmapTexture> importToTexture(const IntSize& size, const IntSize& subsampling, uint32_t fourcc, const Vector<int>& fds, const Vector<uint32_t>& offsets, const Vector<uint32_t>& strides, uint64_t modifier, OptionSet<BitmapTexture::Flags> textureFlags)
 {
     auto& display = PlatformDisplay::sharedDisplay();
     Vector<EGLAttrib> attributes = {
@@ -109,7 +109,7 @@ static RefPtr<BitmapTexture> importToTexture(const IntSize& size, const IntSize&
     if (!image)
         return nullptr;
 
-    auto texture = textureMapper.createTextureForImage(image, textureFlags);
+    auto texture = BitmapTexturePool::singleton().createTextureForImage(image, textureFlags);
     display.destroyEGLImage(image);
     return texture;
 }
@@ -193,7 +193,7 @@ static const HashMap<uint32_t, Vector<YUVPlaneInfo>>& yuvFormatPlaneInfo()
     return yuvFormatsMap;
 }
 
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importYUV(TextureMapper& textureMapper) const
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importYUV() const
 {
     OptionSet<BitmapTexture::Flags> textureFlags;
     if (m_flags.contains(TextureMapperFlags::ShouldBlend))
@@ -211,7 +211,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     const auto& planeInfo = iter->value;
     for (unsigned i = 0; i < planeInfo.size(); ++i) {
         const auto& plane = planeInfo[i];
-        auto texture = importToTexture(attributes.size, plane.subsampling, plane.fourcc, { attributes.fds[i].value() }, { attributes.offsets[i] }, { attributes.strides[i] }, attributes.modifier, textureFlags, textureMapper);
+        auto texture = importToTexture(attributes.size, plane.subsampling, plane.fourcc, { attributes.fds[i].value() }, { attributes.offsets[i] }, { attributes.strides[i] }, attributes.modifier, textureFlags);
         if (!texture)
             return nullptr;
         textures.append(WTF::move(texture));
@@ -252,11 +252,11 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     return CoordinatedPlatformLayerBufferYUV::create(numberOfPlanes, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
 }
 
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importDMABuf(TextureMapper& textureMapper) const
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importDMABuf() const
 {
     const auto& attributes = m_dmabuf->attributes();
     if (formatIsYUV(attributes.fourcc))
-        return importYUV(textureMapper);
+        return importYUV();
 
     OptionSet<BitmapTexture::Flags> textureFlags;
     if (m_flags.contains(TextureMapperFlags::ShouldBlend))
@@ -264,7 +264,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     Vector<int> fds = attributes.fds.map<Vector<int>>([] (const UnixFileDescriptor& fd) {
         return fd.value();
     });
-    auto texture = importToTexture(attributes.size, { 1, 1 }, attributes.fourcc, fds, attributes.offsets, attributes.strides, attributes.modifier, textureFlags, textureMapper);
+    auto texture = importToTexture(attributes.size, { 1, 1 }, attributes.fourcc, fds, attributes.offsets, attributes.strides, attributes.modifier, textureFlags);
     return texture ? CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), m_flags, nullptr) : nullptr;
 }
 
@@ -278,7 +278,7 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
     }
 
     if (!m_dmabuf->buffer())
-        m_dmabuf->setBuffer(importDMABuf(textureMapper));
+        m_dmabuf->setBuffer(importDMABuf());
 
     if (auto* buffer = m_dmabuf->buffer())
         buffer->paintToTextureMapper(textureMapper, targetRect, modelViewMatrix, opacity);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -45,8 +45,8 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> importDMABuf(TextureMapper&) const;
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> importYUV(TextureMapper&) const;
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> importDMABuf() const;
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> importYUV() const;
 
     const Ref<DMABufBuffer> m_dmabuf;
     WTF::UnixFileDescriptor m_fenceFD;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -27,7 +27,7 @@
 #include "CoordinatedPlatformLayerBufferExternalOES.h"
 
 #if USE(COORDINATED_GRAPHICS)
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "PlatformDisplay.h"
 #include "TextureMapper.h"
 #include <wtf/MathExtras.h>
@@ -101,7 +101,7 @@ void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapp
     OptionSet<BitmapTexture::Flags> textureFlags { BitmapTexture::Flags::ExternalOESRenderTarget };
     if (m_flags.contains(TextureMapperFlags::ShouldBlend))
         textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-    auto texture = textureMapper.createTextureForImage(image, textureFlags);
+    auto texture = BitmapTexturePool::singleton().createTextureForImage(image, textureFlags);
     textureMapper.drawTextureExternalOESYUV(texture->id(), m_flags, targetRect, modelViewMatrix, opacity);
     display.destroyEGLImage(image);
 #endif // USE(GSTREAMER) && USE(GBM)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -27,7 +27,7 @@
 #include "CoordinatedPlatformLayerBufferNativeImage.h"
 
 #if USE(COORDINATED_GRAPHICS)
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayerBufferRGB.h"
 #include "NativeImage.h"
 #include "TextureMapper.h"
@@ -103,7 +103,7 @@ CoordinatedPlatformLayerBufferNativeImage::~CoordinatedPlatformLayerBufferNative
 #endif
 }
 
-bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(TextureMapper& textureMapper)
+bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer()
 {
     if (m_buffer)
         return true;
@@ -116,7 +116,7 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(TextureMapper& t
     OptionSet<BitmapTexture::Flags> textureFlags;
     if (m_image->hasAlpha())
         textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-    auto texture = textureMapper.acquireTextureFromPool(m_size, textureFlags);
+    auto texture = BitmapTexturePool::singleton().acquireTexture(m_size, textureFlags);
 
 #if USE(CAIRO)
     auto* surface = m_image->platformImage().get();
@@ -137,7 +137,7 @@ void CoordinatedPlatformLayerBufferNativeImage::paintToTextureMapper(TextureMapp
 {
     waitForContentsIfNeeded();
 
-    if (!tryEnsureBuffer(textureMapper))
+    if (!tryEnsureBuffer())
         return;
 
     m_buffer->paintToTextureMapper(textureMapper, targetRect, modelViewMatrix, opacity);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -43,7 +43,7 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
-    bool tryEnsureBuffer(TextureMapper&);
+    bool tryEnsureBuffer();
 
     RefPtr<NativeImage> m_image;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -28,6 +28,7 @@
 #include "CoordinatedPlatformLayerBufferVideo.h"
 
 #if USE(COORDINATED_GRAPHICS) && ENABLE(VIDEO) && USE(GSTREAMER)
+#include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayerBufferExternalOES.h"
 #include "CoordinatedPlatformLayerBufferRGB.h"
 #include "CoordinatedPlatformLayerBufferYUV.h"
@@ -220,7 +221,7 @@ void CoordinatedPlatformLayerBufferVideo::paintToTextureMapper(TextureMapper& te
             OptionSet<BitmapTexture::Flags> textureFlags;
             if (GST_VIDEO_INFO_HAS_ALPHA(m_mappedVideoFrame->info()))
                 textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-            auto texture = textureMapper.acquireTextureFromPool(m_size, textureFlags);
+            auto texture = BitmapTexturePool::singleton().acquireTexture(m_size, textureFlags);
 
             auto* meta = gst_buffer_get_video_gl_texture_upload_meta(m_mappedVideoFrame->get()->buffer);
             if (meta && meta->n_textures == 1) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -27,6 +27,7 @@
 #include "CoordinatedPlatformLayerBufferYUV.h"
 
 #if USE(COORDINATED_GRAPHICS)
+#include "BitmapTexturePool.h"
 #include "TextureMapper.h"
 
 namespace WebCore {

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -34,7 +34,7 @@
 #include "WCRemoteFrameHostLayerManager.h"
 #include "WCSceneContext.h"
 #include "WCUpdateInfo.h"
-#include <WebCore/BitmapTexture.h>
+#include <WebCore/BitmapTexturePool.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/TextureMapper.h>
 #include <WebCore/TextureMapperGLHeaders.h>
@@ -261,11 +261,11 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
 
     if (update.remoteContextHostedIdentifier) {
         showFPS = false;
-        texture = m_textureMapper->acquireTextureFromPool(update.viewport, { WebCore::BitmapTexture::Flags::SupportsAlpha });
+        texture = WebCore::BitmapTexturePool::singleton().acquireTexture(update.viewport, { WebCore::BitmapTexture::Flags::SupportsAlpha });
         surface = texture.get();
     } else if (m_usesOffscreenRendering) {
         readPixel = true;
-        texture = m_textureMapper->acquireTextureFromPool(update.viewport, { WebCore::BitmapTexture::Flags::SupportsAlpha });
+        texture = WebCore::BitmapTexturePool::singleton().acquireTexture(update.viewport, { WebCore::BitmapTexture::Flags::SupportsAlpha });
         surface = texture.get();
     } else
         glViewport(0, 0, update.viewport.width(), update.viewport.height());

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -257,9 +257,9 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
         ASSERT(!reasons.contains(CompositionReason::RenderingUpdate) || !m_state.isWaitingForTiles);
     }
 #endif
-    m_sceneState->rootLayer().flushCompositingState(reasons, *m_textureMapper);
+    m_sceneState->rootLayer().flushCompositingState(reasons);
     for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState(reasons, *m_textureMapper);
+        layer->flushCompositingState(reasons);
 }
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
@@ -231,9 +231,9 @@ void ThreadedCompositor::updateSceneState()
         m_textureMapper = TextureMapper::create();
 
     auto reasons = OptionSet<CompositionReason>::all();
-    m_sceneState->rootLayer().flushCompositingState(reasons, *m_textureMapper);
+    m_sceneState->rootLayer().flushCompositingState(reasons);
     for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState(reasons, *m_textureMapper);
+        layer->flushCompositingState(reasons);
 }
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size)


### PR DESCRIPTION
#### 18abb7fe7acbbae52060ef6a9c14fbe123de86f1
<pre>
[TextureMapper] Make BitmapTexturePool a singleton
<a href="https://bugs.webkit.org/show_bug.cgi?id=308739">https://bugs.webkit.org/show_bug.cgi?id=308739</a>

Reviewed by Miguel Gomez.

It&apos;s currently used by the main thread to create textures for the layer
tiles and from the compositing thread to create the compositing layer
textures. All those textures belong to the global PlatformDisplay
sharing context, so we could have only one global pool that could be
used from different threads.

* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::SkiaPaintingEngine::createBuffer const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::sizeInBytes const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::singleton):
(WebCore::BitmapTexturePool::BitmapTexturePool):
(WebCore::BitmapTexturePool::acquireTexture):
(WebCore::BitmapTexturePool::createTextureForImage):
(WebCore::BitmapTexturePool::scheduleReleaseUnusedTextures):
(WebCore::BitmapTexturePool::releaseUnusedTexturesTimerFired):
(WebCore::BitmapTexturePool::enterLimitExceededModeIfNeeded):
(WebCore::BitmapTexturePool::exitLimitExceededModeIfNeeded):
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
(WebCore::BitmapTexturePool::Entry::Entry): Deleted.
(WebCore::BitmapTexturePool::Entry::markIsInUse): Deleted.
(WebCore::BitmapTexturePool::Entry::canBeReleased const): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::releaseUnusedTexturesNow):
(WebCore::TextureMapper::drawNumber):
(WebCore::TextureMapper::applyBlurFilter):
(WebCore::TextureMapper::applyDropShadowFilter):
(WebCore::TextureMapper::applySinglePassFilter):
(WebCore::TextureMapper::acquireTextureFromPool): Deleted.
(WebCore::TextureMapper::createTextureForImage): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintWithIntermediateSurface):
(WebCore::TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::importToTexture):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::importYUV const):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::importDMABuf const):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer):
(WebCore::CoordinatedPlatformLayerBufferNativeImage::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp:
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::flushCompositingState):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp:
(WebKit::ThreadedCompositor::updateSceneState):

Canonical link: <a href="https://commits.webkit.org/308545@main">https://commits.webkit.org/308545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70c004609de85b1c80935d144983b0a152527947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113947 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94707 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13129 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158822 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121976 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122178 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76414 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9222 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19633 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->