### PR TITLE
WebDriver: browsingContext.navigate hangs for URLs with unhandleable schemes

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1086,6 +1086,32 @@ void WebAutomationSession::wheelEventsFlushedForPage(const WebPageProxy& page)
 #endif
 }
 
+void WebAutomationSession::failPendingNavigationsForFrame(const WebFrameProxy& frame)
+{
+    Vector<Inspector::CommandCallback<void>> callbacksToFail;
+    auto takeCallback = [&](auto& map, const auto& key) {
+        if (auto callback = map.take(key))
+            callbacksToFail.append(WTF::move(callback));
+    };
+
+    if (!frame.isMainFrame()) {
+        auto frameID = frame.frameID();
+        takeCallback(m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame, frameID);
+        takeCallback(m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame, frameID);
+    } else {
+        auto pageID = frame.page()->identifier();
+        takeCallback(m_pendingNormalNavigationInBrowsingContextCallbacksPerPage, pageID);
+        takeCallback(m_pendingEagerNavigationInBrowsingContextCallbacksPerPage, pageID);
+    }
+
+    if (callbacksToFail.isEmpty())
+        return;
+
+    m_loadTimer.stop();
+    for (auto& callback : callbacksToFail)
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(InternalError)));
+}
+
 #if ENABLE(WEBDRIVER_BIDI)
 void WebAutomationSession::didCreatePage(WebPageProxy& page)
 {
@@ -1118,6 +1144,7 @@ void WebAutomationSession::navigationFailedForFrame(const WebFrameProxy& frame, 
     m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationFailed, { }, [&]() {
         m_bidiProcessor->browsingContextDomainNotifier().navigationFailed(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
     });
+    failPendingNavigationsForFrame(frame);
 }
 
 void WebAutomationSession::navigationAbortedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
@@ -1125,6 +1152,7 @@ void WebAutomationSession::navigationAbortedForFrame(const WebFrameProxy& frame,
     m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationAborted, { }, [&]() {
         m_bidiProcessor->browsingContextDomainNotifier().navigationAborted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
     });
+    failPendingNavigationsForFrame(frame);
 }
 
 void WebAutomationSession::fragmentNavigatedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -168,6 +168,7 @@ public:
     void setProcessPool(WebProcessPool*);
 
     void navigationOccurredForFrame(const WebFrameProxy&);
+    void failPendingNavigationsForFrame(const WebFrameProxy&);
     void documentLoadedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>, WallTime timestamp);
     void loadCompletedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>, WallTime timestamp);
     void inspectorFrontendLoaded(const WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9103,6 +9103,15 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     }
 #endif
 
+#if PLATFORM(COCOA)
+    if (!canHandleRequest && frame.isMainFrame() && m_controlledByAutomation) {
+        if (RefPtr automationSession = activeAutomationSession()) {
+            automationSession->failPendingNavigationsForFrame(frame);
+            return receivedPolicyDecision(PolicyAction::Ignore, protect(m_navigationState->navigation(*navigationID)).get(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
+        }
+    }
+#endif
+
     ShouldExpectSafeBrowsingResult shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::Yes;
     if (!protect(preferences())->safeBrowsingEnabled())
         shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::No;


### PR DESCRIPTION
#### 707aaa96f59837ca8dffa0d3e881778e028674ba
<pre>
WebDriver: browsingContext.navigate hangs for URLs with unhandleable schemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=302399">https://bugs.webkit.org/show_bug.cgi?id=302399</a>
<a href="https://rdar.apple.com/164562489">rdar://164562489</a>

Reviewed by NOBODY (OOPS!).

Navigation error tests (navigate/error.py) were hanging because when canHandleRequest is
false the WebProcess silently drops the load without sending any failure IPC back to the
UIProcess, leaving pending navigation callbacks unresolved. Fixed by detecting this in
decidePolicyForNavigationAction — the canHandleRequest flag is already provided by the
WebProcess, so under automation we now fail immediately via navigationFailedForFrame and
return PolicyAction::Ignore. Added failPendingNavigationsForFrame and wired it into
navigationFailedForFrame and navigationAbortedForFrame to properly resolve pending
callbacks with an error.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::failPendingNavigationsForFrame):
(WebKit::WebAutomationSession::navigationFailedForFrame):
(WebKit::WebAutomationSession::navigationAbortedForFrame):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/707aaa96f59837ca8dffa0d3e881778e028674ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172856 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121079 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/422c7f72-a643-4b74-bcad-24405ed1e40c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127260 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89639 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9e03bb3-0b6a-4f4d-8c2d-79b9dc23bcbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107809 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c1ca086-1efc-4965-9077-97199787dc51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27219 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20621 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138487 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175378 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28204 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135567 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36982 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31326 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135543 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99904 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109623 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35975 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1678 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36122 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->