### PR TITLE
Geolocation: resync WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6536,6 +6536,7 @@ webkit.org/b/291197 imported/w3c/web-platform-tests/geolocation/getCurrentPositi
 webkit.org/b/291197 imported/w3c/web-platform-tests/geolocation/tojson.https.window.html [ Skip ]
 webkit.org/b/291197 imported/w3c/web-platform-tests/geolocation/non-fully-active.https.html [ Skip ]
 webkit.org/b/291197 imported/w3c/web-platform-tests/geolocation/enabled-by-permission-policy-attribute-redirect-on-load.https.sub.html [ Skip ]
+webkit.org/b/291197 imported/w3c/web-platform-tests/geolocation/heading-stationary.https.html [ Skip ]
 # Bug 253126: Permissions-Policy HTTP header not implemented - tests use header to restrict/allow geolocation
 webkit.org/b/253126 imported/w3c/web-platform-tests/geolocation/disabled-by-permissions-policy.https.sub.html [ Skip ]
 webkit.org/b/253126 imported/w3c/web-platform-tests/geolocation/enabled-by-permissions-policy.https.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/disabled-by-permissions-policy.https.sub-expected.txt
@@ -6,3 +6,9 @@ FAIL Permissions-Policy header geolocation=() disallows the top-level document. 
 TIMEOUT Permissions-Policy header geolocation=() disallows same-origin iframes. Test timed out
 NOTRUN Permissions-Policy header geolocation=() disallows cross-origin iframes.
 
+Harness Error (FAIL), message = Unhandled rejection
+
+FAIL Permissions-Policy header geolocation=() disallows the top-level document. promise_test: Unhandled rejection with value: object "[object GeolocationPosition]"
+TIMEOUT Permissions-Policy header geolocation=() disallows same-origin iframes. Test timed out
+NOTRUN Permissions-Policy header geolocation=() disallows cross-origin iframes.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,7 +1,6 @@
 
+Harness Error (FAIL), message = Error: bidi.permissions.set_permission() is not implemented by testdriver-vendor.js
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Permissions-Policy allow="geolocation" allows same-origin redirection Test timed out
-NOTRUN Permissions-Policy allow="geolocation" allows cross-origin redirection
+NOTRUN Permissions-Policy allow="geolocation" allows same-origin redirection
+NOTRUN Permissions-Policy allow="geolocation" disallows cross-origin redirection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-by-permissions-policy.https.sub-expected.txt
@@ -1,5 +1,7 @@
 
-PASS Permissions-Policy header geolocation=* allows the top-level document.
-PASS Permissions-Policy header geolocation=* allows same-origin iframes.
-PASS Permissions-Policy header geolocation=* allows cross-origin iframes.
+Harness Error (FAIL), message = Error: bidi.permissions.set_permission() is not implemented by testdriver-vendor.js
+
+NOTRUN Permissions-Policy header geolocation=* allows the top-level document.
+NOTRUN Permissions-Policy header geolocation=* allows same-origin iframes.
+NOTRUN Permissions-Policy header geolocation=* allows cross-origin iframes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
@@ -1,6 +1,7 @@
 
+Harness Error (FAIL), message = Error: bidi.permissions.set_permission() is not implemented by testdriver-vendor.js
 
-PASS Permissions-Policy header geolocation=(self) allows the top-level document.
-PASS Permissions-Policy header geolocation=(self) allows same-origin iframes.
-FAIL Permissions-Policy header geolocation=(self) disallows cross-origin iframes. assert_false: Geolocation API expected false got true
+NOTRUN Permissions-Policy header geolocation=(self) allows the top-level document.
+NOTRUN Permissions-Policy header geolocation=(self) allows same-origin iframes.
+NOTRUN Permissions-Policy header geolocation=(self) disallows cross-origin iframes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/getCurrentPosition-success.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/getCurrentPosition-success.https-expected.txt
@@ -1,5 +1,6 @@
 
 Harness Error (FAIL), message = Error: bidi.permissions.set_permission() is not implemented by testdriver-vendor.js
 
-NOTRUN Tests Geolocation success callback
+NOTRUN getCurrentPosition called with success and error callbacks
+NOTRUN Error callback is nullable for getCurrentPosition().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (FAIL), message = Test named 'heading is null when stationary (speed is 0)' specified 1 'cleanup' function, and 1 failed.
+
+FAIL heading is null when stationary (speed is 0) promise_test: Unhandled rejection with value: object "Error: bidi.emulation.set_geolocation_override is not implemented by testdriver-vendor.js"
+NOTRUN heading has a value when moving (speed > 0)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Geolocation Test: heading is null when stationary</title>
+<link rel="help" href="https://www.w3.org/TR/geolocation/#c9" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+  const latitude = 51.478;
+  const longitude = -0.166;
+  const accuracy = 100;
+
+  promise_setup(async () => {
+    await test_driver.set_permission({ name: "geolocation" }, "granted");
+  });
+
+  promise_test(async (t) => {
+    t.add_cleanup(async () => {
+      await test_driver.bidi.emulation.set_geolocation_override({
+        coordinates: null,
+      });
+    });
+
+    // Set geolocation with speed = 0 (stationary)
+    await test_driver.bidi.emulation.set_geolocation_override({
+      coordinates: {
+        latitude,
+        longitude,
+        accuracy,
+        speed: 0,
+      },
+    });
+
+    const position = await new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+
+    // When stationary (speed is 0), heading must be null, not NaN
+    assert_equals(
+      position.coords.heading,
+      null,
+      "heading must be null when device is stationary (speed is 0)",
+    );
+    assert_equals(position.coords.speed, 0, "speed should be 0");
+  }, "heading is null when stationary (speed is 0)");
+
+  promise_test(async (t) => {
+    t.add_cleanup(async () => {
+      await test_driver.bidi.emulation.set_geolocation_override({
+        coordinates: null,
+      });
+    });
+
+    // Set geolocation with speed > 0 (moving) and a heading
+    await test_driver.bidi.emulation.set_geolocation_override({
+      coordinates: {
+        latitude,
+        longitude,
+        accuracy,
+        speed: 10,
+        heading: 90,
+      },
+    });
+
+    const position = await new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+
+    // When moving (speed > 0), heading should be the specified value
+    assert_equals(
+      position.coords.heading,
+      90,
+      "heading should be 90 when moving",
+    );
+    assert_equals(position.coords.speed, 10, "speed should be 10");
+  }, "heading has a value when moving (speed > 0)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https-expected.txt
@@ -1,5 +1,8 @@
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Error: bidi.permissions.set_permission() is not implemented by testdriver-vendor.js
 
-TIMEOUT non-fully active document behavior Test timed out
+NOTRUN watchPosition returns 0 for non-fully-active document
+NOTRUN watchPosition calls errorCallback with POSITION_UNAVAILABLE for non-fully-active document
+NOTRUN getCurrentPosition calls errorCallback with POSITION_UNAVAILABLE for non-fully-active document
+NOTRUN re-attached document restores geolocation functionality
 

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https.html
@@ -1,20 +1,25 @@
-<!DOCTYPE html>
+<!doctype html>
 <meta charset="utf-8" />
 <title>Geolocation Test: non-fully active document</title>
 <link rel="help" href="https://github.com/w3c/geolocation-api/pull/97" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="support.js"></script>
 <body></body>
 <script>
   promise_setup(async () => {
-    await test_driver.set_permission({ name: "geolocation" }, "granted");
+    await test_driver.bidi.permissions.set_permission({
+      descriptor: { name: "geolocation" },
+      state: "granted",
+    });
+    await test_driver.bidi.emulation.set_geolocation_override({
+      coordinates: { latitude: 51.478, longitude: -0.166, accuracy: 100 },
+    });
   });
 
   promise_test(async (t) => {
-    // Create the iframe, wait for it to load...
     const iframe = document.createElement("iframe");
     await new Promise((resolve) => {
       iframe.src = "resources/iframe.html";
@@ -23,81 +28,134 @@
       document.body.appendChild(iframe);
     });
 
-    // Steal geolocation.
     const geo = iframe.contentWindow.navigator.geolocation;
-
-    // No longer fully active.
     iframe.remove();
 
-    // Try to watch a position while not fully active...
-    const watchError = await new Promise((resolve, reject) => {
-      const watchId = geo.watchPosition(
-        reject, // We don't want a position
-        resolve // We want an error!
-      );
-      // Always return 0.
-      assert_equals(
-        watchId,
-        0,
-        "watchId is 0 when document is not fully-active"
-      );
-      // And again, to make sure it's not changing
-      const watchId2 = geo.watchPosition(
-        () => {},
-        () => {}
-      );
-      assert_equals(
-        watchId2,
-        0,
-        "watchId remains 0 when document is not fully-active"
+    const watchId = geo.watchPosition(
+      () => {},
+      () => {},
+    );
+    assert_equals(watchId, 0, "watchId is 0 when document is not fully-active");
+
+    const watchId2 = geo.watchPosition(
+      () => {},
+      () => {},
+    );
+    assert_equals(
+      watchId2,
+      0,
+      "watchId remains 0 when document is not fully-active",
+    );
+  }, "watchPosition returns 0 for non-fully-active document");
+
+  promise_test(async (t) => {
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
+
+    const geo = iframe.contentWindow.navigator.geolocation;
+    iframe.remove();
+
+    const result = await new Promise((resolve) => {
+      const timeoutId = t.step_timeout(() => {
+        resolve({ timedOut: true });
+      }, 100);
+
+      geo.watchPosition(
+        () => resolve({ success: true }),
+        (error) => {
+          clearTimeout(timeoutId);
+          resolve({ error });
+        },
       );
     });
 
+    assert_false(result.timedOut, "errorCallback should be called");
+    assert_false(result.success, "successCallback should not be called");
     assert_equals(
-      watchError.code,
+      result.error.code,
       GeolocationPositionError.POSITION_UNAVAILABLE,
-      "watchPosition() returns an error on non-fully-active document"
+      "errorCallback receives POSITION_UNAVAILABLE",
     );
+  }, "watchPosition calls errorCallback with POSITION_UNAVAILABLE for non-fully-active document");
 
-    // Now try to get current position while not fully active...
-    const positionError = await new Promise((resolve, reject) => {
+  promise_test(async (t) => {
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
+
+    const geo = iframe.contentWindow.navigator.geolocation;
+    iframe.remove();
+
+    const result = await new Promise((resolve) => {
+      const timeoutId = t.step_timeout(() => {
+        resolve({ timedOut: true });
+      }, 100);
+
       geo.getCurrentPosition(
-        reject, // We don't want a position
-        resolve // We want an error!
+        () => resolve({ success: true }),
+        (error) => {
+          clearTimeout(timeoutId);
+          resolve({ error });
+        },
       );
     });
+
+    assert_false(result.timedOut, "errorCallback should be called");
+    assert_false(result.success, "successCallback should not be called");
     assert_equals(
-      positionError.code,
+      result.error.code,
       GeolocationPositionError.POSITION_UNAVAILABLE,
-      "getCurrentPosition() calls the errorCallback with POSITION_UNAVAILABLE"
+      "errorCallback receives POSITION_UNAVAILABLE",
     );
+  }, "getCurrentPosition calls errorCallback with POSITION_UNAVAILABLE for non-fully-active document");
 
-    // Re-attach, and go back to fully active.
+  promise_test(async (t) => {
+    t.add_cleanup(async () => {
+      await test_driver.bidi.emulation.set_geolocation_override({
+        coordinates: null,
+      });
+    });
+
+    const iframe = document.createElement("iframe");
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
+
+    iframe.remove();
     document.body.appendChild(iframe);
-    iframe.contentWindow.opener = window;
     await new Promise((resolve) =>
-      iframe.addEventListener("load", resolve, { once: true })
+      iframe.addEventListener("load", resolve, { once: true }),
     );
 
-    // And we are back to fully active.
     let watchId;
     let position = await new Promise((resolve, reject) => {
       watchId = iframe.contentWindow.navigator.geolocation.watchPosition(
         resolve,
-        reject
+        reject,
       );
     });
-    assert_true(Number.isInteger(watchId), "Expected some number for watchId");
+    assert_true(Number.isInteger(watchId), "Expected integer watchId");
     assert_true(Boolean(position), "Expected a position");
 
-    // Finally, let's get the position from the reattached document.
     position = await new Promise((resolve, reject) => {
       iframe.contentWindow.navigator.geolocation.getCurrentPosition(
         resolve,
-        reject
+        reject,
       );
     });
     assert_true(Boolean(position), "Expected a position");
     iframe.contentWindow.navigator.geolocation.clearWatch(watchId);
-  }, "non-fully active document behavior");
+  }, "re-attached document restores geolocation functionality");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/geolocation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/geolocation/w3c-import.log
@@ -30,6 +30,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/geolocation/getCurrentPosition-success.https.html
 /LayoutTests/imported/w3c/web-platform-tests/geolocation/getCurrentPosition_TypeError.https.html
 /LayoutTests/imported/w3c/web-platform-tests/geolocation/getCurrentPosition_permission_deny.https.html
+/LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https.html
 /LayoutTests/imported/w3c/web-platform-tests/geolocation/idlharness.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https.html
 /LayoutTests/imported/w3c/web-platform-tests/geolocation/non-secure-contexts.http.html


### PR DESCRIPTION
#### c3be710994853747773cd7fba5536ddc1132ec3d
<pre>
Geolocation: resync WPT tests
<a href="https://rdar.apple.com/171322322">rdar://171322322</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308789">https://bugs.webkit.org/show_bug.cgi?id=308789</a>

Reviewed by Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/18f431a0eff9334febc25df3671b418ef72e3071">https://github.com/web-platform-tests/wpt/commit/18f431a0eff9334febc25df3671b418ef72e3071</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-by-permission-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/getCurrentPosition-success.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/geolocation/heading-stationary.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/non-fully-active.https.html:
* LayoutTests/imported/w3c/web-platform-tests/geolocation/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/308343@main">https://commits.webkit.org/308343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31a24e3e415aca2b0c7ee664ec3b69a4db635125

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100652 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e210254-5c79-43f4-8ec6-12b4856c4f21) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113473 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80934 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6002e076-b345-4897-9c2c-09512d5dc315) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94233 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/528eb62c-8d33-4738-b040-d222227ccb11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12659 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3363 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158251 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121498 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121701 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31167 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75691 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8738 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19336 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->