### PR TITLE
[macOS] Update the system text input context after clearing out a user-visible selection

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -214,4 +214,9 @@ void EditorState::move(float x, float y)
     clipOwnedRectExtentsToNumericLimits();
 }
 
+bool EditorState::isEditableOrRanged() const
+{
+    return isContentEditable || selectionType == WebCore::SelectionType::Range;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -138,6 +138,7 @@ struct EditorState {
         bool canPaste { false };
     };
 
+    bool isEditableOrRanged() const;
     bool hasPostLayoutData() const { return !!postLayoutData; }
 
     // Visual data is only updated in sync with rendering updates.

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -661,7 +661,7 @@ public:
     void insertText(id string);
     void insertText(id string, NSRange replacementRange);
     NSTextInputContext *inputContext();
-    NSTextInputContext *inputContextIncludingNonEditable();
+    NSTextInputContext *inputContextForSelectionUpdates();
     void unmarkText();
     void setMarkedText(id string, NSRange selectedRange, NSRange replacementRange);
     NSRange NODELETE selectedRange();
@@ -1173,6 +1173,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     bool m_inlinePredictionsEnabled { false };
 #endif
+
+    bool m_lastEditorStateWasEditableOrRanged { false };
 
     // FIXME: Perhaps merge these types at some point?
 #if HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -656,8 +656,10 @@ TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)
     EXPECT_FALSE(NSIsEmptyRect([webView unionRectInVisibleSelectedRange]));
     EXPECT_FALSE(isInView([webView unionRectInVisibleSelectedRange]));
 
+    auto countBeforeClearingSelection = didUpdateSelectionCount;
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
     [webView waitForNextPresentationUpdate];
+    EXPECT_GT(didUpdateSelectionCount, countBeforeClearingSelection);
     EXPECT_TRUE(NSIsEmptyRect([webView unionRectInVisibleSelectedRange]));
 }
 
@@ -695,6 +697,12 @@ TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForEditableCaretSelection)
     EXPECT_GT(caretRect.origin.y, 0);
     EXPECT_TRUE(NSPointInRect(caretRect.origin, [webView documentVisibleRect]));
     EXPECT_GT(didUpdateSelectionCount, 0u);
+
+    auto countBeforeClearingSelection = didUpdateSelectionCount;
+    [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_GT(didUpdateSelectionCount, countBeforeClearingSelection);
+    EXPECT_TRUE(NSIsEmptyRect([webView unionRectInVisibleSelectedRange]));
 }
 
 TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelection)
@@ -728,6 +736,12 @@ TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelecti
     EXPECT_FALSE(NSIsEmptyRect(selectionRect));
     EXPECT_TRUE(NSContainsRect([webView documentVisibleRect], selectionRect));
     EXPECT_GT(didUpdateSelectionCount, 0u);
+
+    auto countBeforeClearingSelection = didUpdateSelectionCount;
+    [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_GT(didUpdateSelectionCount, countBeforeClearingSelection);
+    EXPECT_TRUE(NSIsEmptyRect([webView unionRectInVisibleSelectedRange]));
 }
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 2c57b3458aa21f937d17c8f3ac2be0f227ca3090
<pre>
[macOS] Update the system text input context after clearing out a user-visible selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=308778">https://bugs.webkit.org/show_bug.cgi?id=308778</a>
<a href="https://rdar.apple.com/171209443">rdar://171209443</a>

Reviewed by Abrar Rahman Protyasha.

Call `-textInputClientDidUpdateSelection` to update the system input context following a selection
change, in the case where the selection was previously visible, and the selection is no longer
visible (&quot;visible&quot; in this context, meaning that the selection is either editable, or a ranged non-
editable selection).

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::isEditableOrRanged const):

Add a helper method on `EditorState` to represent &quot;user visible selection&quot;.

* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleProcessSwapOrExit):
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::inputContextForSelectionUpdates):
(WebKit::WebViewImpl::inputContextIncludingNonEditable): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)):
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForEditableCaretSelection)):
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelection)):

Augment existing API tests to verify that the selection is updated again, after programmatically
clearing the selection.

Canonical link: <a href="https://commits.webkit.org/308313@main">https://commits.webkit.org/308313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcf4c078827817c4e7c47568c6c387b09b047df5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155790 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b63044c-4622-40f7-a948-407851bda6b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79307332-380e-46ea-92d0-3c142080a4c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe05a6d1-295d-4ddb-bcad-16f928fe6239) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3232 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158121 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121595 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31144 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131842 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8651 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82960 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->