### PR TITLE
[AutoFill Debugging] Add a way for clients to include/exclude select options

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-covered-button-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-covered-button-expected.txt
@@ -1,0 +1,9 @@
+PASS clickError is ""
+PASS clickCount.textContent is "1"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click Me
+1
+
+This popup covers the button.

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-covered-button.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-covered-button.html
@@ -1,0 +1,68 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        .overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 1000;
+        }
+
+        .popup {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: white;
+            padding: 20px;
+            z-index: 1001;
+        }
+    </style>
+</head>
+<body>
+    <button id="covered-button" aria-label="Covered Button">Click Me</button>
+    <h1 class="click-count">0</h1>
+    <div class="overlay"></div>
+    <div class="popup">
+        <p>This popup covers the button.</p>
+    </div>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        clickCount = document.querySelector(".click-count");
+
+        document.getElementById("covered-button").addEventListener("click", () => {
+            clickCount.textContent = parseInt(clickCount.textContent) + 1;
+        });
+
+        if (!window.testRunner)
+            return;
+
+        const debugText = await UIHelper.requestDebugText({
+            nodeIdentifierInclusion: "interactive",
+            includeAccessibilityAttributes: true,
+            eventListenerCategories: ["all"],
+        });
+
+        clickError = await UIHelper.performTextExtractionInteraction("click", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Covered Button")
+        });
+
+        shouldBeEqualToString("clickError", "");
+        shouldBeEqualToString("clickCount.textContent", "1");
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -116,6 +116,7 @@ addEventListener("load", async () => {
             eventListenerCategories: ["none"],
             includeAccessibilityAttributes: true,
             includeTextInAutoFilledControls: true,
+            includeSelectOptions: true,
             outputFormat,
         });
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-button-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-button-expected.txt
@@ -1,0 +1,7 @@
+PASS clickError is ""
+PASS clickCount.textContent is "1"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click Me
+1

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-button.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-button.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        .offscreen {
+            position: absolute;
+            top: 101vh;
+            left: 0;
+        }
+
+        body {
+            width: 100%;
+            height: 200vh;
+        }
+    </style>
+</head>
+<body>
+    <button id="offscreen-button" class="offscreen" aria-label="Offscreen Button">Click Me</button>
+    <h1 class="click-count">0</h1>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        clickCount = document.querySelector(".click-count");
+
+        document.getElementById("offscreen-button").addEventListener("click", () => {
+            clickCount.textContent = parseInt(clickCount.textContent) + 1;
+        });
+
+        if (!window.testRunner)
+            return;
+
+        const debugText = await UIHelper.requestDebugText({
+            nodeIdentifierInclusion: "interactive",
+            includeAccessibilityAttributes: true,
+            eventListenerCategories: ["all"],
+        });
+
+        clickError = await UIHelper.performTextExtractionInteraction("click", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Offscreen Button")
+        });
+
+        shouldBeEqualToString("clickError", "");
+        shouldBeEqualToString("clickCount.textContent", "1");
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-select-options-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-select-options-expected.txt
@@ -1,0 +1,99 @@
+-- texttree (includeSelectOptions: true)
+
+root
+    'Hello world'
+    select
+        option,value='one','Number 1'
+        option,value='two','Number 2'
+        option,selected,value='three','Number 3'
+    select,multiple
+        option,selected,value='banana'
+        option,selected,value='pear'
+        option,value='apple'
+
+-- json (includeSelectOptions: true)
+
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "text",
+      "content": "Hello world"
+    },
+    {
+      "type": "select",
+      "nodeName": "select",
+      "options": [
+        {
+          "value": "one",
+          "label": "Number 1",
+          "selected": false
+        },
+        {
+          "value": "two",
+          "label": "Number 2",
+          "selected": false
+        },
+        {
+          "value": "three",
+          "label": "Number 3",
+          "selected": true
+        }
+      ]
+    },
+    {
+      "type": "select",
+      "nodeName": "select",
+      "options": [
+        {
+          "value": "banana",
+          "label": "Banana",
+          "selected": true
+        },
+        {
+          "value": "pear",
+          "label": "Pear",
+          "selected": true
+        },
+        {
+          "value": "apple",
+          "label": "Apple",
+          "selected": false
+        }
+      ],
+      "multiple": true
+    }
+  ],
+  "version": 2
+}
+
+-- texttree (includeSelectOptions: false)
+
+root
+    'Hello world'
+    select
+    select,multiple
+
+-- json (includeSelectOptions: false)
+
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "text",
+      "content": "Hello world"
+    },
+    {
+      "type": "select",
+      "nodeName": "select"
+    },
+    {
+      "type": "select",
+      "nodeName": "select",
+      "multiple": true
+    }
+  ],
+  "version": 2
+}
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-select-options.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-select-options.html
@@ -1,0 +1,67 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+.text-representation {
+    white-space: pre-wrap;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p>Hello world</p>
+<select>
+    <option value="one">Number 1</option>
+    <option value="two">Number 2</option>
+    <option selected value="three">Number 3</option>
+</select>
+<select multiple>
+    <option selected value="banana">Banana</option>
+    <option selected value="pear">Pear</option>
+    <option value="apple">Apple</option>
+</select>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const results = [];
+    for (let includeSelectOptions of [true, false]) {
+        for (let outputFormat of ["texttree", "json"]) {
+            const heading = document.createElement("h1");
+            heading.textContent = `-- ${outputFormat} (includeSelectOptions: ${includeSelectOptions})`;
+
+            const container = document.createElement("pre");
+            container.classList.add("text-representation");
+            let textContent = await UIHelper.requestDebugText({
+                normalize: true,
+                includeRects: false,
+                includeURLs: false,
+                includeSelectOptions,
+                nodeIdentifierInclusion: "none",
+                eventListenerCategories: ["none"],
+                outputFormat,
+            });
+
+            if (outputFormat === "json")
+                textContent = JSON.stringify(JSON.parse(textContent), null, "  ");
+
+            container.textContent = textContent;
+            results.push(heading);
+            results.push(container);
+            results.push(document.createElement("br"));
+        }
+    }
+
+    document.body.replaceChildren(...results);
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1684,9 +1684,9 @@ static void dispatchSimulatedClick(Node& targetNode, const String& searchText, C
 
     // Fall back to dispatching a programmatic click.
     if (element->dispatchSimulatedClick(nullptr, SendMouseUpDownEvents))
-        completion(false, "Failed to click (tried falling back to dispatching programmatic click since target could not be hit-tested)"_s);
-    else
         completion(true, { });
+    else
+        completion(false, "Failed to click (tried falling back to dispatching programmatic click since target could not be hit-tested)"_s);
 }
 
 static void dispatchSimulatedClick(NodeIdentifier identifier, const String& searchText, CompletionHandler<void(bool, String&&)>&& completion)

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -50,10 +50,11 @@ namespace WebKit {
 using TextExtractionVersion = unsigned;
 
 enum class TextExtractionOptionFlag : uint8_t {
-    IncludeURLs     = 1 << 0,
-    IncludeRects    = 1 << 1,
-    OnlyIncludeText = 1 << 2,
-    ShortenURLs     = 1 << 3,
+    IncludeURLs          = 1 << 0,
+    IncludeRects         = 1 << 1,
+    OnlyIncludeText      = 1 << 2,
+    ShortenURLs          = 1 << 3,
+    IncludeSelectOptions = 1 << 4,
 };
 
 enum class TextExtractionOutputFormat : uint8_t {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6919,6 +6919,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         filterUsingRules,
         includeURLs = configuration.includeURLs,
         includeRects = configuration.includeRects,
+        includeSelectOptions = configuration.includeSelectOptions,
         onlyIncludeText = configuration.onlyIncludeVisibleText,
         applyDiscretionaryWordLimit = configuration.maxWordsPerParagraphPolicy == _WKTextExtractionWordLimitPolicyDiscretionary,
         shortenURLs = configuration.shortenURLs,
@@ -7050,6 +7051,8 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             optionFlags.add(OnlyIncludeText);
         if (shortenURLs)
             optionFlags.add(ShortenURLs);
+        if (includeSelectOptions)
+            optionFlags.add(IncludeSelectOptions);
         RefPtr urlCache = strongSelf->_textExtractionURLCache;
         WebKit::TextExtractionOptions options {
             WTF::move(mainFrameIdentifier),

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -115,6 +115,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic) BOOL includeRects;
 
 /*!
+ Include options for `select` elements in text extraction output.
+ The default value is `YES`.
+ */
+@property (nonatomic) BOOL includeSelectOptions;
+
+/*!
  Policy determining which nodes should be uniquely identified in the output.
  `.none`          	Prevents collection of any identifiers.
  `.editableOnly`    Limits collection of identifiers to editable elements and form controls.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -59,6 +59,7 @@
     _filterOptions = _WKTextExtractionFilterAll;
     _includeURLs = !onlyVisibleText;
     _includeRects = !onlyVisibleText;
+    _includeSelectOptions = !onlyVisibleText;
     _nodeIdentifierInclusion = onlyVisibleText ? _WKTextExtractionNodeIdentifierInclusionNone : _WKTextExtractionNodeIdentifierInclusionInteractive;
     _eventListenerCategories = onlyVisibleText ? _WKTextExtractionEventListenerCategoryNone : _WKTextExtractionEventListenerCategoryAll;
     _includeAccessibilityAttributes = !onlyVisibleText;
@@ -144,6 +145,13 @@
     ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
 
     _includeRects = value;
+}
+
+- (void)setIncludeSelectOptions:(BOOL)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _includeSelectOptions = value;
 }
 
 - (void)setNodeIdentifierInclusion:(_WKTextExtractionNodeIdentifierInclusion)value

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -47,6 +47,7 @@ dictionary TextExtractionTestOptions {
     boolean clipToBounds = false;
     boolean includeRects = false;
     boolean includeURLs = false;
+    boolean includeSelectOptions = false;
     boolean shortenURLs = false;
     DOMString nodeIdentifierInclusion = "none";
     object eventListenerCategories;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -62,6 +62,7 @@ struct TextExtractionTestOptions {
     bool clipToBounds { false };
     bool includeRects { false };
     bool includeURLs { false };
+    bool includeSelectOptions { false };
     bool shortenURLs { false };
     JSRetainPtr<JSStringRef> nodeIdentifierInclusion;
     JSValueRef eventListenerCategories { nullptr };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -74,6 +74,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.clipToBounds = booleanProperty(context, (JSObjectRef)argument, "clipToBounds", false);
     options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
     options.includeURLs = booleanProperty(context, (JSObjectRef)argument, "includeURLs", false);
+    options.includeSelectOptions = booleanProperty(context, (JSObjectRef)argument, "includeSelectOptions", false);
     options.shortenURLs = booleanProperty(context, (JSObjectRef)argument, "shortenURLs", false);
     options.eventListenerCategories = [&] -> JSValueRef {
         auto value = property(context, (JSObjectRef)argument, "eventListenerCategories");

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -398,6 +398,7 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
     [configuration setIncludeRects:options && options->includeRects];
     [configuration setIncludeURLs:options && options->includeURLs];
+    [configuration setIncludeSelectOptions:options && options->includeSelectOptions];
     [configuration setShortenURLs:options && options->shortenURLs];
     [configuration setNodeIdentifierInclusion:^{
         if (!options)


### PR DESCRIPTION
#### d18b599be780e422898f409e77b8f08427cbda8f
<pre>
[AutoFill Debugging] Add a way for clients to include/exclude select options
<a href="https://bugs.webkit.org/show_bug.cgi?id=308771">https://bugs.webkit.org/show_bug.cgi?id=308771</a>
<a href="https://rdar.apple.com/171291215">rdar://171291215</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a new property to control whether individual `select` options should be included.
See below for more details.

Tests: fast/text-extraction/debug-text-extraction-covered-button.html
       fast/text-extraction/debug-text-extraction-offscreen-button.html
       fast/text-extraction/debug-text-extraction-select-options.html

* LayoutTests/fast/text-extraction/debug-text-extraction-covered-button-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-covered-button.html: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-button-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-button.html: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-select-options-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-select-options.html: Added.

Add tests to cover the behavior changes in this patch.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::dispatchSimulatedClick):

Drive-by fix: also flip this returned value to the completion handler, so that we indicate failure
when the element is disabled or the click fails, not vice versa.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::includeSelectOptions const):
(WebKit::populateJSONForItem):
(WebKit::addPartsForItem):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]):
(-[_WKTextExtractionConfiguration setIncludeSelectOptions:]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/308307@main">https://commits.webkit.org/308307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5eb5d920657399fced05864bddd53566037ba0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155768 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ddb0205-a7b0-4b2a-877d-131d01c94d1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113348 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/764d148a-760b-4c8c-9489-ae328dfa3a81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15573 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94105 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/702bfb46-7fd5-47cc-9256-68958cd601d0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3210 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158099 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1230 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121372 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121573 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31138 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131831 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17118 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8641 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19183 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82938 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18913 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18972 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->