### PR TITLE
[GFC] Correctly handle track sizing with indefinite size but definite minimum size

### DIFF
--- a/LayoutTests/fast/grid/grid-definite-minimum-size-expected.txt
+++ b/LayoutTests/fast/grid/grid-definite-minimum-size-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/grid/grid-definite-minimum-size.html
+++ b/LayoutTests/fast/grid/grid-definite-minimum-size.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+    .wrapper {
+        display: inline-block;
+    }
+    .grid {
+        display: grid;
+        min-width: 400px;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+    }
+    .item1 {
+        width: 100px;
+        height: 100px;
+        grid-row: 1/2;
+    }
+    .item2 {
+        width: 100px;
+        height: 100px;
+        grid-row: 2/3;
+    }
+</style>
+<div class="wrapper">
+    <div class="grid">
+        <div class="item1"></div>
+        <div class="item2"></div>
+    </div>
+</div>
+<div>PASS if no crash.</div>
+<script>
+    window.testRunner?.dumpAsText();
+    document.body.offsetHeight;
+</script>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -401,6 +401,9 @@ static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizin
             [](const CSS::Keyword::Auto&) -> LayoutUnit {
                 return LayoutUnit::max();
             },
+            [](const Style::GridTrackBreadth::Flex&) -> LayoutUnit {
+                return LayoutUnit::max();
+            },
             [](const auto&) -> LayoutUnit {
                 ASSERT_NOT_IMPLEMENTED_YET();
                 return { };
@@ -476,7 +479,7 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& lay
     // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
     auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, inlineAxisComputedSizesList, inlineBorderAndPaddingList, columnSpanList,
         columnTrackSizingFunctionsList, inlineAxisAvailableSpace, blockAxisConstraintList, GridLayoutUtils::inlineAxisGridItemSizingFunctions(formattingContext.integrationUtils()),
-        columnFreeSpaceScenario, layoutState.usedColumnGap, layoutState.usedJustifyContent);
+        columnFreeSpaceScenario, layoutState.usedColumnGap, layoutState.usedJustifyContent, layoutConstraints.inlineAxis.containerMinimumSize());
 
     // To find the inline-axis available space for any items whose block-axis size contributions
     // require it, use the grid column sizes calculated in the previous step.
@@ -488,7 +491,7 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& lay
     // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
     auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, blockAxisComputedSizesList, blockBorderAndPaddingList, rowSpanList,
         rowTrackSizingFunctionsList, blockAxisAvailableSpace, inlineAxisConstraintList, GridLayoutUtils::blockAxisGridItemSizingFunctions(formattingContext),
-        rowFreeSpaceScenario, layoutState.usedRowGap, layoutState.usedAlignContent);
+        rowFreeSpaceScenario, layoutState.usedRowGap, layoutState.usedAlignContent, layoutConstraints.blockAxis.containerMinimumSize());
 
     // 3. Then, if the min-content contribution of any grid item has changed based on the
     // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -417,7 +417,8 @@ static void maximizeTracks(UnsizedTracks& unsizedTracks, std::optional<LayoutUni
 TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const ComputedSizesList& gridItemComputedSizesList,
     const UsedBorderAndPaddingList& borderAndPaddingList, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions,
     std::optional<LayoutUnit> availableGridSpace, const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions& gridItemSizingFunctions,
-    const AxisConstraint::FreeSpaceScenario& freeSpaceScenario, const LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment)
+    const AxisConstraint::FreeSpaceScenario& freeSpaceScenario, const LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment,
+    std::optional<LayoutUnit> containerMinimumSize)
 {
     ASSERT(gridItems.size() == gridItemSpanList.size());
 
@@ -436,20 +437,25 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, co
     // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
     expandFlexibleTracks(unsizedTracks, freeSpaceScenario, availableGridSpace, gapSize, gridItems, gridItemSpanList, oppositeAxisConstraints, gridItemSizingFunctions);
 
-    auto gridContainerHasDefiniteMinimumSize = []() {
-        ASSERT_NOT_IMPLEMENTED_YET();
-        return false;
+    // https://drafts.csswg.org/css-grid-1/#algo-stretch
+    // 5. Stretch 'auto' Tracks
+    // If the free space is indefinite, but the grid container has a definite min-width/height,
+    // use that size to calculate the free space for this step instead.
+    auto freeSpaceForAutoStretchTracks = [&]() -> std::optional<LayoutUnit> {
+        switch (freeSpaceScenario) {
+        case AxisConstraint::FreeSpaceScenario::Definite:
+            return computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
+        case AxisConstraint::FreeSpaceScenario::MinContent:
+        case AxisConstraint::FreeSpaceScenario::MaxContent:
+            // If the free space is indefinite, but the grid container has a definite min-width/height, use that size to calculate the free space for this step instead.
+            if (containerMinimumSize)
+                return computeFreeSpace(containerMinimumSize, unsizedTracks, gapSize);
+            return computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
+        }
+        ASSERT_NOT_REACHED();
+        return { };
     };
-
-    // 5. Expand Stretched auto Tracks
-    auto freeSpace = computeFreeSpace(availableGridSpace, unsizedTracks, gapSize);
-
-    // but the grid container has a definite min-width/height, use that size to calculate the
-    // free space for this step instead.
-    if (!freeSpace && gridContainerHasDefiniteMinimumSize())
-        ASSERT_NOT_IMPLEMENTED_YET();
-
-    stretchAutoTracks(freeSpace, unsizedTracks, usedContentAlignment);
+    stretchAutoTracks(freeSpaceForAutoStretchTracks(), unsizedTracks, usedContentAlignment);
 
     // Each track has a base size, a <length> which grows throughout the algorithm and
     // which will eventually be the track’s final size...

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AxisConstraint.h"
 #include "GridTypeAliases.h"
 #include "LayoutUnit.h"
 
@@ -53,7 +54,8 @@ public:
     static TrackSizes sizeTracks(const PlacedGridItems&, const ComputedSizesList&, const UsedBorderAndPaddingList&,
         const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableGridSpace,
         const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions&,
-        const AxisConstraint::FreeSpaceScenario&, const LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment);
+        const AxisConstraint::FreeSpaceScenario&, const LayoutUnit gapSize, const StyleContentAlignmentData& usedContentAlignment,
+        std::optional<LayoutUnit> containerMinimumSize);
 
 private:
 


### PR DESCRIPTION
#### 8daebc91c7d6e0dd796156986ccd7e615cd5d9cb
<pre>
[GFC] Correctly handle track sizing with indefinite size but definite minimum size
<a href="https://bugs.webkit.org/show_bug.cgi?id=308688">https://bugs.webkit.org/show_bug.cgi?id=308688</a>
&lt;<a href="https://rdar.apple.com/171219386">rdar://171219386</a>&gt;

Reviewed by Sammy Gill.

This PR fixes a bug where we would hit ASSERT_NOT_IMPLEMENTED() when sizing
grid tracks in GFC if the free space is indefinite but the grid container has
a definite minimum size (min-width with fr tracks).

This PR fixes this bug by:

1. properly handling Style::GridTrackBreadth::Flex in
rowSizesForFirstIterationColumnSizing by treating it as indefinite.

2. passing containerMinimumSize to sizeTracks() to correctly
compute free space when stretching auto tracks.

<a href="https://drafts.csswg.org/css-grid-1/#algo-stretch">https://drafts.csswg.org/css-grid-1/#algo-stretch</a>

Combined changes:

* LayoutTests/fast/grid/grid-definite-minimum-size-expected.txt: Added.
* LayoutTests/fast/grid/grid-definite-minimum-size.html: Added.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::rowSizesForFirstIterationColumnSizing):
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/308657@main">https://commits.webkit.org/308657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0706e2d1335b58bb325ea134c9cf941e33e316b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101384 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e89cae7-1565-4e4c-9a13-669b21ccbcdf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114070 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81345 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8313fd0b-907c-4ab6-a7be-3575e20b1abf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94833 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36c1a320-a593-4ce4-9677-32a781292ed4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15457 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13259 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4091 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158986 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122100 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31380 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76606 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9357 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83831 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19801 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->