### PR TITLE
REGRESSION(307450@main): CanvasRenderingContext2D does not account for unrealized saves when resetting the context

### DIFF
--- a/LayoutTests/compositing/canvas/resize-canvas-with-unrealized-saves-crash-expected.txt
+++ b/LayoutTests/compositing/canvas/resize-canvas-with-unrealized-saves-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/compositing/canvas/resize-canvas-with-unrealized-saves-crash.html
+++ b/LayoutTests/compositing/canvas/resize-canvas-with-unrealized-saves-crash.html
@@ -1,0 +1,15 @@
+<body>This test passes if it doesn't crash.<canvas id="canvas"/></body>
+<script>
+ testRunner?.dumpAsText();
+ var ctx = canvas.getContext('2d');
+ var img = new Image();
+ img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+ var pattern = ctx.createPattern(img, "repeat-x");
+ ctx.fillStyle = pattern;
+ ctx.save();
+ ctx.shadowOffsetX = 40;
+ ctx.shadowColor = "black";
+ ctx.save();
+ canvas.width = 10;
+ ctx.fillText("FOO",  0, 0);
+</script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -263,6 +263,7 @@ CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, C
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
 {
 #if ASSERT_ENABLED
+    m_unrealizedSaveCount = 0;
     size_t restoreCount = m_stateStack.size() - 1;
     for (size_t i = 0; i < restoreCount; ++i)
         restore();
@@ -323,12 +324,12 @@ void CanvasRenderingContext2DBase::reset()
 
 void CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties(bool sizeChanged)
 {
+    m_unrealizedSaveCount = 0;
     size_t restoreCount = m_stateStack.size() - 1;
     for (size_t i = 0; i < restoreCount; ++i)
         restore();
     m_stateStack.first() = State();
     m_path.clear();
-    m_unrealizedSaveCount = 0;
     m_cachedContents.emplace<CachedContentsTransparent>();
     m_hasDeferredOperations = false;
     clearAccumulatedDirtyRect();


### PR DESCRIPTION
#### b5da4b2569257bc48c2a4a4d4baebee4749b945d
<pre>
REGRESSION(307450@main): CanvasRenderingContext2D does not account for unrealized saves when resetting the context
<a href="https://bugs.webkit.org/show_bug.cgi?id=308741">https://bugs.webkit.org/show_bug.cgi?id=308741</a>

Reviewed by Kimmo Kinnunen.

When canvas size dimensions are modified the rendering context stack
needs to be restored. However, if there are unrealized saves, the
check at the beginning of CanvasRenderingContext2DBase::restore()
will short-circuit and leave the state inconsistent after the image
buffer is reset or removed.

Resetting the counter for unrealized saves before the restore call
loop prevents this.

Test: compositing/canvas/resize-canvas-with-unrealized-saves-crash.html

* LayoutTests/compositing/canvas/resize-canvas-with-unrealized-saves-crash-expected.txt: Added.
* LayoutTests/compositing/canvas/resize-canvas-with-unrealized-saves-crash.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase):
(WebCore::CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties):

Canonical link: <a href="https://commits.webkit.org/308314@main">https://commits.webkit.org/308314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93bdbb712be6d87b89eae366cd217cd966692369

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113333 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12549 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158082 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1213 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121356 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31145 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131792 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8610 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19166 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82921 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->