### PR TITLE
IOSurface <model> memory lacks process attribution

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -24,7 +24,7 @@
 internal import Metal
 import WebKit
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_weakLinked internal import USDKit
@@ -246,6 +246,7 @@ extension WKBridgeUpdateMesh {
     }
 }
 
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 func decodeValues<T>(from data: Data) -> [T] {
     let stride = MemoryLayout<T>.stride
 
@@ -253,7 +254,6 @@ func decodeValues<T>(from data: Data) -> [T] {
         return []
     }
 
-    #if compiler(>=6.2)
     return unsafe data.withUnsafeBytes { rawBufferPointer in
         guard let baseAddress = rawBufferPointer.baseAddress else {
             return []
@@ -263,17 +263,6 @@ func decodeValues<T>(from data: Data) -> [T] {
         let pointer = unsafe baseAddress.assumingMemoryBound(to: T.self)
         return (0..<count).map { unsafe pointer[$0] }
     }
-    #else
-    return data.withUnsafeBytes { rawBufferPointer in
-        guard let baseAddress = rawBufferPointer.baseAddress else {
-            return []
-        }
-
-        let count = rawBufferPointer.count / stride
-        let pointer = baseAddress.assumingMemoryBound(to: T.self)
-        return (0..<count).map { pointer[$0] }
-    }
-    #endif
 }
 
 extension WKBridgeBlendShapeData {
@@ -332,6 +321,7 @@ extension WKBridgeUpdateMesh {
         return decodeValues(from: data.prefix(expectedSize))
     }
 }
+#endif
 
 @objc
 @implementation
@@ -852,19 +842,12 @@ extension WKBridgeLiteral {
     }
 }
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 internal func toData<T>(_ input: [T]) -> Data {
-    #if compiler(>=6.2)
-    // FIXME: (rdar://164559261) understand/document/remove unsafety
     unsafe input.withUnsafeBytes { bufferPointer in
-        unsafe Data(bufferPointer)
-    }
-    #else
-    input.withUnsafeBytes { bufferPointer in
         Data(bufferPointer)
     }
-    #endif
 }
 
 private func toDataArray<T>(_ input: [[T]]) -> [Data] {
@@ -939,7 +922,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -948,16 +930,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<jointTransformsCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
-            return (0..<jointTransformsCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     var inverseBindPoses: [simd_float4x4] {
@@ -978,7 +950,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -987,16 +958,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<inverseBindPosesCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
-            return (0..<inverseBindPosesCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     var influenceJointIndices: [UInt32] {
@@ -1017,7 +978,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -1026,16 +986,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: UInt32.self)
             return (0..<influenceJointIndicesCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: UInt32.self)
-            return (0..<influenceJointIndicesCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     var influenceWeights: [Float] {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 internal import Metal
 @_weakLinked internal import USDKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 @_weakLinked internal import USDKit
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 internal import QuartzCore
 @_weakLinked internal import USDKit
@@ -47,8 +47,9 @@ nonisolated class Renderer {
     }
     var pose: _Proto_Pose_v1
     var modelDistance: Float = 1.0
+    let memoryOwner: task_id_token_t
 
-    init(device: MTLDevice) throws {
+    init(device: MTLDevice, memoryOwner: task_id_token_t) throws {
         guard let commandQueue = device.makeCommandQueue() else {
             fatalError("Failed to create command queue.")
         }
@@ -57,10 +58,16 @@ nonisolated class Renderer {
         self.device = device
         self.commandQueue = commandQueue
         self.pose = .init(translation: [0, 0, 1], rotation: .init(ix: 0, iy: 0, iz: 0, r: 1))
+        self.memoryOwner = memoryOwner
     }
 
     func createMaterialCompiler(colorPixelFormat: MTLPixelFormat, rasterSampleCount: Int, colorSpace: CGColorSpace? = nil) async throws {
+        #if canImport(RealityCoreRenderer, _version: 9999)
         var configuration = _Proto_LowLevelRenderContextStandaloneConfiguration_v1(device: device)
+        configuration.memoryOwner = self.memoryOwner
+        #else
+        var configuration = _Proto_LowLevelRenderContextStandaloneConfiguration_v1(device: device)
+        #endif
         configuration.residencySetBehavior = _Proto_LowLevelRenderContextStandaloneConfiguration_v1.ResidencySetBehavior.disable
         let renderContext = try await _Proto_makeLowLevelRenderContextStandalone_v1(configuration: configuration)
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -663,7 +663,7 @@ NS_SWIFT_SENDABLE
 @interface WKBridgeUSDConfiguration : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDevice:(id<MTLDevice>)device memoryOwner:(task_id_token_t)memoryOwner NS_DESIGNATED_INITIALIZER;
 
 - (void)createMaterialCompiler:(void (^)(void))completionHandler;
 
@@ -704,6 +704,10 @@ NS_HEADER_AUDIT_END(nullability, sendability)
 #endif
 
 #ifdef __cplusplus
+
+namespace WebCore {
+class ProcessIdentity;
+}
 
 namespace WebModel {
 
@@ -822,6 +826,7 @@ typedef struct WebModelCreateMeshDescriptor {
     Vector<RetainPtr<IOSurfaceRef>> ioSurfaces;
     const WebModel::ImageAsset& diffuseTexture;
     const WebModel::ImageAsset& specularTexture;
+    const WebCore::ProcessIdentity* processIdentity;
 } WebModelCreateMeshDescriptor;
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 @_weakLinked internal import DirectResource
 internal import Metal
@@ -76,17 +76,6 @@ extension _Proto_LowLevelMeshResource_v1 {
     nonisolated func replaceVertexData(_ vertexData: [Data]) {
         for (vertexBufferIndex, vertexData) in vertexData.enumerated() {
             let bufferSizeInByte = vertexData.bytes.byteCount
-            #if compiler(>=6.2)
-            // FIXME: (rdar://164559261) understand/document/remove unsafety
-            self.replaceVertices(at: vertexBufferIndex) { vertexBytes in
-                unsafe vertexBytes.withUnsafeMutableBytes { ptr in
-                    // FIXME(rdar://164559261): understand/document/remove unsafety
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                    // swift-format-ignore: NeverForceUnwrap
-                    unsafe vertexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: bufferSizeInByte)
-                }
-            }
-            #else
             self.replaceVertices(at: vertexBufferIndex) { vertexBytes in
                 vertexBytes.withUnsafeMutableBytes { ptr in
                     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -94,27 +83,17 @@ extension _Proto_LowLevelMeshResource_v1 {
                     vertexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: bufferSizeInByte)
                 }
             }
-            #endif
         }
     }
 
     nonisolated func replaceIndexData(_ indexData: Data?) {
         if let indexData = indexData {
             self.replaceIndices { indicesBytes in
-                #if compiler(>=6.2)
-                // FIXME: (rdar://164559261) understand/document/remove unsafety
-                unsafe indicesBytes.withUnsafeMutableBytes { ptr in
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                    // swift-format-ignore: NeverForceUnwrap
-                    unsafe indexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
-                }
-                #else
                 indicesBytes.withUnsafeMutableBytes { ptr in
                     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                     // swift-format-ignore: NeverForceUnwrap
                     indexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
                 }
-                #endif
             }
         }
     }

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -26,7 +26,7 @@ import OSLog
 import WebKit
 import simd
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_weakLinked @_spi(RealityCoreTextureProcessingAPI) internal import RealityCoreTextureProcessing
@@ -78,6 +78,7 @@ private func makeMTLTextureFromImageAsset(
     _ imageAsset: WKBridgeImageAsset,
     device: MTLDevice,
     generateMips: Bool,
+    memoryOwner: task_id_token_t,
     overridePixelFormat: Bool = false
 ) -> MTLTexture? {
     guard let imageAssetData = imageAsset.data else {
@@ -130,11 +131,11 @@ private func makeMTLTextureFromImageAsset(
         logError("failed to device.makeTexture")
         return nil
     }
+    mtlTexture.__setOwnerWithIdentity(memoryOwner)
 
     let bytesPerRow = imageAsset.width * imageAsset.bytesPerPixel
     let bytesPerImage = bytesPerRow * imageAsset.height
 
-    #if compiler(>=6.2)
     unsafe imageAssetData.bytes.withUnsafeBytes { textureBytes in
         guard let textureBytesBaseAddress = textureBytes.baseAddress else {
             return
@@ -153,26 +154,6 @@ private func makeMTLTextureFromImageAsset(
             )
         }
     }
-    #else
-    imageAssetData.bytes.withUnsafeBytes { textureBytes in
-        guard let textureBytesBaseAddress = textureBytes.baseAddress else {
-            return
-        }
-        for face in 0..<sliceCount {
-            let offset = face * bytesPerImage
-            let facePointer = textureBytesBaseAddress.advanced(by: offset)
-
-            mtlTexture.replace(
-                region: MTLRegionMake2D(0, 0, imageAsset.width, imageAsset.height),
-                mipmapLevel: 0,
-                slice: face,
-                withBytes: facePointer,
-                bytesPerRow: bytesPerRow,
-                bytesPerImage: bytesPerImage
-            )
-        }
-    }
-    #endif
 
     return mtlTexture
 }
@@ -183,6 +164,7 @@ private func makeTextureFromImageAsset(
     renderContext: _Proto_LowLevelRenderContext_v1,
     commandQueue: MTLCommandQueue,
     generateMips: Bool,
+    memoryOwner: task_id_token_t,
     overridePixelFormat: Bool,
     swizzle: MTLTextureSwizzleChannels = .init(red: .red, green: .green, blue: .blue, alpha: .alpha)
 ) -> _Proto_LowLevelTextureResource_v1? {
@@ -191,6 +173,7 @@ private func makeTextureFromImageAsset(
             imageAsset,
             device: device,
             generateMips: generateMips,
+            memoryOwner: memoryOwner,
             overridePixelFormat: overridePixelFormat
         )
     else {
@@ -314,11 +297,11 @@ extension WKBridgeUSDConfiguration {
         get { appRenderer.renderTargetDescriptor }
     }
 
-    @objc(initWithDevice:)
-    init(device: MTLDevice) {
+    @objc
+    init(device: MTLDevice, memoryOwner: task_id_token_t) {
         self.device = device
         do {
-            self.appRenderer = try Renderer(device: device)
+            self.appRenderer = try Renderer(device: device, memoryOwner: memoryOwner)
         } catch {
             fatalError("Exception creating renderer \(error)")
         }
@@ -410,6 +393,11 @@ extension WKBridgeReceiver {
     @nonobjc
     fileprivate var dontCaptureAgain: Bool = false
 
+    @nonobjc
+    fileprivate final var memoryOwner: task_id_token_t {
+        appRenderer.memoryOwner
+    }
+
     init(
         configuration: WKBridgeUSDConfiguration,
         diffuseAsset: WKBridgeImageAsset,
@@ -434,6 +422,7 @@ extension WKBridgeReceiver {
                 renderContext: renderContext,
                 commandQueue: configuration.commandQueue,
                 generateMips: true,
+                memoryOwner: configuration.appRenderer.memoryOwner,
                 overridePixelFormat: false,
                 swizzle: .init(red: .red, green: .red, blue: .red, alpha: .one)
             )
@@ -447,6 +436,7 @@ extension WKBridgeReceiver {
                 renderContext: renderContext,
                 commandQueue: configuration.commandQueue,
                 generateMips: true,
+                memoryOwner: configuration.appRenderer.memoryOwner,
                 overridePixelFormat: false,
                 swizzle: .init(red: .red, green: .red, blue: .red, alpha: .one)
             )
@@ -546,6 +536,7 @@ extension WKBridgeReceiver {
             renderContext: renderContext,
             commandQueue: commandQueue,
             generateMips: true,
+            memoryOwner: self.memoryOwner,
             overridePixelFormat: false
         ) {
             textureResources[textureHash] = textureResource
@@ -752,7 +743,14 @@ extension WKBridgeReceiver {
     @objc
     func setEnvironmentMap(_ imageAsset: WKBridgeImageAsset) {
         do {
-            guard let mtlTextureEquirectangular = makeMTLTextureFromImageAsset(imageAsset, device: device, generateMips: true) else {
+            guard
+                let mtlTextureEquirectangular = makeMTLTextureFromImageAsset(
+                    imageAsset,
+                    device: device,
+                    generateMips: true,
+                    memoryOwner: self.memoryOwner
+                )
+            else {
                 fatalError("Could not make metal texture from environment asset data")
             }
 
@@ -762,6 +760,7 @@ extension WKBridgeReceiver {
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
             let cubeMTLTexture = self.device.makeTexture(descriptor: cubeMTLTextureDescriptor)!
+            cubeMTLTexture.__setOwnerWithIdentity(self.memoryOwner)
 
             let diffuseMTLTextureDescriptor = try self.textureProcessingContext.createImageBasedLightDiffuseDescriptor(
                 fromCube: cubeMTLTexture
@@ -1098,13 +1097,13 @@ extension WKBridgeReceiver {
         var deformers: [_Proto_LowLevelDeformerDescription_v1] = []
 
         if let skinningData = deformationData.skinningData {
-            let skinningDeformer = skinningData.makeDeformerDescription(device: self.device)
+            let skinningDeformer = skinningData.makeDeformerDescription(device: self.device, memoryOwner: self.memoryOwner)
             deformers.append(skinningDeformer)
         }
 
         if let blendShapeData = deformationData.blendShapeData {
             do {
-                let blendShapeDeformer = try blendShapeData.makeDeformerDescription(device: self.device)
+                let blendShapeDeformer = try blendShapeData.makeDeformerDescription(device: self.device, memoryOwner: self.memoryOwner)
                 deformers.append(blendShapeDeformer)
             } catch {
                 logError("Error creating blend shape deformer for \(identifier): \(error.localizedDescription)")
@@ -1114,7 +1113,7 @@ extension WKBridgeReceiver {
         // TODO: add tangent frame data to input
         // if let renormalizationData = deformationData.renormalizationData {
         //     do {
-        //         let renormalization = try renormalizationData.makeDeformerDescription(device: self.device)
+        //         let renormalization = try renormalizationData.makeDeformerDescription(device: self.device, memoryOwner: self.memoryOwner)
         //         deformers.append(renormalization)
         //     } catch {
         //         logError("Error creating renormalization deformer for \(identifier): \(error.localizedDescription)")
@@ -1132,7 +1131,8 @@ extension WKBridgeReceiver {
             let vertexPositionsBuffer = meshResource.readVertices(at: 1, using: commandBuffer)!
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
-            let inputPositionsBuffer = device.makeBuffer(length: vertexPositionsBuffer.length, options: .storageModeShared)!
+            let inputPositionsBuffer = unsafe device.makeBuffer(length: vertexPositionsBuffer.length, options: .storageModeShared)!
+            inputPositionsBuffer.__setOwnerWithIdentity(self.memoryOwner)
 
             // Copy data from vertexPositionsBuffer to inputPositionsBuffer
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -1214,9 +1214,7 @@ extension WKBridgeReceiver {
 }
 
 extension WKBridgeSkinningData {
-    fileprivate func makeDeformerDescription(device: MTLDevice) -> _Proto_LowLevelDeformerDescription_v1 {
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
+    fileprivate func makeDeformerDescription(device: MTLDevice, memoryOwner: mach_port_t) -> _Proto_LowLevelDeformerDescription_v1 {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointTransformsBuffer = unsafe device.makeBuffer(
@@ -1224,15 +1222,7 @@ extension WKBridgeSkinningData {
             length: self.jointTransforms.count * MemoryLayout<simd_float4x4>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let jointTransformsBuffer = device.makeBuffer(
-            bytes: self.jointTransforms,
-            length: self.jointTransforms.count * MemoryLayout<simd_float4x4>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        jointTransformsBuffer.__setOwnerWithIdentity(memoryOwner)
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -1243,8 +1233,6 @@ extension WKBridgeSkinningData {
             elementType: .float4x4
         )!
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let inverseBindPosesBuffer = unsafe device.makeBuffer(
@@ -1252,15 +1240,7 @@ extension WKBridgeSkinningData {
             length: self.inverseBindPoses.count * MemoryLayout<simd_float4x4>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let inverseBindPosesBuffer = device.makeBuffer(
-            bytes: self.inverseBindPoses,
-            length: self.inverseBindPoses.count * MemoryLayout<simd_float4x4>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        inverseBindPosesBuffer.__setOwnerWithIdentity(memoryOwner)
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -1271,8 +1251,6 @@ extension WKBridgeSkinningData {
             elementType: .float4x4
         )!
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointIndicesBuffer = unsafe device.makeBuffer(
@@ -1280,15 +1258,8 @@ extension WKBridgeSkinningData {
             length: self.influenceJointIndices.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let jointIndicesBuffer = device.makeBuffer(
-            bytes: self.influenceJointIndices,
-            length: self.influenceJointIndices.count * MemoryLayout<UInt32>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        jointIndicesBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointIndicesDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1298,8 +1269,6 @@ extension WKBridgeSkinningData {
             elementType: .uint
         )!
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let influenceWeightsBuffer = unsafe device.makeBuffer(
@@ -1307,15 +1276,8 @@ extension WKBridgeSkinningData {
             length: self.influenceWeights.count * MemoryLayout<Float>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let influenceWeightsBuffer = device.makeBuffer(
-            bytes: self.influenceWeights,
-            length: self.influenceWeights.count * MemoryLayout<Float>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        influenceWeightsBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let influenceWeightsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1339,7 +1301,7 @@ extension WKBridgeSkinningData {
 }
 
 extension WKBridgeBlendShapeData {
-    func makeDeformerDescription(device: MTLDevice) throws -> _Proto_LowLevelDeformerDescription_v1 {
+    func makeDeformerDescription(device: MTLDevice, memoryOwner: task_id_token_t) throws -> _Proto_LowLevelDeformerDescription_v1 {
         var weights: [Float] = []
 
         var debugWeights = self.weights
@@ -1351,8 +1313,6 @@ extension WKBridgeBlendShapeData {
             weights += Array(repeating: debugWeights[i], count: positionCount)
         }
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let blendWeightsBuffer = unsafe device.makeBuffer(
@@ -1360,15 +1320,8 @@ extension WKBridgeBlendShapeData {
             length: weights.count * MemoryLayout<Float>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let blendWeightsBuffer = device.makeBuffer(
-            bytes: weights,
-            length: weights.count * MemoryLayout<Float>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        blendWeightsBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let blendWeightsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1379,8 +1332,6 @@ extension WKBridgeBlendShapeData {
         )!
 
         let positionOffsets = debugPositionOffsets.flatMap(\.self)
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let positionOffsetsBuffer = unsafe device.makeBuffer(
@@ -1388,15 +1339,8 @@ extension WKBridgeBlendShapeData {
             length: positionOffsets.count * MemoryLayout<SIMD3<Float>>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let positionOffsetsBuffer = device.makeBuffer(
-            bytes: positionOffsets,
-            length: positionOffsets.count * MemoryLayout<SIMD3<Float>>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        positionOffsetsBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let positionOffsetsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1420,10 +1364,8 @@ extension WKBridgeBlendShapeData {
 }
 
 extension WKBridgeRenormalizationData {
-    func makeDeformerDescription(device: MTLDevice) throws -> _Proto_LowLevelDeformerDescription_v1 {
+    func makeDeformerDescription(device: MTLDevice, memoryOwner: task_id_token_t) throws -> _Proto_LowLevelDeformerDescription_v1 {
         // Create adjacency buffer
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacenciesMetalBuffer = unsafe device.makeBuffer(
@@ -1431,15 +1373,8 @@ extension WKBridgeRenormalizationData {
             length: vertexAdjacencies.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let adjacenciesMetalBuffer = device.makeBuffer(
-            bytes: vertexAdjacencies,
-            length: vertexAdjacencies.count * MemoryLayout<UInt32>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        adjacenciesMetalBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacenciesBuffer = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1450,8 +1385,6 @@ extension WKBridgeRenormalizationData {
         )!
 
         // Create adjacency end indices buffer
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacencyEndIndicesMetalBuffer = unsafe device.makeBuffer(
@@ -1459,15 +1392,8 @@ extension WKBridgeRenormalizationData {
             length: vertexAdjacencyEndIndices.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let adjacencyEndIndicesMetalBuffer = device.makeBuffer(
-            bytes: vertexAdjacencyEndIndices,
-            length: vertexAdjacencyEndIndices.count * MemoryLayout<UInt32>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        adjacencyEndIndicesMetalBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacencyEndIndicesBuffer = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1493,7 +1419,7 @@ extension WKBridgeRenormalizationData {
 @objc
 @implementation
 extension WKBridgeUSDConfiguration {
-    init(device: MTLDevice) {
+    init(device: MTLDevice, memoryOwner: task_id_token_t) {
     }
 
     @objc(createMaterialCompiler:)

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -27,13 +27,15 @@
 #import "WebKitMesh.h"
 
 #import "ModelTypes.h"
-#import "WebKitSwiftSoftLink.h"
 
+#import <WebCore/ProcessIdentity.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/MathExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/spi/cocoa/IOSurfaceSPI.h>
 #import <wtf/threads/BinarySemaphore.h>
+
+#import "WebKitSwiftSoftLink.h"
 
 namespace WebModel {
 
@@ -323,7 +325,7 @@ WebMesh::WebMesh(const WebModelCreateMeshDescriptor& descriptor)
         [m_textures addObject:[device newTextureWithDescriptor:textureDescriptor iosurface:ioSurface.get() plane:0]];
 
 #if ENABLE(GPU_PROCESS_MODEL)
-    WKBridgeUSDConfiguration *configuration = [WebKit::allocWKBridgeUSDConfigurationInstance() initWithDevice:device];
+    WKBridgeUSDConfiguration *configuration = [WebKit::allocWKBridgeUSDConfigurationInstance() initWithDevice:device memoryOwner:descriptor.processIdentity ? descriptor.processIdentity->taskIdToken() : 0];
     WKBridgeImageAsset *diffuseAsset = WebModel::convert(descriptor.diffuseTexture);
     WKBridgeImageAsset *specularAsset = WebModel::convert(descriptor.specularTexture);
     if (configuration) {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -289,12 +289,14 @@ static Vector<UniqueRef<WebCore::IOSurface>> createIOSurfaces(unsigned width, un
 #endif
 
 #if ENABLE(GPU_PROCESS_MODEL)
-static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, const WebCore::ProcessIdentity& processIdentity, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
 {
     auto ioSurfaceVector = createIOSurfaces(width, height);
     Vector<RetainPtr<IOSurfaceRef>> ioSurfaces;
-    for (UniqueRef<WebCore::IOSurface>& ioSurface : ioSurfaceVector)
+    for (UniqueRef<WebCore::IOSurface>& ioSurface : ioSurfaceVector) {
         ioSurfaces.append(ioSurface->surface());
+        ioSurface->setOwnershipIdentity(processIdentity);
+    }
 
     WebModelCreateMeshDescriptor backingDescriptor {
         .width = width,
@@ -302,6 +304,7 @@ static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned 
         .ioSurfaces = WTF::move(ioSurfaces),
         .diffuseTexture = diffuseTexture,
         .specularTexture = specularTexture,
+        .processIdentity = &processIdentity
     };
 
     auto mesh = WebKit::MeshImpl::create(WebMesh::create(backingDescriptor), WTF::move(ioSurfaceVector));
@@ -317,8 +320,10 @@ void RemoteGPU::createModelBacking(unsigned width, unsigned height, const WebMod
 
     Ref objectHeap = m_modelObjectHeap.get();
 
-    RefPtr gpu = m_backing.get();
-    auto mesh = createModelBackingInternal(width, height, diffuseTexture, specularTexture, WTF::move(callback));
+    auto gpuProcessConnection = m_gpuConnectionToWebProcess.get();
+    MESSAGE_CHECK(gpuProcessConnection);
+
+    auto mesh = createModelBackingInternal(width, height, diffuseTexture, specularTexture, gpuProcessConnection->webProcessIdentity(), WTF::move(callback));
     auto remoteMesh = RemoteMesh::create(*m_gpuConnectionToWebProcess.get(), *this, *mesh, objectHeap, Ref { *m_streamConnection }, identifier);
     objectHeap->addObject(identifier, remoteMesh);
 #else


### PR DESCRIPTION
#### 6cef2858442a4012b783876efd7dd8c0c5669cf9
<pre>
IOSurface &lt;model&gt; memory lacks process attribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=308764">https://bugs.webkit.org/show_bug.cgi?id=308764</a>
<a href="https://rdar.apple.com/171286558">rdar://171286558</a>

Reviewed by Etienne Segonzac.

We need to attribute memory RE creates to the respective web content
process on iOS to avoid jetsams when multiple web pages are using &lt;model&gt; elements.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(WKBridgeSkinningData.jointTransforms):
(WKBridgeSkinningData.inverseBindPoses):
(WKBridgeSkinningData.influenceJointIndices):
* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.createMaterialCompiler(_:rasterSampleCount:colorSpace:)):
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(_Proto_LowLevelMeshResource_v1.replaceVertexData(_:)):
(_Proto_LowLevelMeshResource_v1.replaceIndexData(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(Material.memoryOwner):
(Material.updateTexture(_:)):
(Material.setEnvironmentMap(_:)):
(WKBridgeSkinningData.makeDeformerDescription(_:memoryOwner:)):
(WKBridgeBlendShapeData.makeDeformerDescription(_:memoryOwner:)):
(WKBridgeRenormalizationData.makeDeformerDescription(_:memoryOwner:)):
(WKBridgeSkinningData.makeDeformerDescription(_:)): Deleted.
(WKBridgeBlendShapeData.makeDeformerDescription(_:)): Deleted.
(WKBridgeRenormalizationData.makeDeformerDescription(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::WebMesh):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::createModelBackingInternal):
(WebKit::RemoteGPU::createModelBacking):

Canonical link: <a href="https://commits.webkit.org/308728@main">https://commits.webkit.org/308728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/021e410b1786bc9e14e519044c500363f7db5645

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101556 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c234200-5b7d-42ae-9efd-5a76f799f8ac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114205 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81423 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94971 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34c4000c-0920-414b-a0f3-083245c90abc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15579 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13377 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125180 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159159 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122236 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76786 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9492 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84003 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19974 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->