### PR TITLE
Rename WebKit_DerivedSources to mention IPC

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -2419,7 +2419,7 @@ def generate_message_argument_description_implementation(receivers, receiver_hea
 def generate_modulemap(receiver_headers: list[str]) -> str:
     result = []
 
-    result.append('module WebKit_DerivedSources {')
+    result.append('module WebKit_DerivedSources_IPC {')
 
     all_headers = receiver_headers + ['MessageNames.h', 'GeneratedSerializers.h', 'GeneratedWebKitSecureCoding.h']
     for header in all_headers:

--- a/Source/WebKit/Scripts/webkit/tests/module.private.modulemap
+++ b/Source/WebKit/Scripts/webkit/tests/module.private.modulemap
@@ -1,4 +1,4 @@
-module WebKit_DerivedSources {
+module WebKit_DerivedSources_IPC {
   explicit module IPCMessages {
     header "IPCMessages.h"
     export *


### PR DESCRIPTION
#### 1d714e596d234f8ef7b297148fb8394ba1a6ed49
<pre>
Rename WebKit_DerivedSources to mention IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=308746">https://bugs.webkit.org/show_bug.cgi?id=308746</a>
<a href="https://rdar.apple.com/171264950">rdar://171264950</a>

Reviewed by Elliott Williams.

Rename the clang module WebKit_DerivedSources to WebKit_DerivedSources_IPC, to
reflect the fact that it only contains the IPC-related derived sources and not
any others. Future work may add a modulemap for other parts of the
DerivedSources.

Canonical link: <a href="https://commits.webkit.org/308461@main">https://commits.webkit.org/308461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c11ea94b18afc61cfc2e88928062efe2dcc7f6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101026 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3d4cf49-681d-4435-8dd1-a334788a604e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113786 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81155 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ab2a1c0-1bc6-4c05-a04e-991c38e78fef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c3610f2-784b-4cdf-9897-8759a536fb7e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/146933 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3734 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124783 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158627 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121812 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122013 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31243 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76210 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9055 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19710 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83473 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19591 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->