### PR TITLE
Switch emit-clang-header-min-access to be SDK based

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -427,14 +427,13 @@ ENABLE_IPC_TESTING_SWIFT[sdk=macosx26*] = ;
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
 OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)) $(OTHER_SWIFT_FLAGS_MARK_FOUNDATION_AS_OBJC_$(WK_GENERATE_SINGLE_SWIFT_INTEROP_FILE);
-OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = -Xcc -std=c++2b -no-verify-emitted-module-interface $(OTHER_SWIFT_FLAGS_MIN_ACCESS_$(ENABLE_IPC_TESTING_SWIFT));
+OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = -Xcc -std=c++2b -no-verify-emitted-module-interface $(OTHER_SWIFT_FLAGS_MIN_ACCESS);
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = ;
 OTHER_SWIFT_FLAGS_MARK_FOUNDATION_AS_OBJC_YES = -enable-experimental-feature RequiresObjC=Foundation;
 OTHER_SWIFT_FLAGS_MARK_FOUNDATION_AS_OBJC_NO = ;
-OTHER_SWIFT_FLAGS_MIN_ACCESS_ = $(OTHER_SWIFT_FLAGS_MIN_ACCESS_BACK_FORWARD_$(ENABLE_BACK_FORWARD_LIST_SWIFT));
-OTHER_SWIFT_FLAGS_MIN_ACCESS_ENABLE_IPC_TESTING_SWIFT = -Xfrontend -emit-clang-header-min-access -Xfrontend internal;
-OTHER_SWIFT_FLAGS_MIN_ACCESS_BACK_FORWARD_ENABLE_BACK_FORWARD_LIST_SWIFT = -Xfrontend -emit-clang-header-min-access -Xfrontend internal;
-OTHER_SWIFT_FLAGS_MIN_ACCESS_BACK_FORWARD_ = ;
+OTHER_SWIFT_FLAGS_MIN_ACCESS = -Xfrontend -emit-clang-header-min-access -Xfrontend internal;
+OTHER_SWIFT_FLAGS_MIN_ACCESS[sdk=*15*] = ;
+OTHER_SWIFT_FLAGS_MIN_ACCESS[sdk=*26*] = ;
 
 // WebKit's clang module does not build in public SDK builds of these
 // platforms, preventing any Swift compilation. (https://bugs.webkit.org/show_bug.cgi?id=280912)


### PR DESCRIPTION
#### 09598407876cea1814365b7b0dc2cbe0187c8583
<pre>
Switch emit-clang-header-min-access to be SDK based
<a href="https://bugs.webkit.org/show_bug.cgi?id=308749">https://bugs.webkit.org/show_bug.cgi?id=308749</a>
<a href="https://rdar.apple.com/171266342">rdar://171266342</a>

Reviewed by Elliott Williams.

It&apos;s best practice if we can move ENABLE_BACK_FORWARD_LIST_SWIFT into
PlatformEnable.h instead of in xcconfig files. To allow that, cease to depend
upon that flag when determining whether to use the Swift flag
-emit-clang-header-min-access: simply always provide it when there&apos;s a
sufficiently recent SDK.

Canonical link: <a href="https://commits.webkit.org/308427@main">https://commits.webkit.org/308427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/524d36230f3acef433764b9f64503fd42f0babc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100432 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cceba336-35b2-499f-a2ff-0d238bdc6a28) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80838 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12ef71a7-495c-4f2a-9fd7-63489ca78bf1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94042 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95fc796c-8455-4c45-88ea-f8aa9cdc28df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14741 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12516 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3142 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124328 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158031 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1162 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121310 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31220 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75468 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17074 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8584 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82870 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18845 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18996 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18904 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->