### PR TITLE
[Scroll Anchoring] Reddit page becomes blank and jumps to top after clicking "View more comments"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The anchor is preserved even if its used height changes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  height: 2000px;
+}
+.changer {
+  height: 500px;
+  background-color: orange;
+}
+
+.anchor {
+  background-color: green;
+}
+
+body.changed .changer {
+  height: 300px;
+}
+
+.anchor-sizer {
+  width: 10px;
+  height: 200px;
+  background-color: silver;
+  overflow-anchor: none;
+}
+
+body.changed .anchor-sizer {
+  height: 100px;
+}
+</style>
+
+<div class="changer"></div>
+<div class="anchor">
+  <div class="anchor-sizer"></div>
+</div>
+
+<script>
+
+test(() => {
+  document.scrollingElement.scrollTop = 510;
+  document.body.classList.add('changed');
+  assert_equals(document.scrollingElement.scrollTop, 310);
+}, "The anchor is preserved even if its used height changes");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Anchoring adjustment works correctly when the anchor itself has changing negative overflow
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+
+body {
+  height: 2000px;
+}
+.outthere {
+  position: relative;
+  top: -900px;
+  left: -120px;
+  height: 1000px;
+  width: 100px;
+  background-color: orange;
+}
+body.changed .outthere {
+  top: -1200px;
+}
+#changer {
+  height: 100px;
+}
+body.changed #changer {
+  height: 200px;
+}
+#anchor {
+  position: relative;
+  height: 100px;
+  background-color: green;
+}
+
+</style>
+<div id="changer"></div>
+<div id="anchor">
+  <div class="outthere"></div>
+</div>
+<script>
+
+test(() => {
+  document.scrollingElement.scrollTop = 120;
+  document.body.classList.add('changed');
+  assert_equals(document.scrollingElement.scrollTop, 220);
+}, "Anchoring adjustment works correctly when the anchor itself has changing negative overflow");
+
+</script>


### PR DESCRIPTION
#### c6f11ac19f7a5ca1c9ca4f291ded204bfca751e1
<pre>
[Scroll Anchoring] Reddit page becomes blank and jumps to top after clicking &quot;View more comments&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=308788">https://bugs.webkit.org/show_bug.cgi?id=308788</a>
<a href="https://rdar.apple.com/170889205">rdar://170889205</a>

Reviewed by Brent Fulgham.

On the reddit page, there&apos;s an intermediate state where the wrapper for the comments (`SHREDDIT-COMMENT-TREE`)
has its content removed; its only child is a flexbox which has not been laid out yet, so we pick the wrapper
as the anchor. The wrapper happens to have large overflow into negative top and left, and this overflow
changes pre- to post-layout, so anchoring goes haywire.

Fix by trimming negative overflow when computing the local anchor rect; we actually just use the anchor&apos;s
border box, extended in the block direction by layout overflow (since anchoring only affects scrolling on
the block progression axis).

Added two new tests. `negative-layout-overflow-on-anchor.html` tests anchoring with changing negative
overflow on the anchor. `anchor-used-height-change-does-not-suppress.html` was added to test another scenario
I investigated while coming up with the fix, which is an anchor whose used height changes; in all browsers
this does not suppress anchoring.

Tests: imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress.html
       imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-on-anchor.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::candidateLocalRectForAnchoring):
(WebCore::ScrollAnchoringController::computeScrollerRelativeRects const):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):

Canonical link: <a href="https://commits.webkit.org/308352@main">https://commits.webkit.org/308352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f66e330c10296377ad813450bfd3e3635aad6cd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100565 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bd2bffa-233a-498c-8f37-0522c682e8fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113399 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80891 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80067a09-fc3b-47dc-a0f6-00fa8180db2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94159 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2c4093b-0e3a-4a40-8b0d-fb34cf8b35b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12599 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3275 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158164 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1295 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121425 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121628 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75601 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83003 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18979 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->