### PR TITLE
[Cocoa] YouTube shorts start black sometimes

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -99,6 +99,7 @@ public:
     virtual HostingContext hostingContext() const { return { }; }
     virtual WebCore::FloatSize videoLayerSize() const { return { }; }
     virtual void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, FloatSize)>&&) { }
+    virtual void setVideoLayerSize(const FloatSize&) { }
     virtual void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) { }
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -137,6 +137,7 @@ public:
     Ref<BitmapImagePromise> currentBitmapImage() const final;
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
     PlatformLayer* platformVideoLayer() const final;
+    void setVideoLayerSize(const FloatSize&) final;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&) final;
 
     // VideoFullscreenInterface

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -855,10 +855,15 @@ PlatformLayer* AudioVideoRendererAVFObjC::platformVideoLayer() const
     return m_videoLayerManager->videoInlineLayer();
 }
 
-void AudioVideoRendererAVFObjC::setVideoLayerSizeFenced(const FloatSize& newSize, WTF::MachSendRightAnnotated&&)
+void AudioVideoRendererAVFObjC::setVideoLayerSize(const FloatSize& newSize)
 {
     if (!layerOrVideoRenderer() && !newSize.isEmpty())
         updateDisplayLayerIfNeeded();
+}
+
+void AudioVideoRendererAVFObjC::setVideoLayerSizeFenced(const FloatSize& newSize, WTF::MachSendRightAnnotated&&)
+{
+    setVideoLayerSize(newSize);
 }
 
 void AudioVideoRendererAVFObjC::setVideoFullscreenLayer(PlatformLayer *videoFullscreenLayer, WTF::Function<void()>&& completionHandler)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -280,6 +280,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& o
     m_renderer->setPreferences(options.videoRendererPreferences);
     if (RefPtr player = m_player.get()) {
         m_renderer->setPresentationSize(player->presentationSize());
+        m_renderer->setVideoLayerSize(player->videoLayerSize());
         m_renderer->renderingCanBeAcceleratedChanged(player->renderingCanBeAccelerated());
         m_renderer->setVolume(player->volume());
         m_renderer->setMuted(player->muted());

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -584,6 +584,16 @@ void RemoteAudioVideoRendererProxyManager::rendereringModeChanged(RemoteAudioVid
 }
 
 #if PLATFORM(COCOA)
+void RemoteAudioVideoRendererProxyManager::setVideoLayerSize(RemoteAudioVideoRendererIdentifier identifier, const WebCore::FloatSize& size)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString(), ", size: ", size.width(), "x", size.height());
+
+    MESSAGE_CHECK(m_renderers.contains(identifier));
+
+    auto& context = contextFor(identifier);
+    context.layerHostingContextManager.setVideoLayerSize(size);
+}
+
 void RemoteAudioVideoRendererProxyManager::setVideoLayerSizeFenced(RemoteAudioVideoRendererIdentifier identifier, const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
     ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString(), size.width(), "x", size.height());

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -180,6 +180,7 @@ private:
     WebCore::MediaSampleConverter& converterFor(RendererContext&, TrackIdentifier);
 
 #if PLATFORM(COCOA)
+    void setVideoLayerSize(RemoteAudioVideoRendererIdentifier, const WebCore::FloatSize&);
     void setVideoLayerSizeFenced(RemoteAudioVideoRendererIdentifier, const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&);
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -91,6 +91,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     RequestHostingContext(WebKit::RemoteAudioVideoRendererIdentifier identifier) -> (struct WebCore::HostingContext layerHostingContext)
 
 #if PLATFORM(COCOA)
+    SetVideoLayerSize(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::FloatSize size)
     SetVideoLayerSizeFenced(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::FloatSize size, struct MachSendRightAnnotated sendRightAnnotated)
 #endif
 

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
@@ -49,6 +49,7 @@ public:
 
     void requestHostingContext(LayerHostingContextCallback&&);
     std::optional<WebCore::HostingContext> createHostingContextIfNeeded(const PlatformLayerContainer&, bool canShowWhileLocked);
+    void setVideoLayerSize(const WebCore::FloatSize&);
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&, NOESCAPE CompletionHandler<void()>&& postCommitAction);
     WebCore::FloatSize videoLayerSize() const { return m_videoLayerSize; }
     void setVideoLayerSizeIfPossible();

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -92,6 +92,12 @@ std::optional<WebCore::HostingContext> LayerHostingContextManager::createHosting
     return m_inlineLayerHostingContext ? m_inlineLayerHostingContext->hostingContext() : WebCore::HostingContext { };
 }
 
+void LayerHostingContextManager::setVideoLayerSize(const WebCore::FloatSize& size)
+{
+    m_videoLayerSize = size;
+    setVideoLayerSizeIfPossible();
+}
+
 void LayerHostingContextManager::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated, NOESCAPE CompletionHandler<void()>&& postCommitAction)
 {
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -850,6 +850,18 @@ WebCore::FloatSize AudioVideoRendererRemote::videoLayerSize() const
     return m_videoLayerSize;
 }
 
+void AudioVideoRendererRemote::setVideoLayerSize(const WebCore::FloatSize& size)
+{
+    {
+        Locker locker { m_lock };
+        m_videoLayerSize = size;
+    }
+
+    ensureOnDispatcherWithConnection([size](auto& renderer, auto& connection) mutable {
+        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetVideoLayerSize(renderer.m_identifier, size), 0);
+    });
+}
+
 void AudioVideoRendererRemote::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
     {

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -186,6 +186,7 @@ private:
     void setLayerHostingContext(WebCore::HostingContext&&);
 #if PLATFORM(COCOA)
     WebCore::FloatSize videoLayerSize() const;
+    void setVideoLayerSize(const WebCore::FloatSize&) final;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;
 #endif
     void notifyVideoLayerSizeChanged(Function<void(const MediaTime&, WebCore::FloatSize)>&& callback) final;


### PR DESCRIPTION
#### f416aa2c383134e404aad0ed966ef3d1550d5587
<pre>
[Cocoa] YouTube shorts start black sometimes
<a href="https://rdar.apple.com/170368724">rdar://170368724</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308798">https://bugs.webkit.org/show_bug.cgi?id=308798</a>

Reviewed by Jean-Yves Avenard.

Previously fixed in 304722@main, this addresses a different cause of a layer
failing to be placed in the correct screen location. When a video element
previously hosted a layer, but then recreated its MediaPlayer, the resulting
MediaPlayerPrivateMediaSourceAVFObjC would initialize a renderer with a
presentationSize but not the videoLayerSize, causing the resulting layer
to be created with an incorrect initial size.

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setVideoLayerSize):
(WebCore::AudioVideoRendererAVFObjC::setVideoLayerSizeFenced):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.h:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm:
(WebKit::LayerHostingContextManager::setVideoLayerSize):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::setVideoLayerSize):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/308350@main">https://commits.webkit.org/308350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ab323e20de8beb4645be4ce9634fef6f58d0352

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100658 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f732a26-36b3-4b98-a91c-901ae9421b92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113480 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/361bdddc-be64-4c2e-a8c0-e59ecf52f6c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94240 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5f358fe-cd2c-4a7f-ae37-000f198c0a84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14883 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12681 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3369 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158257 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121505 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121708 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31173 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75702 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8748 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83096 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19072 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19222 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->