### PR TITLE
RemoteGraphicsContextProxy::recordResourceUse should use const NativeImage

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -74,7 +74,7 @@ bool NativeImage::hasHDRContent() const
     return colorSpace().usesITUR_2100TF();
 }
 
-void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage)
+void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage) const
 {
     ASSERT(platformImage);
     m_platformImage = WTF::move(platformImage);
@@ -82,7 +82,7 @@ void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage)
 }
 
 #if !USE(CG)
-void NativeImage::computeHeadroom()
+void NativeImage::computeHeadroom() const
 {
 }
 #endif

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -75,7 +75,7 @@ public:
 
     void clearSubimages();
 
-    WEBCORE_EXPORT void replacePlatformImage(PlatformImagePtr&&);
+    WEBCORE_EXPORT void replacePlatformImage(PlatformImagePtr&&) const;
 
 #if USE(COORDINATED_GRAPHICS)
     uint64_t uniqueID() const;
@@ -85,7 +85,7 @@ public:
     GrDirectContext* grContext() const { return m_grContext; }
 #endif
 
-    void addObserver(WeakRef<RenderingResourceObserver>&& observer)
+    void addObserver(WeakRef<RenderingResourceObserver>&& observer) const
     {
         m_observers.add(WTF::move(observer));
     }
@@ -102,7 +102,7 @@ protected:
     WEBCORE_EXPORT NativeImage(PlatformImagePtr&&);
 #endif
 
-    void computeHeadroom();
+    void computeHeadroom() const;
 
     mutable PlatformImagePtr m_platformImage;
     mutable Headroom m_headroom { Headroom::None };

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -112,17 +112,17 @@ RefPtr<ShareableBitmap> ShareableBitmap::create(const ShareableBitmapConfigurati
     return adoptRef(new ShareableBitmap(configuration, WTF::move(sharedMemory)));
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image, const DestinationColorSpace& colorSpace)
+RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(const NativeImage& image, const DestinationColorSpace& colorSpace)
 {
     return createFromImageDraw(image, colorSpace, image.size());
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image, const DestinationColorSpace& colorSpace, const IntSize& destinationSize)
+RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(const NativeImage& image, const DestinationColorSpace& colorSpace, const IntSize& destinationSize)
 {
     return createFromImageDraw(image, colorSpace, destinationSize, destinationSize);
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image, const DestinationColorSpace& colorSpace, const IntSize& destinationSize, const IntSize& sourceSize)
+RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(const NativeImage& image, const DestinationColorSpace& colorSpace, const IntSize& destinationSize, const IntSize& sourceSize)
 {
     auto bitmap = ShareableBitmap::create({ destinationSize, colorSpace });
     if (!bitmap)

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -63,7 +63,7 @@ public:
 #endif
     );
 #if USE(CG)
-    ShareableBitmapConfiguration(NativeImage&);
+    ShareableBitmapConfiguration(const NativeImage&);
 #endif
 
     IntSize size() const { return m_size; }
@@ -148,11 +148,11 @@ public:
 
     // Create a shareable bitmap from a NativeImage.
 #if USE(CG)
-    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImagePixels(NativeImage&);
+    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImagePixels(const NativeImage&);
 #endif
-    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&, const DestinationColorSpace&);
-    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&, const DestinationColorSpace&, const IntSize&);
-    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&, const DestinationColorSpace&, const IntSize& destinationSize, const IntSize& sourceSize);
+    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(const NativeImage&, const DestinationColorSpace&);
+    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(const NativeImage&, const DestinationColorSpace&, const IntSize&);
+    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(const NativeImage&, const DestinationColorSpace&, const IntSize& destinationSize, const IntSize& sourceSize);
 
     // Create a shareable bitmap from a handle.
     WEBCORE_EXPORT static RefPtr<ShareableBitmap> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite, SharedMemory::CopyOnWrite = defaultCopyOnWrite);

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -78,7 +78,7 @@ DestinationColorSpace NativeImage::colorSpace() const
     return DestinationColorSpace(CGImageGetColorSpace(m_platformImage.get()));
 }
 
-void NativeImage::computeHeadroom()
+void NativeImage::computeHeadroom() const
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     float headroom = CGImageGetContentHeadroom(m_platformImage.get());

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(NativeImage& image)
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const NativeImage& image)
     : m_size(image.size())
     , m_colorSpace(image.colorSpace())
     , m_headroom(image.headroom())
@@ -108,7 +108,7 @@ CGBitmapInfo ShareableBitmapConfiguration::calculateBitmapInfo(const Destination
     return info;
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImagePixels(NativeImage& image)
+RefPtr<ShareableBitmap> ShareableBitmap::createFromImagePixels(const NativeImage& image)
 {
     auto colorSpace = image.colorSpace();
     if (CGColorSpaceGetModel(protect(colorSpace.platformColorSpace()).get()) != kCGColorSpaceModelRGB)

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
@@ -66,7 +66,7 @@ void RemoteBarcodeDetectorProxy::detect(const WebCore::NativeImage& image, Compl
         completionHandler({ });
         return;
     }
-    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(const_cast<WebCore::NativeImage&>(image), WebCore::DestinationColorSpace::SRGB())) {
+    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image, WebCore::DestinationColorSpace::SRGB())) {
         completionHandler({ });
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -68,7 +68,7 @@ void RemoteFaceDetectorProxy::detect(const WebCore::NativeImage& image, Completi
         completionHandler({ });
         return;
     }
-    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(const_cast<WebCore::NativeImage&>(image), WebCore::DestinationColorSpace::SRGB())) {
+    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image, WebCore::DestinationColorSpace::SRGB())) {
         completionHandler({ });
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
@@ -67,7 +67,7 @@ void RemoteTextDetectorProxy::detect(const WebCore::NativeImage& image, Completi
         completionHandler({ });
         return;
     }
-    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(const_cast<WebCore::NativeImage&>(image), WebCore::DestinationColorSpace::SRGB())) {
+    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image, WebCore::DestinationColorSpace::SRGB())) {
         completionHandler({ });
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -655,7 +655,7 @@ void RemoteGraphicsContextProxy::setURLForRect(const URL& link, const FloatRect&
     send(Messages::RemoteGraphicsContext::SetURLForRect(link, destRect));
 }
 
-bool RemoteGraphicsContextProxy::recordResourceUse(NativeImage& image)
+bool RemoteGraphicsContextProxy::recordResourceUse(const NativeImage& image)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
     if (!renderingBackend) [[unlikely]] {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -146,7 +146,7 @@ private:
     void endPage() final;
     void setURLForRect(const URL&, const WebCore::FloatRect&) final;
 
-    [[nodiscard]] bool recordResourceUse(WebCore::NativeImage&);
+    [[nodiscard]] bool recordResourceUse(const WebCore::NativeImage&);
     [[nodiscard]] bool recordResourceUse(WebCore::ImageBuffer&);
     std::optional<RemotePathImplIdentifier> recordResourceUse(const WebCore::PathImpl&);
     bool recordResourceUse(const WebCore::SourceImage&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -47,7 +47,7 @@ struct CreateShareableBitmapResult {
 };
 }
 
-static std::optional<CreateShareableBitmapResult> createShareableBitmapForNativeImage(NativeImage& image, const DestinationColorSpace& fallbackColorSpace)
+static std::optional<CreateShareableBitmapResult> createShareableBitmapForNativeImage(const NativeImage& image, const DestinationColorSpace& fallbackColorSpace)
 {
     RefPtr<ShareableBitmap> bitmap;
     PlatformImagePtr platformImage;
@@ -132,7 +132,7 @@ void RemoteResourceCacheProxy::recordFilterUse(Filter& filter)
     }
 }
 
-bool RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image, const DestinationColorSpace& fallbackColorSpace)
+bool RemoteResourceCacheProxy::recordNativeImageUse(const NativeImage& image, const DestinationColorSpace& fallbackColorSpace)
 {
     if (isMainRunLoop())
         WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -63,7 +63,7 @@ public:
 
     Ref<RemoteNativeImageProxy> createNativeImage(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha);
 
-    [[nodiscard]] bool recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
+    [[nodiscard]] bool recordNativeImageUse(const WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     RemotePathImplIdentifier recordPathImplUse(const WebCore::PathImpl&);
     void recordFontUse(WebCore::Font&);
     RemoteGradientIdentifier recordGradientUse(WebCore::Gradient&);


### PR DESCRIPTION
#### e484381cb624c92f80282211597a047bd6fb9020
<pre>
RemoteGraphicsContextProxy::recordResourceUse should use const NativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=308725">https://bugs.webkit.org/show_bug.cgi?id=308725</a>
<a href="https://rdar.apple.com/171248851">rdar://171248851</a>

Reviewed by Anne van Kesteren.

NativeImage is externally immutable, so drawing NativeImage to
GPUP context should not have externally observable effects.
Mark
RemoteGraphicsContextProxy::recordResourceUse(const NativeImage&amp;,...)
and propagate the const further as needed.

The NativeImage accessors
and update functions mutate mutable variables and the the state
behaves as if immutable. Later commits will make the mutable variables
thread-safe.

* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::replacePlatformImage const):
(WebCore::NativeImage::computeHeadroom const):
(WebCore::NativeImage::replacePlatformImage): Deleted.
(WebCore::NativeImage::computeHeadroom): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImage::addObserver const):
(WebCore::NativeImage::addObserver): Deleted.
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmap::createFromImageDraw):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::computeHeadroom const):
(WebCore::NativeImage::computeHeadroom): Deleted.
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmap::createFromImagePixels):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteTextDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapForNativeImage):
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/308290@main">https://commits.webkit.org/308290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5325c603d429ec7706dad92d4921a828e61276b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155705 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ce85073-7243-46be-a03c-4743263ef264) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148897 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113296 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79ec2c99-3bfe-4105-b23d-39e3a9c47ddb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149985 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4933227-7cc0-49e9-8d6d-852d7d208d68) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3147 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158036 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121320 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121521 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31127 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131764 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17084 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82875 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->