### PR TITLE
DataTransfer.types should return the same FrozenArray when unchanged

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL type's state on DataTransfer creation assert_equals: types must return the same object when the data store item list has not changed expected [] but got []
-FAIL Relationship between types and items assert_equals: expected ["text/plain"] but got ["text/plain"]
-FAIL type's identity assert_equals: expected ["text/plain"] but got ["text/plain"]
-FAIL Verify type is a read-only attribute assert_equals: expected [] but got []
-FAIL DataTransfer containing files assert_array_equals: expected property 0 to be "text/plain" but got "Files" (expected array ["text/plain", "Files"] got ["Files", "text/plain"])
+PASS type's state on DataTransfer creation
+PASS Relationship between types and items
+PASS type's identity
+PASS Verify type is a read-only attribute
+PASS DataTransfer containing files
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -707,6 +707,7 @@ bindings/js/JSDOMWindowProperties.cpp
 bindings/js/JSDOMWrapper.cpp
 bindings/js/JSDOMWrapperCache.cpp
 bindings/js/JSDeprecatedCSSOMValueCustom.cpp
+bindings/js/JSDataTransferCustom.cpp
 bindings/js/JSDocumentCustom.cpp
 bindings/js/JSElementCustom.cpp
 bindings/js/JSElementInternalsCustom.cpp

--- a/Source/WebCore/bindings/js/JSDataTransferCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDataTransferCustom.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDataTransfer.h"
+
+#include "DataTransfer.h"
+#include "Document.h"
+#include "IDLTypes.h"
+#include "JSDOMBinding.h"
+#include "JSDOMConvertSequences.h"
+#include "JSDOMConvertStrings.h"
+#include "JSDOMGlobalObject.h"
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+using namespace JSC;
+
+// https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types
+// The types attribute must return the same FrozenArray object each time it is accessed,
+// as long as the data store item list has not changed since the last time the attribute was accessed.
+JSValue JSDataTransfer::types(JSGlobalObject& lexicalGlobalObject) const
+{
+    DataTransfer& impl = wrapped();
+
+    if (impl.typesCacheIsValid()) {
+        if (JSValue cachedValue = m_types.get())
+            return cachedValue;
+    }
+
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+
+    RefPtr context = jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->scriptExecutionContext();
+    if (!context) [[unlikely]]
+        return jsUndefined();
+    Ref document = downcast<Document>(*context);
+
+    JSValue result = toJS<IDLFrozenArray<IDLDOMString>>(lexicalGlobalObject, *globalObject(), throwScope, impl.types(document.get()));
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    m_types.set(JSC::getVM(&lexicalGlobalObject), this, result);
+    impl.didCacheTypes();
+    return result;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -117,6 +117,10 @@ public:
     void didAddFileToItemList();
     void updateFileList(ScriptExecutionContext*);
 
+    bool typesCacheIsValid() const { return m_typesCacheIsValid; }
+    void didCacheTypes() { m_typesCacheIsValid = true; }
+    void incrementTypesVersion() { ++m_typesVersion; m_typesCacheIsValid = false; }
+
 private:
     enum class Type { CopyAndPaste, DragAndDropData, DragAndDropFiles, InputEvent };
     DataTransfer(StoreMode, std::unique_ptr<Pasteboard>, Type = Type::CopyAndPaste, String&& effectAllowed = "uninitialized"_s);
@@ -152,6 +156,8 @@ private:
     const std::unique_ptr<DataTransferItemList> m_itemList;
 
     mutable RefPtr<FileList> m_fileList;
+    uint64_t m_typesVersion { 0 };
+    bool m_typesCacheIsValid { false };
 
 #if ENABLE(DRAG_SUPPORT)
     Type m_type;

--- a/Source/WebCore/dom/DataTransfer.idl
+++ b/Source/WebCore/dom/DataTransfer.idl
@@ -39,7 +39,7 @@
 
     undefined setDragImage(Element image, long x, long y);
 
-    [CallWith=CurrentDocument] readonly attribute FrozenArray<DOMString> types;
+    [CachedAttribute, CustomGetter, CallWith=CurrentDocument] readonly attribute FrozenArray<DOMString> types;
     [CallWith=CurrentDocument] DOMString getData(DOMString format);
     [CallWith=CurrentDocument] undefined setData(DOMString format, DOMString data);
     undefined clearData(optional DOMString format);


### PR DESCRIPTION
#### bc80573459c105ba55abec08b57d16bf8bd850d4
<pre>
DataTransfer.types should return the same FrozenArray when unchanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=266890">https://bugs.webkit.org/show_bug.cgi?id=266890</a>
<a href="https://rdar.apple.com/120373299">rdar://120373299</a>

Reviewed by NOBODY (OOPS!).

DataTransfer.types was creating a new FrozenArray on every access instead of
returning the same object when the data store item list had not changed, as
required by the HTML spec. Additionally, &quot;Files&quot; was incorrectly prepended
before other types instead of being appended last.

Fix both issues:

- Add a `m_typesVersion` counter and `m_typesCacheIsValid` flag to DataTransfer.
  `incrementTypesVersion()` is called at all mutation points (setData, clearData,
  and all DataTransferItemList mutating operations) and atomically clears the
  cache validity flag.

- Add [CachedAttribute, CustomGetter] to the `types` IDL attribute. The custom
  getter in JSDataTransferCustom.cpp returns the cached FrozenArray when the
  cache is valid, and recomputes it otherwise, following the same pattern as
  XMLHttpRequest.response.

- Fix DataTransferItemList::clear() to call ensureItems() before clearing so
  that items backed only by the pasteboard (not yet reflected in m_items) are
  correctly detected, ensuring the version is incremented when the list was
  non-empty.

* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransfer-types-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::clearData):
(WebCore::DataTransfer::setData):
(WebCore::DataTransfer::types const):
* Source/WebCore/dom/DataTransfer.h:
(WebCore::DataTransfer::typesCacheIsValid const):
(WebCore::DataTransfer::didCacheTypes):
(WebCore::DataTransfer::incrementTypesVersion):
* Source/WebCore/dom/DataTransfer.idl:
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::add):
(WebCore::DataTransferItemList::remove):
(WebCore::DataTransferItemList::clear):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc80573459c105ba55abec08b57d16bf8bd850d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100472 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02ebae94-d109-47b4-8d66-7b790b1b73a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113322 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80854 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4ab0ace-94fe-4d95-b01e-03c02e8d7a62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150020 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15568 "Found 2 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132108 "Found 7 new API test failures: TestWebKitAPI.PasteMixedContent.ImageFileAndWebArchive, TestWebKitAPI.PasteMixedContent.ImageDataAndPlainTextAndURLAndHTML, TestWebKitAPI.PasteMixedContent.ImageFileAndURL, TestWebKitAPI.PasteMixedContent.ImageDataAndPlainText, TestWebKitAPI.PasteMixedContent.ImageFileAndRTF, TestWebKitAPI.PasteMixedContent.ImageFileAndHTML, TestWebKitAPI.PasteMixedContent.ImageFileWithHTMLAndURL (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94078 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39fc41c5-51b1-4344-a865-8a2a7a91e68b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14775 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12544 "Found 7 new API test failures: TestWebKitAPI.PasteMixedContent.ImageFileAndWebArchive, TestWebKitAPI.PasteMixedContent.ImageDataAndPlainTextAndURLAndHTML, TestWebKitAPI.PasteMixedContent.ImageFileAndURL, TestWebKitAPI.PasteMixedContent.ImageDataAndPlainText, TestWebKitAPI.PasteMixedContent.ImageFileAndRTF, TestWebKitAPI.PasteMixedContent.ImageFileWithHTMLAndURL, TestWebKitAPI.PasteMixedContent.ImageFileAndHTML (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3182 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124362 "Found 2 new API test failures: TestWebKitAPI.UIPasteboardTests.DataTransferGetDataWhenPastingImageAndText, TestWebKitAPI.DragAndDropTests.DataTransferGetDataWhenDroppingImageAndMarkup (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158071 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1202 "Found 1 new failure in bindings/js/JSDataTransferCustom.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11470 "Found 3 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html editing/pasteboard/data-transfer-item-list-add-file-on-drag.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121343 "Found 2 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19540 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16396 "Found 3 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html editing/pasteboard/data-transfer-item-list-add-file-on-drag.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131787 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75508 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17105 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8606 "Found 3 new test failures: editing/pasteboard/data-transfer-item-list-add-file-multiple-times.html editing/pasteboard/data-transfer-item-list-add-file-on-copy.html editing/pasteboard/data-transfer-item-list-add-file-on-drag.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19155 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82910 "Found 1 new failure in bindings/js/JSDataTransferCustom.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18944 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->