### PR TITLE
[ macOS Sonoma wk2 Release, iOS Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
@@ -39,7 +39,7 @@
             context.fillStyle = "#ff0000";
             context.fillRect(0, 0, 200, 200);
             if (paintingState == 0)
-                window.requestAnimationFrame(doRedImageDraw);
+                setTimeout(doRedImageDraw, 41);
         }
     }
 
@@ -48,7 +48,7 @@
             context.fillStyle = "#00ff00";
             context.fillRect(0, 0, 200, 200);
             if (paintingState == 1)
-                window.requestAnimationFrame(doGreenImageDraw);
+                setTimeout(doGreenImageDraw, 41);
         }
     }
 
@@ -83,19 +83,18 @@
             assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
             blobData = new Blob([blobData, blobEvent.data]);
 
-            if (blobEvent.timecode < 0.5)
+            if (blobEvent.timecode < 0.2)
                 return;
 
-            if (blobEvent.timecode >= 0.5 && paintingState == 0) {
+            if (blobEvent.timecode >= 0.2 && paintingState == 0) {
                 paintingState = 1;
                 doGreenImageDraw();
                 return;
             }
-
-            if (blobEvent.timecode < 1)
+            if (blobEvent.timecode < 0.6)
                 return;
 
-            assert_greater_than(blobEvent.timecode, 1, "more than 1s recorded");
+            assert_greater_than(blobEvent.timecode, .6, "more than .6s recorded");
             if (++paintingState == 2) {
                 recorder.stop();
                 ac.close();
@@ -115,7 +114,7 @@
             });
             player.onplay = () => {
                 player.pause();
-                assert_greater_than(player.duration, 1, 'the duration should be greater than .6s')
+                assert_greater_than(player.duration, .6, 'the duration should be greater than .6s')
                 player.currentTime = player.duration - 0.05;
             };
             player.onseeked = t.step_func(() => {

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
@@ -25,7 +25,7 @@
     var paintingState = 0;
     var canPlayReceived = false;
     var playbackStarted = false;
-    // Needs to be a globabl variable to avoid being GCed (webkit.org/b/271227)
+    // Needs to be a global variable to avoid being GCed (webkit.org/b/271227)
     var oscillator;
 
     function createVideoStream() {
@@ -39,7 +39,7 @@
             context.fillStyle = "#ff0000";
             context.fillRect(0, 0, 200, 200);
             if (paintingState == 0)
-                window.requestAnimationFrame(doRedImageDraw);
+                setTimeout(doRedImageDraw, 41);
         }
     }
 
@@ -48,7 +48,7 @@
             context.fillStyle = "#00ff00";
             context.fillRect(0, 0, 200, 200);
             if (paintingState == 1)
-                window.requestAnimationFrame(doGreenImageDraw);
+                setTimeout(doGreenImageDraw, 41);
         }
     }
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8249,8 +8249,6 @@ webkit.org/b/261344 [ Release ] requestidlecallback/requestidlecallback-does-not
 
 webkit.org/b/297669 [ Release ] http/tests/site-isolation/edge-sampling-viewport-constrained-object.html [ Pass Failure ]
 
-webkit.org/b/297674 [ Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Pass Failure ]
-
 webkit.org/b/295435 compositing/layer-creation/overlap-animation-container.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/css/css-break/block-in-inline-012.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2298,8 +2298,6 @@ webkit.org/b/296202 imported/w3c/web-platform-tests/service-workers/service-work
 
 webkit.org/b/297613 [ Debug ] fast/scrolling/mac/stateless-user-scroll-scrollend.html [ Pass Failure ]
 
-webkit.org/b/297674 [ Sonoma Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Pass Failure ]
-
 # webkit.org/b/297737 [macOS Debug] ipc/send-gradient.html is crashing in EWS
 [ Debug ] ipc/send-gradient.html [ Skip ]
 [ Debug ] ipc/send-filter.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1755,9 +1755,6 @@ webkit.org/b/227910 imported/w3c/web-platform-tests/webrtc/RTCDtlsTransport-stat
 # rdar://80345578 ([ Mac iOS Debug ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html is flaky crashing)
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html [ Pass Failure Crash ]
 
-# On machines with no integrated graphic, the h264 encoder is too slow for this test.
-webkit.org/b/308588 [ x86_64 ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Skip ]
-
 webkit.org/b/225804 imported/w3c/web-platform-tests/webxr/xrBoundedReferenceSpace_updates.https.html [ Pass Failure ]
 
 webkit.org/b/225882 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-process-frozen-array.https.html [ Pass Failure ]


### PR DESCRIPTION
#### 32fdfe1dd40e56e76399e21576c4e79bfb0e1d7b
<pre>
[ macOS Sonoma wk2 Release, iOS Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=297674">https://bugs.webkit.org/show_bug.cgi?id=297674</a>
<a href="https://rdar.apple.com/158787104">rdar://158787104</a>

Reviewed by Eric Carlson.

The tests incorrectly drew a new frame on the canvas as soon as the previous
one had been painted. This resulted in recordings at over 400Hz.
If under load, or on x86 machines this would results in the test timing out
and fails.

We now instead use a 41ms timer (about 24Hz) to paint a new frame.

Update TestExpectations.

* LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html:
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308347@main">https://commits.webkit.org/308347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c788b0cab50f04d1de3fe18727d6d13ec48c6cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100620 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80915 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94205 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14850 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12633 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3331 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158219 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121470 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121673 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75656 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8716 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19304 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19034 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->