### PR TITLE
REGRESSION(306364@main): Form fields in PDFs in dark mode are not readable

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1580,6 +1580,7 @@ String PDFPluginBase::annotationStyle() const
     ".annotation {"
     "    position: absolute;"
     "    pointer-events: auto;"
+    "    color-scheme: only light;"
     "}"
     ""
     "textarea.annotation { "

--- a/Tools/TestWebKitAPI/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/PlatformUtilities.h
@@ -64,6 +64,7 @@ ALWAYS_INLINE std::string toSTD(const String& string) { return toSTD(string.utf8
 
 #if USE(FOUNDATION)
 std::string toSTD(NSString *);
+std::string toSTD(RetainPtr<NSString>);
 bool jsonMatchesExpectedValues(NSString *jsonString, NSDictionary *expected);
 #ifdef __OBJC__
 void waitForConditionWithLogging(std::function<bool()>&&, NSTimeInterval loggingTimeout, NSString *message, ...) NS_FORMAT_FUNCTION(3, 4);

--- a/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
@@ -64,6 +64,11 @@ std::string toSTD(NSString *string)
     return std::string(buffer.get(), stringLength);
 }
 
+std::string toSTD(RetainPtr<NSString> string)
+{
+    return toSTD(string.get());
+}
+
 bool jsonMatchesExpectedValues(NSString *jsonString, NSDictionary *expected)
 {
     NSError *error = nil;


### PR DESCRIPTION
#### 8a4cbc9596bb210fdea652a512ff895ab86100ae
<pre>
REGRESSION(306364@main): Form fields in PDFs in dark mode are not readable
<a href="https://bugs.webkit.org/show_bug.cgi?id=308793">https://bugs.webkit.org/show_bug.cgi?id=308793</a>
<a href="https://rdar.apple.com/171198060">rdar://171198060</a>

Reviewed by Richard Robinson.

After 306364@main, PDF annotation elements respect light/dark color
scheme, but we also respect the text annotation&apos;s font color. Since PDF
content is ordinarily for light mode, the prescribed annotation font
color is dark, which clashes with our text annotation&apos;s dark background
color (in dark mode).

To fix this issue, we simply opt out of dark mode adaptations for PDF
annotations.

Tests: TestWebKitAPI.UnifiedPDF.TextAnnotationBackgroundColorDoesNotAdaptToColorScheme

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::annotationStyle const):
* Tools/TestWebKitAPI/PlatformUtilities.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm:
(TestWebKitAPI::Util::toSTD):

Canonical link: <a href="https://commits.webkit.org/308330@main">https://commits.webkit.org/308330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0320eba716438c420296da70094ad964e82e9bac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100583 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38f0a8b7-3eb7-4df8-8e91-a6e318b41424) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113415 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65cbb479-e190-4366-9443-48da374bce94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94176 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2920f9c-c5c7-4a54-8918-95d3df0d4e47) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12608 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3293 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158182 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121442 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31156 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75619 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8685 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83021 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18997 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19147 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19055 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->