### PR TITLE
AX: visible-content-search-in-scrolled-iframe.html fails with ENABLE(ACCESSIBILITY_LOCAL_FRAME) because isOnScreen() no longer checks iframe visibility

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -61,6 +61,7 @@
 #include "EventNames.h"
 #include "FloatRect.h"
 #include "FocusController.h"
+#include "FrameInlines.h"
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "GeometryUtilities.h"
@@ -3625,6 +3626,27 @@ bool AccessibilityObject::isOnScreen() const
         if (!outerRect.intersects(innerRect))
             return false;
     }
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // The element is visible within its own frame. If this is a child frame,
+    // also check whether the hosting iframe element is visible in the parent frame.
+    if (CheckedPtr cache = axObjectCache()) {
+        RefPtr document = cache->document();
+        RefPtr frame = document ? document->frame() : nullptr;
+        if (RefPtr frameElement = frame && !frame->isMainFrame() ? frame->ownerElement() : nullptr) {
+            // Get the iframe/frame owner element directly rather than using
+            // crossFrameParentObject(), which may return an unignored ancestor
+            // (like WebArea) whose boundingBoxRect doesn't reflect the iframe's
+            // actual position.
+            CheckedPtr parentCache = frameElement->document().axObjectCache();
+            if (RefPtr frameAXObject = parentCache ? parentCache->get(*frameElement) : nullptr) {
+                if (!frameAXObject->isOnScreen())
+                    return false;
+            }
+        }
+    }
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+
     return true;
 }
 


### PR DESCRIPTION
#### df660919d74d1d14b7be0e04703ffba3d7ddddbd
<pre>
AX: visible-content-search-in-scrolled-iframe.html fails with ENABLE(ACCESSIBILITY_LOCAL_FRAME) because isOnScreen() no longer checks iframe visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=308774">https://bugs.webkit.org/show_bug.cgi?id=308774</a>
<a href="https://rdar.apple.com/171297916">rdar://171297916</a>

Reviewed by NOBODY (OOPS!).

With ENABLE(ACCESSIBILITY_LOCAL_FRAME), each frame gets its own
AXObjectCache and AccessibilityScrollView::parentObject() returns
nullptr for root scroll views. This meant isOnScreen() stopped walking
the parent chain at the child frame&apos;s root scroll view, never checking
whether the hosting iframe element was visible in the parent frame.

After the existing visibility loop, add a cross-frame check: for
elements in child frames, get the frame&apos;s ownerElement(), look up its
AX object in the parent frame&apos;s cache, and recursively call isOnScreen()
on it. This uses the owner element directly rather than
crossFrameParentObject(), which may return an unignored ancestor (like
WebArea) whose boundingBoxRect doesn&apos;t reflect the iframe&apos;s actual
position.

Fixes accessibility/mac/visible-content-search-in-scrolled-iframe.html with ENABLE(ACCESSIBILITY_LOCAL_FRAME).

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isOnScreen const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df660919d74d1d14b7be0e04703ffba3d7ddddbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100502 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113350 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80866 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94107 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12561 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3212 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158101 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121374 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121575 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131818 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75538 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8632 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82940 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18915 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->