### PR TITLE
WebAuthn: Respect AbortSignal reason in navigator.credentials.create()

### DIFF
--- a/LayoutTests/http/wpt/webauthn/credential-create-abort-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/credential-create-abort-expected.txt
@@ -1,0 +1,8 @@
+
+PASS create() after abort (no reason)
+PASS create() before abort (no reason)
+PASS create() after abort (string reason)
+PASS create() before abort (string reason)
+PASS create() after abort (Error reason)
+PASS create() before abort (Error reason)
+

--- a/LayoutTests/http/wpt/webauthn/credential-create-abort.html
+++ b/LayoutTests/http/wpt/webauthn/credential-create-abort.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<title>Web Authentication API: PublicKeyCredential's [[create]] abort cases with a mock ccid authenticator.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/util.js"></script>
+<script>
+    function baseOptions() {
+        return {
+            publicKey: {
+                rp: { name: "localhost" },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            }
+        };
+    }
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "info", subStage: "init", error: "data-not-sent" } });
+        const ac = new AbortController();
+        ac.abort();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        await promise_rejects_dom(t, "AbortError", p);
+    }, "create() after abort (no reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        ac.abort();
+        await promise_rejects_dom(t, "AbortError", p);
+    }, "create() before abort (no reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        ac.abort("CustomError");
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        await promise_rejects_exactly(t, "CustomError", p);
+    }, "create() after abort (string reason)");
+    
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        ac.abort("CustomError");
+        await promise_rejects_exactly(t, "CustomError", p);
+    }, "create() before abort (string reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        ac.abort(new Error("error"));
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        await promise_rejects_js(t, Error, p);
+    }, "create() after abort (Error reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        ac.abort(new Error("error"));
+        await p.catch(e => {
+            // TODO: The following line prevents the AbortController (ac) from being garbage collected,
+            // ensuring the abort reason is retained for this test. Ideally, the abort reason should persist
+            // without needing to reference ac here. Investigate if the abort reason can be preserved independently.
+            ac;
+            if (!(e instanceof Error) || e.message !== "error")
+                throw new Error(`Expected an Error with message "error", but got: ${e}`);
+        });
+    }, "create() before abort (Error reason)");
+</script>

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "AuthenticatorCoordinator.h"
+#include "bindings/IDLTypes.h"
 
 #if ENABLE(WEB_AUTHN)
 
@@ -244,7 +245,7 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
 
     auto callback = [promise = WTF::move(promise), abortSignal = WTF::move(abortSignal)](AuthenticatorResponseData&& data, AuthenticatorAttachment attachment, ExceptionData&& exception) mutable {
         if (abortSignal && abortSignal->aborted()) {
-            promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+            promise.rejectType<IDLAny>(abortSignal->reason().getValue());
             return;
         }
 


### PR DESCRIPTION
#### e9c00d99afd5afa605ef3ddcb322b0c54803a976
<pre>
WebAuthn: Respect AbortSignal reason in navigator.credentials.create()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306878">https://bugs.webkit.org/show_bug.cgi?id=306878</a>

Reviewed by NOBODY (OOPS!).

This change intends to fix web-platform-tests/webauthn/createcredential-abort.https.html?label=experimental&amp;label=master&amp;aligned

The abort reason passed to abort() is now propagated.

Reference:
“If `options.signal` is aborted, then return a promise
rejected with `options.signal`’s abort reason”
in <a href="https://w3c.github.io/webappsec-credential-management/#algorithm-create">https://w3c.github.io/webappsec-credential-management/#algorithm-create</a>

* LayoutTests/http/wpt/webauthn/credential-create-abort-expected.txt: Added.
* LayoutTests/http/wpt/webauthn/credential-create-abort.html: Added.
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9c00d99afd5afa605ef3ddcb322b0c54803a976

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147027 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/19707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/148901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/155709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/149989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/158040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/19124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->