### PR TITLE
NEW TEST(289843@main): [macOS iOS Debug]: ASSERTION FAILED: frame->presentationTime() >= m_lastMuxedSampleStartTime

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7803,10 +7803,6 @@ webkit.org/b/287672 imported/w3c/web-platform-tests/css/css-cascade/all-prop-ini
 
 webkit.org/b/287741 fast/viewport/ios/non-responsive-viewport-after-changing-view-scale.html [ Pass Failure ]
 
-# webkit.org/b/288036 NEW TEST(289843@main): [macOS iOS Debug]: ASSERTION FAILED: frame->presentationTime() >= m_lastMuxedSampleStartTime
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Skip ]
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html [ Skip ]
-
 webkit.org/b/288133 imported/w3c/web-platform-tests/scroll-to-text-fragment/find-range-from-text-directive.html [ Pass Failure ]
 
 webkit.org/b/288677 [ Debug arm64 ] fast/scrolling/ios/body-overflow-hidden-keyboard.html [ Pass Crash ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1982,10 +1982,6 @@ imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html [ Pa
 
 webkit.org/b/288025 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Pass Failure ]
 
-# webkit.org/b/288036 NEW TEST(289843@main): [macOS iOS Debug]: ASSERTION FAILED: frame->presentationTime() >= m_lastMuxedSampleStartTime
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Skip ]
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html [ Skip ]
-
 webkit.org/b/288043 [ Release ] inspector/canvas/create-context-bitmaprenderer.html [ Pass Failure ]
  
 webkit.org/b/288053 imported/w3c/web-platform-tests/fetch/http-cache/invalidate.any.serviceworker.html [ Pass Failure ]

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -92,6 +92,7 @@ private:
 
     MediaTime lastEnqueuedAudioTime() const { return MediaTime(m_lastEnqueuedAudioTimeUs.load(), 1000000); }
     MediaTime currentTime() const;
+    MediaTime currentTime(const MediaTime&, const MonotonicTime&) const;
     MediaTime currentEndTime() const;
 
     void flushDataBuffer();


### PR DESCRIPTION
#### aaf48ddc8e5c2f8b6d28b2554803830a3231353b
<pre>
NEW TEST(289843@main): [macOS iOS Debug]: ASSERTION FAILED: frame-&gt;presentationTime() &gt;= m_lastMuxedSampleStartTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=288036">https://bugs.webkit.org/show_bug.cgi?id=288036</a>
<a href="https://rdar.apple.com/145182916">rdar://145182916</a>

Reviewed by Eric Carlson.

When fetchData() was called we would capture the audio time in the task dispatched
on the recorder&apos;s WorkQueue. This current time is calculated for recordings
with audio by looking at instantaneous audio time (atomic access) which is
the time of the latest audio frame received on the audio thread.
At this stage, the code assumed that all video frames prior that time
would have been enqueued for encoding and we would wait for all those
already enqueued frame to finish encoding and write the webm segment.

However, due to when the audio&apos;s time was read, some raw video frames
could have still be in-flight between the capture thread and the recorder&apos;s queue.
They wouldn&apos;t have been encoded by the time we would have written the webm
media segment.

When fetchData was called again, those in-flight frames would have now
been properly enqueued for encoding but would have an earlier time than
the end time of the previously created segment.
WebM requires monotonically increasing timestamps. If we attempted to
use those earlier frames it would enter an error mode and would no longer
mux any further frames, resulting in truncated webm recordings.
In a debug build, this error was caught with the `frame-&gt;presentationTime() &gt;= m_lastMuxedSampleStartTime`
assertion.

The fix is to capture the current time when fetchData is called on the main
thread. With the following recorder&apos;s workqueue dispatch, this guarantees that
there are no in-flight video frames and that we can guarantee monotonically
increasing timestamps with all frames provided to the WebM muxer.

Covered by existing and re-activated tests

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::fetchData):
(WebCore::MediaRecorderPrivateEncoder::currentTime const):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:

Canonical link: <a href="https://commits.webkit.org/308349@main">https://commits.webkit.org/308349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5416750380d581587c7daffbf4529998302e6aee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100523 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/264264d7-7717-456b-8294-1b5d9558494e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113367 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80877 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6d2b34d-c1bc-41fb-a755-741002741074) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cf2ca7b-758a-44d1-b89b-c90364183004) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14796 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12572 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3233 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158122 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121392 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31172 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75559 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8647 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82961 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18937 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->