### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in the UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/APIApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/APIApplicationManifest.h
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    const WebCore::ApplicationManifest& applicationManifest() const { return m_applicationManifest; }
+    const WebCore::ApplicationManifest& applicationManifest() const LIFETIME_BOUND { return m_applicationManifest; }
 
 private:
     WebCore::ApplicationManifest m_applicationManifest;

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -60,7 +60,7 @@ public:
 
     enum class InsertionState : uint8_t { NotInserted, Inserted };
 
-    const WTF::String& identifier() const { return m_identifier; }
+    const WTF::String& identifier() const LIFETIME_BOUND { return m_identifier; }
     void updateAttributes(CompletionHandler<void()>&&);
 
     void invalidate();
@@ -76,11 +76,11 @@ public:
 #endif
     WTF::String mimeType() const;
 
-    const WTF::String& filePath() const { return m_filePath; }
+    const WTF::String& filePath() const LIFETIME_BOUND { return m_filePath; }
     void setFilePath(const WTF::String& filePath) { m_filePath = filePath; }
     WTF::String fileName() const;
 
-    const WTF::String& contentType() const { return m_contentType; }
+    const WTF::String& contentType() const LIFETIME_BOUND { return m_contentType; }
     void setContentType(const WTF::String& contentType) { m_contentType = contentType; }
 
     InsertionState insertionState() const { return m_insertionState; }

--- a/Source/WebKit/UIProcess/API/APIContentRuleList.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.h
@@ -47,7 +47,7 @@ public:
     ContentRuleList(Ref<WebKit::WebCompiledContentRuleList>&&, WebKit::NetworkCache::Data&&);
     virtual ~ContentRuleList();
 
-    const WTF::String& NODELETE name() const;
+    const WTF::String& NODELETE name() const LIFETIME_BOUND;
     const WebKit::WebCompiledContentRuleList& compiledRuleList() const { return m_compiledRuleList.get(); }
     
     static bool supportsRegularExpression(const WTF::String&);

--- a/Source/WebKit/UIProcess/API/APIContentRuleListAction.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListAction.h
@@ -42,7 +42,7 @@ public:
     bool NODELETE blockedCookies() const;
     bool NODELETE redirected() const;
     bool NODELETE modifiedHeaders() const;
-    const Vector<WTF::String>& NODELETE notifications() const;
+    const Vector<WTF::String>& NODELETE notifications() const LIFETIME_BOUND;
 
 private:
     ContentRuleListAction(WebCore::ContentRuleListResults::Result&&);

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -50,7 +50,7 @@ public:
     virtual ~ContentWorld();
 
     WebKit::ContentWorldIdentifier identifier() const { return m_identifier; }
-    const WTF::String& name() const { return m_name; }
+    const WTF::String& name() const LIFETIME_BOUND { return m_name; }
     WebKit::ContentWorldData worldDataForProcess(WebKit::WebProcessProxy&) const;
 
     bool allowAccessToClosedShadowRoots() const { return m_options.contains(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
@@ -43,7 +43,7 @@ public:
 
     Ref<ContentWorldConfiguration> copy() const;
 
-    const WTF::String& NODELETE name() const;
+    const WTF::String& NODELETE name() const LIFETIME_BOUND;
     void setName(WTF::String&&);
 
     bool NODELETE allowAccessToClosedShadowRoots() const;

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfo.h
@@ -43,9 +43,9 @@ public:
         return adoptRef(*new ContextMenuElementInfo(std::forward<Args>(args)...));
     }
     
-    const WTF::URL& url() const { return m_interactionInformation.url; }
+    const WTF::URL& url() const LIFETIME_BOUND { return m_interactionInformation.url; }
 
-    const WebKit::InteractionInformationAtPosition& interactionInformation() const { return m_interactionInformation; }
+    const WebKit::InteractionInformationAtPosition& interactionInformation() const LIFETIME_BOUND { return m_interactionInformation; }
 
     const RetainPtr<NSDictionary> userInfo() const { return m_userInfo; }
 

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -42,9 +42,9 @@ public:
         return adoptRef(*new ContextMenuElementInfoMac(std::forward<Args>(args)...));
     }
 
-    const WebKit::WebHitTestResultData& hitTestResultData() const { return m_hitTestResultData; }
+    const WebKit::WebHitTestResultData& hitTestResultData() const LIFETIME_BOUND { return m_hitTestResultData; }
     WebKit::WebPageProxy* page() { return m_page.get(); }
-    const WTF::String& qrCodePayloadString() const { return m_qrCodePayloadString; }
+    const WTF::String& qrCodePayloadString() const LIFETIME_BOUND { return m_qrCodePayloadString; }
     bool hasEntireImage() const { return m_hasEntireImage; }
     bool allowsFollowingLink() const { return m_allowsFollowingLink; }
     bool allowsFollowingImageURL() const { return m_allowsFollowingImageURL; }

--- a/Source/WebKit/UIProcess/API/APICustomHeaderFields.h
+++ b/Source/WebKit/UIProcess/API/APICustomHeaderFields.h
@@ -39,13 +39,13 @@ public:
 
     CustomHeaderFields() = default;
 
-    const Vector<WebCore::HTTPHeaderField>& fields() const { return m_fields.fields; }
+    const Vector<WebCore::HTTPHeaderField>& fields() const LIFETIME_BOUND { return m_fields.fields; }
     void setFields(Vector<WebCore::HTTPHeaderField>&& fields) { m_fields.fields = WTF::move(fields); }
 
     const Vector<WTF::String> thirdPartyDomains() const { return m_fields.thirdPartyDomains; }
     void setThirdPartyDomains(Vector<WTF::String>&& domains) { m_fields.thirdPartyDomains = WTF::move(domains); }
 
-    const WebCore::CustomHeaderFields& coreFields() const { return m_fields; }
+    const WebCore::CustomHeaderFields& coreFields() const LIFETIME_BOUND { return m_fields; }
 
 private:
     CustomHeaderFields(const WebCore::CustomHeaderFields& fields)

--- a/Source/WebKit/UIProcess/API/APIDataTask.h
+++ b/Source/WebKit/UIProcess/API/APIDataTask.h
@@ -58,7 +58,7 @@ public:
     void cancel();
 
     WebKit::WebPageProxy* page() { return m_page.get(); }
-    const WTF::URL& originalURL() const { return m_originalURL; }
+    const WTF::URL& originalURL() const LIFETIME_BOUND { return m_originalURL; }
     const DataTaskClient& client() const { return m_client.get(); }
     void setClient(Ref<DataTaskClient>&&);
     void networkProcessCrashed();

--- a/Source/WebKit/UIProcess/API/APIDebuggableInfo.h
+++ b/Source/WebKit/UIProcess/API/APIDebuggableInfo.h
@@ -40,19 +40,19 @@ public:
     Inspector::DebuggableType debuggableType() const { return m_data.debuggableType; }
     void setDebuggableType(Inspector::DebuggableType debuggableType) { m_data.debuggableType = debuggableType; }
 
-    const WTF::String& targetPlatformName() const { return m_data.targetPlatformName; }
+    const WTF::String& targetPlatformName() const LIFETIME_BOUND { return m_data.targetPlatformName; }
     void setTargetPlatformName(const WTF::String& targetPlatformName) { m_data.targetPlatformName = targetPlatformName; }
 
-    const WTF::String& targetBuildVersion() const { return m_data.targetBuildVersion; }
+    const WTF::String& targetBuildVersion() const LIFETIME_BOUND { return m_data.targetBuildVersion; }
     void setTargetBuildVersion(const WTF::String& targetBuildVersion) { m_data.targetBuildVersion = targetBuildVersion; }
 
-    const WTF::String& targetProductVersion() const { return m_data.targetProductVersion; }
+    const WTF::String& targetProductVersion() const LIFETIME_BOUND { return m_data.targetProductVersion; }
     void setTargetProductVersion(const WTF::String& targetProductVersion) { m_data.targetProductVersion = targetProductVersion; }
 
     bool targetIsSimulator() const { return m_data.targetIsSimulator; }
     void setTargetIsSimulator(bool targetIsSimulator) { m_data.targetIsSimulator = targetIsSimulator; }
 
-    const WebKit::DebuggableInfoData& debuggableInfoData() const { return m_data; }
+    const WebKit::DebuggableInfoData& debuggableInfoData() const LIFETIME_BOUND { return m_data; }
 
 private:
     explicit DebuggableInfo(const WebKit::DebuggableInfoData&);

--- a/Source/WebKit/UIProcess/API/APIFormInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFormInfo.h
@@ -42,9 +42,9 @@ public:
 
     API::FrameInfo* NODELETE targetFrame() const;
     API::FrameInfo* NODELETE sourceFrame() const;
-    const WTF::URL& NODELETE submissionURL() const;
-    const WTF::String& NODELETE httpMethod() const;
-    const Vector<std::pair<WTF::String, WTF::String>>& NODELETE formValues() const;
+    const WTF::URL& NODELETE submissionURL() const LIFETIME_BOUND;
+    const WTF::String& NODELETE httpMethod() const LIFETIME_BOUND;
+    const Vector<std::pair<WTF::String, WTF::String>>& NODELETE formValues() const LIFETIME_BOUND;
 
 private:
     FormInfo(API::FrameInfo&, API::FrameInfo& sourceFrame, const WTF::URL& submissionURL, const WTF::String& httpMethod, const Vector<std::pair<WTF::String, WTF::String>>& formValues);

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.h
@@ -51,8 +51,8 @@ public:
 
     bool isMainFrame() const { return m_data.isMainFrame; }
     bool isLocalFrame() const { return m_data.frameType == WebKit::FrameType::Local; }
-    const WebCore::ResourceRequest& request() const { return m_data.request; }
-    const WebCore::SecurityOriginData& securityOrigin() const { return m_data.securityOrigin; }
+    const WebCore::ResourceRequest& request() const LIFETIME_BOUND { return m_data.request; }
+    const WebCore::SecurityOriginData& securityOrigin() const LIFETIME_BOUND { return m_data.securityOrigin; }
     Ref<FrameHandle> handle() const;
     WebKit::WebPageProxy* page();
     const WebKit::WebPageProxy* page() const;
@@ -63,7 +63,7 @@ public:
     bool errorOccurred() const { return m_data.errorOccurred; }
     WTF::String title() const;
 
-    const WebKit::FrameInfoData& frameInfoData() const { return m_data; }
+    const WebKit::FrameInfoData& frameInfoData() const LIFETIME_BOUND { return m_data; }
 
 private:
     FrameInfo(WebKit::FrameInfoData&&);

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
@@ -42,8 +42,8 @@ public:
     virtual ~FrameTreeNode();
 
     WebKit::WebPageProxy& page() { return m_page.get(); }
-    const WebKit::FrameInfoData& info() const { return m_data.info; }
-    const Vector<WebKit::FrameTreeNodeData>& childFrames() const { return m_data.children; }
+    const WebKit::FrameInfoData& info() const LIFETIME_BOUND { return m_data.info; }
+    const Vector<WebKit::FrameTreeNodeData>& childFrames() const LIFETIME_BOUND { return m_data.children; }
 
 private:
     FrameTreeNode(WebKit::FrameTreeNodeData&& data, WebKit::WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -76,14 +76,14 @@ public:
 
     WebKit::WebPageProxy* page() { return m_page.get(); }
 
-    const std::optional<WebKit::FrameInfoData>& frameInfo() const { return m_data.frameInfo; }
+    const std::optional<WebKit::FrameInfoData>& frameInfo() const LIFETIME_BOUND { return m_data.frameInfo; }
     const std::optional<WebCore::FrameIdentifier> targetFrame() const { return m_data.targetFrame; }
 
     bool allowsFollowingLink() const { return m_data.allowsFollowingLink; }
 
     bool allowsFollowingImageURL() const { return m_data.allowsFollowingImageURL; }
 
-    const std::optional<WebCore::ResourceResponse>& linkLocalResourceResponse() const { return m_data.linkLocalResourceResponse; }
+    const std::optional<WebCore::ResourceResponse>& linkLocalResourceResponse() const LIFETIME_BOUND { return m_data.linkLocalResourceResponse; }
 
 private:
     explicit HitTestResult(const WebKit::WebHitTestResultData& hitTestResultData, WebKit::WebPageProxy* page)

--- a/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorConfiguration.h
@@ -46,7 +46,7 @@ public:
     virtual ~InspectorConfiguration();
 
     void addURLSchemeHandler(Ref<WebKit::WebURLSchemeHandler>&&, const WTF::String& urlScheme);
-    const Vector<URLSchemeHandlerPair>& urlSchemeHandlers() { return m_customURLSchemes; }
+    const Vector<URLSchemeHandlerPair>& urlSchemeHandlers() LIFETIME_BOUND { return m_customURLSchemes; }
     
     WebKit::WebProcessPool* NODELETE processPool();
     void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);

--- a/Source/WebKit/UIProcess/API/APIInspectorExtension.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtension.h
@@ -45,7 +45,7 @@ class InspectorExtension final : public API::ObjectImpl<Object::Type::InspectorE
 public:
     static Ref<InspectorExtension> create(const WTF::String& identifier, WebKit::WebInspectorUIExtensionControllerProxy&);
 
-    const WTF::String& identifier() const { return m_identifier; }
+    const WTF::String& identifier() const LIFETIME_BOUND { return m_identifier; }
 
     void createTab(const WTF::String& tabName, const WTF::URL& tabIconURL, const WTF::URL& sourceURL, WTF::CompletionHandler<void(Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>)>&&);
     void evaluateScript(const WTF::String& scriptSource, const std::optional<WTF::URL>& frameURL, const std::optional<WTF::URL>& contextSecurityOrigin, const std::optional<bool>& useContentScriptContext, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&&);

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -110,9 +110,9 @@ public:
 
     WebCore::NavigationIdentifier navigationID() const { return m_navigationID; }
 
-    const WebCore::ResourceRequest& originalRequest() const { return m_originalRequest; }
+    const WebCore::ResourceRequest& originalRequest() const LIFETIME_BOUND { return m_originalRequest; }
     void setCurrentRequest(WebCore::ResourceRequest&&, std::optional<WebCore::ProcessIdentifier>);
-    const WebCore::ResourceRequest& currentRequest() const { return m_currentRequest; }
+    const WebCore::ResourceRequest& currentRequest() const LIFETIME_BOUND { return m_currentRequest; }
     std::optional<WebCore::ProcessIdentifier> currentRequestProcessIdentifier() const { return m_currentRequestProcessIdentifier; }
 
     bool currentRequestIsRedirect() const { return m_lastNavigationAction && !m_lastNavigationAction->redirectResponse.isNull(); }
@@ -153,13 +153,13 @@ public:
     std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy() const { return m_lastNavigationAction ? m_lastNavigationAction->ownerPermissionsPolicy : std::nullopt; }
 
     void setLastNavigationAction(const WebKit::NavigationActionData& navigationAction) { m_lastNavigationAction = navigationAction; }
-    const std::optional<WebKit::NavigationActionData>& lastNavigationAction() const { return m_lastNavigationAction; }
+    const std::optional<WebKit::NavigationActionData>& lastNavigationAction() const LIFETIME_BOUND { return m_lastNavigationAction; }
 
     void setOriginatingFrameInfo(const WebKit::FrameInfoData& frameInfo) { m_originatingFrameInfo = frameInfo; }
-    const std::optional<WebKit::FrameInfoData>& originatingFrameInfo() const { return m_originatingFrameInfo; }
+    const std::optional<WebKit::FrameInfoData>& originatingFrameInfo() const LIFETIME_BOUND { return m_originatingFrameInfo; }
 
     void setDestinationFrameSecurityOrigin(const WebCore::SecurityOriginData& origin) { m_destinationFrameSecurityOrigin = origin; }
-    const WebCore::SecurityOriginData& destinationFrameSecurityOrigin() const { return m_destinationFrameSecurityOrigin; }
+    const WebCore::SecurityOriginData& destinationFrameSecurityOrigin() const LIFETIME_BOUND { return m_destinationFrameSecurityOrigin; }
 
     void setEffectiveContentMode(WebKit::WebContentMode mode) { m_effectiveContentMode = mode; }
     WebKit::WebContentMode effectiveContentMode() const { return m_effectiveContentMode; }
@@ -168,7 +168,7 @@ public:
     WTF::String loggingString() const;
 #endif
 
-    const std::unique_ptr<SubstituteData>& substituteData() const { return m_substituteData; }
+    const std::unique_ptr<SubstituteData>& substituteData() const LIFETIME_BOUND { return m_substituteData; }
 
     const WebCore::PrivateClickMeasurement* privateClickMeasurement() const { return m_lastNavigationAction && m_lastNavigationAction->privateClickMeasurement ? &*m_lastNavigationAction->privateClickMeasurement : nullptr; }
 

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -45,17 +45,17 @@ public:
 
     FrameInfo* sourceFrame() const { return m_sourceFrame.get(); }
     FrameInfo* targetFrame() const { return m_targetFrame.get(); }
-    const WTF::String& targetFrameName() const { return m_targetFrameName; }
+    const WTF::String& targetFrameName() const LIFETIME_BOUND { return m_targetFrameName; }
 
-    const WebCore::ResourceRequest& request() const { return m_request; }
-    const WTF::URL& originalURL() const { return !m_originalURL.isNull() ? m_originalURL : m_request.url(); }
+    const WebCore::ResourceRequest& request() const LIFETIME_BOUND { return m_request; }
+    const WTF::URL& originalURL() const LIFETIME_BOUND { return !m_originalURL.isNull() ? m_originalURL : m_request.url(); }
 
     WebCore::NavigationType navigationType() const { return m_navigationActionData.navigationType; }
     OptionSet<WebKit::WebEventModifier> modifiers() const { return m_navigationActionData.modifiers; }
     WebKit::WebMouseEventButton mouseButton() const { return m_navigationActionData.mouseButton; }
     WebKit::WebMouseEventSyntheticClickType syntheticClickType() const { return m_navigationActionData.syntheticClickType; }
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-    const std::optional<WebKit::WebHitTestResultData>& webHitTestResultData() const { return m_navigationActionData.webHitTestResultData; }
+    const std::optional<WebKit::WebHitTestResultData>& webHitTestResultData() const LIFETIME_BOUND { return m_navigationActionData.webHitTestResultData; }
 #endif
     WebCore::FloatPoint clickLocationInRootViewCoordinates() const { return m_navigationActionData.clickLocationInRootViewCoordinates; }
     bool canHandleRequest() const { return m_navigationActionData.canHandleRequest; }
@@ -78,7 +78,7 @@ public:
     void unsetShouldPerformSOAuthorization() { m_shouldPerformSOAuthorization = false; }
 #endif
 
-    const WebKit::NavigationActionData& data() const { return m_navigationActionData; }
+    const WebKit::NavigationActionData& data() const LIFETIME_BOUND { return m_navigationActionData; }
     std::optional<WebCore::FrameIdentifier> mainFrameIDBeforeNavigationActionDecision() { return m_mainFrameIDBeforeNavigationDecision; }
     
 private:

--- a/Source/WebKit/UIProcess/API/APINavigationData.h
+++ b/Source/WebKit/UIProcess/API/APINavigationData.h
@@ -42,8 +42,8 @@ public:
 
     WTF::String title() const { return m_store.title; }
     WTF::String url() const { return m_store.url; }
-    const WebCore::ResourceRequest& originalRequest() const { return m_store.originalRequest; }
-    const WebCore::ResourceResponse& response() const { return m_store.response; }
+    const WebCore::ResourceRequest& originalRequest() const LIFETIME_BOUND { return m_store.originalRequest; }
+    const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_store.response; }
 
 private:
     explicit NavigationData(const WebKit::WebNavigationDataStore&);

--- a/Source/WebKit/UIProcess/API/APINavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/APINavigationResponse.h
@@ -45,13 +45,13 @@ public:
 
     FrameInfo& frame() { return m_frame.get(); }
 
-    const WebCore::ResourceRequest& request() const { return m_request; }
-    const WebCore::ResourceResponse& response() const { return m_response; }
+    const WebCore::ResourceRequest& request() const LIFETIME_BOUND { return m_request; }
+    const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_response; }
     FrameInfo* navigationInitiatingFrame();
     Navigation* navigation() { return m_navigation.get(); }
 
     bool canShowMIMEType() const { return m_canShowMIMEType; }
-    const WTF::String& downloadAttribute() const { return m_downloadAttribute; }
+    const WTF::String& downloadAttribute() const LIFETIME_BOUND { return m_downloadAttribute; }
 
 private:
     NavigationResponse(API::FrameInfo&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, bool canShowMIMEType, WTF::String&& downloadAttribute, Navigation*);

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -72,16 +72,16 @@ public:
     void setUsesBackForwardCache(bool value) { m_usesBackForwardCache = value; }
     bool usesBackForwardCache() const { return m_usesBackForwardCache; }
 
-    const WTF::String& injectedBundlePath() const { return m_injectedBundlePath; }
+    const WTF::String& injectedBundlePath() const LIFETIME_BOUND { return m_injectedBundlePath; }
     void setInjectedBundlePath(const WTF::String& injectedBundlePath) { m_injectedBundlePath = injectedBundlePath; }
 
-    const Vector<WTF::String>& cachePartitionedURLSchemes() { return m_cachePartitionedURLSchemes; }
+    const Vector<WTF::String>& cachePartitionedURLSchemes() LIFETIME_BOUND { return m_cachePartitionedURLSchemes; }
     void setCachePartitionedURLSchemes(Vector<WTF::String>&& cachePartitionedURLSchemes) { m_cachePartitionedURLSchemes = WTF::move(cachePartitionedURLSchemes); }
 
-    const Vector<WTF::String>& alwaysRevalidatedURLSchemes() { return m_alwaysRevalidatedURLSchemes; }
+    const Vector<WTF::String>& alwaysRevalidatedURLSchemes() LIFETIME_BOUND { return m_alwaysRevalidatedURLSchemes; }
     void setAlwaysRevalidatedURLSchemes(Vector<WTF::String>&& alwaysRevalidatedURLSchemes) { m_alwaysRevalidatedURLSchemes = WTF::move(alwaysRevalidatedURLSchemes); }
 
-    const Vector<WTF::String>& additionalReadAccessAllowedPaths() { return m_additionalReadAccessAllowedPaths; }
+    const Vector<WTF::String>& additionalReadAccessAllowedPaths() LIFETIME_BOUND { return m_additionalReadAccessAllowedPaths; }
     void setAdditionalReadAccessAllowedPaths(Vector<WTF::String>&& additionalReadAccessAllowedPaths) { m_additionalReadAccessAllowedPaths = additionalReadAccessAllowedPaths; }
 
     bool fullySynchronousModeIsAllowedForTesting() const { return m_fullySynchronousModeIsAllowedForTesting; }
@@ -132,10 +132,10 @@ public:
     void setProcessSwapsOnNavigationWithinSameNonHTTPFamilyProtocol(bool swaps) { m_processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = swaps; }
 
 #if PLATFORM(PLAYSTATION)
-    const WTF::String& webProcessPath() const { return m_webProcessPath; }
+    const WTF::String& webProcessPath() const LIFETIME_BOUND { return m_webProcessPath; }
     void setWebProcessPath(const WTF::String& webProcessPath) { m_webProcessPath = webProcessPath; }
 
-    const WTF::String& networkProcessPath() const { return m_networkProcessPath; }
+    const WTF::String& networkProcessPath() const LIFETIME_BOUND { return m_networkProcessPath; }
     void setNetworkProcessPath(const WTF::String& networkProcessPath) { m_networkProcessPath = networkProcessPath; }
 
     int32_t userId() const { return m_userId; }
@@ -144,20 +144,20 @@ public:
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void setMemoryPressureHandlerConfiguration(const MemoryPressureHandler::Configuration& configuration) { m_memoryPressureHandlerConfiguration = configuration; }
-    const std::optional<MemoryPressureHandler::Configuration>& memoryPressureHandlerConfiguration() const { return m_memoryPressureHandlerConfiguration; }
+    const std::optional<MemoryPressureHandler::Configuration>& memoryPressureHandlerConfiguration() const LIFETIME_BOUND { return m_memoryPressureHandlerConfiguration; }
 
     bool disableFontHintingForTesting() const { return m_disableFontHintingForTesting; }
     void setDisableFontHintingForTesting(bool override) { m_disableFontHintingForTesting = override; }
 #endif
 
     void setTimeZoneOverride(const WTF::String& timeZoneOverride) { m_timeZoneOverride = timeZoneOverride; }
-    const WTF::String& timeZoneOverride() const { return m_timeZoneOverride; }
+    const WTF::String& timeZoneOverride() const LIFETIME_BOUND { return m_timeZoneOverride; }
 
     void setMemoryFootprintPollIntervalForTesting(Seconds interval) { m_memoryFootprintPollIntervalForTesting = interval; }
     Seconds memoryFootprintPollIntervalForTesting() const { return m_memoryFootprintPollIntervalForTesting; }
 
     void setMemoryFootprintNotificationThresholds(Vector<uint64_t>&& thresholds) { m_memoryFootprintNotificationThresholds = WTF::move(thresholds); }
-    const Vector<uint64_t>& memoryFootprintNotificationThresholds() const { return m_memoryFootprintNotificationThresholds; }
+    const Vector<uint64_t>& memoryFootprintNotificationThresholds() const LIFETIME_BOUND { return m_memoryFootprintNotificationThresholds; }
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     void setSuspendsWebProcessesAggressivelyOnMemoryPressure(bool enabled) { m_suspendsWebProcessesAggressivelyOnMemoryPressure = enabled; }

--- a/Source/WebKit/UIProcess/API/APIResourceLoadInfo.h
+++ b/Source/WebKit/UIProcess/API/APIResourceLoadInfo.h
@@ -44,8 +44,8 @@ public:
     std::optional<WebCore::FrameIdentifier> frameID() const { return m_info.frameID; }
     std::optional<WebCore::FrameIdentifier> parentFrameID() const { return m_info.parentFrameID; }
     Markable<WTF::UUID> documentID() const { return m_info.documentID; }
-    const WTF::URL& originalURL() const { return m_info.originalURL; }
-    const WTF::String& originalHTTPMethod() const { return m_info.originalHTTPMethod; }
+    const WTF::URL& originalURL() const LIFETIME_BOUND { return m_info.originalURL; }
+    const WTF::String& originalHTTPMethod() const LIFETIME_BOUND { return m_info.originalHTTPMethod; }
     WallTime eventTimestamp() const { return m_info.eventTimestamp; }
     bool loadedFromCache() const { return m_info.loadedFromCache; }
     WebKit::ResourceLoadInfo::Type resourceLoadType() const { return m_info.type; }

--- a/Source/WebKit/UIProcess/API/APIResourceLoadStatisticsFirstParty.h
+++ b/Source/WebKit/UIProcess/API/APIResourceLoadStatisticsFirstParty.h
@@ -45,7 +45,7 @@ public:
         RELEASE_ASSERT(RunLoop::isMain());
     }
 
-    const WTF::String& firstPartyDomain() const { return m_firstPartyData.firstPartyDomain.string(); }
+    const WTF::String& firstPartyDomain() const LIFETIME_BOUND { return m_firstPartyData.firstPartyDomain.string(); }
     bool storageAccess() const { return m_firstPartyData.storageAccessGranted; }
     double timeLastUpdated() const { return m_firstPartyData.timeLastUpdated.value(); }
 

--- a/Source/WebKit/UIProcess/API/APIResourceLoadStatisticsThirdParty.h
+++ b/Source/WebKit/UIProcess/API/APIResourceLoadStatisticsThirdParty.h
@@ -45,8 +45,8 @@ public:
         RELEASE_ASSERT(RunLoop::isMain());
     }
 
-    const WTF::String& thirdPartyDomain() const { return m_thirdPartyData.thirdPartyDomain.string(); }
-    const Vector<WebKit::ITPThirdPartyDataForSpecificFirstParty>& underFirstParties() const { return m_thirdPartyData.underFirstParties; }
+    const WTF::String& thirdPartyDomain() const LIFETIME_BOUND { return m_thirdPartyData.thirdPartyDomain.string(); }
+    const Vector<WebKit::ITPThirdPartyDataForSpecificFirstParty>& underFirstParties() const LIFETIME_BOUND { return m_thirdPartyData.underFirstParties; }
 
 private:
     explicit ResourceLoadStatisticsThirdParty(WebKit::ITPThirdPartyData&& thirdPartyData)

--- a/Source/WebKit/UIProcess/API/APIScriptMessage.h
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.h
@@ -50,13 +50,13 @@ public:
     virtual ~ScriptMessage();
 
 #if PLATFORM(COCOA)
-    const RetainPtr<id>& body() const { return m_body; }
+    const RetainPtr<id>& body() const LIFETIME_BOUND { return m_body; }
     NSString *cocoaName() const { return m_cocoaName.get(); }
 #endif
     API::Object* apiBody() const { return m_apiBody.get(); }
     WebKit::WebPageProxy* NODELETE page() const;
     API::FrameInfo& frame() const { return m_frame.get(); }
-    const WTF::String& name() const { return m_name; }
+    const WTF::String& name() const LIFETIME_BOUND { return m_name; }
     API::ContentWorld& world() const { return m_world.get(); }
 
 private:

--- a/Source/WebKit/UIProcess/API/APISerializedNode.h
+++ b/Source/WebKit/UIProcess/API/APISerializedNode.h
@@ -35,7 +35,7 @@ public:
     static Ref<SerializedNode> create(WebCore::SerializedNode&& serializedNode) { return adoptRef(*new SerializedNode(WTF::move(serializedNode))); }
     virtual ~SerializedNode();
 
-    const WebCore::SerializedNode& coreSerializedNode() const { return m_serializedNode; }
+    const WebCore::SerializedNode& coreSerializedNode() const LIFETIME_BOUND { return m_serializedNode; }
 
 private:
     SerializedNode(WebCore::SerializedNode&&);

--- a/Source/WebKit/UIProcess/API/APISessionState.h
+++ b/Source/WebKit/UIProcess/API/APISessionState.h
@@ -36,7 +36,7 @@ public:
     static Ref<SessionState> create(WebKit::SessionState);
     virtual ~SessionState();
 
-    const WebKit::SessionState& sessionState() const { return m_sessionState; }
+    const WebKit::SessionState& sessionState() const LIFETIME_BOUND { return m_sessionState; }
 
 private:
     explicit SessionState(WebKit::SessionState);

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -54,10 +54,10 @@ public:
 
     WebCore::RectEdges<bool> offsetEdges() const { return m_info.offsetEdges; }
 
-    const WTF::String& renderedText() const { return m_info.renderedText; }
-    const WTF::String& searchableText() const { return m_info.searchableText; }
-    const WTF::String& screenReaderText() const { return m_info.screenReaderText; }
-    const Vector<Vector<WTF::String>>& selectors() const { return m_info.selectors; }
+    const WTF::String& renderedText() const LIFETIME_BOUND { return m_info.renderedText; }
+    const WTF::String& searchableText() const LIFETIME_BOUND { return m_info.searchableText; }
+    const WTF::String& screenReaderText() const LIFETIME_BOUND { return m_info.screenReaderText; }
+    const Vector<Vector<WTF::String>>& selectors() const LIFETIME_BOUND { return m_info.selectors; }
     WebCore::PositionType positionType() const { return m_info.positionType; }
     WebCore::FloatRect boundsInRootView() const { return m_info.boundsInRootView; }
     WebCore::FloatRect boundsInWebView() const;
@@ -70,7 +70,7 @@ public:
     bool hasLargeReplacedDescendant() const { return m_info.hasLargeReplacedDescendant; }
     bool hasAudibleMedia() const { return m_info.hasAudibleMedia; }
 
-    const HashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }
+    const HashSet<WTF::URL>& mediaAndLinkURLs() const LIFETIME_BOUND { return m_info.mediaAndLinkURLs; }
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 

--- a/Source/WebKit/UIProcess/API/APITextRun.h
+++ b/Source/WebKit/UIProcess/API/APITextRun.h
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new TextRun(page, WTF::move(string), WTF::move(rect)));
     }
 
-    const WTF::String& string() const { return m_string; }
+    const WTF::String& string() const LIFETIME_BOUND { return m_string; }
     WebCore::FloatRect rectInWebView() const;
 
 private:

--- a/Source/WebKit/UIProcess/API/APIUserScript.h
+++ b/Source/WebKit/UIProcess/API/APIUserScript.h
@@ -42,8 +42,8 @@ public:
 
     UserScript(WebCore::UserScript, API::ContentWorld&);
 
-    WebCore::UserScript& userScript() { return m_userScript; }
-    const WebCore::UserScript& userScript() const { return m_userScript; }
+    WebCore::UserScript& userScript() LIFETIME_BOUND { return m_userScript; }
+    const WebCore::UserScript& userScript() const LIFETIME_BOUND { return m_userScript; }
 
     ContentWorld& contentWorld() { return m_world; }
     const ContentWorld& contentWorld() const { return m_world; }

--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
@@ -42,7 +42,7 @@ public:
 
     UserStyleSheet(WebCore::UserStyleSheet, API::ContentWorld&);
 
-    const WebCore::UserStyleSheet& userStyleSheet() const { return m_userStyleSheet; }
+    const WebCore::UserStyleSheet& userStyleSheet() const LIFETIME_BOUND { return m_userStyleSheet; }
 
     ContentWorld& contentWorld() { return m_world; }
     const ContentWorld& contentWorld() const { return m_world; }

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -39,13 +39,13 @@ public:
     static Ref<WebAuthenticationAssertionResponse> create(Ref<WebCore::AuthenticatorAssertionResponse>&&);
     ~WebAuthenticationAssertionResponse();
 
-    const WTF::String& name() const { return m_response->name(); }
-    const WTF::String& displayName() const { return m_response->displayName(); }
+    const WTF::String& name() const LIFETIME_BOUND { return m_response->name(); }
+    const WTF::String& displayName() const LIFETIME_BOUND { return m_response->displayName(); }
     RefPtr<Data> userHandle() const;
     bool synchronizable() const { return m_response->synchronizable(); }
-    const WTF::String& group() const { return m_response->group(); }
+    const WTF::String& group() const LIFETIME_BOUND { return m_response->group(); }
     RefPtr<Data> credentialID() const;
-    const WTF::String& accessGroup() const { return m_response->accessGroup(); }
+    const WTF::String& accessGroup() const LIFETIME_BOUND { return m_response->accessGroup(); }
 
     void setLAContext(LAContext *context) { m_response->setLAContext(context); }
 

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
@@ -71,7 +71,7 @@ public:
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;
     static Ref<WebAuthenticationPanel> create(const WebKit::AuthenticatorManager&, const WTF::String& rpId, const TransportSet&, WebCore::ClientDataType, const WTF::String& userName);
     WTF::String rpId() const { return m_rpId; }
-    const Vector<WebCore::AuthenticatorTransport>& transports() const { return m_transports; }
+    const Vector<WebCore::AuthenticatorTransport>& transports() const LIFETIME_BOUND { return m_transports; }
     WebCore::ClientDataType clientDataType() const { return m_clientDataType; }
     WTF::String userName() const { return m_userName; }
 

--- a/Source/WebKit/UIProcess/API/APIWebsiteDataRecord.h
+++ b/Source/WebKit/UIProcess/API/APIWebsiteDataRecord.h
@@ -36,7 +36,7 @@ public:
     static Ref<WebsiteDataRecord> create(WebKit::WebsiteDataRecord&&);
     virtual ~WebsiteDataRecord();
 
-    const WebKit::WebsiteDataRecord& websiteDataRecord() const { return m_websiteDataRecord; }
+    const WebKit::WebsiteDataRecord& websiteDataRecord() const LIFETIME_BOUND { return m_websiteDataRecord; }
 
 private:
     explicit WebsiteDataRecord(WebKit::WebsiteDataRecord&&);

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -50,11 +50,11 @@ public:
 
     WebKit::WebsitePoliciesData dataForProcess(WebKit::WebProcessProxy&) const;
 
-    const WebCore::ContentExtensionEnablement& contentExtensionEnablement() const { return m_data.contentExtensionEnablement; }
+    const WebCore::ContentExtensionEnablement& contentExtensionEnablement() const LIFETIME_BOUND { return m_data.contentExtensionEnablement; }
     void setContentExtensionEnablement(WebCore::ContentExtensionEnablement&& enablement) { m_data.contentExtensionEnablement = WTF::move(enablement); }
 
     void setActiveContentRuleListActionPatterns(HashMap<WTF::String, Vector<WTF::String>>&& patterns) { m_data.activeContentRuleListActionPatterns = WTF::move(patterns); }
-    const HashMap<WTF::String, Vector<WTF::String>>& activeContentRuleListActionPatterns() const { return m_data.activeContentRuleListActionPatterns; }
+    const HashMap<WTF::String, Vector<WTF::String>>& activeContentRuleListActionPatterns() const LIFETIME_BOUND { return m_data.activeContentRuleListActionPatterns; }
     
     OptionSet<WebKit::WebsiteAutoplayQuirk> allowedAutoplayQuirks() const { return m_data.allowedAutoplayQuirks; }
     void setAllowedAutoplayQuirks(OptionSet<WebKit::WebsiteAutoplayQuirk> quirks) { m_data.allowedAutoplayQuirks = quirks; }
@@ -67,7 +67,7 @@ public:
     void setDeviceOrientationAndMotionAccessState(WebCore::DeviceOrientationOrMotionPermissionState state) { m_data.deviceOrientationAndMotionAccessState = state; }
 #endif
 
-    const Vector<WebCore::CustomHeaderFields>& customHeaderFields() const { return m_data.customHeaderFields; }
+    const Vector<WebCore::CustomHeaderFields>& customHeaderFields() const LIFETIME_BOUND { return m_data.customHeaderFields; }
     void setCustomHeaderFields(Vector<WebCore::CustomHeaderFields>&& fields) { m_data.customHeaderFields = WTF::move(fields); }
 
     WebKit::WebsitePopUpPolicy popUpPolicy() const { return m_data.popUpPolicy; }
@@ -80,13 +80,13 @@ public:
     void setUserContentController(RefPtr<WebKit::WebUserContentControllerProxy>&&);
 
     void setCustomUserAgent(WTF::String&& customUserAgent) { m_data.customUserAgent = WTF::move(customUserAgent); }
-    const WTF::String& customUserAgent() const { return m_data.customUserAgent; }
+    const WTF::String& customUserAgent() const LIFETIME_BOUND { return m_data.customUserAgent; }
 
     void setCustomUserAgentAsSiteSpecificQuirks(WTF::String&& customUserAgent) { m_data.customUserAgentAsSiteSpecificQuirks = WTF::move(customUserAgent); }
-    const WTF::String& customUserAgentAsSiteSpecificQuirks() const { return m_data.customUserAgentAsSiteSpecificQuirks; }
+    const WTF::String& customUserAgentAsSiteSpecificQuirks() const LIFETIME_BOUND { return m_data.customUserAgentAsSiteSpecificQuirks; }
 
     void setCustomNavigatorPlatform(WTF::String&& customNavigatorPlatform) { m_data.customNavigatorPlatform = WTF::move(customNavigatorPlatform); }
-    const WTF::String& customNavigatorPlatform() const { return m_data.customNavigatorPlatform; }
+    const WTF::String& customNavigatorPlatform() const LIFETIME_BOUND { return m_data.customNavigatorPlatform; }
 
     WebKit::WebContentMode preferredContentMode() const { return m_data.preferredContentMode; }
     void setPreferredContentMode(WebKit::WebContentMode mode) { m_data.preferredContentMode = mode; }
@@ -143,7 +143,7 @@ public:
     bool isUpgradeWithUserMediatedFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSOnly) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback; }
     bool isUpgradeWithAutomaticFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSFirst) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback; }
 
-    const Vector<Vector<HashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
+    const Vector<Vector<HashSet<WTF::String>>>& visibilityAdjustmentSelectors() const LIFETIME_BOUND { return m_data.visibilityAdjustmentSelectors; }
     void setVisibilityAdjustmentSelectors(Vector<Vector<HashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTF::move(selectors); }
 
     WebKit::WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy() const { return m_data.pushAndNotificationsEnabledPolicy; }
@@ -159,14 +159,14 @@ public:
     bool allowSharedProcess() const { return m_data.allowSharedProcess; }
     void setAllowSharedProcess(bool allowSharedProcess) { m_data.allowSharedProcess = allowSharedProcess; }
 
-    const WebCore::ResourceRequest& NODELETE alternateRequest() const;
+    const WebCore::ResourceRequest& NODELETE alternateRequest() const LIFETIME_BOUND;
     void setAlternateRequest(WebCore::ResourceRequest&&);
 
     bool allowsJSHandleCreationInPageWorld() const { return m_data.allowsJSHandleCreationInPageWorld; }
     void setAllowsJSHandleCreationInPageWorld(bool allows) { m_data.allowsJSHandleCreationInPageWorld = allows; }
 
     void setOverrideReferrerForAllRequests(WTF::String&& referrer) { m_data.overrideReferrerForAllRequests = WTF::move(referrer); }
-    const WTF::String& overrideReferrerForAllRequests() const { return m_data.overrideReferrerForAllRequests; }
+    const WTF::String& overrideReferrerForAllRequests() const LIFETIME_BOUND { return m_data.overrideReferrerForAllRequests; }
 
 private:
     WebKit::WebsitePoliciesData m_data;

--- a/Source/WebKit/UIProcess/API/APIWindowFeatures.h
+++ b/Source/WebKit/UIProcess/API/APIWindowFeatures.h
@@ -36,7 +36,7 @@ public:
     static Ref<WindowFeatures> create(const WebCore::WindowFeatures&);
     virtual ~WindowFeatures();
 
-    const WebCore::WindowFeatures& windowFeatures() const { return m_windowFeatures; }
+    const WebCore::WindowFeatures& windowFeatures() const LIFETIME_BOUND { return m_windowFeatures; }
 
 private:
     explicit WindowFeatures(const WebCore::WindowFeatures&);

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2842,7 +2842,8 @@ void WKPageForceRepaint(WKPageRef pageRef, void* context, WKPageForceRepaintFunc
 
 WK_EXPORT WKURLRef WKPageCopyPendingAPIRequestURL(WKPageRef pageRef)
 {
-    const String& pendingAPIRequestURL = protect(toImpl(pageRef))->pageLoadState().pendingAPIRequestURL();
+    RefPtr page = toImpl(pageRef);
+    const String& pendingAPIRequestURL = page->pageLoadState().pendingAPIRequestURL();
 
     if (pendingAPIRequestURL.isNull())
         return nullptr;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -94,7 +94,8 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 
 - (NSString *)activationKey
 {
-    if (auto& activationKey = protect(*_webExtensionCommand)->activationKey(); !activationKey.isEmpty())
+    Ref command = *_webExtensionCommand;
+    if (auto& activationKey = command->activationKey(); !activationKey.isEmpty())
         return activationKey.createNSString().autorelease();
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListAction.mm
@@ -89,7 +89,8 @@
 - (NSArray<NSString *> *)notifications
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    auto& vector = protect(*_action)->notifications();
+    Ref action = *_action;
+    auto& vector = action->notifications();
     if (vector.isEmpty())
         return nil;
     return createNSArray(vector).autorelease();

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
@@ -61,7 +61,7 @@ public:
     WebProtectionSpace* protectionSpace() const;
 
     AuthenticationDecisionListener& listener() const { return m_listener.get(); }
-    const WebCore::AuthenticationChallenge& core() { return m_coreAuthenticationChallenge; }
+    const WebCore::AuthenticationChallenge& core() LIFETIME_BOUND { return m_coreAuthenticationChallenge; }
 
 private:
     AuthenticationChallengeProxy(WebCore::AuthenticationChallenge&&, AuthenticationChallengeIdentifier, Ref<IPC::Connection>&&, WeakPtrSecKeyProxyStore&&);

--- a/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h
+++ b/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h
@@ -38,16 +38,16 @@ public:
         return adoptRef(*new WebProtectionSpace(protectionSpace));
     }
     
-    const String& protocol() const;
-    const String& NODELETE host() const;
+    const String& protocol() const LIFETIME_BOUND;
+    const String& NODELETE host() const LIFETIME_BOUND;
     int NODELETE port() const;
-    const String& NODELETE realm() const;
+    const String& NODELETE realm() const LIFETIME_BOUND;
     bool isProxy() const;
     WebCore::ProtectionSpace::ServerType NODELETE serverType() const;
     bool receivesCredentialSecurely() const;
     WebCore::ProtectionSpace::AuthenticationScheme NODELETE authenticationScheme() const;
 
-    const WebCore::ProtectionSpace& protectionSpace() const { return m_coreProtectionSpace; }
+    const WebCore::ProtectionSpace& protectionSpace() const LIFETIME_BOUND { return m_coreProtectionSpace; }
 
 private:
     explicit WebProtectionSpace(const WebCore::ProtectionSpace&);

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -227,7 +227,8 @@ void BidiBrowsingContextAgent::getTree(const BrowsingContext& optionalRoot, std:
 
     Vector<Ref<WebPageProxy>> pagesToProcess;
 
-    for (Ref process : protect(session->processPool())->processes()) {
+    RefPtr processPool = session->processPool();
+    for (Ref process : processPool->processes()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;

--- a/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
@@ -56,7 +56,8 @@ BidiPermissionsAgent::~BidiPermissionsAgent() = default;
 static Vector<Ref<WebPageProxy>> allPageProxiesFor(const WebAutomationSession& session)
 {
     Vector<Ref<WebPageProxy>> pages;
-    for (Ref process : protect(session.processPool())->processes()) {
+    RefPtr processPool = session.processPool();
+    for (Ref process : processPool->processes()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -415,7 +415,8 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
         pagesToProcess.append(*resolvedPageForContext);
     else {
         // Enumerate all controlled pages; filtering by context happens during collection.
-        for (Ref process : protect(session->processPool())->processes()) {
+        RefPtr processPool = session->processPool();
+        for (Ref process : processPool->processes()) {
             for (Ref page : process->pages()) {
                 if (page->isControlledByAutomation())
                     pagesToProcess.append(page);
@@ -615,7 +616,8 @@ std::optional<String> BidiScriptAgent::contextHandleForFrame(const FrameInfoData
         return std::nullopt;
 
     if (frameInfo.webPageProxyID) {
-        for (Ref process : protect(session->processPool())->processes()) {
+        RefPtr processPool = session->processPool();
+        for (Ref process : processPool->processes()) {
             for (Ref page : process->pages()) {
                 if (page->identifier() == *frameInfo.webPageProxyID)
                     return session->handleForWebPageProxy(page);

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -53,7 +53,7 @@ public:
     void processBidiMessage(const String&);
     void sendBidiMessage(const String&);
 
-    BidiBrowserAgent& browserAgent() const { return m_browserAgent; }
+    BidiBrowserAgent& browserAgent() const LIFETIME_BOUND { return m_browserAgent; }
 
     // Inspector::FrontendChannel methods. Domain events sent via WebDriverBidi domain notifiers are packaged up
     // by FrontendRouter and are then sent back out-of-process via WebAutomationSession::sendBidiMessage().
@@ -61,8 +61,8 @@ public:
     void sendMessageToFrontend(const String&) override;
 
     // Event entry points called from the owning WebAutomationSession.
-    Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const { return m_browsingContextDomainNotifier; }
-    Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const { return m_logDomainNotifier; }
+    Inspector::BidiBrowsingContextFrontendDispatcher& browsingContextDomainNotifier() const LIFETIME_BOUND { return m_browsingContextDomainNotifier; }
+    Inspector::BidiLogFrontendDispatcher& logDomainNotifier() const LIFETIME_BOUND { return m_logDomainNotifier; }
 
 private:
     WeakPtr<WebAutomationSession> m_session;

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -225,7 +225,7 @@ public:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    ExtensionCapabilityGrantMap& extensionCapabilityGrants() { return m_extensionCapabilityGrants; }
+    ExtensionCapabilityGrantMap& extensionCapabilityGrants() LIFETIME_BOUND { return m_extensionCapabilityGrants; }
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/BackingStore.h
+++ b/Source/WebKit/UIProcess/BackingStore.h
@@ -63,7 +63,7 @@ public:
     BackingStore(const WebCore::IntSize&, float deviceScaleFactor);
     ~BackingStore();
 
-    const WebCore::IntSize& size() const { return m_size; }
+    const WebCore::IntSize& size() const LIFETIME_BOUND { return m_size; }
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
 
     void paint(PlatformPaintContextPtr, const WebCore::IntRect&);

--- a/Source/WebKit/UIProcess/BrowsingWarning.h
+++ b/Source/WebKit/UIProcess/BrowsingWarning.h
@@ -61,14 +61,14 @@ public:
     }
 #endif
 
-    const URL& url() const { return m_url; }
-    const String& title() const { return m_title; }
-    const String& warning() const { return m_warning; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
+    const String& title() const LIFETIME_BOUND { return m_title; }
+    const String& warning() const LIFETIME_BOUND { return m_warning; }
     bool forMainFrameNavigation() const { return m_forMainFrameNavigation; }
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> details() const { return m_details; }
 #endif
-    const Data& data() const { return m_data; }
+    const Data& data() const LIFETIME_BOUND { return m_data; }
 
     static RetainPtr<NSURL> visitUnsafeWebsiteSentinel();
     static RetainPtr<NSURL> confirmMalwareSentinel();

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -105,7 +105,7 @@ public:
     void immersiveVideoMetadataChanged(const std::optional<WebCore::ImmersiveVideoMetadata>&);
 
     bool wirelessVideoPlaybackDisabled() const final { return m_wirelessVideoPlaybackDisabled; }
-    const WebCore::VideoReceiverEndpoint& videoReceiverEndpoint() { return m_videoReceiverEndpoint; }
+    const WebCore::VideoReceiverEndpoint& videoReceiverEndpoint() LIFETIME_BOUND { return m_videoReceiverEndpoint; }
 
     void invalidate();
 
@@ -146,7 +146,7 @@ private:
     void setPlayingOnSecondScreen(bool) final;
     void sendRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&) final;
     void NODELETE setVideoReceiverEndpoint(const WebCore::VideoReceiverEndpoint&) final;
-    const WebCore::VideoReceiverEndpoint& videoReceiverEndpoint() const { return m_videoReceiverEndpoint; }
+    const WebCore::VideoReceiverEndpoint& videoReceiverEndpoint() const LIFETIME_BOUND { return m_videoReceiverEndpoint; }
     const std::optional<WebCore::VideoReceiverEndpointIdentifier>& videoReceiverEndpointIdentifier() const { return m_videoReceiverEndpointIdentifier; }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -59,7 +59,7 @@ public:
 #endif
 
     bool isInAcceleratedCompositingMode() const { return !m_layerTreeContext.isEmpty(); }
-    const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
+    const LayerTreeContext& layerTreeContext() const LIFETIME_BOUND { return m_layerTreeContext; }
 
     void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&);
 

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -84,7 +84,7 @@ public:
     void setObserverPreferredFramesPerSecond(Client&, DisplayLinkObserverID, WebCore::FramesPerSecond);
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    DisplayVBlankMonitor& vblankMonitor() const { return *m_vblankMonitor; }
+    DisplayVBlankMonitor& vblankMonitor() const LIFETIME_BOUND { return *m_vblankMonitor; }
 #endif
 
 private:
@@ -133,8 +133,8 @@ private:
 
 class DisplayLinkCollection {
 public:
-    DisplayLink& displayLinkForDisplay(WebCore::PlatformDisplayID);
-    DisplayLink* NODELETE existingDisplayLinkForDisplay(WebCore::PlatformDisplayID) const;
+    DisplayLink& displayLinkForDisplay(WebCore::PlatformDisplayID) LIFETIME_BOUND;
+    DisplayLink* NODELETE existingDisplayLinkForDisplay(WebCore::PlatformDisplayID) const LIFETIME_BOUND;
 
     std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
     void startDisplayLink(DisplayLink::Client&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond preferredFramesPerSecond);

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -77,7 +77,7 @@ public:
     void deref() const final { API::ObjectImpl<API::Object::Type::Download>::deref(); }
 
     DownloadID downloadID() const { return m_downloadID; }
-    const WebCore::ResourceRequest& request() const { return m_request; }
+    const WebCore::ResourceRequest& request() const LIFETIME_BOUND { return m_request; }
     API::Data* legacyResumeData() const { return m_legacyResumeData.get(); }
 
     void cancel(CompletionHandler<void(API::Data*)>&&);
@@ -91,12 +91,12 @@ public:
     WebPageProxy* NODELETE originatingPage() const;
 
     void setRedirectChain(Vector<URL>&& redirectChain) { m_redirectChain = WTF::move(redirectChain); }
-    const Vector<URL>& redirectChain() const { return m_redirectChain; }
+    const Vector<URL>& redirectChain() const LIFETIME_BOUND { return m_redirectChain; }
 
     void setWasUserInitiated(bool value) { m_wasUserInitiated = value; }
     bool wasUserInitiated() const { return m_wasUserInitiated; }
 
-    const String& destinationFilename() const { return m_destinationFilename; }
+    const String& destinationFilename() const LIFETIME_BOUND { return m_destinationFilename; }
     void setDestinationFilename(const String& d) { m_destinationFilename = d; }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -94,7 +94,7 @@ public:
     // FIXME: These should be pure virtual.
     virtual void setBackingStoreIsDiscardable(bool) { }
 
-    const WebCore::IntSize& size() const { return m_size; }
+    const WebCore::IntSize& size() const LIFETIME_BOUND { return m_size; }
     bool setSize(const WebCore::IntSize&, const WebCore::IntSize& scrollOffset = { });
 
     virtual void minimumSizeForAutoLayoutDidChange() { }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
@@ -58,9 +58,9 @@ public:
         schedule();
     }
 
-    const WebExtensionAlarmParameters& parameters() const { return m_parameters; }
+    const WebExtensionAlarmParameters& parameters() const LIFETIME_BOUND { return m_parameters; }
 
-    const String& name() const { return m_parameters.name; }
+    const String& name() const LIFETIME_BOUND { return m_parameters.name; }
     Seconds initialInterval() const { return m_parameters.initialInterval; }
     Seconds repeatInterval() const { return m_parameters.repeatInterval; }
     MonotonicTime nextScheduledTime() const { return m_parameters.nextScheduledTime; }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -86,10 +86,10 @@ public:
 
     bool isActionCommand() const;
 
-    const String& identifier() const { return m_identifier; }
-    const String& description() const { return m_description; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const String& description() const LIFETIME_BOUND { return m_description; }
 
-    const String& activationKey() const { return m_modifierFlags ? m_activationKey : nullString(); }
+    const String& activationKey() const LIFETIME_BOUND { return m_modifierFlags ? m_activationKey : nullString(); }
     bool setActivationKey(String, SuppressEvents = SuppressEvents::No);
 
     OptionSet<ModifierFlags> modifierFlags() const { return !m_activationKey.isEmpty() ? m_modifierFlags : OptionSet<ModifierFlags> { }; }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -339,7 +339,7 @@ public:
     Vector<Ref<API::Error>> errors();
 
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
-    const String& storageDirectory() const { return m_storageDirectory; }
+    const String& storageDirectory() const LIFETIME_BOUND { return m_storageDirectory; }
 
     void invalidateStorage();
 
@@ -354,14 +354,14 @@ public:
     WebExtension& extension() const { return *m_extension; }
     WebExtensionController* extensionController() const { return m_extensionController.get(); }
 
-    const URL& baseURL() const { return m_baseURL; }
+    const URL& baseURL() const LIFETIME_BOUND { return m_baseURL; }
     void setBaseURL(URL&&);
 
     bool isURLForThisExtension(const URL&) const;
 
     bool hasCustomUniqueIdentifier() const { return m_customUniqueIdentifier; }
 
-    const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
+    const String& uniqueIdentifier() const LIFETIME_BOUND { return m_uniqueIdentifier; }
     void setUniqueIdentifier(String&&);
 
     RefPtr<WebExtensionLocalization> localization();
@@ -385,16 +385,16 @@ public:
     URL optionsPageURL() const;
     URL overrideNewTabPageURL() const;
 
-    const PermissionsMap& grantedPermissions();
+    const PermissionsMap& grantedPermissions() LIFETIME_BOUND;
     void setGrantedPermissions(PermissionsMap&&);
 
-    const PermissionsMap& deniedPermissions();
+    const PermissionsMap& deniedPermissions() LIFETIME_BOUND;
     void setDeniedPermissions(PermissionsMap&&);
 
-    const PermissionMatchPatternsMap& grantedPermissionMatchPatterns();
+    const PermissionMatchPatternsMap& grantedPermissionMatchPatterns() LIFETIME_BOUND;
     void setGrantedPermissionMatchPatterns(PermissionMatchPatternsMap&&, EqualityOnly = EqualityOnly::Yes);
 
-    const PermissionMatchPatternsMap& deniedPermissionMatchPatterns();
+    const PermissionMatchPatternsMap& deniedPermissionMatchPatterns() LIFETIME_BOUND;
     void setDeniedPermissionMatchPatterns(PermissionMatchPatternsMap&&, EqualityOnly = EqualityOnly::Yes);
 
     bool requestedOptionalAccessToAllHosts() const { return m_requestedOptionalAccessToAllHosts; }
@@ -541,7 +541,7 @@ public:
 
     NSArray *platformMenuItems(const WebExtensionTab&) const;
 
-    const MenuItemVector& mainMenuItems() const { return m_mainMenuItems; }
+    const MenuItemVector& mainMenuItems() const LIFETIME_BOUND { return m_mainMenuItems; }
     WebExtensionMenuItem* menuItem(const String& identifier) const;
     void performMenuItem(WebExtensionMenuItem&, const WebExtensionMenuItemContextParameters&, UserTriggered = UserTriggered::No);
 
@@ -602,7 +602,7 @@ public:
     // Returns whether or not there are any matched rules after the purge.
     bool purgeMatchedRulesFromBefore(const WallTime&);
 
-    UserStyleSheetVector& dynamicallyInjectedUserStyleSheets() { return m_dynamicallyInjectedUserStyleSheets; };
+    UserStyleSheetVector& dynamicallyInjectedUserStyleSheets() LIFETIME_BOUND { return m_dynamicallyInjectedUserStyleSheets; };
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier() const;
 #if ENABLE(INSPECTOR_EXTENSIONS)
@@ -644,7 +644,7 @@ public:
 
     HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet&&, ContentWorldTypeSet&&, Function<bool(WebProcessProxy&, WebPageProxy&, WebFrameProxy&)>&& predicate = nullptr) const;
 
-    const UserContentControllerProxySet& NODELETE userContentControllers() const;
+    const UserContentControllerProxySet& NODELETE userContentControllers() const LIFETIME_BOUND;
 
     template<typename T>
     void sendToProcesses(const WebProcessProxySet&, const T& message) const;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -111,7 +111,7 @@ public:
 
     enum class ForPrivateBrowsing { No, Yes };
 
-    WebExtensionControllerConfiguration& configuration() const { return m_configuration.get(); }
+    WebExtensionControllerConfiguration& configuration() const LIFETIME_BOUND { return m_configuration.get(); }
     WebExtensionControllerParameters parameters(const API::PageConfiguration&) const;
 
     bool operator==(const WebExtensionController& other) const { return (this == &other); }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -62,7 +62,7 @@ public:
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     bool storageIsTemporary() const { return m_temporary; }
 
-    const String& storageDirectory() const { return m_storageDirectory; }
+    const String& storageDirectory() const LIFETIME_BOUND { return m_storageDirectory; }
     void setStorageDirectory(const String& directory) { m_storageDirectory = directory; }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -54,8 +54,8 @@ public:
 
     using Type = WebExtensionDataType;
 
-    const String& displayName() const { return m_displayName; }
-    const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
+    const String& displayName() const LIFETIME_BOUND { return m_displayName; }
+    const String& uniqueIdentifier() const LIFETIME_BOUND { return m_uniqueIdentifier; }
 
     OptionSet<Type> types() const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -83,7 +83,7 @@ public:
     void removeUserScriptsAndStyleSheets(const String& identifier);
 
     void updateInjectedContent(InjectedContentData& injectedContent) { m_injectedContent = injectedContent; }
-    const InjectedContentData& injectedContent() const { return m_injectedContent; }
+    const InjectedContentData& injectedContent() const LIFETIME_BOUND { return m_injectedContent; }
 
     WebExtensionRegisteredScriptParameters parameters() const { return m_parameters; };
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -118,7 +118,7 @@ public:
     String string() const { return stringWithScheme(nullString()); }
     Vector<String> expandedStrings() const;
 
-    const WebCore::UserContentURLPattern& pattern() const { return m_pattern; }
+    const WebCore::UserContentURLPattern& pattern() const LIFETIME_BOUND { return m_pattern; }
 
     unsigned hash() const { return m_hash; }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -91,8 +91,8 @@ public:
     void update(const WebExtensionMenuItemParameters&);
 
     WebExtensionMenuItemType type() const { return m_type; }
-    const String& identifier() const { return m_identifier; }
-    const String& title() const { return m_title; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const String& title() const LIFETIME_BOUND { return m_title; }
 
     WebExtensionCommand* command() const { return m_command.get(); }
 
@@ -106,12 +106,12 @@ public:
     bool isEnabled() const { return m_enabled; }
     bool isVisible() const { return m_visible; }
 
-    const WebExtension::MatchPatternSet& documentPatterns() const { return m_documentPatterns; }
-    const WebExtension::MatchPatternSet& targetPatterns() const { return m_targetPatterns; }
+    const WebExtension::MatchPatternSet& documentPatterns() const LIFETIME_BOUND { return m_documentPatterns; }
+    const WebExtension::MatchPatternSet& targetPatterns() const LIFETIME_BOUND { return m_targetPatterns; }
     OptionSet<WebExtensionMenuItemContextType> contexts() const { return m_contexts; }
 
     WebExtensionMenuItem* parentMenuItem() const { return m_parentMenuItem.get(); }
-    const MenuItemVector& submenuItems() const { return m_submenuItems; }
+    const MenuItemVector& submenuItems() const LIFETIME_BOUND { return m_submenuItems; }
 
     void addSubmenuItem(WebExtensionMenuItem&);
     void removeSubmenuItem(WebExtensionMenuItem&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -65,7 +65,7 @@ public:
 
     bool operator==(const WebExtensionMessagePort&) const;
 
-    const String& applicationIdentifier() const { return m_applicationIdentifier; }
+    const String& applicationIdentifier() const LIFETIME_BOUND { return m_applicationIdentifier; }
     WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
     WebExtensionContext* extensionContext() const;
 

--- a/Source/WebKit/UIProcess/FrameLoadState.h
+++ b/Source/WebKit/UIProcess/FrameLoadState.h
@@ -76,12 +76,12 @@ public:
     void didSameDocumentNotification(URL&&);
 
     State state() const { return m_state; }
-    const URL& url() const { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     void setURL(URL&&);
-    const URL& provisionalURL() const { return m_provisionalURL; }
+    const URL& provisionalURL() const LIFETIME_BOUND { return m_provisionalURL; }
 
     void setUnreachableURL(const URL&);
-    const URL& unreachableURL() const { return m_unreachableURL; }
+    const URL& unreachableURL() const LIFETIME_BOUND { return m_unreachableURL; }
 
     IsMainFrame isMainFrame() const { return m_isMainFrame; }
 

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -44,11 +44,11 @@ class FrameProcess : public RefCountedAndCanMakeWeakPtr<FrameProcess> {
 public:
     ~FrameProcess();
 
-    const std::optional<WebCore::Site>& site() const { return m_site; }
+    const std::optional<WebCore::Site>& site() const LIFETIME_BOUND { return m_site; }
     const WebProcessProxy& process() const { return m_process.get(); }
     WebProcessProxy& process() { return m_process.get(); }
     bool isSharedProcess() const { return !m_site; }
-    const WebCore::Site& sharedProcessMainFrameSite() const { ASSERT(!m_site); return m_mainFrameSite; }
+    const WebCore::Site& sharedProcessMainFrameSite() const LIFETIME_BOUND { ASSERT(!m_site); return m_mainFrameSite; }
     bool isArchiveProcess() const { return m_isArchiveProcess; }
 
     BrowsingContextGroup* NODELETE browsingContextGroup() const;

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -112,7 +112,7 @@ public:
     NSWindow *window() const { return m_window.get(); }
     WKWebView *webView() const;
 
-    const WebCore::FloatRect& sheetRect() const { return m_sheetRect; }
+    const WebCore::FloatRect& sheetRect() const LIFETIME_BOUND { return m_sheetRect; }
 
     void didBecomeActive();
 #endif

--- a/Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.h
@@ -56,7 +56,7 @@ public:
     void dispatchMessageFromRemote(String&& message) final;
     void setIndicating(bool) final;
 
-    const String& nameOverride() const final { return m_nameOverride; }
+    const String& nameOverride() const LIFETIME_BOUND final { return m_nameOverride; }
     void setNameOverride(const String&);
 
     std::optional<ProcessID> webContentProcessPID() const override;

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -162,7 +162,7 @@ public:
     void attachmentWillMoveFromWindow(NSWindow *oldWindow);
     void attachmentDidMoveToWindow(NSWindow *newWindow);
 
-    const WebCore::FloatRect& sheetRect() const { return m_sheetRect; }
+    const WebCore::FloatRect& sheetRect() const LIFETIME_BOUND { return m_sheetRect; }
 #endif
 
 #if PLATFORM(WIN)

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -54,7 +54,7 @@ public:
     void dispatchMessageFromRemote(String&& message) final;
     void setIndicating(bool) final;
 
-    const String& nameOverride() const final { return m_nameOverride; }
+    const String& nameOverride() const LIFETIME_BOUND final { return m_nameOverride; }
     void setNameOverride(const String&);
 
     void detachFromPage();

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
@@ -55,8 +55,8 @@ public:
     RemoteInspectorClient(String&& hostAndPort, RemoteInspectorObserver&);
     ~RemoteInspectorClient();
 
-    const String& hostAndPort() const { return m_hostAndPort; }
-    const String& backendCommandsURL() const { return m_backendCommandsURL; }
+    const String& hostAndPort() const LIFETIME_BOUND { return m_hostAndPort; }
+    const String& backendCommandsURL() const LIFETIME_BOUND { return m_backendCommandsURL; }
 
     enum class InspectorType { UI, HTTP };
     GString* buildTargetListPage(InspectorType) const;

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.h
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.h
@@ -39,7 +39,7 @@ public:
 
     bool start(GRefPtr<GSocketAddress>&&, unsigned inspectorPort);
     bool isRunning() const { return !!m_server; }
-    const String& inspectorServerAddress() const;
+    const String& inspectorServerAddress() const LIFETIME_BOUND;
 
     void sendMessageToFrontend(uint64_t connectionID, uint64_t targetID, const String& message) const;
     void targetDidClose(uint64_t connectionID, uint64_t targetID);

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h
@@ -70,8 +70,8 @@ public:
         String url;
     };
 
-    const HashMap<ConnectionID, Vector<Target>>& targets() const { return m_targets; }
-    const String& backendCommandsURL() const { return m_backendCommandsURL; }
+    const HashMap<ConnectionID, Vector<Target>>& targets() const LIFETIME_BOUND { return m_targets; }
+    const String& backendCommandsURL() const LIFETIME_BOUND { return m_backendCommandsURL; }
 
     void inspect(ConnectionID, TargetID, Inspector::DebuggableType);
     void sendMessageToBackend(ConnectionID, TargetID, const String&);

--- a/Source/WebKit/UIProcess/LegacyGlobalSettings.h
+++ b/Source/WebKit/UIProcess/LegacyGlobalSettings.h
@@ -41,21 +41,21 @@ public:
     void setCacheModel(CacheModel);
     CacheModel cacheModel() const { return m_cacheModel; }
 
-    const HashSet<String>& schemesToRegisterAsSecure() { return m_schemesToRegisterAsSecure; }
+    const HashSet<String>& schemesToRegisterAsSecure() LIFETIME_BOUND { return m_schemesToRegisterAsSecure; }
     void registerURLSchemeAsSecure(const String& scheme) { m_schemesToRegisterAsSecure.add(scheme); }
 
-    const HashSet<String>& schemesToRegisterAsBypassingContentSecurityPolicy() { return m_schemesToRegisterAsBypassingContentSecurityPolicy; }
+    const HashSet<String>& schemesToRegisterAsBypassingContentSecurityPolicy() LIFETIME_BOUND { return m_schemesToRegisterAsBypassingContentSecurityPolicy; }
     void registerURLSchemeAsBypassingContentSecurityPolicy(const String& scheme) { m_schemesToRegisterAsBypassingContentSecurityPolicy.add(scheme); }
 
-    const HashSet<String>& schemesToRegisterAsLocal() { return m_schemesToRegisterAsLocal; }
+    const HashSet<String>& schemesToRegisterAsLocal() LIFETIME_BOUND { return m_schemesToRegisterAsLocal; }
     void registerURLSchemeAsLocal(const String& scheme) { m_schemesToRegisterAsLocal.add(scheme); }
 
 #if ENABLE(ALL_LEGACY_REGISTERED_SPECIAL_URL_SCHEMES)
-    const HashSet<String>& schemesToRegisterAsNoAccess() { return m_schemesToRegisterAsNoAccess; }
+    const HashSet<String>& schemesToRegisterAsNoAccess() LIFETIME_BOUND { return m_schemesToRegisterAsNoAccess; }
     void registerURLSchemeAsNoAccess(const String& scheme) { m_schemesToRegisterAsNoAccess.add(scheme); }
 #endif
 
-    const HashSet<String>& hostnamesToRegisterAsLocal() const { return m_hostnamesToRegisterAsLocal; }
+    const HashSet<String>& hostnamesToRegisterAsLocal() const LIFETIME_BOUND { return m_hostnamesToRegisterAsLocal; }
     void registerHostnameAsLocal(const String& hostname) { m_hostnamesToRegisterAsLocal.add(hostname); }
 
 private:

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequest.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequest.h
@@ -44,7 +44,7 @@ public:
         completionHandler(success);
     }
 
-    const String& keySystem() const { return m_keySystem; }
+    const String& keySystem() const LIFETIME_BOUND { return m_keySystem; }
 
 private:
     MediaKeySystemPermissionRequest(const String& keySystem, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h
@@ -63,9 +63,9 @@ public:
     WebCore::SecurityOrigin& topLevelDocumentSecurityOrigin() { return m_topLevelDocumentSecurityOrigin.get(); }
     const WebCore::SecurityOrigin& topLevelDocumentSecurityOrigin() const { return m_topLevelDocumentSecurityOrigin.get(); }
 
-    const String& keySystem() const { return m_keySystem; }
+    const String& keySystem() const LIFETIME_BOUND { return m_keySystem; }
 
-    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
+    const String& mediaKeysHashSalt() const LIFETIME_BOUND { return m_mediaKeysHashSalt; }
     void setMediaKeysHashSalt(String&& salt) { m_mediaKeysHashSalt = WTF::move(salt); }
 
     void doDefaultAction();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -304,7 +304,7 @@ public:
     void updateBundleIdentifier(const String&, CompletionHandler<void()>&&);
     void clearBundleIdentifier(CompletionHandler<void()>&&);
 
-    API::CustomProtocolManagerClient& customProtocolManagerClient() { return m_customProtocolManagerClient.get(); }
+    API::CustomProtocolManagerClient& customProtocolManagerClient() LIFETIME_BOUND { return m_customProtocolManagerClient.get(); }
 
 #if PLATFORM(COCOA)
     bool sendXPCEndpointToProcess(AuxiliaryProcessProxy&);

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -57,17 +57,17 @@ public:
         return adoptRef(*new WebNotification(data, std::nullopt, dataStoreIdentifier, sourceConnection));
     }
 
-    const String& title() const { return m_data.title; }
-    const String& body() const { return m_data.body; }
-    const String& iconURL() const { return m_data.iconURL; }
-    const String& tag() const { return m_data.tag; }
-    const String& lang() const { return m_data.language; }
+    const String& title() const LIFETIME_BOUND { return m_data.title; }
+    const String& body() const LIFETIME_BOUND { return m_data.body; }
+    const String& iconURL() const LIFETIME_BOUND { return m_data.iconURL; }
+    const String& tag() const LIFETIME_BOUND { return m_data.tag; }
+    const String& lang() const LIFETIME_BOUND { return m_data.language; }
     WebCore::NotificationDirection dir() const { return m_data.direction; }
-    const WTF::UUID& coreNotificationID() const { return m_data.notificationID; }
+    const WTF::UUID& coreNotificationID() const LIFETIME_BOUND { return m_data.notificationID; }
     const std::optional<WTF::UUID>& dataStoreIdentifier() const { return m_dataStoreIdentifier; }
     PAL::SessionID sessionID() const { return m_data.sourceSession; }
 
-    const WebCore::NotificationData& data() const { return m_data; }
+    const WebCore::NotificationData& data() const LIFETIME_BOUND { return m_data; }
     bool isPersistentNotification() const { return !m_data.serviceWorkerRegistrationURL.isEmpty(); }
 
     const API::SecurityOrigin* origin() const { return m_origin.get(); }

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -145,10 +145,10 @@ public:
 
     bool hasUncommittedLoad() const { return isLoading(m_uncommittedState); }
 
-    const String& provisionalURL() const { return m_committedState.provisionalURL; }
-    const String& url() const { return m_committedState.url; }
-    const WebCore::SecurityOriginData& origin() const { return m_committedState.origin; }
-    const String& unreachableURL() const { return m_committedState.unreachableURL; }
+    const String& provisionalURL() const LIFETIME_BOUND { return m_committedState.provisionalURL; }
+    const String& url() const LIFETIME_BOUND { return m_committedState.url; }
+    const WebCore::SecurityOriginData& origin() const LIFETIME_BOUND { return m_committedState.origin; }
+    const String& unreachableURL() const LIFETIME_BOUND { return m_committedState.unreachableURL; }
 
     String activeURL() const { return activeURL(m_committedState); }
 
@@ -162,12 +162,12 @@ public:
     double NODELETE estimatedProgress() const;
     bool networkRequestsInProgress() const { return m_committedState.networkRequestsInProgress; }
 
-    const WebCore::CertificateInfo& certificateInfo() const { return m_committedState.certificateInfo; }
+    const WebCore::CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_committedState.certificateInfo; }
 
-    const URL& resourceDirectoryURL() const { return m_committedState.resourceDirectoryURL; }
+    const URL& resourceDirectoryURL() const LIFETIME_BOUND { return m_committedState.resourceDirectoryURL; }
 
-    const String& pendingAPIRequestURL() const { return m_committedState.pendingAPIRequest.url; }
-    const PendingAPIRequest& pendingAPIRequest() const { return m_committedState.pendingAPIRequest; }
+    const String& pendingAPIRequestURL() const LIFETIME_BOUND { return m_committedState.pendingAPIRequest.url; }
+    const PendingAPIRequest& pendingAPIRequest() const LIFETIME_BOUND { return m_committedState.pendingAPIRequest; }
     void setPendingAPIRequest(const Transaction::Token&, PendingAPIRequest&& pendingAPIRequest, const URL& resourceDirectoryPath = { });
     void clearPendingAPIRequest(const Transaction::Token&);
 
@@ -185,7 +185,7 @@ public:
 
     void setUnreachableURL(const Transaction::Token&, const String&);
 
-    const String& NODELETE title() const;
+    const String& NODELETE title() const LIFETIME_BOUND;
     void setTitle(const Transaction::Token&, String&&);
     void setTitleFromBrowsingWarning(const Transaction::Token&, const String&);
 

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -104,7 +104,8 @@ void PerActivityStateCPUUsageSampler::loggingTimerFired()
 
 RefPtr<WebPageProxy> PerActivityStateCPUUsageSampler::pageForLogging() const
 {
-    for (Ref webProcess : Ref { m_processPool.get() }->processes()) {
+    Ref processPool = m_processPool;
+    for (Ref webProcess : processPool->processes()) {
         if (!webProcess->pageCount())
             continue;
         return webProcess->pages()[0].ptr();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h
@@ -43,8 +43,8 @@ public:
 
     const RemoteAnimationTimeline& timeline() const { return m_timeline.get(); }
 
-    const OptionSet<WebCore::AcceleratedEffectProperty>& animatedProperties() const { return m_effect->animatedProperties(); }
-    const Vector<WebCore::AcceleratedEffect::Keyframe>& keyframes() const { return m_effect->keyframes(); }
+    const OptionSet<WebCore::AcceleratedEffectProperty>& animatedProperties() const LIFETIME_BOUND { return m_effect->animatedProperties(); }
+    const Vector<WebCore::AcceleratedEffect::Keyframe>& keyframes() const LIFETIME_BOUND { return m_effect->keyframes(); }
 
     void apply(WebCore::AcceleratedEffectValues&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h
@@ -46,9 +46,9 @@ public:
     bool isMonotonic() const { return !m_duration; }
     bool isProgressBased() const { return !!m_duration; }
 
-    const WebCore::WebAnimationTime& currentTime() const { return m_currentTime; }
-    const std::optional<WebCore::WebAnimationTime>& duration() const { return m_duration; }
-    const TimelineID& identifier() const { return m_identifier; }
+    const WebCore::WebAnimationTime& currentTime() const LIFETIME_BOUND { return m_currentTime; }
+    const std::optional<WebCore::WebAnimationTime>& duration() const LIFETIME_BOUND { return m_duration; }
+    const TimelineID& identifier() const LIFETIME_BOUND { return m_identifier; }
 
     Ref<JSON::Object> toJSONForTesting() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -116,7 +116,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const RemoteLayerTreeHost& remoteLayerTreeHost() const { return *m_remoteLayerTreeHost; }
+    const RemoteLayerTreeHost& remoteLayerTreeHost() const LIFETIME_BOUND { return *m_remoteLayerTreeHost; }
     std::unique_ptr<RemoteLayerTreeHost> detachRemoteLayerTreeHost();
 
     virtual std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -78,7 +78,7 @@ public:
     bool isDebugLayerTreeHost() const { return m_isDebugLayerTreeHost; }
 
     typedef HashMap<WebCore::PlatformLayerIdentifier, RetainPtr<WKAnimationDelegate>> LayerAnimationDelegateMap;
-    LayerAnimationDelegateMap& animationDelegates() { return m_animationDelegates; }
+    LayerAnimationDelegateMap& animationDelegates() LIFETIME_BOUND { return m_animationDelegates; }
 
     void animationDidStart(std::optional<WebCore::PlatformLayerIdentifier>, CAAnimation *, MonotonicTime startTime);
     void animationDidEnd(std::optional<WebCore::PlatformLayerIdentifier>, CAAnimation *);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -99,13 +99,13 @@ public:
 
     WebCore::PlatformLayerIdentifier layerID() const { return m_layerID; }
 
-    const WebCore::EventRegion& eventRegion() const { return m_eventRegion; }
+    const WebCore::EventRegion& eventRegion() const LIFETIME_BOUND { return m_eventRegion; }
     void setEventRegion(const WebCore::EventRegion&);
 
     // Non-ancestor scroller that controls positioning of the layer.
     std::optional<WebCore::PlatformLayerIdentifier> actingScrollContainerID() const { return m_actingScrollContainerID.asOptional(); }
     // Ancestor scrollers that don't affect positioning of the layer.
-    const Vector<WebCore::PlatformLayerIdentifier>& stationaryScrollContainerIDs() const { return m_stationaryScrollContainerIDs; }
+    const Vector<WebCore::PlatformLayerIdentifier>& stationaryScrollContainerIDs() const LIFETIME_BOUND { return m_stationaryScrollContainerIDs; }
 
     void setActingScrollContainerID(std::optional<WebCore::PlatformLayerIdentifier> value) { m_actingScrollContainerID = value; }
     void setStationaryScrollContainerIDs(Vector<WebCore::PlatformLayerIdentifier>&& value) { m_stationaryScrollContainerIDs = WTF::move(value); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -78,9 +78,10 @@ std::optional<ScrollingNodeID> RemoteScrollingCoordinatorProxy::rootScrollingNod
 
 const RemoteLayerTreeHost* RemoteScrollingCoordinatorProxy::layerTreeHost() const
 {
-    RefPtr remoteDrawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(m_webPageProxy->drawingArea());
-    ASSERT(remoteDrawingArea);
-    return remoteDrawingArea ? &remoteDrawingArea->remoteLayerTreeHost() : nullptr;
+    if (auto* remoteDrawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(m_webPageProxy->drawingArea()))
+        return &remoteDrawingArea->remoteLayerTreeHost();
+    ASSERT_NOT_REACHED();
+    return nullptr;
 }
 
 ScrollRequestData RemoteScrollingCoordinatorProxy::commitScrollingTreeState(IPC::Connection& connection, const RemoteScrollingCoordinatorTransaction& transaction, std::optional<LayerHostingContextIdentifier> identifier)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm
@@ -38,11 +38,9 @@ using namespace WebCore;
 
 const EventRegion* eventRegionForLayer(CALayer *layer)
 {
-    RefPtr layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
-    if (!layerTreeNode)
-        return nullptr;
-
-    return &layerTreeNode->eventRegion();
+    if (auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer))
+        return &layerTreeNode->eventRegion();
+    return nullptr;
 }
 
 bool layerEventRegionContainsPoint(CALayer *layer, CGPoint localPoint)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -48,7 +48,7 @@ public:
 private:
     ScrollingTreeFrameScrollingNodeRemoteIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
 
-    ScrollingTreeScrollingNodeDelegateIOS* delegate() const;
+    ScrollingTreeScrollingNodeDelegateIOS* delegate() const LIFETIME_BOUND;
 
     bool isScrollingTreeFrameScrollingNodeIOS() const final { return true; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -46,7 +46,7 @@ public:
 private:
     ScrollingTreeOverflowScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
 
-    ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
+    ScrollingTreeScrollingNodeDelegateIOS& delegate() const LIFETIME_BOUND;
 
     bool isScrollingTreeOverflowScrollingNodeIOS() const final { return true; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
@@ -45,7 +45,7 @@ public:
 private:
     ScrollingTreePluginScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
 
-    ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
+    ScrollingTreeScrollingNodeDelegateIOS& delegate() const LIFETIME_BOUND;
 
     bool isScrollingTreePluginScrollingNodeIOS() const final { return true; }
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -100,13 +100,13 @@ public:
     void injectPageIntoNewProcess();
     void processDidTerminate(WebProcessProxy&, ProcessTerminationReason);
 
-    WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
+    WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() LIFETIME_BOUND { return m_messageReceiverRegistration; }
 
     WebProcessProxy& process() { return m_process.get(); }
     WebProcessProxy& siteIsolatedProcess() const { return m_process.get(); }
     WebCore::PageIdentifier pageID() const { return m_webPageID; } // FIXME: Remove this in favor of identifierInSiteIsolatedProcess.
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return m_webPageID; }
-    const WebCore::Site& site() const { return m_site; }
+    const WebCore::Site& site() const LIFETIME_BOUND { return m_site; }
 
     WebProcessActivityState& NODELETE processActivityState();
 

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -70,7 +70,7 @@ public:
     void end();
 
     WebPageProxy* page() { return m_webPageProxy.get(); }
-    const WebCore::SystemPreviewInfo& previewInfo() const { return m_systemPreviewInfo; }
+    const WebCore::SystemPreviewInfo& previewInfo() const LIFETIME_BOUND { return m_systemPreviewInfo; }
 
     void triggerSystemPreviewAction();
 

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
@@ -63,7 +63,7 @@ public:
 
     API::ContentWorld& world() { return m_world.get(); }
 
-    Client& client() const { return *m_client; }
+    Client& client() const LIFETIME_BOUND { return *m_client; }
 
 private:
     WebScriptMessageHandler(std::unique_ptr<Client>, const String&, API::ContentWorld&);

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -127,7 +127,7 @@ public:
     void removeAllContentRuleLists();
 #endif
 
-    const HashMap<String, std::pair<Ref<API::ContentRuleList>, URL>>& contentExtensionRules() { return m_contentRuleLists; }
+    const HashMap<String, std::pair<Ref<API::ContentRuleList>, URL>>& contentExtensionRules() LIFETIME_BOUND { return m_contentRuleLists; }
     Vector<std::pair<WebCompiledContentRuleListData, URL>> contentRuleListData() const;
 #endif
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -77,7 +77,7 @@ public:
 
     std::optional<WebCore::UserMediaRequestIdentifier> userMediaID() const { return m_userMediaID; }
     WebCore::FrameIdentifier mainFrameID() const { return m_mainFrameID; }
-    const FrameInfoData& frameInfo() const { return m_frameInfo; }
+    const FrameInfoData& frameInfo() const LIFETIME_BOUND { return m_frameInfo; }
     WebCore::FrameIdentifier frameID() const { return m_frameInfo.frameID; }
 
     WebCore::SecurityOrigin& topLevelDocumentSecurityOrigin() { return m_topLevelDocumentSecurityOrigin.get(); }
@@ -85,12 +85,12 @@ public:
     const WebCore::SecurityOrigin& topLevelDocumentSecurityOrigin() const { return m_topLevelDocumentSecurityOrigin.get(); }
     const WebCore::SecurityOrigin& userMediaDocumentSecurityOrigin() const { return m_userMediaDocumentSecurityOrigin.get(); }
 
-    const WebCore::MediaStreamRequest& userRequest() const { return m_request; }
+    const WebCore::MediaStreamRequest& userRequest() const LIFETIME_BOUND { return m_request; }
 
     WebCore::MediaStreamRequest::Type requestType() const { return m_request.type; }
 
     void setDeviceIdentifierHashSalts(WebCore::MediaDeviceHashSalts&& salts) { m_deviceIdentifierHashSalts = WTF::move(salts); }
-    const WebCore::MediaDeviceHashSalts& deviceIdentifierHashSalts() const { return m_deviceIdentifierHashSalts; }
+    const WebCore::MediaDeviceHashSalts& deviceIdentifierHashSalts() const LIFETIME_BOUND { return m_deviceIdentifierHashSalts; }
 
     WebCore::CaptureDevice audioDevice() const { return m_eligibleAudioDevices.isEmpty() ? WebCore::CaptureDevice { } : m_eligibleAudioDevices[0]; }
     WebCore::CaptureDevice videoDevice() const { return m_eligibleVideoDevices.isEmpty() ? WebCore::CaptureDevice { } : m_eligibleVideoDevices[0]; }

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -165,7 +165,7 @@ public:
     void gestureEventWasNotHandledByWebCore(PlatformScrollEvent, WebCore::FloatPoint origin);
 
     void setCustomSwipeViews(Vector<RetainPtr<NSView>> views) { m_customSwipeViews = WTF::move(views); }
-    const WebCore::FloatBoxExtent& customSwipeViewsObscuredContentInsets() const { return m_customSwipeViewsObscuredContentInsets; }
+    const WebCore::FloatBoxExtent& customSwipeViewsObscuredContentInsets() const LIFETIME_BOUND { return m_customSwipeViewsObscuredContentInsets; }
     void setCustomSwipeViewsObscuredContentInsets(WebCore::FloatBoxExtent&& insets) { m_customSwipeViewsObscuredContentInsets = WTF::move(insets); }
     WebCore::FloatRect windowRelativeBoundsForCustomSwipeViews() const;
     void setDidMoveSwipeSnapshotCallback(BlockPtr<void (CGRect)>&& callback) { m_didMoveSwipeSnapshotCallback = WTF::move(callback); }

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -75,7 +75,7 @@ protected:
     Authenticator();
 
     AuthenticatorObserver* observer() const { return m_observer.get(); }
-    const WebAuthenticationRequestData& requestData() const { return *m_pendingRequestData; }
+    const WebAuthenticationRequestData& requestData() const LIFETIME_BOUND { return *m_pendingRequestData; }
 
     void receiveRespond(AuthenticatorObserverRespond&&) const;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -79,7 +79,7 @@ public:
 protected:
     AuthenticatorManager();
 
-    RunLoop::Timer& requestTimeOutTimer() { return m_requestTimeOutTimer; }
+    RunLoop::Timer& requestTimeOutTimer() LIFETIME_BOUND { return m_requestTimeOutTimer; }
     void clearStateAsync(); // To void cyclic dependence.
     void clearState();
     void invokePendingCompletionHandler(Respond&&);
@@ -91,7 +91,7 @@ protected:
     void startDiscovery(const TransportSet&);
 
 protected:
-    const Vector<Ref<AuthenticatorTransportService>>& services() const { return m_services; }
+    const Vector<Ref<AuthenticatorTransportService>>& services() const LIFETIME_BOUND { return m_services; }
 
 private:
     enum class Mode {

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -154,7 +154,7 @@ public:
 
     bool NODELETE isMainFrame() const;
 
-    FrameLoadState& frameLoadState() { return m_frameLoadState; }
+    FrameLoadState& frameLoadState() LIFETIME_BOUND { return m_frameLoadState; }
 
     void navigateServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier, const URL&, CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)>&&);
 
@@ -162,18 +162,18 @@ public:
     // Sub frames only. For main frames, use WebPageProxy::loadData.
     void loadData(std::span<const uint8_t>, const String& MIMEType, const String& encodingName, const URL& baseURL);
 
-    const URL& url() const { return m_frameLoadState.url(); }
-    const URL& provisionalURL() const { return m_frameLoadState.provisionalURL(); }
+    const URL& url() const LIFETIME_BOUND { return m_frameLoadState.url(); }
+    const URL& provisionalURL() const LIFETIME_BOUND { return m_frameLoadState.provisionalURL(); }
 
     void setUnreachableURL(const URL&);
-    const URL& unreachableURL() const { return m_frameLoadState.unreachableURL(); }
+    const URL& unreachableURL() const LIFETIME_BOUND { return m_frameLoadState.unreachableURL(); }
 
-    const String& mimeType() const { return m_MIMEType; }
+    const String& mimeType() const LIFETIME_BOUND { return m_MIMEType; }
     bool containsPluginDocument() const { return m_containsPluginDocument; }
 
-    const String& title() const { return m_title; }
+    const String& title() const LIFETIME_BOUND { return m_title; }
 
-    const WebCore::CertificateInfo& certificateInfo() const { return m_certificateInfo; }
+    const WebCore::CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; }
 
     bool canProvideSource() const;
 

--- a/Source/WebKit/UIProcess/WebGrammarDetail.h
+++ b/Source/WebKit/UIProcess/WebGrammarDetail.h
@@ -45,9 +45,9 @@ public:
     int location() const { return m_grammarDetail.range.location; }
     int length() const { return m_grammarDetail.range.length; }
     Ref<API::Array> guesses() const;
-    const String& userDescription() const { return m_grammarDetail.userDescription; }
+    const String& userDescription() const LIFETIME_BOUND { return m_grammarDetail.userDescription; }
 
-    const WebCore::GrammarDetail& grammarDetail() { return m_grammarDetail; }
+    const WebCore::GrammarDetail& grammarDetail() LIFETIME_BOUND { return m_grammarDetail; }
 
 private:
     WebGrammarDetail(int location, int length, API::Array* guesses, const String& userDescription);

--- a/Source/WebKit/UIProcess/WebPageGroup.h
+++ b/Source/WebKit/UIProcess/WebPageGroup.h
@@ -48,7 +48,7 @@ public:
 
     PageGroupIdentifier pageGroupID() const { return m_data.pageGroupID; }
 
-    const WebPageGroupData& data() const { return m_data; }
+    const WebPageGroupData& data() const LIFETIME_BOUND { return m_data; }
 
     WebPreferences& preferences() const { return m_preferences; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -767,7 +767,7 @@ public:
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
     DrawingAreaProxy* NODELETE provisionalDrawingArea() const;
 
-    WebNavigationState& navigationState() { return m_navigationState; }
+    WebNavigationState& navigationState() LIFETIME_BOUND { return m_navigationState; }
 
     WebsiteDataStore& websiteDataStore() { return m_websiteDataStore; }
 
@@ -819,7 +819,7 @@ public:
 
     WebInspectorUIProxy* NODELETE inspector() const;
 
-    GeolocationPermissionRequestManagerProxy& NODELETE geolocationPermissionRequestManager();
+    GeolocationPermissionRequestManagerProxy& NODELETE geolocationPermissionRequestManager() LIFETIME_BOUND;
 
     void resourceLoadDidSendRequest(ResourceLoadInfo&&, WebCore::ResourceRequest&&);
     void resourceLoadDidPerformHTTPRedirection(ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&);
@@ -836,7 +836,7 @@ public:
 
     RefPtr<WebAutomationSession> activeAutomationSession() const;
 
-    WebPageInspectorController& inspectorController() { return m_inspectorController.get(); }
+    WebPageInspectorController& inspectorController() LIFETIME_BOUND { return m_inspectorController.get(); }
 
 #if PLATFORM(IOS_FAMILY)
     void showInspectorIndication();
@@ -872,7 +872,7 @@ public:
     WebFullScreenManagerProxy* NODELETE fullScreenManager();
     void setFullScreenClientForTesting(std::unique_ptr<WebKit::WebFullScreenManagerProxyClient>&&);
 
-    API::FullscreenClient& fullscreenClient() const { return *m_fullscreenClient; }
+    API::FullscreenClient& fullscreenClient() const LIFETIME_BOUND { return *m_fullscreenClient; }
     void setFullscreenClient(std::unique_ptr<API::FullscreenClient>&&);
 #endif
 
@@ -939,13 +939,13 @@ public:
 #endif
 
 #if ENABLE(CONTEXT_MENUS)
-    API::ContextMenuClient& contextMenuClient() { return *m_contextMenuClient; }
+    API::ContextMenuClient& contextMenuClient() LIFETIME_BOUND { return *m_contextMenuClient; }
     void setContextMenuClient(std::unique_ptr<API::ContextMenuClient>&&);
 #endif
 
-    API::FindClient& findClient() { return *m_findClient; }
+    API::FindClient& findClient() LIFETIME_BOUND { return *m_findClient; }
     void setFindClient(std::unique_ptr<API::FindClient>&&);
-    API::FindMatchesClient& findMatchesClient() { return *m_findMatchesClient; }
+    API::FindMatchesClient& findMatchesClient() LIFETIME_BOUND { return *m_findMatchesClient; }
     void setFindMatchesClient(std::unique_ptr<API::FindMatchesClient>&&);
     API::DiagnosticLoggingClient* diagnosticLoggingClient() { return m_diagnosticLoggingClient.get(); }
     void setDiagnosticLoggingClient(std::unique_ptr<API::DiagnosticLoggingClient>&&);
@@ -957,14 +957,14 @@ public:
     void setInjectedBundleClient(const WKPageInjectedBundleClientBase*);
     void setResourceLoadClient(std::unique_ptr<API::ResourceLoadClient>&&);
 
-    API::UIClient& uiClient() { return *m_uiClient; }
+    API::UIClient& uiClient() LIFETIME_BOUND { return *m_uiClient; }
     void setUIClient(std::unique_ptr<API::UIClient>&&);
 
 #if PLATFORM(VISION)
     void dispatchWillPresentModalUI();
 #endif
 
-    API::IconLoadingClient& iconLoadingClient() { return *m_iconLoadingClient; }
+    API::IconLoadingClient& iconLoadingClient() LIFETIME_BOUND { return *m_iconLoadingClient; }
     void setIconLoadingClient(std::unique_ptr<API::IconLoadingClient>&&);
 
     void setPageLoadStateObserver(RefPtr<PageLoadStateObserverBase>&&);
@@ -1038,7 +1038,7 @@ public:
 
     String currentURL() const;
 
-    const WebCore::FloatBoxExtent& NODELETE obscuredContentInsets() const;
+    const WebCore::FloatBoxExtent& NODELETE obscuredContentInsets() const LIFETIME_BOUND;
     void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
 #if PLATFORM(MAC)
@@ -1147,7 +1147,7 @@ public:
     void executeEditCommand(const String& commandName, const String& argument, CompletionHandler<void()>&&);
     void validateCommand(const String& commandName, CompletionHandler<void(bool, int32_t)>&&);
 
-    const EditorState& NODELETE editorState() const;
+    const EditorState& NODELETE editorState() const LIFETIME_BOUND;
     bool canDelete() const { return hasSelectedRange() && isContentEditable(); }
     bool NODELETE hasSelectedRange() const;
     bool NODELETE isContentEditable() const;
@@ -1430,7 +1430,7 @@ public:
     WPEView* wpeView() const;
 #endif
 
-    const std::optional<WebCore::Color>& NODELETE backgroundColor() const;
+    const std::optional<WebCore::Color>& NODELETE backgroundColor() const LIFETIME_BOUND;
     void setBackgroundColor(const std::optional<WebCore::Color>&);
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
@@ -1500,16 +1500,16 @@ public:
     void scrollBy(WebCore::ScrollDirection, WebCore::ScrollGranularity);
     void centerSelectionInVisibleArea();
 
-    const String& toolTip() const { return m_toolTip; }
+    const String& toolTip() const LIFETIME_BOUND { return m_toolTip; }
 
-    const String& userAgent() const { return m_userAgent; }
+    const String& userAgent() const LIFETIME_BOUND { return m_userAgent; }
     String userAgentForURL(const URL&);
     void setApplicationNameForUserAgent(const String&);
-    const String& applicationNameForUserAgent() const { return m_applicationNameForUserAgent; }
+    const String& applicationNameForUserAgent() const LIFETIME_BOUND { return m_applicationNameForUserAgent; }
     void setApplicationNameForDesktopUserAgent(const String& applicationName) { m_applicationNameForDesktopUserAgent = applicationName; }
-    const String& applicationNameForDesktopUserAgent() const { return m_applicationNameForDesktopUserAgent; }
+    const String& applicationNameForDesktopUserAgent() const LIFETIME_BOUND { return m_applicationNameForDesktopUserAgent; }
     void setCustomUserAgent(String&&);
-    const String& customUserAgent() const { return m_customUserAgent; }
+    const String& customUserAgent() const LIFETIME_BOUND { return m_customUserAgent; }
     static String standardUserAgent(const String& applicationName = String());
 #if PLATFORM(IOS_FAMILY)
     String predictedUserAgentForRequest(const WebCore::ResourceRequest&) const;
@@ -1579,7 +1579,7 @@ public:
     void setUseFixedLayout(bool);
     void setFixedLayoutSize(const WebCore::IntSize&);
     bool useFixedLayout() const { return m_useFixedLayout; };
-    const WebCore::IntSize& NODELETE fixedLayoutSize() const;
+    const WebCore::IntSize& NODELETE fixedLayoutSize() const LIFETIME_BOUND;
 
     void setDefaultUnobscuredSize(const WebCore::FloatSize&);
     WebCore::FloatSize NODELETE defaultUnobscuredSize() const;
@@ -1945,8 +1945,8 @@ public:
     void drawPagesForPrinting(WebFrameProxy&, const PrintInfo&, CompletionHandler<void(std::optional<WebCore::SharedMemoryHandle>&&, WebCore::ResourceError&&)>&&);
 #endif
 
-    const PageLoadState& NODELETE pageLoadState() const;
-    PageLoadState& pageLoadState();
+    const PageLoadState& NODELETE pageLoadState() const LIFETIME_BOUND;
+    PageLoadState& pageLoadState() LIFETIME_BOUND;
 
 #if PLATFORM(COCOA)
     void handleAlternativeTextUIResult(const String& result);
@@ -2186,7 +2186,7 @@ public:
     void setWaitingForPostLayoutEditorStateUpdateAfterFocusingElement(bool waitingForPostLayoutEditorStateUpdateAfterFocusingElement) { m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement = waitingForPostLayoutEditorStateUpdateAfterFocusingElement; }
     bool waitingForPostLayoutEditorStateUpdateAfterFocusingElement() const { return m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement; }
 
-    const Function<bool()>& deviceOrientationUserPermissionHandlerForTesting() const { return m_deviceOrientationUserPermissionHandlerForTesting; };
+    const Function<bool()>& deviceOrientationUserPermissionHandlerForTesting() const LIFETIME_BOUND { return m_deviceOrientationUserPermissionHandlerForTesting; };
     void setDeviceOrientationUserPermissionHandlerForTesting(Function<bool()>&& handler) { m_deviceOrientationUserPermissionHandlerForTesting = WTF::move(handler); }
 
     void statusBarWasTapped();
@@ -2299,7 +2299,7 @@ public:
 
     void getTextFragmentMatch(CompletionHandler<void(const String&)>&&);
 
-    const WebPreferencesStore& NODELETE preferencesStore() const;
+    const WebPreferencesStore& NODELETE preferencesStore() const LIFETIME_BOUND;
 
     bool NODELETE isPageOpenedByDOMShowingInitialEmptyDocument() const;
 
@@ -2400,11 +2400,11 @@ public:
     void didFindTextManipulationItems(const Vector<WebCore::TextManipulationItem>&);
     void completeTextManipulation(const Vector<WebCore::TextManipulationItem>&, CompletionHandler<void(Vector<WebCore::TextManipulationControllerManipulationFailure>&&)>&&);
 
-    const String& overriddenMediaType() const { return m_overriddenMediaType; }
+    const String& overriddenMediaType() const LIFETIME_BOUND { return m_overriddenMediaType; }
     void setOverriddenMediaType(const String&);
 
     void setCORSDisablingPatterns(Vector<String>&&);
-    const Vector<String>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
+    const Vector<String>& corsDisablingPatterns() const LIFETIME_BOUND { return m_corsDisablingPatterns; }
 
     void getProcessDisplayName(CompletionHandler<void(String&&)>&&);
 
@@ -2421,7 +2421,7 @@ public:
     bool isHandlingPreventableTouchEnd() const { return m_handlingPreventableTouchEndCount; }
 
     bool NODELETE hasQueuedKeyEvent() const;
-    const NativeWebKeyboardEvent& NODELETE firstQueuedKeyEvent() const;
+    const NativeWebKeyboardEvent& NODELETE firstQueuedKeyEvent() const LIFETIME_BOUND;
 
     void grantAccessToAssetServices();
     void revokeAccessToAssetServices();
@@ -2464,7 +2464,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_USAGE)
-    MediaUsageManager& mediaUsageManager();
+    MediaUsageManager& mediaUsageManager() LIFETIME_BOUND;
     void addMediaUsageManagerSession(WebCore::MediaSessionIdentifier, const String&, const URL&);
     void updateMediaUsageManagerSessionState(WebCore::MediaSessionIdentifier, const WebCore::MediaUsageInfo&);
     void removeMediaUsageManagerSession(WebCore::MediaSessionIdentifier);
@@ -2723,7 +2723,7 @@ public:
     void preferredBufferFormatsDidChange();
 #endif
 
-    WebPageProxyMessageReceiverRegistration& NODELETE messageReceiverRegistration();
+    WebPageProxyMessageReceiverRegistration& NODELETE messageReceiverRegistration() LIFETIME_BOUND;
 
 #if HAVE(ESIM_AUTOFILL_SYSTEM_SUPPORT)
     bool shouldAllowAutoFillForCellularIdentifiers() const;
@@ -2875,7 +2875,7 @@ public:
     void startNetworkRequestsForPageLoadTiming(WebCore::FrameIdentifier);
     void endNetworkRequestsForPageLoadTiming(WebCore::FrameIdentifier, WallTime);
 
-    WebProcessActivityState& processActivityState() { return m_mainFrameProcessActivityState; }
+    WebProcessActivityState& processActivityState() LIFETIME_BOUND { return m_mainFrameProcessActivityState; }
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     void updateWebProcessSuspensionDelay();
@@ -2895,7 +2895,7 @@ public:
     void restoreSessionStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
 #if HAVE(AUDIT_TOKEN)
-    const std::optional<audit_token_t>& NODELETE presentingApplicationAuditToken() const;
+    const std::optional<audit_token_t>& NODELETE presentingApplicationAuditToken() const LIFETIME_BOUND;
     void setPresentingApplicationAuditToken(const audit_token_t&);
 #endif
 
@@ -3145,7 +3145,7 @@ private:
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    MediaKeySystemPermissionRequestManagerProxy& mediaKeySystemPermissionRequestManager();
+    MediaKeySystemPermissionRequestManagerProxy& mediaKeySystemPermissionRequestManager() LIFETIME_BOUND;
 #endif
     void requestMediaKeySystemPermissionForFrame(IPC::Connection&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, WebCore::ClientOrigin&&, const String&);
 
@@ -3385,7 +3385,7 @@ private:
     void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);
     void sendWheelEventScrollingAccelerationCurveIfNecessary(WebCore::FrameIdentifier, const WebWheelEvent&);
 
-    WebWheelEventCoalescer& wheelEventCoalescer();
+    WebWheelEventCoalescer& wheelEventCoalescer() LIFETIME_BOUND;
 
 #if HAVE(DISPLAY_LINK)
     void wheelEventHysteresisUpdated(PAL::HysteresisState);
@@ -3601,8 +3601,8 @@ private:
 #endif
 
     struct Internals;
-    Internals& internals() { return m_internals; }
-    const Internals& internals() const { return m_internals; }
+    Internals& internals() LIFETIME_BOUND { return m_internals; }
+    const Internals& internals() const LIFETIME_BOUND { return m_internals; }
 
     void takeVisibleActivity();
     void takeAudibleActivity();

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -137,7 +137,7 @@ public:
             didVisitDomain(WebCore::RegistrableDomain(url));
     }
 
-    const ListHashSet<WebCore::RegistrableDomain>& visitedDomains() const
+    const ListHashSet<WebCore::RegistrableDomain>& visitedDomains() const LIFETIME_BOUND
     {
         return m_visitedDomains;
     }
@@ -458,7 +458,7 @@ public:
     explicit Internals(WebPageProxy&, std::optional<WebCore::SecurityOriginData>);
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    SpeechSynthesisData& speechSynthesisData();
+    SpeechSynthesisData& speechSynthesisData() LIFETIME_BOUND;
 #endif
 
     // WebPopupMenuProxy::Client

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -65,7 +65,7 @@ public:
     void addPage(WebPageProxy&);
     void removePage(WebPageProxy&);
 
-    const WebPreferencesStore& store() const { return m_store; }
+    const WebPreferencesStore& store() const LIFETIME_BOUND { return m_store; }
 
     // Implemented in generated file WebPreferencesGetterSetters.cpp.
     FOR_EACH_WEBKIT_PREFERENCE(DECLARE_PREFERENCE_GETTER_AND_SETTERS)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -217,7 +217,7 @@ public:
     void setLegacyDownloadClient(RefPtr<API::DownloadClient>&&);
     void setAutomationClient(std::unique_ptr<API::AutomationClient>&&);
 
-    const Vector<Ref<WebProcessProxy>>& processes() const { return m_processes; }
+    const Vector<Ref<WebProcessProxy>>& processes() const LIFETIME_BOUND { return m_processes; }
 
     // WebProcessProxy object which does not have a running process which is used for convenience, to avoid
     // null checks in WebPageProxy.
@@ -270,7 +270,7 @@ public:
 #endif
 
 #if HAVE(DISPLAY_LINK)
-    DisplayLinkCollection& displayLinks() { return m_displayLinks; }
+    DisplayLinkCollection& displayLinks() LIFETIME_BOUND { return m_displayLinks; }
 #endif
 
     void NODELETE addSupportedPlugin(String&& matchingDomain, String&& name, HashSet<String>&& mimeTypes, HashSet<String> extensions);
@@ -317,8 +317,8 @@ public:
     // Downloads.
     Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, const WebCore::ResourceRequest&, WebPageProxy* originatingPage, const std::optional<FrameInfoData>&);
 
-    API::LegacyContextHistoryClient& historyClient() { return *m_historyClient; }
-    WebContextClient& client() { return m_client; }
+    API::LegacyContextHistoryClient& historyClient() LIFETIME_BOUND { return *m_historyClient; }
+    WebContextClient& client() LIFETIME_BOUND { return m_client; }
 
     struct Statistics {
         unsigned wkViewCount;
@@ -515,11 +515,11 @@ public:
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void setSandboxEnabled(bool);
     void addSandboxPath(const CString& path, SandboxPermission permission) { m_extraSandboxPaths.add(path, permission); };
-    const HashMap<CString, SandboxPermission>& sandboxPaths() const { return m_extraSandboxPaths; };
+    const HashMap<CString, SandboxPermission>& sandboxPaths() const LIFETIME_BOUND { return m_extraSandboxPaths; };
     bool sandboxEnabled() const { return m_sandboxEnabled; };
 
     void setUserMessageHandler(Function<void(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&)>&& handler) { m_userMessageHandler = WTF::move(handler); }
-    const Function<void(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&)>& userMessageHandler() const { return m_userMessageHandler; }
+    const Function<void(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&)>& userMessageHandler() const LIFETIME_BOUND { return m_userMessageHandler; }
 
 #if USE(ATSPI)
     const String& accessibilityBusAddress() const;
@@ -538,7 +538,7 @@ public:
     void setDelaysWebProcessLaunchDefaultValue(bool delaysWebProcessLaunchDefaultValue) { m_delaysWebProcessLaunchDefaultValue = delaysWebProcessLaunchDefaultValue; }
 
     void setJavaScriptConfigurationDirectory(String&& directory) { m_javaScriptConfigurationDirectory = directory; }
-    const String& javaScriptConfigurationDirectory() const { return m_javaScriptConfigurationDirectory; }
+    const String& javaScriptConfigurationDirectory() const LIFETIME_BOUND { return m_javaScriptConfigurationDirectory; }
 
     void setOverrideLanguages(Vector<String>&&);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -219,7 +219,7 @@ public:
     inline WebProcessPool& processPool() const; // This function is implemented in WebProcessPool.h.
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
-    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return m_sharedPreferencesForWebProcess; }
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const LIFETIME_BOUND { return m_sharedPreferencesForWebProcess; }
     std::optional<SharedPreferencesForWebProcess> updateSharedPreferences(const WebPreferencesStore&);
     void didSyncSharedPreferencesForWebProcessWithNetworkProcess(uint64_t syncedPreferencesVersion);
 #if ENABLE(GPU_PROCESS)
@@ -231,16 +231,16 @@ public:
     void waitForSharedPreferencesForWebProcessToSync(uint64_t sharedPreferencesVersion, CompletionHandler<void(bool success)>&&);
 
     enum class SiteState : uint8_t { NotYetSpecified, MultipleSites, SharedProcess };
-    const Expected<WebCore::Site, SiteState>& site() const { return m_site; }
+    const Expected<WebCore::Site, SiteState>& site() const LIFETIME_BOUND { return m_site; }
 
     bool isSharedProcess() const { return !m_site && m_site.error() == SiteState::SharedProcess; }
-    const std::optional<WebCore::Site>& sharedProcessMainFrameSite() const { return m_sharedProcessMainFrameSite; }
+    const std::optional<WebCore::Site>& sharedProcessMainFrameSite() const LIFETIME_BOUND { return m_sharedProcessMainFrameSite; }
     void addSharedProcessDomain(const WebCore::RegistrableDomain&);
-    const HashSet<WebCore::RegistrableDomain>& sharedProcessDomains() const { return m_sharedProcessDomains; }
+    const HashSet<WebCore::RegistrableDomain>& sharedProcessDomains() const LIFETIME_BOUND { return m_sharedProcessDomains; }
 
     IsolatedProcessType isolatedProcessType() const { return m_isolatedProcessType; }
     void setIsolatedProcessType(IsolatedProcessType, std::optional<WebCore::Site> mainFrameSite);
-    const std::optional<WebCore::Site>& mainFrameSite() const { return m_mainFrameSite; }
+    const std::optional<WebCore::Site>& mainFrameSite() const LIFETIME_BOUND { return m_mainFrameSite; }
 
     enum class WillShutDown : bool { No, Yes };
     void setIsInProcessCache(bool, WillShutDown = WillShutDown::No);
@@ -402,7 +402,7 @@ public:
 #endif
 
 #if HAVE(DISPLAY_LINK)
-    DisplayLink::Client& displayLinkClient() { return m_displayLinkClient; }
+    DisplayLink::Client& displayLinkClient() LIFETIME_BOUND { return m_displayLinkClient; }
     std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
 
     void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
@@ -496,7 +496,7 @@ public:
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION)
-    AudioSessionRoutingArbitratorProxy* audioSessionRoutingArbitrator() { return m_routingArbitrator.get(); }
+    AudioSessionRoutingArbitratorProxy* audioSessionRoutingArbitrator() LIFETIME_BOUND { return m_routingArbitrator.get(); }
 #endif
 
 #if ENABLE(IPC_TESTING_API)
@@ -509,8 +509,8 @@ public:
 
 #if ENABLE(MEDIA_STREAM)
     static void muteCaptureInPagesExcept(WebCore::PageIdentifier);
-    SpeechRecognitionRemoteRealtimeMediaSourceManager& ensureSpeechRecognitionRemoteRealtimeMediaSourceManager();
-    SpeechRecognitionRemoteRealtimeMediaSourceManager* speechRecognitionRemoteRealtimeMediaSourceManager() const { return m_speechRecognitionRemoteRealtimeMediaSourceManager.get(); }
+    SpeechRecognitionRemoteRealtimeMediaSourceManager& ensureSpeechRecognitionRemoteRealtimeMediaSourceManager() LIFETIME_BOUND;
+    SpeechRecognitionRemoteRealtimeMediaSourceManager* speechRecognitionRemoteRealtimeMediaSourceManager() const LIFETIME_BOUND { return m_speechRecognitionRemoteRealtimeMediaSourceManager.get(); }
 #endif
     void pageMutedStateChanged(WebCore::PageIdentifier, WebCore::MediaProducerMutedStateFlags);
     void pageIsBecomingInvisible(WebCore::PageIdentifier);
@@ -551,8 +551,8 @@ public:
     void hardwareConsoleStateChanged();
 #endif
 
-    const WeakHashSet<WebProcessProxy>* NODELETE serviceWorkerClientProcesses() const;
-    const WeakHashSet<WebProcessProxy>* NODELETE sharedWorkerClientProcesses() const;
+    const WeakHashSet<WebProcessProxy>* NODELETE serviceWorkerClientProcesses() const LIFETIME_BOUND;
+    const WeakHashSet<WebProcessProxy>* NODELETE sharedWorkerClientProcesses() const LIFETIME_BOUND;
 
     static void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
     void processPermissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
@@ -567,7 +567,7 @@ public:
     Seconds totalSuspendedTime() const;
 
 #if ENABLE(WEBXR)
-    const WebCore::ProcessIdentity& processIdentity();
+    const WebCore::ProcessIdentity& processIdentity() LIFETIME_BOUND;
 #endif
 
     bool isAlwaysOnLoggingAllowed() const;

--- a/Source/WebKit/UIProcess/WebViewportAttributes.h
+++ b/Source/WebKit/UIProcess/WebViewportAttributes.h
@@ -40,7 +40,7 @@ public:
 
     virtual ~WebViewportAttributes();
 
-    const WebCore::ViewportAttributes& originalAttributes() const { return m_attributes; }
+    const WebCore::ViewportAttributes& originalAttributes() const LIFETIME_BOUND { return m_attributes; }
 
 private:
     explicit WebViewportAttributes(const WebCore::ViewportAttributes&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -84,43 +84,43 @@ public:
     void setIsDeclarativeWebPushEnabled(bool enabled) { m_isDeclarativeWebPushEnabled = enabled; }
 #endif
     
-    const String& mediaCacheDirectory() const { return m_directories.mediaCacheDirectory; }
+    const String& mediaCacheDirectory() const LIFETIME_BOUND { return m_directories.mediaCacheDirectory; }
     void setMediaCacheDirectory(String&& directory) { m_directories.mediaCacheDirectory = WTF::move(directory); }
     
-    const String& mediaKeysStorageDirectory() const { return m_directories.mediaKeysStorageDirectory; }
+    const String& mediaKeysStorageDirectory() const LIFETIME_BOUND { return m_directories.mediaKeysStorageDirectory; }
     void setMediaKeysStorageDirectory(String&& directory) { m_directories.mediaKeysStorageDirectory = WTF::move(directory); }
     
-    const String& alternativeServicesDirectory() const { return m_directories.alternativeServicesDirectory; }
+    const String& alternativeServicesDirectory() const LIFETIME_BOUND { return m_directories.alternativeServicesDirectory; }
     void setAlternativeServicesDirectory(String&& directory) { m_directories.alternativeServicesDirectory = WTF::move(directory); }
 
-    const String& javaScriptConfigurationDirectory() const { return m_directories.javaScriptConfigurationDirectory; }
+    const String& javaScriptConfigurationDirectory() const LIFETIME_BOUND { return m_directories.javaScriptConfigurationDirectory; }
     void setJavaScriptConfigurationDirectory(String&& directory) { m_directories.javaScriptConfigurationDirectory = WTF::move(directory); }
 
-    const String& searchFieldHistoryDirectory() const { return m_directories.searchFieldHistoryDirectory; }
+    const String& searchFieldHistoryDirectory() const LIFETIME_BOUND { return m_directories.searchFieldHistoryDirectory; }
     void setSearchFieldHistoryDirectory(String&& directory) { m_directories.searchFieldHistoryDirectory = WTF::move(directory); }
 
     // indexedDBDatabaseDirectory is sort of deprecated. Data is migrated from here to
     // generalStoragePath unless useCustomStoragePaths is true.
-    const String& indexedDBDatabaseDirectory() const { return m_directories.indexedDBDatabaseDirectory; }
+    const String& indexedDBDatabaseDirectory() const LIFETIME_BOUND { return m_directories.indexedDBDatabaseDirectory; }
     void setIndexedDBDatabaseDirectory(String&& directory) { m_directories.indexedDBDatabaseDirectory = WTF::move(directory); }
 
-    const String& webSQLDatabaseDirectory() const { return m_directories.webSQLDatabaseDirectory; }
+    const String& webSQLDatabaseDirectory() const LIFETIME_BOUND { return m_directories.webSQLDatabaseDirectory; }
     void setWebSQLDatabaseDirectory(String&& directory) { m_directories.webSQLDatabaseDirectory = WTF::move(directory); }
 
-    const String& hstsStorageDirectory() const { return m_directories.hstsStorageDirectory; }
+    const String& hstsStorageDirectory() const LIFETIME_BOUND { return m_directories.hstsStorageDirectory; }
     void setHSTSStorageDirectory(String&& directory) { m_directories.hstsStorageDirectory = WTF::move(directory); }
 
     // localStorageDirectory is sort of deprecated. Data is migrated from here to
     // generalStoragePath unless useCustomStoragePaths is true.
-    const String& localStorageDirectory() const { return m_directories.localStorageDirectory; }
+    const String& localStorageDirectory() const LIFETIME_BOUND { return m_directories.localStorageDirectory; }
     void setLocalStorageDirectory(String&& directory) { m_directories.localStorageDirectory = WTF::move(directory); }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-    const String& modelElementCacheDirectory() const { return m_directories.modelElementCacheDirectory; }
+    const String& modelElementCacheDirectory() const LIFETIME_BOUND { return m_directories.modelElementCacheDirectory; }
     void setModelElementCacheDirectory(String&& directory) { m_directories.modelElementCacheDirectory = WTF::move(directory); }
 #endif
 
-    const String& boundInterfaceIdentifier() const { return m_boundInterfaceIdentifier; }
+    const String& boundInterfaceIdentifier() const LIFETIME_BOUND { return m_boundInterfaceIdentifier; }
     void setBoundInterfaceIdentifier(String&& identifier) { m_boundInterfaceIdentifier = WTF::move(identifier); }
 
     bool allowsCellularAccess() const { return m_allowsCellularAccess; }
@@ -155,56 +155,56 @@ public:
     void setProxyConfiguration(CFDictionaryRef configuration) { m_proxyConfiguration = configuration; }
 #endif
     
-    const String& deviceIdHashSaltsStorageDirectory() const { return m_directories.deviceIdHashSaltsStorageDirectory; }
+    const String& deviceIdHashSaltsStorageDirectory() const LIFETIME_BOUND { return m_directories.deviceIdHashSaltsStorageDirectory; }
     void setDeviceIdHashSaltsStorageDirectory(String&& directory) { m_directories.deviceIdHashSaltsStorageDirectory = WTF::move(directory); }
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    const String& mediaKeysHashSaltsStorageDirectory() const { return m_directories.mediaKeysHashSaltsStorageDirectory; }
+    const String& mediaKeysHashSaltsStorageDirectory() const LIFETIME_BOUND { return m_directories.mediaKeysHashSaltsStorageDirectory; }
     void setMediaKeysHashSaltsStorageDirectory(String&& directory) { m_directories.mediaKeysHashSaltsStorageDirectory = WTF::move(directory); }
 #endif
 
-    const String& cookieStorageFile() const { return m_directories.cookieStorageFile; }
+    const String& cookieStorageFile() const LIFETIME_BOUND { return m_directories.cookieStorageFile; }
     void setCookieStorageFile(String&& directory) { m_directories.cookieStorageFile = WTF::move(directory); }
     
-    const String& resourceLoadStatisticsDirectory() const { return m_directories.resourceLoadStatisticsDirectory; }
+    const String& resourceLoadStatisticsDirectory() const LIFETIME_BOUND { return m_directories.resourceLoadStatisticsDirectory; }
     void setResourceLoadStatisticsDirectory(String&& directory) { m_directories.resourceLoadStatisticsDirectory = WTF::move(directory); }
 
-    const String& networkCacheDirectory() const { return m_directories.networkCacheDirectory; }
+    const String& networkCacheDirectory() const LIFETIME_BOUND { return m_directories.networkCacheDirectory; }
     void setNetworkCacheDirectory(String&& directory) { m_directories.networkCacheDirectory = WTF::move(directory); }
     
-    const String& cacheStorageDirectory() const { return m_directories.cacheStorageDirectory; }
+    const String& cacheStorageDirectory() const LIFETIME_BOUND { return m_directories.cacheStorageDirectory; }
     void setCacheStorageDirectory(String&& directory) { m_directories.cacheStorageDirectory = WTF::move(directory); }
 
-    const String& generalStorageDirectory() const { return m_directories.generalStorageDirectory; }
+    const String& generalStorageDirectory() const LIFETIME_BOUND { return m_directories.generalStorageDirectory; }
     void setGeneralStorageDirectory(String&& directory) { m_directories.generalStorageDirectory = WTF::move(directory); }
 
     UnifiedOriginStorageLevel unifiedOriginStorageLevel() const { return m_unifiedOriginStorageLevel; }
     void setUnifiedOriginStorageLevel(UnifiedOriginStorageLevel level) { m_unifiedOriginStorageLevel = level; }
 
-    const String& webPushPartitionString() const { return m_webPushPartitionString; }
+    const String& webPushPartitionString() const LIFETIME_BOUND { return m_webPushPartitionString; }
     void setWebPushPartitionString(String&& string) { m_webPushPartitionString = WTF::move(string); }
     
-    const String& serviceWorkerRegistrationDirectory() const { return m_directories.serviceWorkerRegistrationDirectory; }
+    const String& serviceWorkerRegistrationDirectory() const LIFETIME_BOUND { return m_directories.serviceWorkerRegistrationDirectory; }
     void setServiceWorkerRegistrationDirectory(String&& directory) { m_directories.serviceWorkerRegistrationDirectory = WTF::move(directory); }
     
     bool serviceWorkerProcessTerminationDelayEnabled() const { return m_serviceWorkerProcessTerminationDelayEnabled; }
     void setServiceWorkerProcessTerminationDelayEnabled(bool enabled) { m_serviceWorkerProcessTerminationDelayEnabled = enabled; }
 
-    const String& sourceApplicationBundleIdentifier() const { return m_sourceApplicationBundleIdentifier; }
+    const String& sourceApplicationBundleIdentifier() const LIFETIME_BOUND { return m_sourceApplicationBundleIdentifier; }
     void setSourceApplicationBundleIdentifier(String&& identifier) { m_sourceApplicationBundleIdentifier = WTF::move(identifier); }
 
-    const String& sourceApplicationSecondaryIdentifier() const { return m_sourceApplicationSecondaryIdentifier; }
+    const String& sourceApplicationSecondaryIdentifier() const LIFETIME_BOUND { return m_sourceApplicationSecondaryIdentifier; }
     void setSourceApplicationSecondaryIdentifier(String&& identifier) { m_sourceApplicationSecondaryIdentifier = WTF::move(identifier); }
     
 #if ENABLE(CONTENT_EXTENSIONS)
-    const String& resourceMonitorThrottlerDirectory() const { return m_directories.resourceMonitorThrottlerDirectory; }
+    const String& resourceMonitorThrottlerDirectory() const LIFETIME_BOUND { return m_directories.resourceMonitorThrottlerDirectory; }
     void setResourceMonitorThrottlerDirectory(String&& directory) { m_directories.resourceMonitorThrottlerDirectory = WTF::move(directory); }
 #endif
 
-    const URL& httpProxy() const { return m_httpProxy; }
+    const URL& httpProxy() const LIFETIME_BOUND { return m_httpProxy; }
     void setHTTPProxy(URL&& proxy) { m_httpProxy = WTF::move(proxy); }
 
-    const URL& httpsProxy() const { return m_httpsProxy; }
+    const URL& httpsProxy() const LIFETIME_BOUND { return m_httpsProxy; }
     void setHTTPSProxy(URL&& proxy) { m_httpsProxy = WTF::move(proxy); }
 
     bool deviceManagementRestrictionsEnabled() const { return m_deviceManagementRestrictionsEnabled; }
@@ -235,7 +235,7 @@ public:
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue() const { return m_overrideServiceWorkerRegistrationCountTestingValue; }
     void setOverrideServiceWorkerRegistrationCountTestingValue(unsigned count) { m_overrideServiceWorkerRegistrationCountTestingValue = count; }
 
-    const URL& standaloneApplicationURL() const { return m_standaloneApplicationURL; }
+    const URL& standaloneApplicationURL() const LIFETIME_BOUND { return m_standaloneApplicationURL; }
     void setStandaloneApplicationURL(URL&& url) { m_standaloneApplicationURL = WTF::move(url); }
 
     bool enableInAppBrowserPrivacyForTesting() const { return m_enableInAppBrowserPrivacyForTesting; }
@@ -245,23 +245,23 @@ public:
     void setAllowsHSTSWithUntrustedRootCertificate(bool allows) { m_allowsHSTSWithUntrustedRootCertificate = allows; }
     
     void setPCMMachServiceName(String&& name) { m_pcmMachServiceName = WTF::move(name); }
-    const String& pcmMachServiceName() const { return m_pcmMachServiceName; }
+    const String& pcmMachServiceName() const LIFETIME_BOUND { return m_pcmMachServiceName; }
 
     void setWebPushMachServiceName(String&& name) { m_webPushMachServiceName = WTF::move(name); }
-    const String& webPushMachServiceName() const { return m_webPushMachServiceName; }
+    const String& webPushMachServiceName() const LIFETIME_BOUND { return m_webPushMachServiceName; }
 
     void setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds) { m_memoryFootprintNotificationThresholds = WTF::move(thresholds); }
-    const Vector<size_t>& memoryFootprintNotificationThresholds() { return m_memoryFootprintNotificationThresholds; }
+    const Vector<size_t>& memoryFootprintNotificationThresholds() LIFETIME_BOUND { return m_memoryFootprintNotificationThresholds; }
 
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     void setWebContentRestrictionsConfigurationFile(String&& file) { m_webContentRestrictionsConfigurationFile = WTF::move(file); }
-    const String& webContentRestrictionsConfigurationFile() const { return m_webContentRestrictionsConfigurationFile; }
+    const String& webContentRestrictionsConfigurationFile() const LIFETIME_BOUND { return m_webContentRestrictionsConfigurationFile; }
 #endif
 
     void setAdditionalDomainsWithUserInteractionForTesting(String&& domains) { m_additionalDomainsWithUserInteractionForTesting = WTF::move(domains); }
-    const String& additionalDomainsWithUserInteractionForTesting() const { return m_additionalDomainsWithUserInteractionForTesting; }
+    const String& additionalDomainsWithUserInteractionForTesting() const LIFETIME_BOUND { return m_additionalDomainsWithUserInteractionForTesting; }
 
-    const String& enhancedSecurityDirectory() const { return m_directories.enhancedSecurityDirectory; }
+    const String& enhancedSecurityDirectory() const LIFETIME_BOUND { return m_directories.enhancedSecurityDirectory; }
     void setEnhancedSecurityDirectory(String&& directory) { m_directories.enhancedSecurityDirectory = WTF::move(directory); }
 
     struct Directories {
@@ -294,7 +294,7 @@ public:
         Directories isolatedCopy() const&;
         Directories isolatedCopy() &&;
     };
-    const Directories& directories() const { return m_directories; }
+    const Directories& directories() const LIFETIME_BOUND { return m_directories; }
 
 private:
     static Ref<WebsiteDataStoreConfiguration> create(IsPersistent isPersistent, ShouldInitializePaths shouldInitializePaths) { return adoptRef(*new WebsiteDataStoreConfiguration(isPersistent, shouldInitializePaths)); }

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -704,10 +704,7 @@ std::optional<WebBackForwardList> ViewGestureController::backForwardListForNavig
 
 WebBackForwardList* ViewGestureController::backForwardListForNavigation() const
 {
-    if (RefPtr page = m_webPageProxy.get())
-        return &page->backForwardList();
-
-    return nullptr;
+    return m_webPageProxy ? &m_webPageProxy->backForwardList() : nullptr;
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -556,15 +556,15 @@ public:
 
     void enterAcceleratedCompositingWithRootLayer(CALayer *);
     void setAcceleratedCompositingRootLayer(CALayer *);
-    CALayer *acceleratedCompositingRootLayer() const { return m_rootLayer.get(); }
+    CALayer *acceleratedCompositingRootLayer() const LIFETIME_BOUND { return m_rootLayer.get(); }
 
     void setThumbnailView(_WKThumbnailView *);
     RetainPtr<_WKThumbnailView> thumbnailView() const { return m_thumbnailView.get(); }
 
     void setHeaderBannerLayer(CALayer *);
-    CALayer *headerBannerLayer() const { return m_headerBannerLayer.get(); }
+    CALayer *headerBannerLayer() const LIFETIME_BOUND { return m_headerBannerLayer.get(); }
     void setFooterBannerLayer(CALayer *);
-    CALayer *footerBannerLayer() const { return m_footerBannerLayer.get(); }
+    CALayer *footerBannerLayer() const LIFETIME_BOUND { return m_footerBannerLayer.get(); }
 
     void setInspectorAttachmentView(NSView *);
     RetainPtr<NSView> inspectorAttachmentView();
@@ -615,12 +615,12 @@ public:
     void insertTextPlaceholderWithSize(CGSize, void(^completionHandler)(NSTextPlaceholder *));
     void removeTextPlaceholder(NSTextPlaceholder *, bool willInsertText, void(^completionHandler)());
 
-    _WKWarningView *warningView() { return m_warningView.get(); }
+    _WKWarningView *warningView() LIFETIME_BOUND { return m_warningView.get(); }
 
     ViewGestureController* gestureController() const { return m_gestureController.get(); }
     ViewGestureController& ensureGestureController();
 #if HAVE(APPKIT_GESTURES_SUPPORT)
-    WKAppKitGestureController *appKitGestureController() const { return m_appKitGestureController.get(); }
+    WKAppKitGestureController *appKitGestureController() const LIFETIME_BOUND { return m_appKitGestureController.get(); }
 #endif
     void NODELETE setAllowsBackForwardNavigationGestures(bool);
     bool allowsBackForwardNavigationGestures() const { return m_allowsBackForwardNavigationGestures; }
@@ -744,7 +744,7 @@ public:
 #if HAVE(TOUCH_BAR)
     NSTouchBar *makeTouchBar();
     void updateTouchBar();
-    NSTouchBar *currentTouchBar() const { return m_currentTouchBar.get(); }
+    NSTouchBar *currentTouchBar() const LIFETIME_BOUND { return m_currentTouchBar.get(); }
     NSCandidateListTouchBarItem *candidateListTouchBarItem() const;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     WebCore::PlatformPlaybackSessionInterface* playbackSessionInterface() const;
@@ -787,7 +787,7 @@ public:
 
     void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteRequiresInteraction, const WebCore::IntRect&, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);
     void handleDOMPasteRequestForCategoryWithResult(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteAccessResponse);
-    NSMenu *domPasteMenu() const { return m_domPasteMenu.get(); }
+    NSMenu *domPasteMenu() const LIFETIME_BOUND { return m_domPasteMenu.get(); }
     void hideDOMPasteMenuWithResult(WebCore::DOMPasteAccessResponse);
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
@@ -835,7 +835,7 @@ public:
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     void updateScrollPocket();
-    NSScrollPocket *topScrollPocket() const { return m_topScrollPocket.get(); }
+    NSScrollPocket *topScrollPocket() const LIFETIME_BOUND { return m_topScrollPocket.get(); }
     void registerViewAboveScrollPocket(NSView *);
     void unregisterViewAboveScrollPocket(NSView *);
     void updateScrollPocketVisibilityWhenScrolledToTop();
@@ -847,7 +847,7 @@ public:
 
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     void setBannerView(WKBannerView *);
-    WKBannerView *bannerView() const { return m_bannerView.get(); }
+    WKBannerView *bannerView() const LIFETIME_BOUND { return m_bannerView.get(); }
 
     void applyBannerViewOverlayHeight(CGFloat, bool);
     CGFloat bannerViewHeight() const;


### PR DESCRIPTION
#### 2e367222b748d3f6b3de2938f8e02ee5049da78d
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=308799">https://bugs.webkit.org/show_bug.cgi?id=308799</a>

Reviewed by Darin Adler.

Adopt `LIFETIME_BOUND` annotation in more places in the UIProcess. For
now, I am focusing on member functions that return references to data
members that are neither ref-counted or CanMakeCheckedPtr as they bring
the most value at the moment.

* Source/WebKit/UIProcess/API/APIApplicationManifest.h:
* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/UIProcess/API/APIContentRuleList.h:
* Source/WebKit/UIProcess/API/APIContentRuleListAction.h:
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/APIContextMenuElementInfo.h:
* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:
* Source/WebKit/UIProcess/API/APICustomHeaderFields.h:
* Source/WebKit/UIProcess/API/APIDataTask.h:
(API::DataTask::originalURL const): Deleted.
* Source/WebKit/UIProcess/API/APIDebuggableInfo.h:
* Source/WebKit/UIProcess/API/APIFormInfo.h:
* Source/WebKit/UIProcess/API/APIFrameInfo.h:
* Source/WebKit/UIProcess/API/APIFrameTreeNode.h:
* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::frameInfo const): Deleted.
(API::HitTestResult::linkLocalResourceResponse const): Deleted.
* Source/WebKit/UIProcess/API/APIInspectorConfiguration.h:
* Source/WebKit/UIProcess/API/APIInspectorExtension.h:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::originalRequest const): Deleted.
(API::Navigation::currentRequest const): Deleted.
(API::Navigation::lastNavigationAction const): Deleted.
(API::Navigation::originatingFrameInfo const): Deleted.
(API::Navigation::destinationFrameSecurityOrigin const): Deleted.
(API::Navigation::substituteData const): Deleted.
* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/APINavigationData.h:
(API::NavigationData::originalRequest const): Deleted.
(API::NavigationData::response const): Deleted.
* Source/WebKit/UIProcess/API/APINavigationResponse.h:
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/APIResourceLoadInfo.h:
* Source/WebKit/UIProcess/API/APIResourceLoadStatisticsFirstParty.h:
* Source/WebKit/UIProcess/API/APIResourceLoadStatisticsThirdParty.h:
* Source/WebKit/UIProcess/API/APIScriptMessage.h:
* Source/WebKit/UIProcess/API/APISerializedNode.h:
* Source/WebKit/UIProcess/API/APISessionState.h:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/APITextRun.h:
* Source/WebKit/UIProcess/API/APIUserScript.h:
* Source/WebKit/UIProcess/API/APIUserStyleSheet.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/API/APIWebsiteDataRecord.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/APIWindowFeatures.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageCopyPendingAPIRequestURL):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand activationKey]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListAction.mm:
(-[_WKContentRuleListAction notifications]):
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h:
(WebKit::AuthenticationChallengeProxy::core): Deleted.
* Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h:
(WebKit::WebProtectionSpace::protectionSpace const): Deleted.
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::extensionCapabilityGrants): Deleted.
* Source/WebKit/UIProcess/BackingStore.h:
(WebKit::BackingStore::size const): Deleted.
* Source/WebKit/UIProcess/BrowsingWarning.h:
(WebKit::BrowsingWarning::url const): Deleted.
(WebKit::BrowsingWarning::title const): Deleted.
(WebKit::BrowsingWarning::warning const): Deleted.
(WebKit::BrowsingWarning::data const): Deleted.
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/DisplayLink.h:
(WebKit::DisplayLink::vblankMonitor const): Deleted.
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
(WebKit::DownloadProxy::request const): Deleted.
(WebKit::DownloadProxy::redirectChain const): Deleted.
(WebKit::DownloadProxy::destinationFilename const): Deleted.
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::size const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h:
(WebKit::WebExtensionAlarm::parameters const): Deleted.
(WebKit::WebExtensionAlarm::name const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
(WebKit::WebExtensionCommand::identifier const): Deleted.
(WebKit::WebExtensionCommand::description const): Deleted.
(WebKit::WebExtensionCommand::activationKey const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::storageDirectory const): Deleted.
(WebKit::WebExtensionContext::baseURL const): Deleted.
(WebKit::WebExtensionContext::uniqueIdentifier const): Deleted.
(WebKit::WebExtensionContext::mainMenuItems const): Deleted.
(WebKit::WebExtensionContext::dynamicallyInjectedUserStyleSheets): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::configuration const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::storageDirectory const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
(WebKit::WebExtensionDataRecord::displayName const): Deleted.
(WebKit::WebExtensionDataRecord::uniqueIdentifier const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::injectedContent const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
(WebKit::WebExtensionMatchPattern::pattern const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
(WebKit::WebExtensionMenuItem::identifier const): Deleted.
(WebKit::WebExtensionMenuItem::title const): Deleted.
(WebKit::WebExtensionMenuItem::documentPatterns const): Deleted.
(WebKit::WebExtensionMenuItem::targetPatterns const): Deleted.
(WebKit::WebExtensionMenuItem::submenuItems const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h:
(WebKit::WebExtensionMessagePort::applicationIdentifier const): Deleted.
* Source/WebKit/UIProcess/FrameLoadState.h:
(WebKit::FrameLoadState::url const): Deleted.
(WebKit::FrameLoadState::provisionalURL const): Deleted.
(WebKit::FrameLoadState::unreachableURL const): Deleted.
* Source/WebKit/UIProcess/FrameProcess.h:
(WebKit::FrameProcess::site const): Deleted.
(WebKit::FrameProcess::sharedProcessMainFrameSite const): Deleted.
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
(WebKit::RemoteWebInspectorUIProxy::sheetRect const): Deleted.
* Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::sheetRect const): Deleted.
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h:
(WebKit::RemoteInspectorClient::hostAndPort const): Deleted.
(WebKit::RemoteInspectorClient::backendCommandsURL const): Deleted.
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.h:
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.h:
* Source/WebKit/UIProcess/LegacyGlobalSettings.h:
(WebKit::LegacyGlobalSettings::schemesToRegisterAsSecure): Deleted.
(WebKit::LegacyGlobalSettings::schemesToRegisterAsBypassingContentSecurityPolicy): Deleted.
(WebKit::LegacyGlobalSettings::schemesToRegisterAsLocal): Deleted.
(WebKit::LegacyGlobalSettings::schemesToRegisterAsNoAccess): Deleted.
(WebKit::LegacyGlobalSettings::hostnamesToRegisterAsLocal const): Deleted.
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequest.h:
(WebKit::MediaKeySystemPermissionRequest::keySystem const): Deleted.
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h:
(WebKit::MediaKeySystemPermissionRequestProxy::keySystem const): Deleted.
(WebKit::MediaKeySystemPermissionRequestProxy::mediaKeysHashSalt const): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
(WebKit::WebNotification::title const): Deleted.
(WebKit::WebNotification::body const): Deleted.
(WebKit::WebNotification::iconURL const): Deleted.
(WebKit::WebNotification::tag const): Deleted.
(WebKit::WebNotification::lang const): Deleted.
(WebKit::WebNotification::coreNotificationID const): Deleted.
(WebKit::WebNotification::data const): Deleted.
* Source/WebKit/UIProcess/PageLoadState.h:
(WebKit::PageLoadState::provisionalURL const): Deleted.
(WebKit::PageLoadState::url const): Deleted.
(WebKit::PageLoadState::origin const): Deleted.
(WebKit::PageLoadState::unreachableURL const): Deleted.
(WebKit::PageLoadState::certificateInfo const): Deleted.
(WebKit::PageLoadState::resourceDirectoryURL const): Deleted.
(WebKit::PageLoadState::pendingAPIRequestURL const): Deleted.
(WebKit::PageLoadState::pendingAPIRequest const): Deleted.
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
(WebKit::PerActivityStateCPUUsageSampler::pageForLogging const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimation.h:
(WebKit::RemoteAnimation::animatedProperties const): Deleted.
(WebKit::RemoteAnimation::keyframes const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationTimeline.h:
(WebKit::RemoteAnimationTimeline::currentTime const): Deleted.
(WebKit::RemoteAnimationTimeline::duration const): Deleted.
(WebKit::RemoteAnimationTimeline::identifier const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::remoteLayerTreeHost const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::animationDelegates): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::layerTreeHost const):
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm:
(WebKit::eventRegionForLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h:
* Source/WebKit/UIProcess/RemotePageProxy.h:
(WebKit::RemotePageProxy::messageReceiverRegistration): Deleted.
(WebKit::RemotePageProxy::site const): Deleted.
* Source/WebKit/UIProcess/SystemPreviewController.h:
(WebKit::SystemPreviewController::previewInfo const): Deleted.
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h:
(WebKit::WebScriptMessageHandler::client const): Deleted.
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
(WebKit::WebUserContentControllerProxy::contentExtensionRules): Deleted.
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
(WebKit::UserMediaPermissionRequestProxy::frameInfo const): Deleted.
(WebKit::UserMediaPermissionRequestProxy::userRequest const): Deleted.
(WebKit::UserMediaPermissionRequestProxy::deviceIdentifierHashSalts const): Deleted.
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.h:
(WebKit::Authenticator::requestData const): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
(WebKit::AuthenticatorManager::requestTimeOutTimer): Deleted.
(WebKit::AuthenticatorManager::services const): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::frameLoadState): Deleted.
(WebKit::WebFrameProxy::url const): Deleted.
(WebKit::WebFrameProxy::provisionalURL const): Deleted.
(WebKit::WebFrameProxy::unreachableURL const): Deleted.
(WebKit::WebFrameProxy::mimeType const): Deleted.
(WebKit::WebFrameProxy::title const): Deleted.
(WebKit::WebFrameProxy::certificateInfo const): Deleted.
* Source/WebKit/UIProcess/WebGrammarDetail.h:
(WebKit::WebGrammarDetail::userDescription const): Deleted.
(WebKit::WebGrammarDetail::grammarDetail): Deleted.
* Source/WebKit/UIProcess/WebPageGroup.h:
(WebKit::WebPageGroup::data const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebPreferences.h:
(WebKit::WebPreferences::store const): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebViewportAttributes.h:
(WebKit::WebViewportAttributes::originalAttributes const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::mediaCacheDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::mediaKeysStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::alternativeServicesDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::javaScriptConfigurationDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::searchFieldHistoryDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::indexedDBDatabaseDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::webSQLDatabaseDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::hstsStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::localStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::modelElementCacheDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::boundInterfaceIdentifier const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::deviceIdHashSaltsStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::mediaKeysHashSaltsStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::cookieStorageFile const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::resourceLoadStatisticsDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::networkCacheDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::cacheStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::generalStorageDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::webPushPartitionString const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::serviceWorkerRegistrationDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::sourceApplicationBundleIdentifier const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::sourceApplicationSecondaryIdentifier const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::resourceMonitorThrottlerDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::httpProxy const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::httpsProxy const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::standaloneApplicationURL const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::pcmMachServiceName const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::webPushMachServiceName const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::memoryFootprintNotificationThresholds): Deleted.
(WebKit::WebsiteDataStoreConfiguration::webContentRestrictionsConfigurationFile const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::additionalDomainsWithUserInteractionForTesting const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::enhancedSecurityDirectory const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::directories const): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView observeValueForKeyPath:ofObject:change:context:]):
(-[WKContentView shouldHideSelectionInFixedPositionWhenScrolling]):
(-[WKContentView _scrollingNodeScrollingDidEnd:]):
(-[WKContentView gestureRecognizerShouldBegin:]):
(-[WKContentView canShowNonEmptySelectionView]):
(-[WKContentView webSelectionRects]):
(-[WKContentView supportedPasteboardTypesForCurrentSelection]):
(-[WKContentView _cascadeInteractionTintColor]):
(-[WKContentView shouldAllowHighlightLinkCreation]):
(-[WKContentView canPerformAction:withSender:]):
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView toggleUnderlineForWebView:]):
(-[WKContentView removeBackgroundMenu]):
(-[WKContentView _characterInRelationToCaretSelection:]):
(-[WKContentView textFirstRect]):
(-[WKContentView textLastRect]):
(-[WKContentView textInRange:]):
(-[WKContentView selectedTextRange]):
(-[WKContentView markedTextRange]):
(-[WKContentView hasText]):
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView _hasContent]):
(-[WKContentView _updateInitialWritingDirectionIfNecessary]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):
(-[WKContentView _updateChangedSelection:]):
(-[WKContentView _shouldHideSelectionDuringOverflowScroll:]):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::backForwardListForNavigation const):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Canonical link: <a href="https://commits.webkit.org/308388@main">https://commits.webkit.org/308388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c80b3477caea641f8325f9c694eef64187f86ddc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100617 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/581de128-dec7-403e-b218-610d9a6952f8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113441 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80913 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30901abb-568d-4210-b051-7c89558dfb15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94202 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/019b42db-dde1-48ad-a7be-f25410c83ae6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12631 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3328 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124440 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158216 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1347 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121467 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121670 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31195 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75653 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8711 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83055 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->