### PR TITLE
[ Gardening ] Rebasline layout tests after 308186@main

### DIFF
--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-inputs-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (8,1) size 148x20 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (155,1) size 29x18
           text run at (155,1) width 29: "text "
-        RenderTextControl {INPUT} at (183,1) size 147x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (183,1) size 147x20 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (329,1) size 20x18
           text run at (329,1) width 13: "b "
           text run at (341,1) width 8: "a"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 142x13
         RenderText {#text} at (148,20) size 66x19
           text run at (148,20) width 66: "password "
-        RenderTextControl {INPUT} at (213,20) size 147x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderTextControl {INPUT} at (213,20) size 147x20 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 140x13
             RenderBlock {DIV} at (0,0) size 140x13
         RenderText {#text} at (359,20) size 9x19
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,5) size 13x12
         RenderText {#text} at (24,1) size 66x18
           text run at (24,1) width 66: "checkbox "
-        RenderBlock {INPUT} at (91,5) size 13x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (91,5) size 13x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (105,1) size 9x18
           text run at (105,1) width 9: "b"
       RenderBlock {DIV} at (10,397) size 450x22 [border: (1px solid #FF0000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,5) size 13x12
         RenderText {#text} at (24,1) size 37x18
           text run at (24,1) width 37: "radio "
-        RenderBlock {INPUT} at (62,5) size 13x12 [color=color(srgb 0.341176 0.341176 0.341176)]
+        RenderBlock {INPUT} at (62,5) size 13x12 [color=oklab(0.34 0 0)]
         RenderText {#text} at (76,1) size 9x18
           text run at (76,1) width 9: "b"
 layer at (29,328) size 142x13 scrollWidth 161

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-textareas-expected.txt
@@ -219,7 +219,7 @@ layer at (0,0) size 785x1395
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
         layer at (164,73) size 161x32 clip at (165,74) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "
@@ -782,7 +782,7 @@ layer at (0,0) size 785x1395
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
         layer at (164,73) size 161x32 clip at (165,74) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 104: "Lorem ipsum  dolor "

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-textareas-quirks-expected.txt
@@ -238,7 +238,7 @@ layer at (24,75) size 161x32 clip at (25,76) size 144x30 scrollHeight 56
         text run at (0,26) width 59: "TUVWXYZ "
         text run at (0,39) width 130: "abcdefghijklmnopqrstuv "
 layer at (24,126) size 161x32 clip at (25,127) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 101: "Lorem ipsum dolor "

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-appearance-disabled-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 404x18
         text run at (0,0) width 404: "This tests that text can not be inserted into a disabled text field."
       RenderBR {BR} at (403,0) size 1x18
-      RenderTextControl {INPUT} at (0,18) size 146x19 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 146x19 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 140x13
   RenderBlock {DIV} at (3,3) size 140x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-disabled-color-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 521x18
         text run at (0,0) width 521: "This tests that the text color changes appropriately when the text field is disabled."
       RenderBR {BR} at (520,0) size 1x18
-      RenderTextControl {INPUT} at (0,18) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,18) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (145,18) size 5x18
         text run at (145,18) width 5: " "
       RenderTextControl {INPUT} at (149,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         text run at (145,37) width 5: " "
       RenderTextControl {INPUT} at (149,37) size 149x20 [color=#FF0000] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderBR {BR} at (297,37) size 1x19
-      RenderTextControl {INPUT} at (0,57) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#0000FF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,57) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderText {#text} at (145,56) size 5x19
         text run at (145,56) width 5: " "
       RenderTextControl {INPUT} at (149,57) size 149x20 [bgcolor=#0000FF] [border: (2px inset #808080)]
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         text run at (145,76) width 5: " "
       RenderTextControl {INPUT} at (149,76) size 149x20 [color=#FF0000] [bgcolor=#0000FF] [border: (2px inset #808080)]
       RenderBR {BR} at (297,76) size 1x19
-      RenderTextControl {INPUT} at (0,95) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#000000] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,95) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderText {#text} at (145,95) size 5x19
         text run at (145,95) width 5: " "
       RenderTextControl {INPUT} at (149,95) size 149x20 [bgcolor=#000000] [border: (2px inset #808080)]
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         text run at (145,114) width 5: " "
       RenderTextControl {INPUT} at (149,115) size 149x20 [color=#FFFFFF] [bgcolor=#000000] [border: (2px inset #808080)]
       RenderBR {BR} at (297,114) size 1x19
-      RenderTextControl {INPUT} at (0,134) size 146x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#808080] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (0,134) size 146x20 [color=oklab(0.34 0 0)] [bgcolor=#808080] [border: (2px inset #808080)]
       RenderText {#text} at (145,134) size 5x19
         text run at (145,134) width 5: " "
       RenderTextControl {INPUT} at (149,134) size 149x20 [bgcolor=#808080] [border: (2px inset #808080)]

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
             text run at (248,8) width 87: " Normal state"
       RenderBlock {DIV} at (0,81) size 784x29
         RenderInline {LABEL} at (0,8) size 341x18
-          RenderTextControl {INPUT} at (0,0) size 247x29 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+          RenderTextControl {INPUT} at (0,0) size 247x29 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
             RenderFlexibleBox {DIV} at (3,0) size 241x29
               RenderBlock {DIV} at (0,3) size 222x23
           RenderText {#text} at (246,8) size 95x18

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/placeholder-pseudo-style-expected.txt
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 142x13
       RenderText {#text} at (451,18) size 5x18
         text run at (451,18) width 5: " "
-      RenderTextControl {INPUT} at (455,18) size 147x20 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+      RenderTextControl {INPUT} at (455,18) size 147x20 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (2px inset #808080)]
       RenderText {#text} at (601,18) size 5x18
         text run at (601,18) width 5: " "
       RenderTextControl {INPUT} at (605,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -20,7 +20,7 @@ layer at (8,26) size 161x32 clip at (9,27) size 159x30
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "text"
 layer at (173,26) size 161x32 clip at (174,27) size 159x30
-  RenderTextControl {TEXTAREA} at (165,18) size 161x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (165,18) size 161x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#640000]
       RenderText {#text} at (0,0) size 68x13
@@ -32,7 +32,7 @@ layer at (338,26) size 161x32 clip at (339,27) size 159x30
       RenderText {#text} at (0,0) size 37x13
         text run at (0,0) width 37: "default"
 layer at (503,26) size 161x32 clip at (504,27) size 159x30
-  RenderTextControl {TEXTAREA} at (495,18) size 161x32 [color=color(srgb 0.341176 0.341176 0.341176)] [bgcolor=#FFFFFF] [border: (1px solid color(srgb 0.341176 0.341176 0.341176))]
+  RenderTextControl {TEXTAREA} at (495,18) size 161x32 [color=oklab(0.34 0 0)] [bgcolor=#FFFFFF] [border: (1px solid oklab(0.34 0 0))]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 85x13


### PR DESCRIPTION
#### f51541b9b7ca9b975f74e1d518779619ee834b21
<pre>
[ Gardening ] Rebasline layout tests after 308186@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=308766">https://bugs.webkit.org/show_bug.cgi?id=308766</a>
<a href="https://rdar.apple.com/171289732">rdar://171289732</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/textarea-placeholder-pseudo-style-expected.txt:

Canonical link: <a href="https://commits.webkit.org/308386@main">https://commits.webkit.org/308386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80287998e4e238994ae15940bd143ab74b00ff97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100487 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9dab75f5-6b6b-4b06-8e7a-bedb3b21f173) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113337 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80861 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd3f0815-9afd-463e-af21-15d8860ac7ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94093 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ece09a93-584d-4a18-a317-9b6b5ec08dd7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12552 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3197 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158086 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75523 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8625 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19170 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18959 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->