### PR TITLE
Build fix for missing header after 308275@main

### DIFF
--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -38,6 +38,7 @@
 #include <unicode/uloc.h>
 #include <unicode/uscript.h>
 #include <wtf/DateMath.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuffer.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/icu/ICUHelpers.h>


### PR DESCRIPTION
#### 6e624ae6c56c943c62a6ce311409658811f3aed1
<pre>
Build fix for missing header after 308275@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=308761">https://bugs.webkit.org/show_bug.cgi?id=308761</a>

Unreviewed build fix

Add TZoneMallocInlines.h header to provide
WTF_MAKE_TZONE_ALLOCATED_IMPL to LocalICU.cpp

No new tests, build fix only

* Source/WebCore/platform/text/LocaleICU.cpp:

Canonical link: <a href="https://commits.webkit.org/308292@main">https://commits.webkit.org/308292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eecf2244970976829fa046f676ff2adb004e532d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155738 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148930 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113319 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150018 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94075 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3180 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158069 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121341 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19538 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121542 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/31130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131796 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22678 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82908 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->