### PR TITLE
[YARR] Clear captures when backtracking out of positive lookahead in JIT

### DIFF
--- a/JSTests/stress/regexp-lookahead-capture-backtrack.js
+++ b/JSTests/stress/regexp-lookahead-capture-backtrack.js
@@ -1,0 +1,75 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected + (msg ? " (" + msg + ")" : ""));
+}
+
+function shouldBeNull(actual, msg) {
+    if (actual !== null)
+        throw new Error("Bad value: " + JSON.stringify(actual) + " expected: null" + (msg ? " (" + msg + ")" : ""));
+}
+
+function shouldBeUndefined(actual, msg) {
+    if (actual !== undefined)
+        throw new Error("Bad value: " + JSON.stringify(actual) + " expected: undefined" + (msg ? " (" + msg + ")" : ""));
+}
+
+for (var i = 0; i < testLoopCount; i++) {
+    var r;
+
+    r = "x".match(/(?:(?=(x))y|x)/);
+    shouldBe(r[0], "x", "case 1 match");
+    shouldBeUndefined(r[1], "case 1 group 1");
+
+    r = "ab".match(/(?:(?=(a)(b))x|.)/);
+    shouldBe(r[0], "a", "case 2 match");
+    shouldBeUndefined(r[1], "case 2 group 1");
+    shouldBeUndefined(r[2], "case 2 group 2");
+
+    r = "abcdef".match(/(?:c(?=(def))x|c)/);
+    shouldBe(r[0], "c", "case 3 match");
+    shouldBeUndefined(r[1], "case 3 group 1");
+
+    r = "abc".match(/(?:(?=(abc))d|a)/);
+    shouldBe(r[0], "a", "case 4 match");
+    shouldBeUndefined(r[1], "case 4 group 1");
+
+    r = "ab".match(/(?:(?:(?=(ab))c|a)d|ab)/);
+    shouldBe(r[0], "ab", "case 5 match");
+    shouldBeUndefined(r[1], "case 5 group 1");
+
+    r = "x".match(/(?:(?=(x))(?=(x))y|x)/);
+    shouldBe(r[0], "x", "case 6 match");
+    shouldBeUndefined(r[1], "case 6 group 1");
+    shouldBeUndefined(r[2], "case 6 group 2");
+
+    r = "x".match(/(?:y|(?=(x))z|x)/);
+    shouldBe(r[0], "x", "case 7 match");
+    shouldBeUndefined(r[1], "case 7 group 1");
+
+    r = "ab".match(/(?:(?=(a)(b))xy|ab)/);
+    shouldBe(r[0], "ab", "case 8 match");
+    shouldBeUndefined(r[1], "case 8 group 1");
+    shouldBeUndefined(r[2], "case 8 group 2");
+
+    r = "a".match(/(?:(?=(a))b|(?=(c))d|a)/);
+    shouldBe(r[0], "a", "case 9 match");
+    shouldBeUndefined(r[1], "case 9 group 1");
+    shouldBeUndefined(r[2], "case 9 group 2");
+
+    r = "x".match(/(?:(?=(?<n>x))y|x)/);
+    shouldBe(r[0], "x", "case 10 match");
+    shouldBeUndefined(r[1], "case 10 named group");
+
+    r = "abc".match(/(?:(?=(abc))+d|abc)/);
+    shouldBe(r[0], "abc", "case 11 match");
+    shouldBeUndefined(r[1], "case 11 group 1");
+
+    r = "a".match(/(?:(?=(a))b|a)(.?)/);
+    shouldBe(r[0], "a", "case 12 match");
+    shouldBeUndefined(r[1], "case 12 group 1");
+    shouldBe(r[2], "", "case 12 group 2");
+
+    r = "x".match(/(?:(?=(?<a>x))y|(?=(?<a>x))x)/);
+    shouldBe(r[0], "x", "case 13 match");
+    shouldBe(r.groups.a, "x", "case 13 duplicate named group");
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5169,6 +5169,16 @@ class YarrGenerator final : public YarrJITInfo {
             }
             case YarrOpCode::ParentheticalAssertionEnd: {
                 // Never backtrack into an assertion; later failures bail to before the begin.
+                // For positive assertions with captures, we must clear the captures before
+                // propagating the backtrack. The assertion matched and set captures, but
+                // something after it failed, so those captures must be reset to undefined.
+                PatternTerm* term = op.m_term;
+                if (!term->invert() && shouldRecordSubpatterns() && term->containsAnyCaptures()) {
+                    m_backtrackingState.link(*this, op);
+                    for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                        clearSubpattern(subpattern);
+                    m_backtrackingState.fallthrough();
+                }
                 m_backtrackingState.takeBacktracksToJumpList(op.m_jumps, &m_jit);
                 break;
             }


### PR DESCRIPTION
#### 0bebf49082ee03d028cd6c079ff4416ae25ddf89
<pre>
[YARR] Clear captures when backtracking out of positive lookahead in JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=308738">https://bugs.webkit.org/show_bug.cgi?id=308738</a>

Reviewed by Yusuke Suzuki.

When a positive lookahead with captures succeeds but the following
pattern fails, the JIT leaks stale capture values into subsequent
alternatives. The interpreter already clears them in
backtrackParentheticalAssertionEnd; this patch adds the same logic
to the JIT&apos;s ParentheticalAssertionEnd backtrack handler.

  &quot;x&quot;.match(/(?:(?=(x))y|x)/)

      Expected: [&quot;x&quot;, undefined]
      Actual  : [&quot;x&quot;, &quot;x&quot;]

Test: JSTests/stress/regexp-lookahead-capture-backtrack.js

* JSTests/stress/regexp-lookahead-capture-backtrack.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/308517@main">https://commits.webkit.org/308517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29bb973b381153736fcab2e0cebcec36d4af24f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113281 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80835 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94037 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12698 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3133 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158022 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/7797 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1153 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121303 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31285 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75459 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8576 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82861 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45658 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->