### PR TITLE
[Site Isolation] Update existing ews bots to run newly added tests with site isolation enabled

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -192,6 +192,7 @@ class StressTestFactory(TestFactory):
         self.getProduct()
         self.addStep(WaitForCrashCollection())
         self.addStep(RunWebKitTestsInStressMode())
+        self.addStep(RunWebKitTestsInSiteIsolation())
         self.addStep(TriggerCrashLogSubmission())
         self.addStep(SetBuildSummary())
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -389,6 +389,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'wait-for-crash-collection',
             'run-layout-tests-in-stress-mode',
+            'run-layout-tests-in-site-isolation',
             'trigger-crash-log-submission',
             'set-build-summary'
         ],

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4497,6 +4497,22 @@ class RunWebKitTestsInStressGuardmallocMode(RunWebKitTestsInStressMode):
     ENABLE_GUARD_MALLOC = True
 
 
+class RunWebKitTestsInSiteIsolation(RunWebKitTestsInStressMode):
+    name = 'run-layout-tests-in-site-isolation'
+    suffix = 'site-isolation'
+    FAILURE_MSG_IN_STRESS_MODE = 'Found test failures in site isolation'
+
+    def __init__(self):
+        super().__init__()
+
+    def setLayoutTestCommand(self):
+        RunWebKitTests.setLayoutTestCommand(self)
+        self.command += ['--site-isolation']
+        modified_tests = self.getProperty('modified_tests')
+        if modified_tests:
+            self.command += modified_tests
+
+
 class ReRunWebKitTests(RunWebKitTests):
     name = 're-run-layout-tests'
     NUM_FAILURES_TO_DISPLAY = 10


### PR DESCRIPTION
#### fda27e4d5c3135984b8cbe3eedf75d96c34119b5
<pre>
[Site Isolation] Update existing ews bots to run newly added tests with site isolation enabled
<a href="https://rdar.apple.com/160387897">rdar://160387897</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308777">https://bugs.webkit.org/show_bug.cgi?id=308777</a>

Reviewed by Jonathan Bedard.

This change is to add a step to the macOS-Release-WK2-Stress-Tests-EWS queue that will run a
second test run after run-layout-tests-in-stress-mode by running the same tests, but with
--site-isolation.

* Tools/CISupport/ews-build/factories.py:
(StressTestFactory.__init__):
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTestsInSiteIsolation):
(RunWebKitTestsInSiteIsolation.__init__):
(RunWebKitTestsInSiteIsolation.setLayoutTestCommand):

Canonical link: <a href="https://commits.webkit.org/308741@main">https://commits.webkit.org/308741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0e1a075a1b4010277946b574494bb3f2e008f2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157006 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62e51365-4ca8-4110-9b33-b2c011563bf1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7250e76e-7630-44f6-9738-00542f21ea02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/481cff92-9e7c-4b26-80cd-626dfd35cb4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15709 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4443 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159339 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122386 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/147721 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122605 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33340 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76968 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9650 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20424 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20156 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->