### PR TITLE
Use an enum class for NodeType

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1344,7 +1344,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/NamedNodeMap.h
     dom/NativeNodeFilter.h
     dom/Node.h
-    dom/NodeConstants.h
     dom/NodeDocument.h
     dom/NodeFilter.h
     dom/NodeFilterCondition.h
@@ -1354,6 +1353,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/NodeList.h
     dom/NodeRenderStyle.h
     dom/NodeTraversal.h
+    dom/NodeType.h
     dom/ParserContentPolicy.h
     dom/PointerEvent.h
     dom/PointerEventTypeNames.h

--- a/Source/WebCore/bindings/js/JSDOMWrapper.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.h
@@ -24,9 +24,10 @@
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/StructureInlines.h>
 #include <WebCore/JSDOMGlobalObject.h>
-#include <WebCore/NodeConstants.h>
+#include <WebCore/NodeType.h>
 #include <wtf/Compiler.h>
 #include <wtf/SignedPtr.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -40,22 +41,22 @@ class ScriptExecutionContext;
 // offset | 7 | 6 | 5 | 4 | 3   2   1   0  |
 // value  | 1 | 1 | 1 | 1 |    NodeType    |
 
-static const uint8_t JSDOMWrapperType                = 0b11101110;
-static const uint8_t JSEventType                     = 0b11101111;
-static const uint8_t JSNodeType                      = 0b11110000;
-static const uint8_t JSNodeTypeMask                  = 0b00001111;
-static const uint8_t JSTextNodeType                  = JSNodeType | NodeConstants::TEXT_NODE;
-static const uint8_t JSProcessingInstructionNodeType = JSNodeType | NodeConstants::PROCESSING_INSTRUCTION_NODE;
-static const uint8_t JSDocumentTypeNodeType          = JSNodeType | NodeConstants::DOCUMENT_TYPE_NODE;
-static const uint8_t JSDocumentFragmentNodeType      = JSNodeType | NodeConstants::DOCUMENT_FRAGMENT_NODE;
-static const uint8_t JSDocumentWrapperType           = JSNodeType | NodeConstants::DOCUMENT_NODE;
-static const uint8_t JSCommentNodeType               = JSNodeType | NodeConstants::COMMENT_NODE;
-static const uint8_t JSCDATASectionNodeType          = JSNodeType | NodeConstants::CDATA_SECTION_NODE;
-static const uint8_t JSAttrNodeType                  = JSNodeType | NodeConstants::ATTRIBUTE_NODE;
-static const uint8_t JSElementType                   = 0b11110000 | NodeConstants::ELEMENT_NODE;
+static constexpr uint8_t JSDOMWrapperType                = 0b11101110;
+static constexpr uint8_t JSEventType                     = 0b11101111;
+static constexpr uint8_t JSNodeType                      = 0b11110000;
+static constexpr uint8_t JSNodeTypeMask                  = 0b00001111;
+static constexpr uint8_t JSTextNodeType                  = JSNodeType | std::to_underlying(NodeType::Text);
+static constexpr uint8_t JSProcessingInstructionNodeType = JSNodeType | std::to_underlying(NodeType::ProcessingInstruction);
+static constexpr uint8_t JSDocumentTypeNodeType          = JSNodeType | std::to_underlying(NodeType::DocumentType);
+static constexpr uint8_t JSDocumentFragmentNodeType      = JSNodeType | std::to_underlying(NodeType::DocumentFragment);
+static constexpr uint8_t JSDocumentWrapperType           = JSNodeType | std::to_underlying(NodeType::Document);
+static constexpr uint8_t JSCommentNodeType               = JSNodeType | std::to_underlying(NodeType::Comment);
+static constexpr uint8_t JSCDATASectionNodeType          = JSNodeType | std::to_underlying(NodeType::CDATASection);
+static constexpr uint8_t JSAttrNodeType                  = JSNodeType | std::to_underlying(NodeType::Attribute);
+static constexpr uint8_t JSElementType                   = 0b11110000 | std::to_underlying(NodeType::Element);
 
 static_assert(JSDOMWrapperType > JSC::LastJSCObjectType, "JSC::JSType offers the highest bit.");
-static_assert(NodeConstants::LastNodeType <= JSNodeTypeMask, "NodeType should be represented in 4bit.");
+static_assert(lastNodeType <= JSNodeTypeMask, "NodeType should be represented in 4bit.");
 
 class JSDOMObject : public JSC::JSDestructibleObject {
 public:

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -98,47 +98,47 @@ static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalOb
     
     JSDOMObject* wrapper;    
     switch (node->nodeType()) {
-        case Node::ELEMENT_NODE:
-            if (auto* htmlElement = dynamicDowncast<HTMLElement>(node.get()))
-                wrapper = createJSHTMLWrapper(globalObject, *htmlElement);
-            else if (auto* svgElement = dynamicDowncast<SVGElement>(node.get()))
-                wrapper = createJSSVGWrapper(globalObject, *svgElement);
+    case NodeType::Element:
+        if (auto* htmlElement = dynamicDowncast<HTMLElement>(node.get()))
+            wrapper = createJSHTMLWrapper(globalObject, *htmlElement);
+        else if (auto* svgElement = dynamicDowncast<SVGElement>(node.get()))
+            wrapper = createJSSVGWrapper(globalObject, *svgElement);
 #if ENABLE(MATHML)
-            else if (auto* mathmlElement = dynamicDowncast<MathMLElement>(node.get()))
-                wrapper = createJSMathMLWrapper(globalObject, *mathmlElement);
+        else if (auto* mathmlElement = dynamicDowncast<MathMLElement>(node.get()))
+            wrapper = createJSMathMLWrapper(globalObject, *mathmlElement);
 #endif
-            else
-                wrapper = createWrapper<Element>(globalObject, WTF::move(node));
-            break;
-        case Node::ATTRIBUTE_NODE:
-            wrapper = createWrapper<Attr>(globalObject, WTF::move(node));
-            break;
-        case Node::TEXT_NODE:
-            wrapper = createWrapper<Text>(globalObject, WTF::move(node));
-            break;
-        case Node::CDATA_SECTION_NODE:
-            wrapper = createWrapper<CDATASection>(globalObject, WTF::move(node));
-            break;
-        case Node::PROCESSING_INSTRUCTION_NODE:
-            wrapper = createWrapper<ProcessingInstruction>(globalObject, WTF::move(node));
-            break;
-        case Node::COMMENT_NODE:
-            wrapper = createWrapper<Comment>(globalObject, WTF::move(node));
-            break;
-        case Node::DOCUMENT_NODE:
-            // we don't want to cache the document itself in the per-document dictionary
-            return toJS(lexicalGlobalObject, globalObject, uncheckedDowncast<Document>(node.get()));
-        case Node::DOCUMENT_TYPE_NODE:
-            wrapper = createWrapper<DocumentType>(globalObject, WTF::move(node));
-            break;
-        case Node::DOCUMENT_FRAGMENT_NODE:
-            if (node->isShadowRoot())
-                wrapper = createWrapper<ShadowRoot>(globalObject, WTF::move(node));
-            else
-                wrapper = createWrapper<DocumentFragment>(globalObject, WTF::move(node));
-            break;
-        default:
-            wrapper = createWrapper<Node>(globalObject, WTF::move(node));
+        else
+            wrapper = createWrapper<Element>(globalObject, WTF::move(node));
+        break;
+    case NodeType::Attribute:
+        wrapper = createWrapper<Attr>(globalObject, WTF::move(node));
+        break;
+    case NodeType::Text:
+        wrapper = createWrapper<Text>(globalObject, WTF::move(node));
+        break;
+    case NodeType::CDATASection:
+        wrapper = createWrapper<CDATASection>(globalObject, WTF::move(node));
+        break;
+    case NodeType::ProcessingInstruction:
+        wrapper = createWrapper<ProcessingInstruction>(globalObject, WTF::move(node));
+        break;
+    case NodeType::Comment:
+        wrapper = createWrapper<Comment>(globalObject, WTF::move(node));
+        break;
+    case NodeType::Document:
+        // we don't want to cache the document itself in the per-document dictionary
+        return toJS(lexicalGlobalObject, globalObject, uncheckedDowncast<Document>(node.get()));
+    case NodeType::DocumentType:
+        wrapper = createWrapper<DocumentType>(globalObject, WTF::move(node));
+        break;
+    case NodeType::DocumentFragment:
+        if (node->isShadowRoot())
+            wrapper = createWrapper<ShadowRoot>(globalObject, WTF::move(node));
+        else
+            wrapper = createWrapper<DocumentFragment>(globalObject, WTF::move(node));
+        break;
+    default:
+        wrapper = createWrapper<Node>(globalObject, WTF::move(node));
     }
 
     return wrapper;

--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -1534,9 +1534,12 @@ sub GenerateCompileTimeCheckForEnumsIfNeeded
 
     my @checks = ();
     foreach my $constant (@{$interface->constants}) {
-        my $scope = $constant->extendedAttributes->{"ImplementedBy"} || $baseScope;
+        next if $constant->extendedAttributes->{"DoNotCheckConstants"};
+        my $constantEnum = $constant->extendedAttributes->{"ConstantsEnum"} || $enum;
+        $constantEnum =~ s/^"(.*)"$/$1/ if $constantEnum;
+        my $scope = $constant->extendedAttributes->{"ImplementedBy"} || $constantEnum || $baseScope;
         my $name = $constant->extendedAttributes->{"ImplementedAs"} || $constant->name;
-        my $value = $enum ? "static_cast<" . $enum . ">(" . $constant->value . ")" : $constant->value;
+        my $value = $constantEnum ? "static_cast<" . $constantEnum . ">(" . $constant->value . ")" : $constant->value;
         my $conditional = $constant->extendedAttributes->{"Conditional"};
         push(@checks, "#if " . $generator->GenerateConditionalStringFromAttributeValue($conditional) . "\n") if $conditional;
         push(@checks, "static_assert(${scope}::${name} == ${value}, \"${name} in ${scope} does not match value from IDL\");\n");

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -93,7 +93,7 @@
             "values": ["*"]
         },
         "ConstantsEnum": {
-            "contextsAllowed": ["interface"],
+            "contextsAllowed": ["interface", "constant"],
             "values": ["*"]
         },
         "ContextAllowsMediaDevices": {
@@ -165,7 +165,7 @@
             "supportsConjunction": true
         },
         "DoNotCheckConstants": {
-            "contextsAllowed": ["interface"]
+            "contextsAllowed": ["interface", "constant"]
         },
         "DoNotCheckSecurity": {
             "contextsAllowed": ["attribute", "operation"]

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -86,7 +86,7 @@ static bool isAcceptableCSSStyleSheetParent(Node* parentNode)
         || is<HTMLLinkElement>(*parentNode)
         || is<HTMLStyleElement>(*parentNode)
         || is<SVGStyleElement>(*parentNode)
-        || parentNode->nodeType() == Node::PROCESSING_INSTRUCTION_NODE;
+        || parentNode->nodeType() == NodeType::ProcessingInstruction;
 }
 #endif // ASSERT_ENABLED
 

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -50,14 +50,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Attr);
 using namespace HTMLNames;
 
 Attr::Attr(Element& element, const QualifiedName& name)
-    : Node(element.document(), ATTRIBUTE_NODE, { })
+    : Node(element.document(), NodeType::Attribute, { })
     , m_element(element)
     , m_name(name)
 {
 }
 
 Attr::Attr(Document& document, const QualifiedName& name, const AtomString& standaloneValue)
-    : Node(document, ATTRIBUTE_NODE, { })
+    : Node(document, NodeType::Attribute, { })
     , m_name(name)
     , m_standaloneValue(standaloneValue)
 {

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -87,5 +87,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Attr)
-    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::Node::ATTRIBUTE_NODE; }
+    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::NodeType::Attribute; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDATASection);
 
 inline CDATASection::CDATASection(Document& document, String&& data)
-    : Text(document, WTF::move(data), CDATA_SECTION_NODE, { })
+    : Text(document, WTF::move(data), NodeType::CDATASection, { })
 {
 }
 

--- a/Source/WebCore/dom/CDATASection.h
+++ b/Source/WebCore/dom/CDATASection.h
@@ -44,5 +44,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CDATASection)
-    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::Node::CDATA_SECTION_NODE; }
+    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::NodeType::CDATASection; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/Comment.cpp
+++ b/Source/WebCore/dom/Comment.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Comment);
 
 inline Comment::Comment(Document& document, String&& text)
-    : CharacterData(document, WTF::move(text), COMMENT_NODE)
+    : CharacterData(document, WTF::move(text), NodeType::Comment)
 {
 }
 

--- a/Source/WebCore/dom/Comment.h
+++ b/Source/WebCore/dom/Comment.h
@@ -43,5 +43,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Comment)
-    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::Node::COMMENT_NODE; }
+    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::NodeType::Comment; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentFragment);
 
 DocumentFragment::DocumentFragment(Document& document, OptionSet<TypeFlag> typeFlags)
-    : ContainerNode(document, DOCUMENT_FRAGMENT_NODE, typeFlags)
+    : ContainerNode(document, NodeType::DocumentFragment, typeFlags)
 {
     if (document.usesNullCustomElementRegistry())
         setUsesNullCustomElementRegistry();
@@ -66,11 +66,11 @@ String DocumentFragment::nodeName() const
 bool DocumentFragment::childTypeAllowed(NodeType type) const
 {
     switch (type) {
-    case ELEMENT_NODE:
-    case PROCESSING_INSTRUCTION_NODE:
-    case COMMENT_NODE:
-    case TEXT_NODE:
-    case CDATA_SECTION_NODE:
+    case NodeType::Element:
+    case NodeType::ProcessingInstruction:
+    case NodeType::Comment:
+    case NodeType::Text:
+    case NodeType::CDATASection:
         return true;
     default:
         return false;

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentType);
 
 DocumentType::DocumentType(Document& document, const String& name, const String& publicId, const String& systemId)
-    : Node(document, DOCUMENT_TYPE_NODE, { })
+    : Node(document, NodeType::DocumentType, { })
     , m_name(name)
     , m_publicId(publicId.isNull() ? emptyString() : publicId)
     , m_systemId(systemId.isNull() ? emptyString() : systemId)

--- a/Source/WebCore/dom/DocumentType.h
+++ b/Source/WebCore/dom/DocumentType.h
@@ -59,5 +59,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DocumentType)
-    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::Node::DOCUMENT_TYPE_NODE; }
+    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::NodeType::DocumentType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -303,7 +303,7 @@ Ref<Element> Element::create(const QualifiedName& tagName, Document& document)
 }
 
 Element::Element(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> typeFlags)
-    : ContainerNode(document, ELEMENT_NODE, typeFlags | TypeFlag::IsElement)
+    : ContainerNode(document, NodeType::Element, typeFlags | TypeFlag::IsElement)
     , m_tagName(tagName)
 {
 }
@@ -3627,11 +3627,11 @@ CustomElementDefaultARIA* Element::customElementDefaultARIAIfExists() const
 bool Element::childTypeAllowed(NodeType type) const
 {
     switch (type) {
-    case ELEMENT_NODE:
-    case TEXT_NODE:
-    case COMMENT_NODE:
-    case PROCESSING_INSTRUCTION_NODE:
-    case CDATA_SECTION_NODE:
+    case NodeType::Element:
+    case NodeType::Text:
+    case NodeType::Comment:
+    case NodeType::ProcessingInstruction:
+    case NodeType::CDATASection:
         return true;
     default:
         break;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/EventTarget.h>
 #include <WebCore/NodeIdentifier.h>
+#include <WebCore/NodeType.h>
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleValidity.h>
@@ -126,22 +127,6 @@ public:
     // This opts the entire Node family tree into being allocated in the BuiltinTypeDescriptor TZone category.
     static constexpr bool usesBuiltinTypeDescriptorTZoneCategory = true;
 
-    enum NodeType {
-        ELEMENT_NODE = 1,
-        ATTRIBUTE_NODE = 2,
-        TEXT_NODE = 3,
-        CDATA_SECTION_NODE = 4,
-        PROCESSING_INSTRUCTION_NODE = 7,
-        COMMENT_NODE = 8,
-        DOCUMENT_NODE = 9,
-        DOCUMENT_TYPE_NODE = 10,
-        DOCUMENT_FRAGMENT_NODE = 11,
-    };
-    enum DeprecatedNodeType {
-        ENTITY_REFERENCE_NODE = 5,
-        ENTITY_NODE = 6,
-        NOTATION_NODE = 12,
-    };
     enum DocumentPosition {
         DOCUMENT_POSITION_EQUIVALENT = 0x00,
         DOCUMENT_POSITION_DISCONNECTED = 0x01,
@@ -264,9 +249,9 @@ public:
     virtual bool isHTMLFrameOwnerElement() const { return false; }
     virtual bool isPluginElement() const { return false; }
 
-    bool isDocumentNode() const { return nodeType() == DOCUMENT_NODE; }
+    bool isDocumentNode() const { return nodeType() == NodeType::Document; }
     bool isTreeScope() const { return isDocumentNode() || isShadowRoot(); }
-    bool isDocumentFragment() const { return nodeType() == DOCUMENT_FRAGMENT_NODE; }
+    bool isDocumentFragment() const { return nodeType() == NodeType::DocumentFragment; }
     bool isShadowRoot() const { return isDocumentFragment() && hasTypeFlag(TypeFlag::IsShadowRootOrFormControlElement); }
     inline bool isUserAgentShadowRoot() const; // Defined in NodeInlines.h
 
@@ -456,7 +441,7 @@ public:
     // https://dom.spec.whatwg.org/#in-a-document-tree
     bool isInDocumentTree() const { return isConnected() && !isInShadowTree(); }
 
-    bool isDocumentTypeNode() const { return nodeType() == DOCUMENT_TYPE_NODE; }
+    bool isDocumentTypeNode() const { return nodeType() == NodeType::DocumentType; }
     virtual bool NODELETE childTypeAllowed(NodeType) const { return false; }
     inline unsigned NODELETE countChildNodes() const;
     inline unsigned NODELETE length() const;
@@ -646,7 +631,7 @@ protected:
     };
     static constexpr auto typeFlagBitCount = 12;
 
-    static uint16_t constructBitFieldsFromNodeTypeAndFlags(NodeType type, OptionSet<TypeFlag> flags) { return (type << typeFlagBitCount) | flags.toRaw(); }
+    static uint16_t constructBitFieldsFromNodeTypeAndFlags(NodeType type, OptionSet<TypeFlag> flags) { return (std::to_underlying(type) << typeFlagBitCount) | flags.toRaw(); }
     static NodeType nodeTypeFromBitFields(uint16_t bitFields) { return static_cast<NodeType>((bitFields >> typeFlagBitCount) & 0xf); }
     // Don't bother masking with (1 << typeFlagBitCount) - 1 since OptionSet tolerates the upper 4-bits being used for other purposes.
     bool hasTypeFlag(TypeFlag flag) const { return OptionSet<TypeFlag>::fromRaw(m_typeBitFields).contains(flag); }

--- a/Source/WebCore/dom/Node.idl
+++ b/Source/WebCore/dom/Node.idl
@@ -25,20 +25,21 @@
     ExportMacro=WEBCORE_EXPORT,
     JSCustomHeader,
     JSCustomMarkFunction,
-    Exposed=Window
+    Exposed=Window,
+    ConstantsEnum=NodeType
 ] interface Node : EventTarget {
-    const unsigned short ELEMENT_NODE = 1;
-    const unsigned short ATTRIBUTE_NODE = 2;
-    const unsigned short TEXT_NODE = 3;
-    const unsigned short CDATA_SECTION_NODE = 4;
-    const unsigned short ENTITY_REFERENCE_NODE = 5; // Historical.
-    const unsigned short ENTITY_NODE = 6; // Historical.
-    const unsigned short PROCESSING_INSTRUCTION_NODE = 7;
-    const unsigned short COMMENT_NODE = 8;
-    const unsigned short DOCUMENT_NODE = 9;
-    const unsigned short DOCUMENT_TYPE_NODE = 10;
-    const unsigned short DOCUMENT_FRAGMENT_NODE = 11;
-    const unsigned short NOTATION_NODE = 12; // Historical.
+    [ImplementedAs=Element] const unsigned short ELEMENT_NODE = 1;
+    [ImplementedAs=Attribute] const unsigned short ATTRIBUTE_NODE = 2;
+    [ImplementedAs=Text] const unsigned short TEXT_NODE = 3;
+    [ImplementedAs=CDATASection] const unsigned short CDATA_SECTION_NODE = 4;
+    [DoNotCheckConstants] const unsigned short ENTITY_REFERENCE_NODE = 5; // Historical.
+    [DoNotCheckConstants] const unsigned short ENTITY_NODE = 6; // Historical.
+    [ImplementedAs=ProcessingInstruction] const unsigned short PROCESSING_INSTRUCTION_NODE = 7;
+    [ImplementedAs=Comment] const unsigned short COMMENT_NODE = 8;
+    [ImplementedAs=Document] const unsigned short DOCUMENT_NODE = 9;
+    [ImplementedAs=DocumentType] const unsigned short DOCUMENT_TYPE_NODE = 10;
+    [ImplementedAs=DocumentFragment] const unsigned short DOCUMENT_FRAGMENT_NODE = 11;
+    [DoNotCheckConstants] const unsigned short NOTATION_NODE = 12; // Historical.
     [DOMJIT=Getter, CustomGetter] readonly attribute unsigned short nodeType;
     readonly attribute DOMString nodeName;
 
@@ -64,12 +65,12 @@
     boolean isEqualNode(Node? other);
     boolean isSameNode(Node? other); // Historical alias of ===.
 
-    const unsigned short DOCUMENT_POSITION_DISCONNECTED = 0x01;
-    const unsigned short DOCUMENT_POSITION_PRECEDING = 0x02;
-    const unsigned short DOCUMENT_POSITION_FOLLOWING = 0x04;
-    const unsigned short DOCUMENT_POSITION_CONTAINS = 0x08;
-    const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 0x10;
-    const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
+    [ImplementedBy=Node, ConstantsEnum="Node::DocumentPosition"] const unsigned short DOCUMENT_POSITION_DISCONNECTED = 0x01;
+    [ImplementedBy=Node, ConstantsEnum="Node::DocumentPosition"] const unsigned short DOCUMENT_POSITION_PRECEDING = 0x02;
+    [ImplementedBy=Node, ConstantsEnum="Node::DocumentPosition"] const unsigned short DOCUMENT_POSITION_FOLLOWING = 0x04;
+    [ImplementedBy=Node, ConstantsEnum="Node::DocumentPosition"] const unsigned short DOCUMENT_POSITION_CONTAINS = 0x08;
+    [ImplementedBy=Node, ConstantsEnum="Node::DocumentPosition"] const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 0x10;
+    [ImplementedBy=Node, ConstantsEnum="Node::DocumentPosition"] const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
     unsigned short compareDocumentPosition(Node other);
     boolean contains(Node? other);
 

--- a/Source/WebCore/dom/NodeType.h
+++ b/Source/WebCore/dom/NodeType.h
@@ -27,26 +27,18 @@
 
 namespace WebCore {
 
-struct NodeConstants {
-    enum NodeType {
-        ELEMENT_NODE = 1,
-        ATTRIBUTE_NODE = 2,
-        TEXT_NODE = 3,
-        CDATA_SECTION_NODE = 4,
-        PROCESSING_INSTRUCTION_NODE = 7,
-        COMMENT_NODE = 8,
-        DOCUMENT_NODE = 9,
-        DOCUMENT_TYPE_NODE = 10,
-        DOCUMENT_FRAGMENT_NODE = 11,
-    };
-
-    enum DeprecatedNodeType {
-        ENTITY_REFERENCE_NODE = 5,
-        ENTITY_NODE = 6,
-        NOTATION_NODE = 12,
-    };
-
-    static const uint8_t LastNodeType = NOTATION_NODE;
+enum class NodeType : uint8_t {
+    Element = 1,
+    Attribute = 2,
+    Text = 3,
+    CDATASection = 4,
+    ProcessingInstruction = 7,
+    Comment = 8,
+    Document = 9,
+    DocumentType = 10,
+    DocumentFragment = 11,
 };
 
-} // namespace WebCore::NodeType
+static constexpr uint8_t lastNodeType = 12; // Historical NOTATION_NODE.
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -50,7 +50,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessingInstruction);
 
 inline ProcessingInstruction::ProcessingInstruction(Document& document, String&& target, String&& data)
-    : CharacterData(document, WTF::move(data), PROCESSING_INSTRUCTION_NODE)
+    : CharacterData(document, WTF::move(data), NodeType::ProcessingInstruction)
     , m_target(WTF::move(target))
 {
 }

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -99,5 +99,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ProcessingInstruction)
-    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::Node::PROCESSING_INSTRUCTION_NODE; }
+    static bool isType(const WebCore::Node& node) { return node.nodeType() == WebCore::NodeType::ProcessingInstruction; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -53,8 +53,8 @@ Ref<StaticRange> StaticRange::create(const SimpleRange& range)
 static bool NODELETE isDocumentTypeOrAttr(Node& node)
 {
     switch (node.nodeType()) {
-    case Node::ATTRIBUTE_NODE:
-    case Node::DOCUMENT_TYPE_NODE:
+    case NodeType::Attribute:
+    case NodeType::DocumentType:
         return true;
     default:
         return false;

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -47,7 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Text);
 
 Ref<Text> Text::createEditingText(Document& document, String&& data)
 {
-    auto node = adoptRef(*new Text(document, WTF::move(data), TEXT_NODE, { TypeFlag::IsPseudoElementOrSpecialInternalNode }));
+    auto node = adoptRef(*new Text(document, WTF::move(data), NodeType::Text, { TypeFlag::IsPseudoElementOrSpecialInternalNode }));
     ASSERT(node->isEditingText());
     return node;
 }

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -36,7 +36,7 @@ public:
 
     static Ref<Text> create(Document& document, String&& data)
     {
-        return adoptRef(*new Text(document, WTF::move(data), TEXT_NODE, { }));
+        return adoptRef(*new Text(document, WTF::move(data), NodeType::Text, { }));
     }
     static Ref<Text> createEditingText(Document&, String&&);
 

--- a/Source/WebCore/dom/Traversal.h
+++ b/Source/WebCore/dom/Traversal.h
@@ -51,7 +51,7 @@ protected:
 
     bool matchesWhatToShow(const Node& node) const
     {
-        unsigned nodeMask = 1 << (node.nodeType() - 1);
+        unsigned nodeMask = 1 << (std::to_underlying(node.nodeType()) - 1);
         return nodeMask & m_whatToShow;
     }
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -842,38 +842,38 @@ void MarkupAccumulator::appendNonElementNode(StringBuilder& result, const Node& 
         namespaces->checkConsistency();
 
     switch (node.nodeType()) {
-    case Node::TEXT_NODE:
+    case NodeType::Text:
         appendText(result, uncheckedDowncast<Text>(node));
         break;
-    case Node::COMMENT_NODE:
+    case NodeType::Comment:
         // FIXME: Comment content is not escaped, but that may be OK because XMLSerializer (and possibly other callers) should raise an exception if it includes "-->".
         result.append("<!--"_s, uncheckedDowncast<Comment>(node).data(), "-->"_s);
         break;
-    case Node::DOCUMENT_NODE:
+    case NodeType::Document:
         appendXMLDeclaration(result, uncheckedDowncast<Document>(node));
         break;
-    case Node::DOCUMENT_FRAGMENT_NODE:
+    case NodeType::DocumentFragment:
         break;
-    case Node::DOCUMENT_TYPE_NODE:
+    case NodeType::DocumentType:
         appendDocumentType(result, uncheckedDowncast<DocumentType>(node));
         break;
-    case Node::PROCESSING_INSTRUCTION_NODE: {
+    case NodeType::ProcessingInstruction: {
         auto& instruction = uncheckedDowncast<ProcessingInstruction>(node);
         // FIXME: PI data is not escaped, but XMLSerializer (and possibly other callers) this should raise an exception if it includes "?>".
         result.append("<?"_s, instruction.target(), ' ', instruction.data(), "?>"_s);
         break;
     }
-    case Node::ELEMENT_NODE:
+    case NodeType::Element:
         ASSERT_NOT_REACHED();
         break;
-    case Node::CDATA_SECTION_NODE:
+    case NodeType::CDATASection:
         if (inXMLFragmentSerialization()) {
             // FIXME: CDATA content is not escaped, but XMLSerializer (and possibly other callers) should raise an exception if it includes "]]>".
             result.append("<![CDATA["_s, uncheckedDowncast<CDATASection>(node).data(), "]]>"_s);
         } else
             appendText(result, uncheckedDowncast<Text>(node));
         break;
-    case Node::ATTRIBUTE_NODE:
+    case NodeType::Attribute:
         appendAttributeValue(result, uncheckedDowncast<Attr>(node).value());
         break;
     }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -102,7 +102,7 @@ static inline bool NODELETE isLegalNode(Node& node)
         || node.hasTagName(HTMLNames::rtTag)
         || node.hasTagName(HTMLNames::rubyTag)
         || node.hasTagName(HTMLNames::spanTag)
-        || node.nodeType() == Node::TEXT_NODE;
+        || node.nodeType() == NodeType::Text;
 }
 
 static Exception invalidNodeException(Node& node)
@@ -179,7 +179,7 @@ ExceptionOr<Ref<TextTrackCue>> TextTrackCue::create(Document& document, double s
     if (!cueFragment.firstChild())
         return Exception { ExceptionCode::InvalidNodeTypeError, "Empty cue fragment"_s };
 
-    if (cueFragment.firstChild()->nodeType() == Node::TEXT_NODE)
+    if (cueFragment.firstChild()->nodeType() == NodeType::Text)
         return Exception { ExceptionCode::InvalidNodeTypeError, "Invalid first child"_s };
 
     for (RefPtr node = cueFragment.firstChild(); node; node = node->nextSibling()) {

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -417,7 +417,7 @@ std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& nod
     addStringToSHA1(sha1, node.nodeName());
     addStringToSHA1(sha1, node.nodeValue());
 
-    if (node.nodeType() == Node::ELEMENT_NODE) {
+    if (node.nodeType() == NodeType::Element) {
         RefPtr child = node.firstChild();
         while (child) {
             std::unique_ptr<Digest> childInfo = createDigest(*child, unusedNodesMap);

--- a/Source/WebCore/inspector/InspectorNodeFinder.cpp
+++ b/Source/WebCore/inspector/InspectorNodeFinder.cpp
@@ -82,13 +82,13 @@ void InspectorNodeFinder::searchUsingDOMTreeTraversal(Node& parentNode)
     // Manual plain text search.
     for (RefPtr node = &parentNode; node; node = NodeTraversal::next(*node, &parentNode)) {
         switch (node->nodeType()) {
-        case Node::TEXT_NODE:
-        case Node::COMMENT_NODE:
-        case Node::CDATA_SECTION_NODE:
+        case NodeType::Text:
+        case NodeType::Comment:
+        case NodeType::CDATASection:
             if (checkContains(node->nodeValue(), m_query))
                 m_results.add(node);
             break;
-        case Node::ELEMENT_NODE:
+        case NodeType::Element:
             if (matchesElement(downcast<Element>(*node)))
                 m_results.add(node);
             if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*node))

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -551,7 +551,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Node>> Inspecto
 void InspectorDOMAgent::pushChildNodesToFrontend(Inspector::Protocol::DOM::NodeId nodeId, int depth)
 {
     RefPtr node = nodeForId(nodeId);
-    if (!node || (node->nodeType() != Node::ELEMENT_NODE && node->nodeType() != Node::DOCUMENT_NODE && node->nodeType() != Node::DOCUMENT_FRAGMENT_NODE))
+    if (!node || (node->nodeType() != NodeType::Element && node->nodeType() != NodeType::Document && node->nodeType() != NodeType::DocumentFragment))
         return;
 
     if (m_childrenRequested.contains(nodeId)) {
@@ -1979,23 +1979,23 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
     String nodeValue;
 
     switch (node->nodeType()) {
-    case Node::PROCESSING_INSTRUCTION_NODE:
+    case NodeType::ProcessingInstruction:
         nodeName = node->nodeName();
         localName = node->localName();
         [[fallthrough]];
-    case Node::TEXT_NODE:
-    case Node::COMMENT_NODE:
-    case Node::CDATA_SECTION_NODE:
+    case NodeType::Text:
+    case NodeType::Comment:
+    case NodeType::CDATASection:
         nodeValue = node->nodeValue();
         if (nodeValue.length() > maxTextSize)
             nodeValue = makeString(StringView(nodeValue).left(maxTextSize), horizontalEllipsisUTF16);
         break;
-    case Node::ATTRIBUTE_NODE:
+    case NodeType::Attribute:
         localName = node->localName();
         break;
-    case Node::DOCUMENT_FRAGMENT_NODE:
-    case Node::DOCUMENT_NODE:
-    case Node::ELEMENT_NODE:
+    case NodeType::DocumentFragment:
+    case NodeType::Document:
+    case NodeType::Element:
     default:
         nodeName = node->nodeName();
         localName = node->localName();
@@ -2099,7 +2099,7 @@ Ref<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::buildArray
     if (depth == 0) {
         // Special-case the only text child - pretend that container's children have been requested.
         RefPtr firstChild = container->firstChild();
-        if (firstChild && firstChild->nodeType() == Node::TEXT_NODE && !firstChild->nextSibling()) {
+        if (firstChild && firstChild->nodeType() == NodeType::Text && !firstChild->nextSibling()) {
             children->addItem(buildObjectForNode(firstChild.get(), 0));
             m_childrenRequested.add(bind(*container));
         }

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -690,7 +690,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(Node& node, const Arch
     Vector<Ref<Node>> nodeList;
     String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode, &nodeList, ResolveURLs::No, std::nullopt, SerializeShadowRoots::AllForInterchange, { }, options.markupExclusionRules);
     auto nodeType = node.nodeType();
-    if (nodeType != Node::DOCUMENT_NODE && nodeType != Node::DOCUMENT_TYPE_NODE)
+    if (nodeType != NodeType::Document && nodeType != NodeType::DocumentType)
         markupString = makeString(documentTypeString(node.document()), markupString);
 
     return createInternal(markupString, options, *frame, WTF::move(nodeList), frameFilter);

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -139,7 +139,7 @@ static String getTagName(Node* n)
 {
     if (n->isDocumentNode())
         return ""_s;
-    if (n->nodeType() == Node::COMMENT_NODE)
+    if (n->nodeType() == NodeType::Comment)
         return "COMMENT"_s;
     return n->nodeName();
 }

--- a/Source/WebCore/xml/XPathStep.cpp
+++ b/Source/WebCore/xml/XPathStep.cpp
@@ -150,13 +150,13 @@ void Step::evaluate(Node& context, NodeSet& nodes) const
 }
 
 #if ASSERT_ENABLED
-static inline Node::NodeType primaryNodeType(Step::Axis axis)
+static inline NodeType primaryNodeType(Step::Axis axis)
 {
     switch (axis) {
         case Step::AttributeAxis:
-            return Node::ATTRIBUTE_NODE;
+            return NodeType::Attribute;
         default:
-            return Node::ELEMENT_NODE;
+            return NodeType::Element;
     }
 }
 #endif // ASSERT_ENABLED
@@ -166,12 +166,12 @@ inline bool nodeMatchesBasicTest(Node& node, Step::Axis axis, const Step::NodeTe
 {
     switch (nodeTest.m_kind) {
         case Step::NodeTest::TextNodeTest:
-            return node.nodeType() == Node::TEXT_NODE || node.nodeType() == Node::CDATA_SECTION_NODE;
+            return node.nodeType() == NodeType::Text || node.nodeType() == NodeType::CDATASection;
         case Step::NodeTest::CommentNodeTest:
-            return node.nodeType() == Node::COMMENT_NODE;
+            return node.nodeType() == NodeType::Comment;
         case Step::NodeTest::ProcessingInstructionNodeTest: {
             const AtomString& name = nodeTest.m_data;
-            return node.nodeType() == Node::PROCESSING_INSTRUCTION_NODE && (name.isEmpty() || node.nodeName() == name);
+            return node.nodeType() == NodeType::ProcessingInstruction && (name.isEmpty() || node.nodeName() == name);
         }
         case Step::NodeTest::AnyNodeTest:
             return true;
@@ -202,7 +202,7 @@ inline bool nodeMatchesBasicTest(Node& node, Step::Axis axis, const Step::NodeTe
             ASSERT(axis != Step::NamespaceAxis);
 
             // For other axes, the principal node type is element.
-            ASSERT(primaryNodeType(axis) == Node::ELEMENT_NODE);
+            ASSERT(primaryNodeType(axis) == NodeType::Element);
             RefPtr element = dynamicDowncast<Element>(node);
             if (!element)
                 return false;

--- a/Source/WebCore/xml/XPathUtil.cpp
+++ b/Source/WebCore/xml/XPathUtil.cpp
@@ -41,15 +41,15 @@ bool isRootDomNode(Node* node)
 String stringValue(Node& node)
 {
     switch (node.nodeType()) {
-        case Node::ATTRIBUTE_NODE:
-        case Node::PROCESSING_INSTRUCTION_NODE:
-        case Node::COMMENT_NODE:
-        case Node::TEXT_NODE:
-        case Node::CDATA_SECTION_NODE:
-            return node.nodeValue();
-        default:
-            if (isRootDomNode(&node) || node.isElementNode())
-                return TextNodeTraversal::contentsAsString(node);
+    case NodeType::Attribute:
+    case NodeType::ProcessingInstruction:
+    case NodeType::Comment:
+    case NodeType::Text:
+    case NodeType::CDATASection:
+        return node.nodeValue();
+    default:
+        if (isRootDomNode(&node) || node.isElementNode())
+            return TextNodeTraversal::contentsAsString(node);
     }
     return String();
 }
@@ -57,17 +57,17 @@ String stringValue(Node& node)
 bool isValidContextNode(Node& node)
 {
     switch (node.nodeType()) {
-        case Node::ATTRIBUTE_NODE:
-        case Node::CDATA_SECTION_NODE:
-        case Node::COMMENT_NODE:
-        case Node::DOCUMENT_NODE:
-        case Node::ELEMENT_NODE:
-        case Node::PROCESSING_INSTRUCTION_NODE:
-        case Node::TEXT_NODE:
-            return true;
-        case Node::DOCUMENT_FRAGMENT_NODE:
-        case Node::DOCUMENT_TYPE_NODE:
-            return false;
+    case NodeType::Attribute:
+    case NodeType::CDATASection:
+    case NodeType::Comment:
+    case NodeType::Document:
+    case NodeType::Element:
+    case NodeType::ProcessingInstruction:
+    case NodeType::Text:
+        return true;
+    case NodeType::DocumentFragment:
+    case NodeType::DocumentType:
+        return false;
     }
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMPrivate.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMPrivate.cpp
@@ -35,7 +35,6 @@ G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 WebKitDOMNode* wrap(WebCore::Node* node)
 {
     ASSERT(node);
-    ASSERT(node->nodeType());
 
 #if PLATFORM(GTK)
     if (auto* wrapper = wrapNodeGtk(node))
@@ -43,17 +42,17 @@ WebKitDOMNode* wrap(WebCore::Node* node)
 #endif
 
     switch (node->nodeType()) {
-    case WebCore::Node::ELEMENT_NODE:
+    case WebCore::NodeType::Element:
         return WEBKIT_DOM_NODE(wrapElement(downcast<WebCore::Element>(node)));
-    case WebCore::Node::DOCUMENT_NODE:
+    case WebCore::NodeType::Document:
         return WEBKIT_DOM_NODE(wrapDocument(downcast<WebCore::Document>(node)));
-    case WebCore::Node::ATTRIBUTE_NODE:
-    case WebCore::Node::TEXT_NODE:
-    case WebCore::Node::CDATA_SECTION_NODE:
-    case WebCore::Node::PROCESSING_INSTRUCTION_NODE:
-    case WebCore::Node::COMMENT_NODE:
-    case WebCore::Node::DOCUMENT_TYPE_NODE:
-    case WebCore::Node::DOCUMENT_FRAGMENT_NODE:
+    case WebCore::NodeType::Attribute:
+    case WebCore::NodeType::Text:
+    case WebCore::NodeType::CDATASection:
+    case WebCore::NodeType::ProcessingInstruction:
+    case WebCore::NodeType::Comment:
+    case WebCore::NodeType::DocumentType:
+    case WebCore::NodeType::DocumentFragment:
         break;
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeGtk.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/JSNode.h>
 #include <wtf/GetPtr.h>
 #include <wtf/RefPtr.h>
+#include <wtf/StdLibExtras.h>
 
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 
@@ -516,7 +517,7 @@ gushort webkit_dom_node_get_node_type(WebKitDOMNode* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_NODE(self), 0);
     WebCore::Node* item = WebKit::core(self);
-    gushort result = item->nodeType();
+    gushort result = std::to_underlying(item->nodeType());
     return result;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMPrivateGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMPrivateGtk.cpp
@@ -72,30 +72,29 @@ using namespace WebCore::HTMLNames;
 WebKitDOMNode* wrapNodeGtk(Node* node)
 {
     ASSERT(node);
-    ASSERT(node->nodeType());
 
     switch (node->nodeType()) {
-    case Node::ELEMENT_NODE:
+    case NodeType::Element:
         if (is<HTMLElement>(*node))
             return WEBKIT_DOM_NODE(wrap(downcast<HTMLElement>(node)));
         return nullptr;
-    case Node::ATTRIBUTE_NODE:
+    case NodeType::Attribute:
         return WEBKIT_DOM_NODE(wrapAttr(static_cast<Attr*>(node)));
-    case Node::TEXT_NODE:
+    case NodeType::Text:
         return WEBKIT_DOM_NODE(wrapText(downcast<Text>(node)));
-    case Node::CDATA_SECTION_NODE:
+    case NodeType::CDATASection:
         return WEBKIT_DOM_NODE(wrapCDATASection(static_cast<CDATASection*>(node)));
-    case Node::PROCESSING_INSTRUCTION_NODE:
+    case NodeType::ProcessingInstruction:
         return WEBKIT_DOM_NODE(wrapProcessingInstruction(static_cast<ProcessingInstruction*>(node)));
-    case Node::COMMENT_NODE:
+    case NodeType::Comment:
         return WEBKIT_DOM_NODE(wrapComment(static_cast<Comment*>(node)));
-    case Node::DOCUMENT_NODE:
+    case NodeType::Document:
         if (is<HTMLDocument>(*node))
             return WEBKIT_DOM_NODE(wrapHTMLDocument(downcast<HTMLDocument>(node)));
         return nullptr;
-    case Node::DOCUMENT_TYPE_NODE:
+    case NodeType::DocumentType:
         return WEBKIT_DOM_NODE(wrapDocumentType(static_cast<DocumentType*>(node)));
-    case Node::DOCUMENT_FRAGMENT_NODE:
+    case NodeType::DocumentFragment:
         return WEBKIT_DOM_NODE(wrapDocumentFragment(static_cast<DocumentFragment*>(node)));
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
@@ -67,18 +67,18 @@ DOMCache<WebCore::Range*, __unsafe_unretained WKDOMRange *>& WKDOMRangeCache()
 static Class WKDOMNodeClassSingleton(WebCore::Node* impl)
 {
     switch (impl->nodeType()) {
-    case WebCore::Node::ELEMENT_NODE:
+    case WebCore::NodeType::Element:
         return [WKDOMElement class];
-    case WebCore::Node::DOCUMENT_NODE:
+    case WebCore::NodeType::Document:
         return [WKDOMDocument class];
-    case WebCore::Node::TEXT_NODE:
+    case WebCore::NodeType::Text:
         return [WKDOMText class];
-    case WebCore::Node::ATTRIBUTE_NODE:
-    case WebCore::Node::CDATA_SECTION_NODE:
-    case WebCore::Node::PROCESSING_INSTRUCTION_NODE:
-    case WebCore::Node::COMMENT_NODE:
-    case WebCore::Node::DOCUMENT_TYPE_NODE:
-    case WebCore::Node::DOCUMENT_FRAGMENT_NODE:
+    case WebCore::NodeType::Attribute:
+    case WebCore::NodeType::CDATASection:
+    case WebCore::NodeType::ProcessingInstruction:
+    case WebCore::NodeType::Comment:
+    case WebCore::NodeType::DocumentType:
+    case WebCore::NodeType::DocumentFragment:
         return [WKDOMNode class];
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -266,28 +266,28 @@ IGNORE_WARNINGS_END
 Class kitClass(Node* impl)
 {
     switch (impl->nodeType()) {
-        case Node::ELEMENT_NODE:
-            if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*impl))
-                return elementClass(htmlElement->tagQName(), [DOMHTMLElement class]);
-            return [DOMElement class];
-        case Node::ATTRIBUTE_NODE:
-            return [DOMAttr class];
-        case Node::TEXT_NODE:
-            return [DOMText class];
-        case Node::CDATA_SECTION_NODE:
-            return [DOMCDATASection class];
-        case Node::PROCESSING_INSTRUCTION_NODE:
-            return [DOMProcessingInstruction class];
-        case Node::COMMENT_NODE:
-            return [DOMComment class];
-        case Node::DOCUMENT_NODE:
-            if (is<HTMLDocument>(impl))
-                return [DOMHTMLDocument class];
-            return [DOMDocument class];
-        case Node::DOCUMENT_TYPE_NODE:
-            return [DOMDocumentType class];
-        case Node::DOCUMENT_FRAGMENT_NODE:
-            return [DOMDocumentFragment class];
+    case NodeType::Element:
+        if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*impl))
+            return elementClass(htmlElement->tagQName(), [DOMHTMLElement class]);
+        return [DOMElement class];
+    case NodeType::Attribute:
+        return [DOMAttr class];
+    case NodeType::Text:
+        return [DOMText class];
+    case NodeType::CDATASection:
+        return [DOMCDATASection class];
+    case NodeType::ProcessingInstruction:
+        return [DOMProcessingInstruction class];
+    case NodeType::Comment:
+        return [DOMComment class];
+    case NodeType::Document:
+        if (is<HTMLDocument>(impl))
+            return [DOMHTMLDocument class];
+        return [DOMDocument class];
+    case NodeType::DocumentType:
+        return [DOMDocumentType class];
+    case NodeType::DocumentFragment:
+        return [DOMDocumentFragment class];
     }
     ASSERT_NOT_REACHED();
     return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -103,7 +103,7 @@ DOMNode *kit(Node* value)
 - (unsigned short)nodeType
 {
     JSMainThreadNullState state;
-    return unwrap(*self).nodeType();
+    return std::to_underlying(unwrap(*self).nodeType());
 }
 
 - (DOMNode *)parentNode

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -143,8 +143,8 @@ using namespace JSC;
     auto& node = *core(self);
 
     String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode);
-    Node::NodeType nodeType = node.nodeType();
-    if (nodeType != Node::DOCUMENT_NODE && nodeType != Node::DOCUMENT_TYPE_NODE)
+    auto nodeType = node.nodeType();
+    if (nodeType != NodeType::Document && nodeType != NodeType::DocumentType)
         markupString = makeString(documentTypeString(node.document()), markupString);
 
     return markupString.createNSString().autorelease();


### PR DESCRIPTION
#### 72ca3c92c833fef50a4efc4c820da90a69737f27
<pre>
Use an enum class for NodeType
<a href="https://bugs.webkit.org/show_bug.cgi?id=308745">https://bugs.webkit.org/show_bug.cgi?id=308745</a>
<a href="https://rdar.apple.com/171332209">rdar://171332209</a>

Reviewed by Ryosuke Niwa.

Also remove DeprecatedNodeType entirely as it&apos;s not used in the code.
We keep DocumentPosition as-is for now (with some slight binding tweaks
to allow for that) as making it an enum class would require a lot of
conversion due to all the bitwise operations. Might still be worth
doing, but probably best as a separate change.

Canonical link: <a href="https://commits.webkit.org/308331@main">https://commits.webkit.org/308331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b9bf6b435f6f237d837131fada51555bfef0f48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155872 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113434 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df33bfab-6cd0-4c0f-aa73-1474b725924d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94195 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a36d56d-1fc0-4e65-83c3-4f3696b1db8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14848 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12625 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3315 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158203 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121461 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121664 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131906 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75640 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22692 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8702 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83042 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->