### PR TITLE
Web Extension's fromArray() and fromObject() needs to use Protect<JSValueRef>.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -377,15 +377,16 @@ void WebExtensionAPIDeclarativeNetRequest::isRegexSupported(NSDictionary *option
         return;
 
     NSString *regexString = objectForKey<NSString>(options, regexKey);
-    if (![WKContentRuleList _supportsRegularExpression:regexString])
+    if (![WKContentRuleList _supportsRegularExpression:regexString]) {
         callback->call(fromObject(callback->globalContext(), {
-            { "isSupported"_s, JSValueMakeBoolean(callback->globalContext(), false) },
-            { "reason"_s, JSValueMakeString(callback->globalContext(), toJSString("syntaxError"_s).get()) }
+            { "isSupported"_s, Protected(callback->globalContext(), JSValueMakeBoolean(callback->globalContext(), false)) },
+            { "reason"_s, Protected(callback->globalContext(), JSValueMakeString(callback->globalContext(), toJSString("syntaxError"_s).get())) }
         }));
-    else
+    } else {
         callback->call(fromObject(callback->globalContext(), {
-            { "isSupported"_s, JSValueMakeBoolean(callback->globalContext(), true) }
+            { "isSupported"_s, Protected(callback->globalContext(), JSValueMakeBoolean(callback->globalContext(), true)) }
         }));
+    }
 }
 
 void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -85,17 +85,18 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
             // If an error occurred, element 0 will be undefined, and element 1 will contain an object giving details about the error.
             String valueKey = result.value().error() ? result.value().error()->message : emptyString();
             SUPPRESS_UNCOUNTED_ARG auto valueData = JSValueMakeString(globalContext, toJSString(valueKey).get());
-            callback->call(fromArray(globalContext, { undefinedValue, fromObject(globalContext, {
-                { "isExceptionKey"_s, JSValueMakeBoolean(globalContext, true) },
-                { "valueKey"_s, valueData }
-            }) }));
+            SUPPRESS_UNCOUNTED_ARG auto resultObject = fromObject(globalContext, {
+                { "isExceptionKey"_s, Protected(globalContext, JSValueMakeBoolean(globalContext, true)) },
+                { "valueKey"_s, Protected(globalContext, valueData) }
+            });
+            callback->call(fromArray(globalContext, { Protected(globalContext, undefinedValue), Protected(globalContext, resultObject) }));
             return;
         }
 
         auto scriptResult = result.value()->toJS(globalContext);
 
         // If no error occurred, element 0 will contain the result of evaluating the expression, and element 1 will be undefined.
-        callback->call(fromArray(globalContext, { scriptResult.get(), undefinedValue }));
+        callback->call(fromArray(globalContext, { Protected(globalContext, scriptResult.get()), Protected(globalContext, undefinedValue) }));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -58,8 +58,8 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
         auto originsValue = fromArray(globalContext, WTF::move(origins));
 
         callback->call(fromObject(globalContext, {
-            { permissionsKey, permissionsValue },
-            { originsKey, originsValue }
+            { permissionsKey, Protected(globalContext, permissionsValue) },
+            { originsKey, Protected(globalContext, originsValue) }
         }));
     }, extensionContext().identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -218,8 +218,8 @@ void WebExtensionAPIRuntime::getPlatformInfo(Ref<WebExtensionCallbackHandler>&& 
 
     auto globalContext = callback->globalContext();
     callback->call(fromObject(callback->globalContext(), {
-        { "os"_s, JSValueMakeString(globalContext, toJSString(osValue).get()) },
-        { "arch"_s, JSValueMakeString(globalContext, toJSString(archValue).get()) }
+        { "os"_s, Protected(globalContext, JSValueMakeString(globalContext, toJSString(osValue).get())) },
+        { "arch"_s, Protected(globalContext, JSValueMakeString(globalContext, toJSString(archValue).get())) }
     }));
 }
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "Protected.h"
 #include <JavaScriptCore/JSRetainPtr.h>
 #if PLATFORM(COCOA)
 #include <JavaScriptCore/JavaScriptCore.h>
@@ -151,12 +152,12 @@ bool isDictionary(JSContextRef, JSValueRef);
 bool isRegularExpression(JSContextRef, JSValueRef);
 bool isThenable(JSContextRef, JSValueRef);
 
-JSValueRef fromArray(JSContextRef, Vector<JSValueRef>&&);
+JSValueRef fromArray(JSContextRef, Vector<Protected<JSValueRef>>&&);
 JSValueRef fromArray(JSContextRef, Vector<size_t>&&);
 JSValueRef fromArray(JSContextRef, Vector<String>&&);
 
 JSValueRef fromJSON(JSContextRef, RefPtr<JSON::Value>);
-JSValueRef fromObject(JSContextRef, HashMap<String, JSValueRef>&&);
+JSValueRef fromObject(JSContextRef, HashMap<String, Protected<JSValueRef>>&&);
 
 JSValueRef toJSValueRef(JSContextRef, const String&, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
 


### PR DESCRIPTION
#### f3e843380ebd3fe0765728ac9097059cbfbb1062
<pre>
Web Extension&apos;s fromArray() and fromObject() needs to use Protect&lt;JSValueRef&gt;.
<a href="https://webkit.org/b/308782">https://webkit.org/b/308782</a>
<a href="https://rdar.apple.com/167782059">rdar://167782059</a>

Reviewed by Keith Miller, Brian Weinstein, and Dan Hecht.

We need to protect all the JSValueRefs we use inside Vector and HashMap.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::isRegexSupported):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::getAll):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getPlatformInfo):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::fromJSONArray):
(WebKit::fromArray):
(WebKit::fromObject):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:

Canonical link: <a href="https://commits.webkit.org/308346@main">https://commits.webkit.org/308346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba7b28ff238b13b6d22d4c04f492c92fbcdd09e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff93f5c4-73b0-4c50-99b2-011e7156da6e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113376 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80880 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f1cdd61-8067-44d8-bde3-6de093c5b836) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94134 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0aeb584-ff33-4594-8e67-a3145cb8c94f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12581 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3242 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158131 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1262 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121401 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121602 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75568 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22696 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8655 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82970 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18946 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19096 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19004 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->