### PR TITLE
Simplify WebKit-Swift inclusions

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WebKit.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.h
@@ -87,6 +87,6 @@
 #import <WebKit/WKWebsiteDataStore.h>
 #import <WebKit/WKWindowFeatures.h>
 
-#if !defined(TARGET_OS_MACCATALYST) || !TARGET_OS_MACCATALYST
+#if (!defined(TARGET_OS_MACCATALYST) || !TARGET_OS_MACCATALYST) && !defined(WEBKIT_SWIFT_IMPLEMENTATION)
 #import <WebKit/WebKitLegacy.h>
 #endif

--- a/Source/WebKit/Shared/WebKit-Swift.h
+++ b/Source/WebKit/Shared/WebKit-Swift.h
@@ -25,6 +25,14 @@
 
 #pragma once
 
+// Avoid recursively including WebKit-Swift-Generated.h while generating
+// clang modules upon which the Swift code depends.
+#ifndef __swift__
+
+// Only include the generated code if any WebKit features are enabled
+// that require Swift/C++ interop.
+#if ENABLE(SWIFT_DEMO_URI_SCHEME) || ENABLE(IPC_TESTING_SWIFT) || ENABLE(BACK_FORWARD_LIST_SWIFT)
+
 // Anything needing to use Swift types or functions should include
 // this rather than directly including WebKit-Swift-Generated.h. Its purposes:
 // - include any pre-requisite headers
@@ -51,6 +59,9 @@
 #include <WebKitAdditions/WebKit-Swift-Additions.h>
 #endif
 
+// rdar://165068038
+#define WEBKIT_SWIFT_IMPLEMENTATION
+
 // rdar://165192318
 IGNORE_CLANG_WARNINGS_BEGIN("arc-bridge-casts-disallowed-in-nonarc")
 #ifdef GENERATE_SINGLE_SWIFT_INTEROP_FILE
@@ -59,3 +70,9 @@ IGNORE_CLANG_WARNINGS_BEGIN("arc-bridge-casts-disallowed-in-nonarc")
 #include "WebKit-Swift-CPP.h"
 #endif
 IGNORE_CLANG_WARNINGS_END
+
+#undef WEBKIT_SWIFT_IMPLEMENTATION
+
+#endif // ENABLE(SWIFT_DEMO_URI_SCHEME) || ENABLE(IPC_TESTING_SWIFT) || ENABLE(BACK_FORWARD_LIST_SWIFT)
+
+#endif // __swift__

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -118,10 +118,6 @@
 #import <UIKit/UITraitCollection.h>
 #endif
 
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
-#endif
-
 #import <pal/ios/ManagedConfigurationSoftLink.h>
 
 #define FORWARD_ACTION_TO_WKCONTENTVIEW(_action) \

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -26,11 +26,6 @@
 #import "config.h"
 #import "WKWebViewMac.h"
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
-#endif
-
 #if PLATFORM(MAC)
 
 #import "AppKitSPI.h"

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -74,11 +74,6 @@
 #include "WebDriverBidiProcessor.h"
 #endif
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
-#endif
-
 namespace WebKit {
 
 using namespace Inspector;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -63,12 +63,6 @@
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
 #include <wtf/TZoneMallocInlines.h>
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebBackForwardListSwiftUtilities.h"
-#include "WebKit-Swift.h"
-#endif
-
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -69,11 +69,6 @@
 #include "WebDeviceOrientationUpdateProviderProxy.h"
 #endif
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
-#endif
-
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemotePageProxy);

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -53,11 +53,6 @@
 #include "ViewGestureGeometryCollectorMessages.h"
 #endif
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
-#endif
-
 namespace WebKit {
 using namespace WebCore;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -34,7 +34,6 @@
 #include "WebBackForwardCache.h"
 #include "WebBackForwardListCounts.h"
 #include "WebBackForwardListFrameItem.h"
-#include "WebBackForwardListSwiftUtilities.h"
 #include "WebFrameProxy.h"
 #include "WebInspectorUtilities.h"
 #include "WebPageProxy.h"
@@ -46,11 +45,6 @@
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
-#endif
-
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
 #endif
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -29,6 +29,7 @@
 #include "LoadedWebArchive.h"
 #include "MessageReceiver.h"
 #include "WebBackForwardListItem.h"
+#include "WebKit-Swift.h"
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <wtf/Ref.h>
@@ -133,9 +134,6 @@ private:
 using WebBackForwardListWrapper = WebBackForwardList;
 
 #else // ENABLE(BACK_FORWARD_LIST_SWIFT)
-
-// Avoid including WebKit-Swift.h in header files to avoid dependency loops.
-class WebBackForwardList;
 
 // This C++ stub object exists to forward API calls through to the Swift implementation.
 // Although the BackForwardList is in Swift, we retain a C++

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -462,10 +462,7 @@
 #include "ModelPresentationManagerProxy.h"
 #endif
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(SWIFT_DEMO_URI_SCHEME) || ENABLE(IPC_TESTING_SWIFT) || ENABLE(BACK_FORWARD_LIST_SWIFT)
 #include "WebKit-Swift.h"
-#endif
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 #include "RemoteAudioSessionConfiguration.h"
@@ -17758,6 +17755,11 @@ WebBackForwardListMessageForwarder& WebPageProxy::backForwardListMessageReceiver
 IGNORE_CLANG_WARNINGS_BEGIN("return-stack-address")
     return backForwardList().getMessageReceiver().get();
 IGNORE_CLANG_WARNINGS_END
+}
+
+WebBackForwardList& WebPageProxy::backForwardList() const
+{
+    return m_backForwardList->getImpl();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -46,11 +46,6 @@
 #include "DisplayLinkObserverID.h"
 #endif
 
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebBackForwardList.h"
-#include "WebBackForwardListMessages.h"
-#endif
-
 namespace API {
 class Attachment;
 class ContentWorld;
@@ -548,6 +543,7 @@ class WebAutomationSession;
 class WebBackForwardCache;
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
 class WebBackForwardListWrapper;
+class WebBackForwardListMessageForwarder;
 #else
 class WebBackForwardList;
 using WebBackForwardListWrapper = WebBackForwardList;
@@ -798,7 +794,7 @@ public:
 
     WebBackForwardListWrapper& backForwardListWrapper() { return m_backForwardList; }
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
-    WebBackForwardList& backForwardList() const { return m_backForwardList->getImpl(); }
+    WebBackForwardList& backForwardList() const;
     WebBackForwardListMessageForwarder& backForwardListMessageReceiver() const;
 #else
     WebBackForwardList& backForwardList() const { return m_backForwardList; }

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -27,11 +27,6 @@
 #import "ViewGestureController.h"
 #import <optional>
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#import "WebKit-Swift.h"
-#endif
-
 #if PLATFORM(MAC)
 
 #import "APINavigation.h"

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -26,11 +26,6 @@
 #import "config.h"
 #import "WebViewImpl.h"
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=306415
-#if ENABLE(BACK_FORWARD_LIST_SWIFT)
-#include "WebKit-Swift.h"
-#endif
-
 #if PLATFORM(MAC)
 
 #import "APIAttachment.h"

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -68,10 +68,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-
-#if ENABLE(IPC_TESTING_SWIFT)
 #include "WebKit-Swift.h"
-#endif
 
 namespace WebKit::IPCTestingAPI {
 


### PR DESCRIPTION
#### 0cb3e1def9cb6d387552b618d420a8f8214fda37
<pre>
Simplify WebKit-Swift inclusions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308743">https://bugs.webkit.org/show_bug.cgi?id=308743</a>
<a href="https://rdar.apple.com/171262985">rdar://171262985</a>

Reviewed by NOBODY (OOPS!).

We are building a Swift version of the WebBackForwardList. Existing C++ code
needs to call into that Swift version using APIs which are put into an
autogenerated WebKit-Swift-Generated.h file (which itself is always included
via a wrapper WebKit-Swift.h).

At the same time, the Swift WebBackForwardList code needs to call various
existing C++ APIs as described in WebKit C++ headers.

This obviously presents a risk of circular dependencies:

C++ header file includes WebKit-Swift.h...
WebKit-Swift.h generated by Swift code...
Swift code depends on C++ types...
Described in C++ header files

To avoid this risk, we previously had an informal rule that WebKit-Swift.h
could only be included from .cpp or .mm implementation files, never from .h
header files. This led to repetitive inclusions of WebKit-Swift.h in many
places; as well as being repetitive this also felt like a bit of a
breach of encapsulation since ideally WebBackForwardList.h should ideally
describe the nature of the back forward list, whether it&apos;s written in C++
or in Swift.

Experience suggests that we can now back away from this strict rule and
allow inclusion of WebKit-Swift.h from header files. This PR removes the

How do we avoid circular dependency problems like the above?

WebKit headers are conceptually &quot;above&quot; or &quot;below&quot; Swift. Swift may
depend upon those headers &quot;below&quot;; headers &quot;above&quot; Swift may depend
upon WebKit-Swift.h.

In practice:
nearly all WebKit headers are &quot;below&quot; Swift.
but, there are individual WebKit headers which are &quot;above&quot; Swift in
that they describe an implementation that&apos;s done in Swift.

In the case of the WebBackForwardList work, all WebKit headers are
&quot;below&quot; Swift except for WebBackForwardList.h, which describes the
Swift implementation to any callers.

Experience suggests that currently this does not need to be actually
enforced, and probably doesn&apos;t even need to feature in engineers&apos; brains.

What&apos;s the consequence if this rule is violated? Thanks to some
simply won&apos;t be able to see types exposed from Swift. Compilation of
their modules will fail if they depend upon Swift types. That&apos;s why
it seems safe to relax this rule.

Other changes in this PR:
- WebKit-Swift.h is also now guarded by the enablement of any
  feature which uses it. It&apos;s therefore safe to include it anywhere.
- We&apos;ve had to un-inline the getter for the Swift
  BackForwardList implementation, since that caused WebPageProxy.h
  (&quot;below&quot; Swift) to depend upon WebBackForwardList.h (&quot;above&quot;
  Swift)
- Due to <a href="https://rdar.apple.com/165068038">rdar://165068038</a>, WebKit-Swift-Generated.h erroneously
  include WebKit.h. Unfortunately, that causes some headers to
  see a mix of WebKit and WebKitLegacy definitions. This would
  likely have caused problems eventually even without the rest
  of this change. The only known workaround right now is to put
  a guard into WebKit.h, so that&apos;s what this change does.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb3e1def9cb6d387552b618d420a8f8214fda37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100426 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc4c564b-2cc4-401a-927c-0c5414329ec1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113283 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80837 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b2167ed-f520-4c2c-aff2-06f6a61430e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94039 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99dbbcbb-bc83-4830-a1f9-a1a0fd6ce2d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14736 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12511 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3136 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124323 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158025 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1156 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121306 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75462 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17071 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8579 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82864 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->