### PR TITLE
[GStreamer][GL] Use a media player weak pointer in the video sink

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -57,14 +57,12 @@ struct _WebKitGLVideoSinkPrivate {
     ~_WebKitGLVideoSinkPrivate()
     {
         ASSERT(isMainThread());
-        if (mediaPlayerPrivate)
-            g_signal_handlers_disconnect_by_data(appSink.get(), mediaPlayerPrivate);
-
+        webKitVideoSinkDisconnectSignalHandlers(appSink.get(), signalIdentifiers);
         GST_DEBUG_OBJECT(appSink.get(), "WebKitGLVideoSink finalized.");
     }
 
     GRefPtr<GstElement> appSink;
-    MediaPlayerPrivateGStreamer* mediaPlayerPrivate;
+    WebKitVideoSinkSignalIdentifiers signalIdentifiers;
 };
 
 #define GST_GL_CAPS_FORMAT "{ A420, RGBx, RGBA, I420, Y444, YV12, Y41B, Y42B, NV12, NV21, VUYA }"
@@ -275,12 +273,11 @@ static void webkit_gl_video_sink_class_init(WebKitGLVideoSinkClass* klass)
     elementClass->change_state = GST_DEBUG_FUNCPTR(webKitGLVideoSinkChangeState);
 }
 
-void webKitGLVideoSinkSetMediaPlayerPrivate(WebKitGLVideoSink* sink, MediaPlayerPrivateGStreamer* player)
+void webKitGLVideoSinkSetMediaPlayerPrivate(WebKitGLVideoSink* sink, const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
 {
     WebKitGLVideoSinkPrivate* priv = sink->priv;
 
-    priv->mediaPlayerPrivate = player;
-    webKitVideoSinkSetMediaPlayerPrivate(priv->appSink.get(), priv->mediaPlayerPrivate);
+    priv->signalIdentifiers = webKitVideoSinkSetMediaPlayerPrivate(priv->appSink.get(), player);
 }
 
 bool webKitGLVideoSinkProbePlatform()

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.h
@@ -21,6 +21,7 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
 
 #include <gst/gst.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class MediaPlayerPrivateGStreamer;
@@ -41,7 +42,7 @@ typedef struct _WebKitGLVideoSinkPrivate WebKitGLVideoSinkPrivate;
 struct _WebKitGLVideoSink {
     GstBin parent;
 
-    WebKitGLVideoSinkPrivate *priv;
+    WebKitGLVideoSinkPrivate* priv;
 };
 
 struct _WebKitGLVideoSinkClass {
@@ -50,9 +51,9 @@ struct _WebKitGLVideoSinkClass {
 
 GType webkit_gl_video_sink_get_type(void);
 
-bool webKitGLVideoSinkProbePlatform();
-void webKitGLVideoSinkSetMediaPlayerPrivate(WebKitGLVideoSink*, WebCore::MediaPlayerPrivateGStreamer*);
-
 G_END_DECLS
+
+bool webKitGLVideoSinkProbePlatform();
+void webKitGLVideoSinkSetMediaPlayerPrivate(WebKitGLVideoSink*, const ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamer>&);
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER_GL)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -34,7 +34,7 @@ class WebKitVideoSinkProbe {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitVideoSinkProbe);
 public:
 
-    WebKitVideoSinkProbe(MediaPlayerPrivateGStreamer* player)
+    WebKitVideoSinkProbe(const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
         : m_player(player)
     {
     }
@@ -50,14 +50,18 @@ public:
         // AbortableTaskQueue start/finishAborting.
         ASSERT(isMainThread());
 
+        RefPtr player = m_player.get();
+        if (!player)
+            return;
+
         if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_START) {
             if (!m_isFlushing) {
                 GST_DEBUG_OBJECT(pad, "FLUSH_START received, aborting all pending tasks in the player sinkTaskQueue.");
                 m_isFlushing = true;
-                m_player->sinkTaskQueue().startAborting();
+                player->sinkTaskQueue().startAborting();
 #if USE(GSTREAMER_GL)
                     GST_DEBUG_OBJECT(pad, "Flushing current buffer in response to %" GST_PTR_FORMAT, info->data);
-                    m_player->flushCurrentBuffer();
+                    player->flushCurrentBuffer();
 #endif
             } else
                 GST_DEBUG_OBJECT(pad, "Received FLUSH_START while already flushing, ignoring.");
@@ -68,7 +72,7 @@ public:
         if (m_isFlushing) {
             GST_DEBUG_OBJECT(pad, "FLUSH_STOP received, allowing operation in the player sinkTaskQueue again.");
             m_isFlushing = false;
-            m_player->sinkTaskQueue().finishAborting();
+            player->sinkTaskQueue().finishAborting();
             return;
         }
 
@@ -78,7 +82,9 @@ public:
     static GstPadProbeReturn doProbe([[maybe_unused]] GstPad* pad, GstPadProbeInfo* info, gpointer userData)
     {
         auto* self = static_cast<WebKitVideoSinkProbe*>(userData);
-        auto* player = self->m_player;
+        RefPtr player = self->m_player.get();
+        if (!player)
+            return GST_PAD_PROBE_REMOVE;
 
         // Usually flushes propagate in the main thread as a synchronous consequence of a seek.
         // However, this doesn't have to be the case:
@@ -148,35 +154,58 @@ public:
     }
 
 private:
-    MediaPlayerPrivateGStreamer* m_player;
+    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
     bool m_isFlushing { false };
 };
 
-void webKitVideoSinkSetMediaPlayerPrivate(GstElement* appSink, MediaPlayerPrivateGStreamer* player)
+struct MediaPlayerPrivateNotifier {
+    MediaPlayerPrivateNotifier(const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
+        : m_player(player)
+    {
+    }
+
+    static void destruct(void* notifier, GClosure*)
+    {
+        delete static_cast<MediaPlayerPrivateNotifier*>(notifier);
+    }
+
+    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
+};
+
+WebKitVideoSinkSignalIdentifiers webKitVideoSinkSetMediaPlayerPrivate(GstElement* appSink, const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_gst_video_sink_common_debug, "webkitvideosinkcommon", 0, "WebKit Video Sink Common utilities");
     });
 
-    g_signal_connect(appSink, "new-sample", G_CALLBACK(+[](GstElement* sink, MediaPlayerPrivateGStreamer* player) -> GstFlowReturn {
-        GRefPtr<GstSample> sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
+    WebKitVideoSinkSignalIdentifiers identifiers;
+    identifiers.newSample = g_signal_connect_data(appSink, "new-sample", G_CALLBACK(+[](GstElement* sink, MediaPlayerPrivateNotifier* notifier) -> GstFlowReturn {
+        GRefPtr<GstSample> sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK_CAST(sink)));
 #ifndef GST_DISABLE_GST_DEBUG
         GstBuffer* buffer = gst_sample_get_buffer(sample.get());
         GST_TRACE_OBJECT(sink, "new-sample with PTS=%" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(buffer)));
 #endif
+        RefPtr player = notifier->m_player.get();
+        if (!player)
+            return GST_FLOW_OK;
+
         player->triggerRepaint(WTF::move(sample));
         return GST_FLOW_OK;
-    }), player);
-    g_signal_connect(appSink, "new-preroll", G_CALLBACK(+[](GstElement* sink, MediaPlayerPrivateGStreamer* player) -> GstFlowReturn {
-        GRefPtr<GstSample> sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
+    }), new MediaPlayerPrivateNotifier { player }, MediaPlayerPrivateNotifier::destruct, static_cast<GConnectFlags>(0));
+    identifiers.newPreroll = g_signal_connect_data(appSink, "new-preroll", G_CALLBACK(+[](GstElement* sink, MediaPlayerPrivateNotifier* notifier) -> GstFlowReturn {
+        GRefPtr<GstSample> sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK_CAST(sink)));
 #ifndef GST_DISABLE_GST_DEBUG
         GstBuffer* buffer = gst_sample_get_buffer(sample.get());
         GST_DEBUG_OBJECT(sink, "new-preroll with PTS=%" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(buffer)));
 #endif
+        RefPtr player = notifier->m_player.get();
+        if (!player)
+            return GST_FLOW_OK;
+
         player->triggerRepaint(WTF::move(sample));
         return GST_FLOW_OK;
-    }), player);
+    }), new MediaPlayerPrivateNotifier { player }, MediaPlayerPrivateNotifier::destruct, static_cast<GConnectFlags>(0));
 
     GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
 
@@ -184,12 +213,32 @@ void webKitVideoSinkSetMediaPlayerPrivate(GstElement* appSink, MediaPlayerPrivat
         | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
         WebKitVideoSinkProbe::doProbe, new WebKitVideoSinkProbe(player), WebKitVideoSinkProbe::deleteUserData);
 
-    if (!player->requiresVideoSinkCapsNotifications())
+    RefPtr strongPlayer = player.get();
+    if (!strongPlayer) [[unlikely]]
+        return identifiers;
+
+    if (!strongPlayer->requiresVideoSinkCapsNotifications())
+        return identifiers;
+
+    identifiers.notifyCaps = g_signal_connect_data(pad.get(), "notify::caps", G_CALLBACK(+[](GstPad* videoSinkPad, GParamSpec*, MediaPlayerPrivateNotifier* notifier) {
+        RefPtr player = notifier->m_player.get();
+        if (!player)
+            return;
+        player->videoSinkCapsChanged(videoSinkPad);
+    }), new MediaPlayerPrivateNotifier { player }, MediaPlayerPrivateNotifier::destruct, static_cast<GConnectFlags>(0));
+    return identifiers;
+}
+
+void webKitVideoSinkDisconnectSignalHandlers(GstElement* appSink, const WebKitVideoSinkSignalIdentifiers& identifiers)
+{
+    g_signal_handler_disconnect(appSink, identifiers.newPreroll);
+    g_signal_handler_disconnect(appSink, identifiers.newSample);
+
+    if (!identifiers.notifyCaps)
         return;
 
-    g_signal_connect(pad.get(), "notify::caps", G_CALLBACK(+[](GstPad* videoSinkPad, GParamSpec*, MediaPlayerPrivateGStreamer* player) {
-        player->videoSinkCapsChanged(videoSinkPad);
-    }), player);
+    auto pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
+    g_signal_handler_disconnect(pad.get(), identifiers.notifyCaps);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h
@@ -21,11 +21,21 @@
 #if ENABLE(VIDEO)
 
 #include <gst/gst.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class MediaPlayerPrivateGStreamer;
-}
 
-void webKitVideoSinkSetMediaPlayerPrivate(GstElement*, WebCore::MediaPlayerPrivateGStreamer*);
+struct WebKitVideoSinkSignalIdentifiers {
+    unsigned long newSample { 0 };
+    unsigned long newPreroll { 0 };
+    unsigned long notifyCaps { 0 };
+};
+
+} // namespace WebCore
+
+WebCore::WebKitVideoSinkSignalIdentifiers webKitVideoSinkSetMediaPlayerPrivate(GstElement*, const ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamer>&);
+
+void webKitVideoSinkDisconnectSignalHandlers(GstElement*, const WebCore::WebKitVideoSinkSignalIdentifiers&);
 
 #endif // ENABLE(VIDEO)


### PR DESCRIPTION
#### 69dc735207ba5e20e5cf261629579a115d0e5328
<pre>
[GStreamer][GL] Use a media player weak pointer in the video sink
<a href="https://bugs.webkit.org/show_bug.cgi?id=308740">https://bugs.webkit.org/show_bug.cgi?id=308740</a>

Reviewed by Xabier Rodriguez-Calvar.

Get rid of the raw MediaPlayerPrivateGStreamer pointer in GObject signal handlers, hopefully
improving runtime safety.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(_WebKitGLVideoSinkPrivate::~_WebKitGLVideoSinkPrivate):
(webKitGLVideoSinkSetMediaPlayerPrivate):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
(WebKitVideoSinkProbe::WebKitVideoSinkProbe):
(WebKitVideoSinkProbe::handleFlushEvent):
(WebKitVideoSinkProbe::doProbe):
(MediaPlayerPrivateNotifier::MediaPlayerPrivateNotifier):
(MediaPlayerPrivateNotifier::destruct):
(webKitVideoSinkSetMediaPlayerPrivate):
(webKitVideoSinkDisconnectSignalHandlers):
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h:

Canonical link: <a href="https://commits.webkit.org/308457@main">https://commits.webkit.org/308457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e8feccaf35061a5c1706c83c22a7121851890d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156313 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113803 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12993 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158647 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1783 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121830 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122031 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31239 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132300 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76230 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9080 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83493 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->