### PR TITLE
Skip GlyphDisplayListCache to test if ShapedTextCache is sufficient for text painting

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3,6 +3,17 @@
 # See http://trac.webkit.org/wiki/TestExpectations for more information on this file.
 
 #//////////////////////////////////////////////////////////////////////////////////////////
+# GlyphDisplayListCache is intentionally bypassed for testing ShapedTextCache coverage.
+#//////////////////////////////////////////////////////////////////////////////////////////
+
+fast/text/glyph-display-lists/glyph-display-list-color.html [ Skip ]
+fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html [ Skip ]
+fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html [ Skip ]
+fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html [ Skip ]
+fast/text/glyph-display-lists/glyph-display-list-sharing-colr.html [ Skip ]
+fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html [ Skip ]
+
+#//////////////////////////////////////////////////////////////////////////////////////////
 # Platform-specific tests. Skipped here, then re-enabled on the appropriate platform.
 #//////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -662,7 +662,8 @@ void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)
 
     if (isInsideShapedContent() && paintForegroundForShapeRange(textPainter))
         return;
-    textPainter.setGlyphDisplayListIfNeeded(textBox().box(), m_paintInfo, m_style, m_paintTextRun);
+    // Skipping GlyphDisplayListCache: text drawing goes through FontCascade::drawText() which hits the ShapedTextCache.
+    // textPainter.setGlyphDisplayListIfNeeded(textBox().box(), m_paintInfo, m_style, m_paintTextRun);
     // TextPainter wants the box rectangle and text origin of the entire line box.
     textPainter.paintRange(m_paintTextRun, m_paintRect, textOriginFromPaintRect(m_paintRect), markedText.startOffset, markedText.endOffset);
 }

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -125,31 +125,11 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
         return;
     }
 
-    RefPtr glyphDisplayList = WTF::move(m_glyphDisplayList);
+    // Skipping GlyphDisplayListCache: always draw directly via FontCascade::drawText() which hits the ShapedTextCache.
     if (!emphasisMark.isEmpty())
         m_context.drawEmphasisMarks(font, textRun, emphasisMark, textOrigin + FloatSize(0, emphasisMarkOffset), startOffset, endOffset);
-    else if (startOffset || endOffset < textRun.length() || !glyphDisplayList)
+    else
         m_context.drawText(font, textRun, textOrigin, startOffset, endOffset);
-    else {
-        bool needsStateSave = false;
-        for (auto& item : glyphDisplayList->items()) {
-            if (std::holds_alternative<DisplayList::SetInlineFillColor>(item)
-                || std::holds_alternative<DisplayList::SetInlineStroke>(item)) {
-                needsStateSave = true;
-                break;
-            }
-        }
-
-        if (needsStateSave) {
-            GraphicsContextStateSaver stateSaver(m_context);
-            m_context.translate(textOrigin);
-            m_context.drawDisplayList(*glyphDisplayList);
-        } else {
-            m_context.translate(textOrigin);
-            m_context.drawDisplayList(*glyphDisplayList);
-            m_context.translate(-textOrigin);
-        }
-    }
 }
 
 void TextPainter::paintTextWithShadows(const Style::TextShadows* shadows, const Style::AppleColorFilter& colorFilter, const FontCascade& font, const TextRun& textRun, const FloatRect& boxRect, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset, const AtomString& emphasisMark, float emphasisMarkOffset, bool stroked)


### PR DESCRIPTION
#### 860338746b653ddf36ad3e6fd6f4f7252a9f53bb
<pre>
Skip GlyphDisplayListCache to test if ShapedTextCache is sufficient for text painting
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Comment out the call to setGlyphDisplayListIfNeeded in TextBoxPainter
and remove the display list branch in paintTextOrEmphasisMarks so text
drawing always goes through FontCascade::drawText(), which hits the
ShapedTextCache (layoutText cache). Skip the glyph-display-list tests
that validate cache internals.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/860338746b653ddf36ad3e6fd6f4f7252a9f53bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100580 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3a40661-d39a-4a4c-972a-ff6a6eaca65a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19748 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113412 "Found 3 new test failures: fast/backgrounds/background-clip-text-alpha.html fast/multicol/layers-in-multicol.html imported/w3c/web-platform-tests/css/css-color/opacity-overlapping-letters.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80895 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/611d2afb-c02a-4393-8644-4124028896d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94173 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a94e8a26-d79d-4004-827c-6872466d064d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158179 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11569 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121439 "Found 2 new test failures: fast/multicol/layers-in-multicol.html imported/w3c/web-platform-tests/css/css-color/opacity-overlapping-letters.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121642 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75616 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8683 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18994 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19144 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->