### PR TITLE
[JSC] Fix WebAssembly.compileStreaming and .instantiateStreaming to accept compileOptions

### DIFF
--- a/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming-expected.txt
+++ b/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming-expected.txt
@@ -1,0 +1,17 @@
+Test that WebAssembly.compileStreaming and .instantiateStreaming can accept compile options for JS String Builtins
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS compileStreaming with builtins option succeeded
+PASS instantiateStreaming with builtins option succeeded
+PASS compileStreaming without builtins, import via importObject succeeded
+PASS instantiateStreaming without builtins, import via importObject succeeded
+PASS compileStreaming with invalid options threw TypeError
+PASS instantiateStreaming with invalid options threw TypeError
+PASS compileStreaming with wrong builtin signature threw CompileError
+PASS instantiateStreaming with wrong builtin signature threw CompileError
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming.html
+++ b/LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming.html
@@ -1,0 +1,183 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmJSStringBuiltins=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>WebAssembly JS String Builtins Streaming Test</title>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Test that WebAssembly.compileStreaming and .instantiateStreaming can accept compile options for JS String Builtins");
+window.jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function runTest() {
+    /*
+    (module
+        (; 0000000b ;)    (type (; 0 ;)
+        (; 0000000b ;)      (func
+        (; 0000000d ;)        (param i32)
+        (; 0000000f ;)        (result (ref extern)
+                            )
+                        )
+        (; 00000011 ;)    (import "wasm:js-string" "fromCharCode" (func (; 0 ;) (type 0)
+                            (param  (; 0 ;) i32)
+                            (result (ref extern)
+                        ))
+                        )
+        )
+    */
+    let bytes = new Int8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 7, 1, 96, 1, 127, 1, 100, 111, 2, 31, 1, 14, 119, 97,
+        115, 109, 58, 106, 115, 45, 115, 116, 114, 105, 110, 103, 12, 102, 114, 111, 109, 67, 104, 97, 114, 67, 111,
+        100, 101, 0, 0, 3, 1, 0, 5, 4, 1, 1, 0, 0, 7, 10, 1, 6, 109, 101, 109, 111, 114, 121, 2, 0, 10,
+        -127, -128, -128, 0, 0]);
+
+    // Test WebAssembly.compileStreaming with builtins option
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        let module = await WebAssembly.compileStreaming(response, { builtins: ["js-string"] });
+        await WebAssembly.instantiate(module, {}, { builtins: ["js-string"] });
+        testPassed("compileStreaming with builtins option succeeded");
+    } catch (e) {
+        testFailed("compileStreaming with builtins option threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Test WebAssembly.instantiateStreaming with builtins option
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, {}, { builtins: ["js-string"] });
+        testPassed("instantiateStreaming with builtins option succeeded");
+    } catch (e) {
+        testFailed("instantiateStreaming with builtins option threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Import object to satisfy the wasm:js-string import manually
+    let importObject = {
+        "wasm:js-string": {
+            fromCharCode: (code) => String.fromCharCode(code)
+        }
+    };
+
+    // Test WebAssembly.compileStreaming without builtins, import satisfied via importObject
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        let module = await WebAssembly.compileStreaming(response);
+        await WebAssembly.instantiate(module, importObject);
+        testPassed("compileStreaming without builtins, import via importObject succeeded");
+    } catch (e) {
+        testFailed("compileStreaming without builtins, import via importObject threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Test WebAssembly.instantiateStreaming without builtins, import satisfied via importObject
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, importObject);
+        testPassed("instantiateStreaming without builtins, import via importObject succeeded");
+    } catch (e) {
+        testFailed("instantiateStreaming without builtins, import via importObject threw " + e.constructor.name + ": " + e.message);
+    }
+
+    // Test WebAssembly.compileStreaming with invalid options (number instead of object)
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.compileStreaming(response, 42);
+        testFailed("compileStreaming with invalid options should throw, but did not");
+    } catch (e) {
+        if (e instanceof TypeError)
+            testPassed("compileStreaming with invalid options threw TypeError");
+        else
+            testFailed("compileStreaming with invalid options threw " + e.constructor.name + " instead of TypeError");
+    }
+
+    // Test WebAssembly.instantiateStreaming with invalid options (number instead of object)
+    try {
+        let response = new Response(bytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, {}, 42);
+        testFailed("instantiateStreaming with invalid options should throw, but did not");
+    } catch (e) {
+        if (e instanceof TypeError)
+            testPassed("instantiateStreaming with invalid options threw TypeError");
+        else
+            testFailed("instantiateStreaming with invalid options threw " + e.constructor.name + " instead of TypeError");
+    }
+
+    // Module that imports "fromCharCode" but with the wrong signature (two i32 params instead of one).
+    // This should cause a CompileError when compiled with { builtins: ["js-string"] } because
+    // the signature doesn't match the expected builtin signature.
+    /*
+    (module
+      (type (func (param i32 i32) (result externref)))
+      (import "wasm:js-string" "fromCharCode" (func (type 0)))
+    )
+    */
+    let wrongSignatureBytes = new Int8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60,
+        0x02, 0x7f, 0x7f, 0x01, 0x6f, 0x02, 0x1f, 0x01, 0x0e, 0x77, 0x61, 0x73, 0x6d, 0x3a, 0x6a, 0x73, 0x2d, 0x73,
+        0x74, 0x72, 0x69, 0x6e, 0x67, 0x0c, 0x66, 0x72, 0x6f, 0x6d, 0x43, 0x68, 0x61, 0x72, 0x43, 0x6f, 0x64, 0x65,
+        0x00, 0x00]);
+
+    // Test WebAssembly.compileStreaming with wrong builtin signature throws CompileError
+    try {
+        let response = new Response(wrongSignatureBytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.compileStreaming(response, { builtins: ["js-string"] });
+        testFailed("compileStreaming with wrong builtin signature should throw, but did not");
+    } catch (e) {
+        if (e instanceof WebAssembly.CompileError)
+            testPassed("compileStreaming with wrong builtin signature threw CompileError");
+        else
+            testFailed("compileStreaming with wrong builtin signature threw " + e.constructor.name + " instead of CompileError");
+    }
+
+    // Test WebAssembly.instantiateStreaming with wrong builtin signature throws CompileError
+    try {
+        let response = new Response(wrongSignatureBytes, {
+            headers: {
+                "Content-Type": "application/wasm"
+            }
+        });
+        await WebAssembly.instantiateStreaming(response, {}, { builtins: ["js-string"] });
+        testFailed("instantiateStreaming with wrong builtin signature should throw, but did not");
+    } catch (e) {
+        if (e instanceof WebAssembly.CompileError)
+            testPassed("instantiateStreaming with wrong builtin signature threw CompileError");
+        else
+            testFailed("instantiateStreaming with wrong builtin signature threw " + e.constructor.name + " instead of CompileError");
+    }
+
+    finishJSTest();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1489,6 +1489,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/js/WebAssemblySuspending.h
     wasm/js/JSWebAssemblyTable.h
     wasm/js/WebAssemblyBuiltin.h
+    wasm/js/WebAssemblyCompileOptions.h
     wasm/js/WebAssemblyFunction.h
     wasm/js/WebAssemblyFunctionBase.h
     wasm/js/WebAssemblyGCStructure.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -809,7 +809,7 @@
 		237C93DE2E95A89A00F62455 /* WebAssemblySuspendingPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */; };
 		23863EEB2E5EC93E00E57879 /* WebAssemblyBuiltinTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 23863EEA2E5EC92900E57879 /* WebAssemblyBuiltinTrampoline.h */; };
 		2392A1302DD51DB100DD1CB9 /* WebAssemblyBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; };
+		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23968F0E2F295B1B001AED63 /* WebAssemblySuspending.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0C2F295B1B001AED63 /* WebAssemblySuspending.h */; };
 		23968F0F2F295B1B001AED63 /* WebAssemblyPromising.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0A2F295B1B001AED63 /* WebAssemblyPromising.h */; };
 		23A356912E9790F40039C82A /* PinballCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A3568E2E9790F40039C82A /* PinballCompletion.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/JavaScriptCore/builtins/WebAssembly.js
+++ b/Source/JavaScriptCore/builtins/WebAssembly.js
@@ -26,15 +26,19 @@
 function compileStreaming(source) {
     "use strict";
 
-    return @promiseResolve(@Promise, source).@then(@webAssemblyCompileStreamingInternal);
+    var compileOptions = @argument(1);
+    return @promiseResolve(@Promise, source).@then((source) => {
+        return @webAssemblyCompileStreamingInternal(source, compileOptions);
+    });
 }
 
 function instantiateStreaming(source) {
     "use strict";
 
     var importObject = @argument(1);
+    var compileOptions = @argument(2);
     return @promiseResolve(@Promise, source).@then((source) => {
-        return @webAssemblyInstantiateStreamingInternal(source, importObject);
+        return @webAssemblyInstantiateStreamingInternal(source, importObject, compileOptions);
     });
 }
 

--- a/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
+++ b/Source/JavaScriptCore/runtime/GlobalObjectMethodTable.h
@@ -24,6 +24,10 @@
 #include <JavaScriptCore/Exception.h>
 #include <wtf/Forward.h>
 
+#if ENABLE(WEBASSEMBLY)
+#include <JavaScriptCore/WebAssemblyCompileOptions.h>
+#endif
+
 namespace JSC {
 
 class Identifier;
@@ -71,8 +75,13 @@ struct GlobalObjectMethodTable {
     ScriptExecutionStatus (*scriptExecutionStatus)(JSGlobalObject*, JSObject* scriptExecutionOwner);
     void (*reportViolationForUnsafeEval)(JSGlobalObject*, const String&);
     String (*defaultLanguage)();
-    JSPromise* (*compileStreaming)(JSGlobalObject*, JSValue);
-    JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject*);
+#if ENABLE(WEBASSEMBLY)
+    JSPromise* (*compileStreaming)(JSGlobalObject*, JSValue, std::optional<WebAssemblyCompileOptions>&&);
+    JSPromise* (*instantiateStreaming)(JSGlobalObject*, JSValue, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&);
+#else
+    void* compileStreamingPlaceholder; // placeholders to make positional initializers consistent
+    void* instantiateStreamingPlaceholder;
+#endif
     JSGlobalObject* (*deriveShadowRealmGlobalObject)(JSGlobalObject*);
     String (*codeForEval)(JSGlobalObject*, JSValue);
     bool (*canCompileStrings)(JSGlobalObject*, CompilationType, String, const ArgList&);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2019,10 +2019,10 @@ public:
         return &vm.destructibleObjectSpace();
     }
 
-    WasmStreamingCompiler(VM& vm, Structure* structure, Wasm::CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, const SourceCode& source)
+    WasmStreamingCompiler(VM& vm, Structure* structure, Wasm::CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source)
         : Base(vm, structure)
         , m_promise(promise, WriteBarrierEarlyInit)
-        , m_streamingCompiler(Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, source))
+        , m_streamingCompiler(Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source))
     {
         DollarVMAssertScope assertScope;
     }
@@ -2032,7 +2032,7 @@ public:
         DollarVMAssertScope assertScope;
         JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
         Structure* structure = createStructure(vm, globalObject, jsNull());
-        WasmStreamingCompiler* result = new (NotNull, allocateCell<WasmStreamingCompiler>(vm)) WasmStreamingCompiler(vm, structure, compilerMode, globalObject, promise, importObject, source);
+        WasmStreamingCompiler* result = new (NotNull, allocateCell<WasmStreamingCompiler>(vm)) WasmStreamingCompiler(vm, structure, compilerMode, globalObject, promise, importObject, std::nullopt, source);
         result->finishCreation(vm);
         return result;
     }

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/WasmStreamingParser.h>
+#include <JavaScriptCore/WebAssemblyCompileOptions.h>
 #include <wtf/Platform.h>
 
 #if ENABLE(WEBASSEMBLY)
@@ -48,7 +49,7 @@ class StreamingPlan;
 
 class StreamingCompiler final : public StreamingParserClient, public ThreadSafeRefCounted<StreamingCompiler> {
 public:
-    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject*, const SourceCode&);
+    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&);
 
     JS_EXPORT_PRIVATE ~StreamingCompiler();
 
@@ -60,7 +61,7 @@ public:
     void didCompileFunction(StreamingPlan&);
 
 private:
-    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject*, const SourceCode&);
+    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&);
 
     bool didReceiveFunctionData(FunctionCodeIndex, const FunctionData&) final;
     void didFinishParsing() final;
@@ -72,6 +73,7 @@ private:
     bool m_eagerFailed WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_finalized WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_threadedCompilationStarted { false };
+    std::optional<WebAssemblyCompileOptions> m_compileOptions;
     Lock m_lock;
     unsigned m_remainingCompilationRequests { 0 };
     DeferredWorkTimer::Ticket m_ticket;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -444,20 +444,52 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyValidateFunc, (JSGlobalObject* globalObject,
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileStreamingInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    std::optional<WebAssemblyCompileOptions> compileOptions;
+    if (Options::useWasmJSStringBuiltins()) {
+        JSValue compileOptionsArgument = callFrame->argument(1);
+        JSObject* compileOptionsObject = compileOptionsArgument.getObject();
+        if (!compileOptionsArgument.isUndefined() && !compileOptionsObject) [[unlikely]]
+            RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.compileStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)))));
+        compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
+        if (scope.exception()) [[unlikely]] {
+            auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+        }
+    }
+
     ASSERT(globalObject->globalObjectMethodTable()->compileStreaming);
-    return JSValue::encode(globalObject->globalObjectMethodTable()->compileStreaming(globalObject, callFrame->argument(0)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(globalObject->globalObjectMethodTable()->compileStreaming(globalObject, callFrame->argument(0), WTF::move(compileOptions))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue importArgument = callFrame->argument(1);
     JSObject* importObject = importArgument.getObject();
     if (!importArgument.isUndefined() && !importObject) [[unlikely]]
-        return JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument))));
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument)))));
+
+    std::optional<WebAssemblyCompileOptions> compileOptions;
+    if (Options::useWasmJSStringBuiltins()) {
+        JSValue compileOptionsArgument = callFrame->argument(2);
+        JSObject* compileOptionsObject = compileOptionsArgument.getObject();
+        if (!compileOptionsArgument.isUndefined() && !compileOptionsObject) [[unlikely]]
+            RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, createTypeError(globalObject, "third argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)))));
+        compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
+        if (scope.exception()) [[unlikely]] {
+            auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+        }
+    }
 
     ASSERT(globalObject->globalObjectMethodTable()->instantiateStreaming);
     // FIXME: <http://webkit.org/b/184888> if there's an importObject and it contains a Memory, then we can compile the module with the right memory type (fast or not) by looking at the memory's type.
-    return JSValue::encode(globalObject->globalObjectMethodTable()->instantiateStreaming(globalObject, callFrame->argument(0), importObject));
+    RELEASE_AND_RETURN(scope, JSValue::encode(globalObject->globalObjectMethodTable()->instantiateStreaming(globalObject, callFrame->argument(0), importObject, WTF::move(compileOptions))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyGetterJSTag, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.h
@@ -27,8 +27,8 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "IteratorOperations.h"
-#include "WasmModule.h"
+#include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/WasmModule.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -28,6 +28,9 @@
 
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/WeakGCMap.h>
+#if ENABLE(WEBASSEMBLY)
+#include <JavaScriptCore/WebAssemblyCompileOptions.h>
+#endif
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
 
@@ -126,8 +129,8 @@ protected:
     static void promiseRejectionTracker(JSC::JSGlobalObject*, JSC::JSPromise*, JSC::JSPromiseRejectionOperation);
 
 #if ENABLE(WEBASSEMBLY)
-    static JSC::JSPromise* compileStreaming(JSC::JSGlobalObject*, JSC::JSValue);
-    static JSC::JSPromise* instantiateStreaming(JSC::JSGlobalObject*, JSC::JSValue, JSC::JSObject*);
+    static JSC::JSPromise* compileStreaming(JSC::JSGlobalObject*, JSC::JSValue, std::optional<JSC::WebAssemblyCompileOptions>&&);
+    static JSC::JSPromise* instantiateStreaming(JSC::JSGlobalObject*, JSC::JSValue, JSC::JSObject* importObject, std::optional<JSC::WebAssemblyCompileOptions>&&);
 #endif
 
     static JSC::Identifier moduleLoaderResolve(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue, JSC::JSValue, JSC::JSValue);

--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -1,0 +1,2 @@
+[ iOS ] UIProcess/API/ios/WKWebViewIOS.mm
+[ iOS ] UIProcess/ios/WKContentViewInteraction.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,3 +2,14 @@
 [ iOS ] UIProcess/API/Cocoa/WKWebViewConfiguration.mm
 [ iOS ] UIProcess/ios/ViewGestureControllerIOS.mm
 [ iOS ] WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+JSWebExtensionAPIExtension.mm
+JSWebExtensionAPINamespace.mm
+JSWebExtensionAPIRuntime.mm
+JSWebExtensionAPIStorage.mm
+JSWebExtensionAPIStorageArea.mm
+JSWebExtensionAPITabs.mm
+JSWebExtensionAPIWebPageNamespace.mm
+JSWebExtensionAPIWindows.mm
+WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,1 +1,34 @@
+JSWebExtensionAPIAction.mm
+JSWebExtensionAPIAlarms.mm
+JSWebExtensionAPICommands.mm
+JSWebExtensionAPICookies.mm
+JSWebExtensionAPIDOM.mm
+JSWebExtensionAPIDeclarativeNetRequest.mm
+[ macOS ] JSWebExtensionAPIDevTools.mm
+[ macOS ] JSWebExtensionAPIDevToolsExtensionPanel.mm
+[ macOS ] JSWebExtensionAPIDevToolsInspectedWindow.mm
+[ macOS ] JSWebExtensionAPIDevToolsNetwork.mm
+[ macOS ] JSWebExtensionAPIDevToolsPanels.mm
+JSWebExtensionAPIEvent.mm
+JSWebExtensionAPIExtension.mm
+JSWebExtensionAPILocalization.mm
+JSWebExtensionAPIMenus.mm
+JSWebExtensionAPINamespace.mm
+JSWebExtensionAPINotifications.mm
+JSWebExtensionAPIPermissions.mm
+JSWebExtensionAPIPort.mm
+JSWebExtensionAPIRuntime.mm
+JSWebExtensionAPIScripting.mm
+JSWebExtensionAPIStorage.mm
+JSWebExtensionAPIStorageArea.mm
+JSWebExtensionAPITabs.mm
+JSWebExtensionAPITest.mm
+JSWebExtensionAPIWebNavigation.mm
+JSWebExtensionAPIWebNavigationEvent.mm
+JSWebExtensionAPIWebPageNamespace.mm
+JSWebExtensionAPIWebPageRuntime.mm
+JSWebExtensionAPIWebRequest.mm
+JSWebExtensionAPIWebRequestEvent.mm
+JSWebExtensionAPIWindows.mm
+JSWebExtensionAPIWindowsEvent.mm
 [ iOS ] UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,3 +1,8 @@
+[ macOS ] JSWebExtensionAPIDevTools.mm
+[ macOS ] JSWebExtensionAPIDevToolsExtensionPanel.mm
+[ macOS ] JSWebExtensionAPIDevToolsInspectedWindow.mm
+[ macOS ] JSWebExtensionAPIDevToolsNetwork.mm
+[ macOS ] JSWebExtensionAPIDevToolsPanels.mm
 Storage/StorageAreaImpl.cpp
 Storage/WebDatabaseProvider.cpp
 WebCoreSupport/WebResourceLoadScheduler.cpp


### PR DESCRIPTION
#### 4f51c89e3c773af6ea3a556ba0ce11540368b319
<pre>
[JSC] Fix WebAssembly.compileStreaming and .instantiateStreaming to accept compileOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308136">https://bugs.webkit.org/show_bug.cgi?id=308136</a>
<a href="https://rdar.apple.com/170989896">rdar://170989896</a>

Reviewed by Marcus Plutowski.

[Re-landing an earlier PR #59278. This iteration adds SaferCPP expectations for source files, most
of them under DerivedSources, in which SaferCPP started detecting uncounted args and vars. These
files are unrelated to the patch, but an added #include made SaferCPP detect issues that previously
went unnoticed]:

    * Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations: Added.
    * Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
    * Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
    * Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
    * Source/WebKitLegacy/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

This patch adds the support required by the JS string builtin proposal to the streaming
compilation and instantiation APIs of WebAssembly (defined in the Web Embedding rather
than the JavaScript Embedding document of the proposal).

Highlights:

Added support for the optional compileOptions parameter to the JS builtins and
the underlying internal functions in:

    * Source/JavaScriptCore/builtins/WebAssembly.js
    * Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:

Added the plumbing to carry the options from the JS builtins to the streaming
compiler (function signature changes in multiple places).

Added the handling of compileOptions to:

    * Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
    * Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:

Added tests:

    * LayoutTests/http/tests/wasm/wasm-js-string-builtins-streaming.html

Canonical link: <a href="https://commits.webkit.org/308419@main">https://commits.webkit.org/308419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e28b43b73b081b1cf97e882b98c2bf303c0147be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100900 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4be433ba-ff35-47f2-8a85-39afad580904) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81067 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72814858-603d-4812-9d0c-f45c359f4fe3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72c4c766-40d4-4248-bb7e-5b65b5d76fb2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15075 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3608 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139455 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158500 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8273 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1637 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121699 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31215 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132163 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76010 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8943 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83347 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45777 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19314 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->