### PR TITLE
[Smart Lists] Creating a new dashed or bulleted list underneath a dashed or bulleted list converts both lists to the new type

### DIFF
--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -111,9 +111,10 @@ bool InsertListCommand::selectionHasListOfType(const VisibleSelection& selection
     return true;
 }
 
-InsertListCommand::InsertListCommand(Ref<Document>&& document, Type type)
+InsertListCommand::InsertListCommand(Ref<Document>&& document, Type type, Style::ListStyleType styleType)
     : CompositeEditCommand(WTF::move(document))
     , m_type(type)
+    , m_listStyleType(styleType)
 {
 }
 
@@ -371,7 +372,7 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
     moveParagraphs(start, end, insertionPoint, true);
 }
 
-static RefPtr<HTMLElement> adjacentEnclosingList(const VisiblePosition& pos, const VisiblePosition& adjacentPos, const HTMLQualifiedName& listTag)
+static RefPtr<HTMLElement> adjacentEnclosingList(const VisiblePosition& pos, const VisiblePosition& adjacentPos, const HTMLQualifiedName& listTag, Style::ListStyleType newListStyleType)
 {
     RefPtr listNode = outermostEnclosingList(protect(adjacentPos.deepEquivalent().deprecatedNode()).get());
 
@@ -381,10 +382,13 @@ static RefPtr<HTMLElement> adjacentEnclosingList(const VisiblePosition& pos, con
     RefPtr previousCell = enclosingTableCell(pos.deepEquivalent());
     RefPtr currentCell = enclosingTableCell(adjacentPos.deepEquivalent());
 
+    Style::ListStyleType currentListStyleType = listNode->renderer() ? listNode->renderer()->style().listStyleType() : CSS::Keyword::None { };
+
     if (!listNode->hasTagName(listTag)
         || listNode->contains(pos.deepEquivalent().deprecatedNode())
         || previousCell != currentCell
-        || enclosingList(listNode.get()) != enclosingList(protect(pos.deepEquivalent().deprecatedNode()).get()))
+        || enclosingList(listNode.get()) != enclosingList(protect(pos.deepEquivalent().deprecatedNode()).get())
+        || (currentListStyleType != newListStyleType && newListStyleType != CSS::Keyword::None { }))
         return nullptr;
 
     return listNode;
@@ -404,8 +408,8 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
     appendNode(placeholder.copyRef(), listItemElement.copyRef());
 
     // Place list item into adjoining lists.
-    auto previousList = adjacentEnclosingList(start.deepEquivalent(), start.previous(CannotCrossEditingBoundary), listTag);
-    auto nextList = adjacentEnclosingList(start.deepEquivalent(), end.next(CannotCrossEditingBoundary), listTag);
+    auto previousList = adjacentEnclosingList(start.deepEquivalent(), start.previous(CannotCrossEditingBoundary), listTag, m_listStyleType);
+    auto nextList = adjacentEnclosingList(start.deepEquivalent(), end.next(CannotCrossEditingBoundary), listTag, m_listStyleType);
     RefPtr<HTMLElement> listElement;
     if (previousList)
         appendNode(WTF::move(listItemElement), *previousList);

--- a/Source/WebCore/editing/InsertListCommand.h
+++ b/Source/WebCore/editing/InsertListCommand.h
@@ -36,9 +36,9 @@ class InsertListCommand final : public CompositeEditCommand {
 public:
     enum class Type : uint8_t { OrderedList, UnorderedList };
 
-    static Ref<InsertListCommand> create(Ref<Document>&& document, Type listType)
+    static Ref<InsertListCommand> create(Ref<Document>&& document, Type listType, Style::ListStyleType styleType = CSS::Keyword::None { })
     {
-        return adoptRef(*new InsertListCommand(WTF::move(document), listType));
+        return adoptRef(*new InsertListCommand(WTF::move(document), listType, styleType));
     }
 
     static RefPtr<HTMLElement> insertList(Ref<Document>&&, Type);
@@ -46,7 +46,7 @@ public:
     bool preservesTypingStyle() const final { return true; }
 
 private:
-    InsertListCommand(Ref<Document>&&, Type);
+    InsertListCommand(Ref<Document>&&, Type, Style::ListStyleType);
 
     void doApply() final;
     EditAction editingAction() const final;
@@ -59,6 +59,7 @@ private:
     RefPtr<HTMLElement> listifyParagraph(const VisiblePosition& originalStart, const HTMLQualifiedName& listTag);
     RefPtr<HTMLElement> m_listElement;
     Type m_type;
+    Style::ListStyleType m_listStyleType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -170,7 +170,7 @@ bool InsertTextCommand::applySmartListsIfNeeded()
 
     Ref document = this->document();
     auto listType = smartList->ordered ? InsertListCommand::Type::OrderedList : InsertListCommand::Type::UnorderedList;
-    applyCommandToComposite(InsertListCommand::create(document.copyRef(), listType), *range);
+    applyCommandToComposite(InsertListCommand::create(document.copyRef(), listType, smartList->styleType), *range);
 
     // This list is the one that was just created or modified.
     RefPtr listElement = enclosingList(endingSelection().base().anchorNode());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -353,6 +353,30 @@ TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
     runTest(input, expectedHTML.createNSString().get(), @"//body/text()", input.length);
 }
 
+TEST(SmartLists, InsertingDifferentListStylesDoesNotMergeLists)
+{
+    auto dashMarker = WTF::makeString(WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+
+    static constexpr auto expectedHTMLTemplate = R"""(
+    <body contenteditable="">
+        <ul style="list-style-type: disc;" class="Apple-disc-list" webkitsmartlistmarker="*">
+            <li>A</li>
+            <li>B</li>
+            <li>C</li>
+            <li>D</li>
+        </ul>
+        <div>
+            <ul class="Apple-dash-list" style="list-style-type: '<DASH_MARKER>';" webkitsmartlistmarker="-">
+                <li>A</li>
+            </ul>
+        </div>
+    </body>)"""_s;
+
+    RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<DASH_MARKER>"_s, dashMarker).createNSString();
+
+    runTest(@"* A\nB\nC\n\n* D\n\n- A", expectedHTML.get(), @"//body/div/ul/li[1]/text()", @"A".length);
+}
+
 TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)
 {
     static constexpr auto expectedHTML = R"""(


### PR DESCRIPTION
#### 66bba79d2a8b392443624cfafe23d9b65cd8db92
<pre>
[Smart Lists] Creating a new dashed or bulleted list underneath a dashed or bulleted list converts both lists to the new type
<a href="https://bugs.webkit.org/show_bug.cgi?id=308780">https://bugs.webkit.org/show_bug.cgi?id=308780</a>
<a href="https://rdar.apple.com/167771342">rdar://167771342</a>

Reviewed by Richard Robinson, Ryosuke Niwa, and Wenson Hsieh.

Previously, adjacentEnclosingList only checked for
the type of list: unordered or ordered. If the existing
list was the same type as the new list, it would be
appended. Dashed and bulleted list are both unordered,
while numbered lists are ordered.
However, dashed and bulleted have different style types.

Thus, this issue occurred due to not checking for
style types before appending/inserting the new list
to adjacent ones.

So, get the new list style type in
InsertTextCommand::applySmartListsIfNeeded. Then, use
the new list style type, compare it to the adjacent
lists in adjacentEnclosingList, and do not append/insert
if the style types are different.

Add an API test for this change.

* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::InsertListCommand):
(WebCore::adjacentEnclosingList):
(WebCore::InsertListCommand::listifyParagraph):
* Source/WebCore/editing/InsertListCommand.h:
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
((SmartLists, InsertingDifferentListStylesDoesNotMergeLists)):

Canonical link: <a href="https://commits.webkit.org/308575@main">https://commits.webkit.org/308575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/913bcd681a70907ad0c7d2b3ebff531f53fe64a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101218 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b380fa31-7d8a-41cd-b162-114c9f0e02f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81255 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12a59fa7-fffd-4e95-8026-fdc82ddef42b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94704 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15342 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13130 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3926 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158821 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121973 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122175 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76413 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17677 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9225 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83665 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19783 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->