### PR TITLE
[Cocoa] Plumb 'previewID' down from UIProcess to WebContent

### DIFF
--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -114,6 +114,8 @@ public:
     WEBCORE_EXPORT UniqueRef<CaptionUserPreferencesTestingModeToken> NODELETE createTestingModeToken();
 
     virtual String captionPreviewTitle() const;
+    virtual String captionPreviewProfileID() const { return emptyString(); }
+    virtual void setCaptionPreviewProfileID(const String&) { }
 
     PageGroup& NODELETE pageGroup() const;
 

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "CaptionUserPreferencesMediaAF.h"
 
-#if ENABLE(VIDEO)
+#if ENABLE(VIDEO) && HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 #include "AudioTrackList.h"
 #include "CSSValueKeywords.h"
@@ -40,6 +40,7 @@
 #include "UserAgentParts.h"
 #include "UserStyleSheetTypes.h"
 #include <algorithm>
+#include <pal/spi/cf/CFNotificationCenterSPI.h>
 #include <ranges>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
@@ -55,15 +56,9 @@
 #include <wtf/text/cf/StringConcatenateCF.h>
 #include <wtf/unicode/Collator.h>
 
-#if PLATFORM(COCOA)
-#include <pal/spi/cf/CFNotificationCenterSPI.h>
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 #include "WebCoreThreadRun.h"
 #endif
-
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 #include <CoreText/CoreText.h>
 #include <MediaAccessibility/MediaAccessibility.h>
@@ -73,13 +68,9 @@
 SOFT_LINK_FRAMEWORK_OPTIONAL(MediaToolbox)
 SOFT_LINK_OPTIONAL(MediaToolbox, MTEnableCaption2015Behavior, Boolean, (), ())
 
-#endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CaptionUserPreferencesMediaAF);
-
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 static std::unique_ptr<CaptionPreferencesDelegate>& captionPreferencesDelegate()
 {
@@ -99,6 +90,19 @@ static std::optional<Vector<String>>& NODELETE cachedPreferredLanguages()
     return preferredLanguages;
 }
 
+template<typename... Types> void appendCSS(StringBuilder& builder, CSSPropertyID id, bool important, const Types&... values)
+{
+    builder.append(nameLiteral(id), ':', values..., important ? " !important;"_s : ";"_s);
+}
+
+static String colorPropertyCSS(CSSPropertyID id, const Color& color, bool important)
+{
+    StringBuilder builder;
+    // FIXME: Seems like this should be using serializationForCSS instead?
+    appendCSS(builder, id, important, serializationForHTML(color));
+    return builder.toString();
+}
+
 static void userCaptionPreferencesChangedNotificationCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void*, CFDictionaryRef)
 {
     RefPtr userPreferences = CaptionUserPreferencesMediaAF::extractCaptionUserPreferencesMediaAF(observer);
@@ -113,7 +117,19 @@ static void userCaptionPreferencesChangedNotificationCallback(CFNotificationCent
     }
 }
 
-#endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
+template<std::invocable<> F, typename R = std::invoke_result_t<F>>
+R runWithPreviewProfile(const String& previewProfileID, F&& task)
+{
+    if (previewProfileID.isEmpty() || !canLoad_MediaAccessibility_MACaptionAppearanceExecuteBlockForProfileID())
+        return task();
+
+    __block R returnVal = { };
+    RetainPtr cfPreviewProfileID = previewProfileID.createCFString();
+    MACaptionAppearanceExecuteBlockForProfileID(cfPreviewProfileID.get(), ^{
+        returnVal = task();
+    });
+    return returnVal;
+}
 
 Ref<CaptionUserPreferencesMediaAF> CaptionUserPreferencesMediaAF::create(PageGroup& group)
 {
@@ -122,9 +138,7 @@ Ref<CaptionUserPreferencesMediaAF> CaptionUserPreferencesMediaAF::create(PageGro
 
 CaptionUserPreferencesMediaAF::CaptionUserPreferencesMediaAF(PageGroup& group)
     : CaptionUserPreferences(group)
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     , m_updateStyleSheetTimer(*this, &CaptionUserPreferencesMediaAF::updateTimerFired)
-#endif
 {
     static bool initialized;
     if (!initialized) {
@@ -148,17 +162,13 @@ CaptionUserPreferencesMediaAF::CaptionUserPreferencesMediaAF(PageGroup& group)
 
 CaptionUserPreferencesMediaAF::~CaptionUserPreferencesMediaAF()
 {
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     if (m_observer) {
         if (kMAXCaptionAppearanceSettingsChangedNotification)
             CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), RetainPtr { kMAXCaptionAppearanceSettingsChangedNotification }.get(), 0);
         if (kMAAudibleMediaSettingsChangedNotification)
             CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenterSingleton(), m_observer.get(), RetainPtr { kMAAudibleMediaSettingsChangedNotification }.get(), 0);
     }
-#endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 }
-
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 CaptionUserPreferences::CaptionDisplayMode CaptionUserPreferencesMediaAF::captionDisplayMode() const
 {
@@ -324,53 +334,59 @@ static bool behaviorShouldNotBeOverriden(MACaptionAppearanceBehavior behavior)
 
 String CaptionUserPreferencesMediaAF::captionsWindowCSS() const
 {
-    MACaptionAppearanceBehavior behavior;
-    RetainPtr color = adoptCF(MACaptionAppearanceCopyWindowColor(kMACaptionAppearanceDomainUser, &behavior));
+    return runWithPreviewProfile(m_previewProfileID, [] {
+        MACaptionAppearanceBehavior behavior;
+        RetainPtr color = adoptCF(MACaptionAppearanceCopyWindowColor(kMACaptionAppearanceDomainUser, &behavior));
 
-    Color windowColor(roundAndClampToSRGBALossy(color.get()));
-    if (!windowColor.isValid())
-        windowColor = Color::transparentBlack;
+        Color windowColor(roundAndClampToSRGBALossy(color.get()));
+        if (!windowColor.isValid())
+            windowColor = Color::transparentBlack;
 
-    bool important = behaviorShouldNotBeOverriden(behavior);
-    CGFloat opacity = MACaptionAppearanceGetWindowOpacity(kMACaptionAppearanceDomainUser, &behavior);
-    if (!important)
-        important = behaviorShouldNotBeOverriden(behavior);
-    return colorPropertyCSS(CSSPropertyBackgroundColor, windowColor.colorWithAlpha(opacity), important);
+        bool important = behaviorShouldNotBeOverriden(behavior);
+        CGFloat opacity = MACaptionAppearanceGetWindowOpacity(kMACaptionAppearanceDomainUser, &behavior);
+        if (!important)
+            important = behaviorShouldNotBeOverriden(behavior);
+        return colorPropertyCSS(CSSPropertyBackgroundColor, windowColor.colorWithAlpha(opacity), important);
+    });
 }
 
 String CaptionUserPreferencesMediaAF::captionsBackgroundCSS() const
 {
-    // This must match the ::cue background color of WebCore/Modules/modern-media-controls/controls/text-tracks.css
-    constexpr auto defaultBackgroundColor = Color::black.colorWithAlphaByte(204);
+    return runWithPreviewProfile(m_previewProfileID, [] {
+        // This must match the ::cue background color of WebCore/Modules/modern-media-controls/controls/text-tracks.css
+        constexpr auto defaultBackgroundColor = Color::black.colorWithAlphaByte(204);
 
-    MACaptionAppearanceBehavior behavior;
+        MACaptionAppearanceBehavior behavior;
 
-    RetainPtr color = adoptCF(MACaptionAppearanceCopyBackgroundColor(kMACaptionAppearanceDomainUser, &behavior));
-    Color backgroundColor(roundAndClampToSRGBALossy(color.get()));
-    if (!backgroundColor.isValid())
-        backgroundColor = defaultBackgroundColor;
+        RetainPtr color = adoptCF(MACaptionAppearanceCopyBackgroundColor(kMACaptionAppearanceDomainUser, &behavior));
+        Color backgroundColor(roundAndClampToSRGBALossy(color.get()));
+        if (!backgroundColor.isValid())
+            backgroundColor = defaultBackgroundColor;
 
-    bool important = behaviorShouldNotBeOverriden(behavior);
-    CGFloat opacity = MACaptionAppearanceGetBackgroundOpacity(kMACaptionAppearanceDomainUser, &behavior);
-    if (!important)
-        important = behaviorShouldNotBeOverriden(behavior);
-    return colorPropertyCSS(CSSPropertyBackgroundColor, backgroundColor.colorWithAlpha(opacity), important);
+        bool important = behaviorShouldNotBeOverriden(behavior);
+        CGFloat opacity = MACaptionAppearanceGetBackgroundOpacity(kMACaptionAppearanceDomainUser, &behavior);
+        if (!important)
+            important = behaviorShouldNotBeOverriden(behavior);
+        return colorPropertyCSS(CSSPropertyBackgroundColor, backgroundColor.colorWithAlpha(opacity), important);
+    });
 }
 
 Color CaptionUserPreferencesMediaAF::captionsTextColor(bool& important) const
 {
-    MACaptionAppearanceBehavior behavior;
-    RetainPtr color = adoptCF(MACaptionAppearanceCopyForegroundColor(kMACaptionAppearanceDomainUser, &behavior)).get();
-    Color textColor(roundAndClampToSRGBALossy(color.get()));
-    if (!textColor.isValid()) {
-        // This must match the ::cue text color of WebCore/Modules/modern-media-controls/controls/text-tracks.css
-        textColor = Color::white;
-    }
-    important = behaviorShouldNotBeOverriden(behavior);
-    CGFloat opacity = MACaptionAppearanceGetForegroundOpacity(kMACaptionAppearanceDomainUser, &behavior);
-    if (!important)
+    return runWithPreviewProfile(m_previewProfileID, [&important] {
+        MACaptionAppearanceBehavior behavior;
+        RetainPtr color = adoptCF(MACaptionAppearanceCopyForegroundColor(kMACaptionAppearanceDomainUser, &behavior)).get();
+        Color textColor(roundAndClampToSRGBALossy(color.get()));
+        if (!textColor.isValid()) {
+            // This must match the ::cue text color of WebCore/Modules/modern-media-controls/controls/text-tracks.css
+            textColor = Color::white;
+        }
         important = behaviorShouldNotBeOverriden(behavior);
-    return textColor.colorWithAlpha(opacity);
+        CGFloat opacity = MACaptionAppearanceGetForegroundOpacity(kMACaptionAppearanceDomainUser, &behavior);
+        if (!important)
+            important = behaviorShouldNotBeOverriden(behavior);
+        return textColor.colorWithAlpha(opacity);
+    });
 }
 
 String CaptionUserPreferencesMediaAF::captionsTextColorCSS() const
@@ -382,50 +398,41 @@ String CaptionUserPreferencesMediaAF::captionsTextColorCSS() const
     return colorPropertyCSS(CSSPropertyColor, textColor, important);
 }
 
-template<typename... Types> void appendCSS(StringBuilder& builder, CSSPropertyID id, bool important, const Types&... values)
-{
-    builder.append(nameLiteral(id), ':', values..., important ? " !important;"_s : ";"_s);
-}
-
 String CaptionUserPreferencesMediaAF::windowRoundedCornerRadiusCSS() const
 {
-    MACaptionAppearanceBehavior behavior;
-    CGFloat radius = MACaptionAppearanceGetWindowRoundedCornerRadius(kMACaptionAppearanceDomainUser, &behavior);
-    if (!radius)
-        return emptyString();
+    return runWithPreviewProfile(m_previewProfileID, [] {
+        MACaptionAppearanceBehavior behavior;
+        CGFloat radius = MACaptionAppearanceGetWindowRoundedCornerRadius(kMACaptionAppearanceDomainUser, &behavior);
+        if (!radius)
+            return emptyString();
 
-    StringBuilder builder;
-    appendCSS(builder, CSSPropertyBorderRadius, behaviorShouldNotBeOverriden(behavior), radius, "px"_s);
-    appendCSS(builder, CSSPropertyPadding, behaviorShouldNotBeOverriden(behavior), radius / 4, "px"_s);
-    return builder.toString();
-}
-
-String CaptionUserPreferencesMediaAF::colorPropertyCSS(CSSPropertyID id, const Color& color, bool important) const
-{
-    StringBuilder builder;
-    // FIXME: Seems like this should be using serializationForCSS instead?
-    appendCSS(builder, id, important, serializationForHTML(color));
-    return builder.toString();
+        StringBuilder builder;
+        appendCSS(builder, CSSPropertyBorderRadius, behaviorShouldNotBeOverriden(behavior), radius, "px"_s);
+        appendCSS(builder, CSSPropertyPadding, behaviorShouldNotBeOverriden(behavior), radius / 4, "px"_s);
+        return builder.toString();
+    });
 }
 
 bool CaptionUserPreferencesMediaAF::captionStrokeWidthForFont(float fontSize, const String& language, float& strokeWidth, bool& important) const
 {
     if (!canLoad_MediaAccessibility_MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle())
         return false;
-    
-    MACaptionAppearanceBehavior behavior;
-    auto trackLanguage = language.createCFString();
-    CGFloat strokeWidthPt;
-    
-    RetainPtr fontDescriptor = adoptCF(MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle(kMACaptionAppearanceDomainUser, &behavior, kMACaptionAppearanceFontStyleDefault, trackLanguage.get(), fontSize, &strokeWidthPt));
 
-    if (!fontDescriptor)
-        return false;
+    return runWithPreviewProfile(m_previewProfileID, [fontSize, &language, &strokeWidth, &important] {
+        MACaptionAppearanceBehavior behavior;
+        auto trackLanguage = language.createCFString();
+        CGFloat strokeWidthPt;
 
-    // Since only half of the stroke is visible because the stroke is drawn before the fill, we double the stroke width here.
-    strokeWidth = strokeWidthPt * 2;
-    important = behaviorShouldNotBeOverriden(behavior);
-    return true;
+        RetainPtr fontDescriptor = adoptCF(MACaptionAppearanceCopyFontDescriptorWithStrokeForStyle(kMACaptionAppearanceDomainUser, &behavior, kMACaptionAppearanceFontStyleDefault, trackLanguage.get(), fontSize, &strokeWidthPt));
+
+        if (!fontDescriptor)
+            return false;
+
+        // Since only half of the stroke is visible because the stroke is drawn before the fill, we double the stroke width here.
+        strokeWidth = strokeWidthPt * 2;
+        important = behaviorShouldNotBeOverriden(behavior);
+        return true;
+    });
 }
 
 bool CaptionUserPreferencesMediaAF::testingMode() const
@@ -435,70 +442,74 @@ bool CaptionUserPreferencesMediaAF::testingMode() const
 
 String CaptionUserPreferencesMediaAF::captionsTextEdgeCSS() const
 {
-    MACaptionAppearanceBehavior behavior;
-    MACaptionAppearanceTextEdgeStyle textEdgeStyle = MACaptionAppearanceGetTextEdgeStyle(kMACaptionAppearanceDomainUser, &behavior);
-    
-    if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleUndefined || textEdgeStyle == kMACaptionAppearanceTextEdgeStyleNone)
-        return emptyString();
+    return runWithPreviewProfile(m_previewProfileID, [] {
+        MACaptionAppearanceBehavior behavior;
+        MACaptionAppearanceTextEdgeStyle textEdgeStyle = MACaptionAppearanceGetTextEdgeStyle(kMACaptionAppearanceDomainUser, &behavior);
 
-    StringBuilder builder;
-    bool important = behaviorShouldNotBeOverriden(behavior);
-    if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleRaised)
-        appendCSS(builder, CSSPropertyTextShadow, important, "-.1em -.1em .16em black"_s);
-    else if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDepressed)
-        appendCSS(builder, CSSPropertyTextShadow, important, ".1em .1em .16em black"_s);
-    else if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDropShadow)
-        appendCSS(builder, CSSPropertyTextShadow, important, "0 .1em .16em black"_s);
+        if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleUndefined || textEdgeStyle == kMACaptionAppearanceTextEdgeStyleNone)
+            return emptyString();
 
-    if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDropShadow || textEdgeStyle == kMACaptionAppearanceTextEdgeStyleUniform) {
-        appendCSS(builder, CSSPropertyStrokeColor, important, "black"_s);
-        appendCSS(builder, CSSPropertyPaintOrder, important, nameLiteral(CSSValueStroke));
-        appendCSS(builder, CSSPropertyStrokeLinejoin, important, nameLiteral(CSSValueRound));
-        appendCSS(builder, CSSPropertyStrokeLinecap, important, nameLiteral(CSSValueRound));
-    }
-    
-    return builder.toString();
+        StringBuilder builder;
+        bool important = behaviorShouldNotBeOverriden(behavior);
+        if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleRaised)
+            appendCSS(builder, CSSPropertyTextShadow, important, "-.1em -.1em .16em black"_s);
+        else if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDepressed)
+            appendCSS(builder, CSSPropertyTextShadow, important, ".1em .1em .16em black"_s);
+        else if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDropShadow)
+            appendCSS(builder, CSSPropertyTextShadow, important, "0 .1em .16em black"_s);
+
+        if (textEdgeStyle == kMACaptionAppearanceTextEdgeStyleDropShadow || textEdgeStyle == kMACaptionAppearanceTextEdgeStyleUniform) {
+            appendCSS(builder, CSSPropertyStrokeColor, important, "black"_s);
+            appendCSS(builder, CSSPropertyPaintOrder, important, nameLiteral(CSSValueStroke));
+            appendCSS(builder, CSSPropertyStrokeLinejoin, important, nameLiteral(CSSValueRound));
+            appendCSS(builder, CSSPropertyStrokeLinecap, important, nameLiteral(CSSValueRound));
+        }
+
+        return builder.toString();
+    });
 }
 
 String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
 {
-    MACaptionAppearanceBehavior behavior;
-    
-    RetainPtr font = adoptCF(MACaptionAppearanceCopyFontDescriptorForStyle(kMACaptionAppearanceDomainUser, &behavior, kMACaptionAppearanceFontStyleDefault));
-    if (!font)
-        return emptyString();
+    return runWithPreviewProfile(m_previewProfileID, [] {
+        MACaptionAppearanceBehavior behavior;
 
-    RetainPtr name = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(font.get(), kCTFontNameAttribute)));
-    if (!name)
-        return emptyString();
+        RetainPtr font = adoptCF(MACaptionAppearanceCopyFontDescriptorForStyle(kMACaptionAppearanceDomainUser, &behavior, kMACaptionAppearanceFontStyleDefault));
+        if (!font)
+            return emptyString();
 
-    if (fontNameIsSystemFont(name.get())) {
-        if (CFStringHasPrefix(name.get(), CFSTR(".AppleSystemUIFontMonospaced")))
-            name = CFSTR("ui-monospace");
-        else if (CFStringHasPrefix(name.get(), CFSTR(".AppleSystemUIFont")))
-            name = CFSTR("system-ui");
-        else {
-            // FIXME: Add more fallbacks for system font names
-            // Default to "system-ui" for all other disallowed system fonts
-            name = CFSTR("system-ui");
+        RetainPtr name = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(font.get(), kCTFontNameAttribute)));
+        if (!name)
+            return emptyString();
+
+        if (fontNameIsSystemFont(name.get())) {
+            if (CFStringHasPrefix(name.get(), CFSTR(".AppleSystemUIFontMonospaced")))
+                name = CFSTR("ui-monospace");
+            else if (CFStringHasPrefix(name.get(), CFSTR(".AppleSystemUIFont")))
+                name = CFSTR("system-ui");
+            else {
+                // FIXME: Add more fallbacks for system font names
+                // Default to "system-ui" for all other disallowed system fonts
+                name = CFSTR("system-ui");
+            }
         }
-    }
 
-    StringBuilder builder;
-    builder.append("font-family: \""_s, name.get(), '"');
-    if (RetainPtr cascadeList = adoptCF(static_cast<CFArrayRef>(CTFontDescriptorCopyAttribute(font.get(), kCTFontCascadeListAttribute)))) {
-        for (CFIndex i = 0; i < CFArrayGetCount(cascadeList.get()); i++) {
-            RetainPtr fontCascade = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(cascadeList.get(), i));
-            if (!fontCascade)
-                continue;
-            RetainPtr fontCascadeName = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontCascade.get(), kCTFontNameAttribute)));
-            if (!fontCascadeName)
-                continue;
-            builder.append(", \""_s, fontCascadeName.get(), '"');
+        StringBuilder builder;
+        builder.append("font-family: \""_s, name.get(), '"');
+        if (RetainPtr cascadeList = adoptCF(static_cast<CFArrayRef>(CTFontDescriptorCopyAttribute(font.get(), kCTFontCascadeListAttribute)))) {
+            for (CFIndex i = 0; i < CFArrayGetCount(cascadeList.get()); i++) {
+                RetainPtr fontCascade = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(cascadeList.get(), i));
+                if (!fontCascade)
+                    continue;
+                RetainPtr fontCascadeName = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontCascade.get(), kCTFontNameAttribute)));
+                if (!fontCascadeName)
+                    continue;
+                builder.append(", \""_s, fontCascadeName.get(), '"');
+            }
         }
-    }
-    builder.append(behaviorShouldNotBeOverriden(behavior) ? " !important;"_s : ";"_s);
-    return builder.toString();
+        builder.append(behaviorShouldNotBeOverriden(behavior) ? " !important;"_s : ";"_s);
+        return builder.toString();
+    });
 }
 
 String CaptionUserPreferencesMediaAF::captionsFontSizeCSS() const
@@ -521,7 +532,10 @@ float CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance(bool& imp
 
     MACaptionAppearanceBehavior behavior;
     CGFloat characterScale = CaptionUserPreferences::captionFontSizeScaleAndImportance(important);
-    CGFloat scaleAdjustment = MACaptionAppearanceGetRelativeCharacterSize(kMACaptionAppearanceDomainUser, &behavior);
+
+    CGFloat scaleAdjustment = runWithPreviewProfile(m_previewProfileID, [&behavior] mutable {
+        return MACaptionAppearanceGetRelativeCharacterSize(kMACaptionAppearanceDomainUser, &behavior);
+    });
 
     if (!scaleAdjustment)
         return characterScale;
@@ -619,18 +633,16 @@ bool CaptionUserPreferencesMediaAF::hasNullCaptionProfile() const
 
     return captionProfile.isEmpty();
 }
-#endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 String CaptionUserPreferencesMediaAF::captionsStyleSheetOverride() const
 {
     if (testingMode() || hasNullCaptionProfile())
         return CaptionUserPreferences::captionsStyleSheetOverride();
-    
-    StringBuilder captionsOverrideStyleSheet;
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     if (!MediaAccessibilityLibrary())
         return CaptionUserPreferences::captionsStyleSheetOverride();
+
+    StringBuilder captionsOverrideStyleSheet;
 
     String captionsColor = captionsTextColorCSS();
     String edgeStyle = captionsTextEdgeCSS();
@@ -645,7 +657,6 @@ String CaptionUserPreferencesMediaAF::captionsStyleSheetOverride() const
     String windowCornerRadius = windowRoundedCornerRadiusCSS();
     if (!windowColor.isEmpty() || !windowCornerRadius.isEmpty())
         captionsOverrideStyleSheet.append(" ::"_s, UserAgentParts::webkitMediaTextTrackDisplayBackdrop(), '{', windowColor, windowCornerRadius, '}');
-#endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
     LOG(Media, "CaptionUserPreferencesMediaAF::captionsStyleSheetOverrideSetting style to:\n%s", captionsOverrideStyleSheet.toString().utf8().data());
 
@@ -1050,6 +1061,20 @@ String CaptionUserPreferencesMediaAF::nameForProfileID(const String& profileID)
     return cfProfileName.get();
 }
 
+String CaptionUserPreferencesMediaAF::captionPreviewProfileID() const
+{
+    return m_previewProfileID;
+}
+
+void CaptionUserPreferencesMediaAF::setCaptionPreviewProfileID(const String& previewProfileID)
+{
+    if (m_previewProfileID == previewProfileID)
+        return;
+
+    m_previewProfileID = previewProfileID;
+    captionPreferencesChanged();
+}
+
 String CaptionUserPreferencesMediaAF::captionPreviewTitle() const
 {
     if (testingMode())
@@ -1069,4 +1094,4 @@ String CaptionUserPreferencesMediaAF::captionPreviewTitle() const
 
 }
 
-#endif // ENABLE(VIDEO)
+#endif // ENABLE(VIDEO) && HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/Platform.h>
-#if ENABLE(VIDEO)
+#if ENABLE(VIDEO) && HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CaptionPreferencesDelegate.h>
@@ -34,9 +34,7 @@
 #include <WebCore/Color.h>
 #include <wtf/TZoneMalloc.h>
 
-#if PLATFORM(COCOA)
 OBJC_CLASS WebCaptionUserPreferencesMediaAFWeakObserver;
-#endif
 
 namespace WebCore {
 
@@ -46,7 +44,6 @@ public:
     WEBCORE_EXPORT static Ref<CaptionUserPreferencesMediaAF> create(PageGroup&);
     virtual ~CaptionUserPreferencesMediaAF();
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     CaptionDisplayMode captionDisplayMode() const override;
     void setCaptionDisplayMode(CaptionDisplayMode) override;
 
@@ -86,22 +83,18 @@ public:
     WEBCORE_EXPORT static void setCaptionPreferencesDelegate(std::unique_ptr<CaptionPreferencesDelegate>&&);
 
     bool testingMode() const final;
-#else
-    bool shouldFilterTrackMenu() const { return false; }
-#endif
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK) && PLATFORM(COCOA)
     static RefPtr<CaptionUserPreferencesMediaAF> extractCaptionUserPreferencesMediaAF(void* observer);
-#endif
 
     WEBCORE_EXPORT String captionsStyleSheetOverride() const override;
     Vector<Ref<AudioTrack>> sortedTrackListForMenu(AudioTrackList*) override;
     Vector<Ref<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>) override;
     String displayNameForTrack(const AudioTrack&) const override;
     String displayNameForTrack(const TextTrack&) const override;
+    String captionPreviewProfileID() const override;
+    void setCaptionPreviewProfileID(const String&) override;
     String captionPreviewTitle() const override;
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     WEBCORE_EXPORT String captionsWindowCSS() const;
     WEBCORE_EXPORT String captionsBackgroundCSS() const;
     WEBCORE_EXPORT String captionsTextColorCSS() const;
@@ -110,30 +103,23 @@ public:
     WEBCORE_EXPORT String captionsFontSizeCSS() const;
     WEBCORE_EXPORT String windowRoundedCornerRadiusCSS() const;
     WEBCORE_EXPORT String captionsTextEdgeCSS() const;
-    WEBCORE_EXPORT String colorPropertyCSS(CSSPropertyID, const Color&, bool) const;
-#endif
 
 private:
     explicit CaptionUserPreferencesMediaAF(PageGroup&);
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     void updateTimerFired();
     bool hasNullCaptionProfile() const;
-#endif
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK) && PLATFORM(COCOA)
     static RetainPtr<WebCaptionUserPreferencesMediaAFWeakObserver> createWeakObserver(CaptionUserPreferencesMediaAF*);
 
     const RetainPtr<WebCaptionUserPreferencesMediaAFWeakObserver> m_observer;
-#endif
 
-#if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     Timer m_updateStyleSheetTimer;
     bool m_listeningForPreferenceChanges { false };
     bool m_registeringForNotification { false };
-#endif
+    String m_previewProfileID;
 };
 
 } // namespace WebCore
 
-#endif // ENABLE(VIDEO)
+#endif // ENABLE(VIDEO) && HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp
@@ -61,6 +61,7 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceSetActiveProfileID, void, (CFStringRef profileID), (profileID), WEBCORE_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyProfileName, CFStringRef, (CFStringRef profileID), (profileID), WEBCORE_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceCopyPreviewText, CFStringRef, (CFStringRef profileID, CFStringRef trackLanguage), (profileID, trackLanguage), WEBCORE_EXPORT);
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(WebCore, MediaAccessibility, MACaptionAppearanceExecuteBlockForProfileID, void, (CFStringRef profileID, void (^aBlock)(void)), (profileID, aBlock), WEBCORE_EXPORT);
 
 
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
+++ b/Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h
@@ -91,6 +91,8 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionApp
 #define MACaptionAppearanceCopyProfileName softLink_MediaAccessibility_MACaptionAppearanceCopyProfileName
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceCopyPreviewText, CFStringRef, (CFStringRef profileID, CFStringRef trackLanguage), (profileID, trackLanguage));
 #define MACaptionAppearanceCopyPreviewText softLink_MediaAccessibility_MACaptionAppearanceCopyPreviewText
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebCore, MediaAccessibility, MACaptionAppearanceExecuteBlockForProfileID, void, (CFStringRef profileID, void (^aBlock)(void)), (profileID, aBlock));
+#define MACaptionAppearanceExecuteBlockForProfileID softLink_MediaAccessibility_MACaptionAppearanceExecuteBlockForProfileID
 
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -96,7 +96,7 @@ public:
     virtual void setTextTrackRepresentationBounds(const IntRect&) { }
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    virtual void requestShowCaptionDisplaySettingsPreview() { }
+    virtual void requestShowCaptionDisplaySettingsPreview(const String&) { }
     virtual void requestHideCaptionDisplaySettingsPreview() { }
 #endif
 

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -420,11 +420,9 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
 
 - (void)setCaptionPreviewProfileID:(NSString * _Nonnull)profileID position:(CGPoint)position text:(nullable NSString *)text
 {
-    CaptionUserPreferencesMediaAF::setActiveProfileID(profileID);
-
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
     if (RefPtr model = _presentationModel.get())
-        model->requestShowCaptionDisplaySettingsPreview();
+        model->requestShowCaptionDisplaySettingsPreview(profileID);
 #endif
 
     _showingCaptionPreview = YES;

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -126,7 +126,7 @@ private:
     void setTextTrackRepresentationBounds(const WebCore::IntRect&) final;
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    void requestShowCaptionDisplaySettingsPreview() final;
+    void requestShowCaptionDisplaySettingsPreview(const String&) final;
     void requestHideCaptionDisplaySettingsPreview() final;
 #endif
 
@@ -261,7 +261,7 @@ private:
     void setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier, const WebCore::IntRect&);
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    void requestShowCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier);
+    void requestShowCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier, const String&);
     void requestHideCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier);
     void performCaptionDisplaySettingsAction(PlaybackSessionContextIdentifier, Function<void(WebPageProxy&, const FrameInfoData&, WebCore::HTMLMediaElementIdentifier)>&& action);
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -552,10 +552,10 @@ void VideoPresentationModelContext::setTextTrackRepresentationBounds(const IntRe
 }
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-void VideoPresentationModelContext::requestShowCaptionDisplaySettingsPreview()
+void VideoPresentationModelContext::requestShowCaptionDisplaySettingsPreview(const String& profileID)
 {
     if (RefPtr manager = m_manager.get())
-        manager->requestShowCaptionDisplaySettingsPreview(m_contextId);
+        manager->requestShowCaptionDisplaySettingsPreview(m_contextId, profileID);
 }
 
 void VideoPresentationModelContext::requestHideCaptionDisplaySettingsPreview()
@@ -1376,9 +1376,10 @@ void VideoPresentationManagerProxy::performCaptionDisplaySettingsAction(Playback
     });
 }
 
-void VideoPresentationManagerProxy::requestShowCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier contextId)
+void VideoPresentationManagerProxy::requestShowCaptionDisplaySettingsPreview(PlaybackSessionContextIdentifier contextId, const String& profileID)
 {
-    performCaptionDisplaySettingsAction(contextId, [](WebPageProxy& page, const FrameInfoData& frameInfo, WebCore::HTMLMediaElementIdentifier htmlMediaElementIdentifier) {
+    performCaptionDisplaySettingsAction(contextId, [profileID](WebPageProxy& page, const FrameInfoData& frameInfo, WebCore::HTMLMediaElementIdentifier htmlMediaElementIdentifier) {
+        page.setCaptionDisplaySettingsPreviewProfileID(frameInfo, profileID);
         page.showCaptionDisplaySettingsPreview(frameInfo, htmlMediaElementIdentifier);
     });
 }

--- a/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)captionStyleMenuWillOpen:(PlatformMenu *)menu;
 - (void)captionStyleMenuDidClose:(PlatformMenu *)menu;
 @optional
+- (void)captionStyleMenu:(PlatformMenu *)menu setPreviewProfileID:(NSString *)profileID;
 - (void)captionStyleMenu:(PlatformMenu *)menu didSelectProfile:(NSString *)profileID;
 @end
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1542,6 +1542,11 @@ void WebPageProxy::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifie
     completionHandler(makeUnexpected<WebCore::ExceptionData>({ ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s }));
 }
 
+void WebPageProxy::setCaptionDisplaySettingsPreviewProfileID(const FrameInfoData& frameInfo, const String& profileID)
+{
+    sendToProcessContainingFrame(frameInfo.frameID, Messages::WebPage::SetCaptionDisplaySettingsPreviewProfileID(profileID));
+}
+
 void WebPageProxy::showCaptionDisplaySettingsPreview(const FrameInfoData& frameInfo, WebCore::HTMLMediaElementIdentifier identifier)
 {
     sendToProcessContainingFrame(frameInfo.frameID, Messages::WebPage::ShowCaptionDisplaySettingsPreview(identifier));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2936,6 +2936,7 @@ public:
 #endif
 
 #if ENABLE(VIDEO)
+    void setCaptionDisplaySettingsPreviewProfileID(const FrameInfoData&, const String&);
     void showCaptionDisplaySettingsPreview(const FrameInfoData&, WebCore::HTMLMediaElementIdentifier);
     void hideCaptionDisplaySettingsPreview(const FrameInfoData&, WebCore::HTMLMediaElementIdentifier);
 #endif

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
@@ -100,6 +100,7 @@ typedef NS_ENUM(NSInteger, _WKElementActionType);
 #endif
 - (NSArray<UIMenuElement *> *)additionalMediaControlsContextMenuItemsForActionSheetAssistant:(WKActionSheetAssistant *)assistant;
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
+- (void)captionStyleMenuSetPreviewProfileID:(NSString *)profileID frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier;
 - (void)captionStyleMenuWillOpenWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier;
 - (void)captionStyleMenuDidCloseWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier;
 #endif

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -103,6 +103,7 @@ static LSAppLink *appLinkForURL(NSURL *url)
 @interface WKActionSheetAssistant () <WKCaptionStyleMenuControllerDelegate>
 - (void)captionStyleMenuWillOpen:(PlatformMenu *)menu;
 - (void)captionStyleMenuDidClose:(PlatformMenu *)menu;
+- (void)captionStyleMenu:(PlatformMenu *)menu setPreviewProfileID:(NSString *)profileID;
 - (void)captionStyleMenu:(PlatformMenu *)menu didSelectProfile:(NSString *)profileID;
 @end
 #endif
@@ -931,6 +932,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr protectedDelegate = _delegate.get();
     if ([protectedDelegate respondsToSelector:@selector(captionStyleMenuWillOpenWithFrameInfo:identifier:)] && _mediaElementIdentifier && _frameInfo)
         [protectedDelegate captionStyleMenuWillOpenWithFrameInfo:*_frameInfo identifier:*_mediaElementIdentifier];
+}
+
+- (void)captionStyleMenu:(PlatformMenu *)captionStyleMenu setPreviewProfileID:(NSString *)profileID
+{
+    RetainPtr protectedDelegate = _delegate.get();
+    if ([protectedDelegate respondsToSelector:@selector(captionStyleMenuWillOpenWithFrameInfo:identifier:)] && _frameInfo)
+        [protectedDelegate captionStyleMenuSetPreviewProfileID:profileID frameInfo:*_frameInfo identifier:*_mediaElementIdentifier];
 }
 
 - (void)captionStyleMenu:(PlatformMenu *)captionStyleMenu didSelectProfile:(NSString *)profileID

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12339,6 +12339,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     [protect(_actionSheetAssistant) showMediaControlsContextMenu:WTF::move(targetFrame) items:WTF::move(items) frameInfo:frameInfo identifier:identifier completionHandler:WTF::move(completionHandler)];
 }
 
+- (void)captionStyleMenuSetPreviewProfileID:(NSString *)profileID frameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier
+{
+    protect(_page)->setCaptionDisplaySettingsPreviewProfileID(frameInfo, profileID);
+}
+
 - (void)captionStyleMenuWillOpenWithFrameInfo:(const WebKit::FrameInfoData&)frameInfo identifier:(WebCore::HTMLMediaElementIdentifier)identifier
 {
     protect(_page)->showCaptionDisplaySettingsPreview(frameInfo, identifier);

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
@@ -259,13 +259,8 @@ static bool menuHasMenuAncestor(UIMenu *targetMenu, UIMenu *ancestorMenu)
 #pragma mark - Internal
 - (void)setPreviewProfileID:(NSString *)profileID
 {
-    if (profileID) {
-        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(profileID));
-        return;
-    }
-
-    if (self.savedActiveProfileID && self.savedActiveProfileID.length > 0)
-        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(self.savedActiveProfileID));
+    if (auto delegate = self.delegate; delegate && [delegate respondsToSelector:@selector(captionStyleMenu:setPreviewProfileID:)])
+        [delegate captionStyleMenu:self.menu setPreviewProfileID:profileID];
 }
 @end
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -77,6 +77,7 @@ public:
 
     void didShowContextMenu(NSMenu *);
     void didDismissContextMenu(NSMenu *);
+    void captionStyleMenuSetPreviewProfileID(const String&);
     void captionStyleMenuWillOpen();
     void captionStyleMenuDidClose();
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -236,6 +236,11 @@
     protect(*_menuProxy)->captionStyleMenuDidClose();
 }
 
+- (void)captionStyleMenu:(PlatformMenu *)menu setPreviewProfileID:(NSString *)profileID
+{
+    protect(*_menuProxy)->captionStyleMenuSetPreviewProfileID(profileID);
+}
+
 @end
 
 namespace WebKit {
@@ -1138,6 +1143,11 @@ void WebContextMenuProxyMac::didDismissContextMenu(NSMenu *menu)
 
     if (m_captionStyleMenuController && [m_captionStyleMenuController hasAncestor:menu])
         captionStyleMenuDidClose();
+}
+
+void WebContextMenuProxyMac::captionStyleMenuSetPreviewProfileID(const String& profileID)
+{
+    protect(page())->setCaptionDisplaySettingsPreviewProfileID(m_frameInfo, profileID);
 }
 
 void WebContextMenuProxyMac::captionStyleMenuWillOpen()

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
@@ -185,17 +185,12 @@ static bool menuHasMenuAncestor(NSMenu *childMenu, NSMenu *ancestorMenu)
 
 - (void)setPreviewProfileID:(NSString *)profileID
 {
-    if (profileID) {
-        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(profileID));
-
-        if (auto delegate = self.delegate)
+    if (auto delegate = self.delegate) {
+        if (profileID)
             [delegate captionStyleMenuWillOpen:_menu.get()];
-
-        return;
+        if ([delegate respondsToSelector:@selector(captionStyleMenu:setPreviewProfileID:)])
+            [delegate captionStyleMenu:self.menu setPreviewProfileID:profileID];
     }
-
-    if (self.savedActiveProfileID && self.savedActiveProfileID.length > 0)
-        CaptionUserPreferencesMediaAF::setActiveProfileID(WTF::String(self.savedActiveProfileID));
 }
 
 - (void)systemCaptionStyleSettingsItemSelected:(NSMenuItem *)sender
@@ -207,8 +202,6 @@ static bool menuHasMenuAncestor(NSMenu *childMenu, NSMenu *ancestorMenu)
 
 - (void)menuWillOpen:(NSMenu *)menu
 {
-    self.savedActiveProfileID = CaptionUserPreferencesMediaAF::platformActiveProfileID().createNSString().get();
-
     if (auto delegate = self.delegate)
         [delegate captionStyleMenuWillOpen:_menu.get()];
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -190,6 +190,7 @@
 #include <WebCore/BackForwardController.h>
 #include <WebCore/BitmapImage.h>
 #include <WebCore/CachedPage.h>
+#include <WebCore/CaptionUserPreferences.h>
 #include <WebCore/Chrome.h>
 #include <WebCore/CommonVM.h>
 #include <WebCore/ContactsRequestData.h>
@@ -278,6 +279,7 @@
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageConfiguration.h>
+#include <WebCore/PageGroup.h>
 #include <WebCore/PageInspectorController.h>
 #include <WebCore/PingLoader.h>
 #include <WebCore/PlatformKeyboardEvent.h>
@@ -10498,6 +10500,14 @@ bool WebPage::hasAccessoryMousePointingDevice() const
 #endif
 
 #if ENABLE(VIDEO)
+void WebPage::setCaptionDisplaySettingsPreviewProfileID(const String& profileID)
+{
+    if (RefPtr pageGroup = m_pageGroup) {
+        if (RefPtr captionPreferences = pageGroup->corePageGroup()->captionPreferences())
+            captionPreferences->setCaptionPreviewProfileID(profileID);
+    }
+}
+
 void WebPage::showCaptionDisplaySettingsPreview(HTMLMediaElementIdentifier identifier)
 {
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2174,6 +2174,7 @@ public:
     void paintRemoteFrameContents(WebCore::FrameIdentifier, const WebCore::IntRect&, WebCore::GraphicsContext&);
 
 #if ENABLE(VIDEO)
+    void setCaptionDisplaySettingsPreviewProfileID(const String&);
     void showCaptionDisplaySettingsPreview(WebCore::HTMLMediaElementIdentifier);
     void hideCaptionDisplaySettingsPreview(WebCore::HTMLMediaElementIdentifier);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -957,6 +957,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(VIDEO)
+    SetCaptionDisplaySettingsPreviewProfileID(String profileID)
     ShowCaptionDisplaySettingsPreview(WebCore::MediaPlayerClientIdentifier identifier)
     HideCaptionDisplaySettingsPreview(WebCore::MediaPlayerClientIdentifier identifier)
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -441,6 +441,54 @@ TEST_F(CaptionPreferenceTests, TextEdge)
     EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "stroke-color:black;paint-order:stroke;stroke-linejoin:round;stroke-linecap:round;");
 }
 
+TEST_F(CaptionPreferenceTests, PreviewStyles)
+{
+    if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
+        return;
+
+    MediaAccessibilityShim shim;
+
+    auto shimmedMACaptionAppearanceExecuteBlockForProfileID = [](CFStringRef profileID, void (^aBlock)(void)) -> void {
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetDisplayType, kMACaptionAppearanceDisplayTypeAutomatic);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyForegroundColor, cachedCGColor(Color::magenta));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyBackgroundColor, cachedCGColor(Color::yellow));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyWindowColor, cachedCGColor(Color::cyan));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyFontDescriptorForStyle, adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR(".AppleSystemUIFontMonospaced"), 10)));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetForegroundOpacity, 0.75);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetBackgroundOpacity, 0.5);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowOpacity, 0.25);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetWindowRoundedCornerRadius, (CGFloat)5.f);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetRelativeCharacterSize, (CGFloat)2.f);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceGetTextEdgeStyle, kMACaptionAppearanceTextEdgeStyleDropShadow);
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyProfileIDs, adoptCF((__bridge CFArrayRef)@[@"Profile 1", @"Profile 2", @"Profile 3"]));
+        SOFT_LINK_SHIM_SET_RESULT(MACaptionAppearanceCopyActiveProfileID, CFSTR("Profile 1"));
+
+        aBlock();
+    };
+    SoftLinkShim<void, CFStringRef, void (^)(void)> MACaptionAppearanceExecuteBlockForProfileIDShim { &softLinkMediaAccessibilityMACaptionAppearanceExecuteBlockForProfileID, shimmedMACaptionAppearanceExecuteBlockForProfileID, canLoad_MediaAccessibility_MACaptionAppearanceExecuteBlockForProfileID };
+
+    UniqueRef group = PageGroup::create("CaptionPreferenceTests"_s);
+    auto preferences = CaptionUserPreferencesMediaAF::create(group);
+
+    EXPECT_STREQ(preferences->captionsTextColorCSS().utf8().data(), "color:#ffffff;");
+    EXPECT_STREQ(preferences->captionsBackgroundCSS().utf8().data(), "background-color:#000000;");
+    EXPECT_STREQ(preferences->captionsWindowCSS().utf8().data(), "background-color:#000000;");
+    EXPECT_STREQ(preferences->windowRoundedCornerRadiusCSS().utf8().data(), "");
+    EXPECT_STREQ(preferences->captionsDefaultFontCSS().utf8().data(), "font-family: \"system-ui\";");
+    EXPECT_STREQ(preferences->captionsFontSizeCSS().utf8().data(), "font-size: 5cqmin;");
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "");
+
+    preferences->setCaptionPreviewProfileID("Profile 2"_s);
+
+    EXPECT_STREQ(preferences->captionsTextColorCSS().utf8().data(), "color:rgba(255, 0, 255, 0.75);");
+    EXPECT_STREQ(preferences->captionsBackgroundCSS().utf8().data(), "background-color:rgba(255, 255, 0, 0.5);");
+    EXPECT_STREQ(preferences->captionsWindowCSS().utf8().data(), "background-color:rgba(0, 255, 255, 0.25);");
+    EXPECT_STREQ(preferences->windowRoundedCornerRadiusCSS().utf8().data(), "border-radius:5px;padding:1.25px;");
+    EXPECT_STREQ(preferences->captionsDefaultFontCSS().utf8().data(), "font-family: \"ui-monospace\";");
+    EXPECT_STREQ(preferences->captionsFontSizeCSS().utf8().data(), "font-size: 10cqmin;");
+    EXPECT_STREQ(preferences->captionsTextEdgeCSS().utf8().data(), "text-shadow:0 .1em .16em black;stroke-color:black;paint-order:stroke;stroke-linejoin:round;stroke-linecap:round;");
+}
+
 #if !HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
 TEST_F(CaptionPreferenceTests, CaptionStyleMenu)
 {
@@ -500,10 +548,10 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenuHighlight)
         // TODO: Menu highlighting is currently not supported on IOS_FAMILY
 #if PLATFORM(MAC)
         [menu performSelector:@selector(highlightItem:) withObject:[menu itemAtIndex:1]];
-        EXPECT_WK_STREQ("Profile 2", CaptionUserPreferencesMediaAF::platformActiveProfileID());
+        EXPECT_WK_STREQ("Profile 1", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 
         [menu performSelector:@selector(highlightItem:) withObject:[menu itemAtIndex:2]];
-        EXPECT_WK_STREQ("Profile 3", CaptionUserPreferencesMediaAF::platformActiveProfileID());
+        EXPECT_WK_STREQ("Profile 1", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 #endif
     });
 


### PR DESCRIPTION
#### 01b33bd6c1891b229cfb9479aff5013146e05887
<pre>
[Cocoa] Plumb &apos;previewID&apos; down from UIProcess to WebContent
<a href="https://rdar.apple.com/171088321">rdar://171088321</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308760">https://bugs.webkit.org/show_bug.cgi?id=308760</a>

Reviewed by Andy Estes.

Previously, when a user hovered over a caption style selection in the
caption menu, that would temporarily change the active global caption
style for all applications which observed MediaAccessibility. Rather
than relying on MediaAccessibility broadcasting that change to a wide
audience, send the user&apos;s preview style selection through XPC down to
the WebContent process, and adopt new MediaAccessibility API to
apply that style temporarily in order to generate the appropriate CSS
styles for VTT tracks.

* Source/WebCore/page/CaptionUserPreferences.h:
(WebCore::CaptionUserPreferences::captionPreviewProfileID const):
(WebCore::CaptionUserPreferences::setCaptionPreviewProfileID):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::userCaptionPreferencesChangedNotificationCallback):
(WebCore::runWithPreviewProfile):
(WebCore::CaptionUserPreferencesMediaAF::CaptionUserPreferencesMediaAF):
(WebCore::CaptionUserPreferencesMediaAF::~CaptionUserPreferencesMediaAF):
(WebCore::CaptionUserPreferencesMediaAF::captionStrokeWidthForFont const):
(WebCore::CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance const):
(WebCore::CaptionUserPreferencesMediaAF::hasNullCaptionProfile const):
(WebCore::CaptionUserPreferencesMediaAF::captionsStyleSheetOverride const):
(WebCore::CaptionUserPreferencesMediaAF::captionPreviewProfileID const):
(WebCore::CaptionUserPreferencesMediaAF::setCaptionPreviewProfileID):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.cpp:
* Source/WebCore/platform/cf/MediaAccessibilitySoftLink.h:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModel::requestShowCaptionDisplaySettingsPreview):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setCaptionPreviewProfileID:position:text:]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::requestShowCaptionDisplaySettingsPreview):
(WebKit::VideoPresentationManagerProxy::requestShowCaptionDisplaySettingsPreview):
* Source/WebKit/UIProcess/Cocoa/_WKCaptionStyleMenuController.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setCaptionDisplaySettingsPreviewProfileID):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant captionStyleMenu:setPreviewProfileID:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView captionStyleMenuSetPreviewProfileID:frameInfo:identifier:]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
(-[WKCaptionStyleMenuController setPreviewProfileID:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuDelegate captionStyleMenu:setPreviewProfileID:]):
(WebKit::WebContextMenuProxyMac::captionStyleMenuSetPreviewProfileID):
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm:
(-[WKCaptionStyleMenuController setPreviewProfileID:]):
(-[WKCaptionStyleMenuController menuWillOpen:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setCaptionDisplaySettingsPreviewProfileID):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/308467@main">https://commits.webkit.org/308467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45d24cc05a185c6f743299215592b6f1adcbfd17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100756 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89495097-4454-441e-a9c4-f78d5f5e31cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113561 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80989 "Exiting early after 60 failures. 15326 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bf9b82f-4330-44b4-96b6-b11145ceb77c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94319 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ec41ec4-8d9c-4fd4-a519-d0d03c0b688c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14966 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12744 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3464 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158355 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121588 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31247 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75814 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8826 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19440 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83202 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19321 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->