### PR TITLE
[WTF] Improve RefCountDebugger::applyRefDerefThreadingCheck() to catch more bugs

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -42,6 +42,10 @@
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
+#if OS(WINDOWS)
+#include <windows.h>
+#endif
+
 #if USE(CF)
 #include <wtf/RetainPtr.h>
 #endif

--- a/Source/WTF/wtf/SizeLimits.cpp
+++ b/Source/WTF/wtf/SizeLimits.cpp
@@ -36,6 +36,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -43,7 +44,7 @@ namespace WTF {
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
 struct SameSizeAsRefCounted {
     int a;
-    bool b;
+    ThreadLikeAssertion b;
     bool c;
     bool d;
     bool e;

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -56,6 +56,7 @@ public:
 protected:
     ThreadSafeRefCountedBase()
     {
+        m_refCountDebugger.initAsThreadSafe();
         // FIXME: Lots of subclasses violate our adoption requirements. Migrate
         // this call into only those subclasses that need it.
         m_refCountDebugger.relaxAdoptionRequirement();

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -58,6 +58,7 @@ public:
 protected:
     ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
     {
+        m_refCountDebugger.initAsThreadSafe();
         // FIXME: Lots of subclasses violate our adoption requirements. Migrate
         // this call into only those subclasses that need it.
         m_refCountDebugger.relaxAdoptionRequirement();

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -28,6 +28,7 @@
 
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
+#include <wtf/WallTime.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/PAL/pal/text/TextCodec.h
+++ b/Source/WebCore/PAL/pal/text/TextCodec.h
@@ -32,6 +32,7 @@
 #include <span>
 #include <unicode/umachine.h>
 #include <wtf/Forward.h>
+#include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.h
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <wtf/Function.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/text/StringView.h>
 

--- a/Source/WebCore/page/WebKitPoint.h
+++ b/Source/WebCore/page/WebKitPoint.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -2299,7 +2299,7 @@ extension WebGPU.CommandEncoder {
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=283385 - https://bugs.webkit.org/show_bug.cgi?id=283088 should be reverted when the blocking issue is resolved
             finalizeBlitCommandEncoder()
             let workaround = m_device.ptr().resolveTimestampsSharedEvent()
-            // The signal value does not matter, the event alone prevents reordering
+            // The signal value does not matter, the event alone prevents reordering.
             m_commandBuffer?.encodeSignalEvent(workaround, value: 1)
             m_commandBuffer?.encodeWaitForEvent(workaround, value: 1)
             guard ensureBlitCommandEncoder() != nil else {

--- a/Source/WebKit/UIProcess/API/glib/WebKitScriptDialogPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitScriptDialogPrivate.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "WebKitScriptDialog.h"
+#include <wtf/Function.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 

--- a/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
@@ -28,6 +28,10 @@
 #include "Test.h"
 #include <wtf/DateMath.h>
 
+#if PLATFORM(WIN)
+#include <windows.h>
+#endif
+
 namespace TestWebKitAPI {
 
 // Note: The results of these function look weird if you do not understand the following mappings:

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
@@ -32,6 +32,7 @@
 #include "RefLogger.h"
 #include "Test.h"
 #include <string>
+#include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/UniqueRef.h>


### PR DESCRIPTION
#### 0be79662c16816e7b9cd91a73f77cb5939c27b14
<pre>
[WTF] Improve RefCountDebugger::applyRefDerefThreadingCheck() to catch more bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=308806">https://bugs.webkit.org/show_bug.cgi?id=308806</a>
<a href="https://rdar.apple.com/169618659">rdar://169618659</a>

Reviewed by Ryosuke Niwa.

Improve RefCountDebugger::applyRefDerefThreadingCheck() to catch more
bugs. In particular, we now make sure the refcount always gets
incremented on the same thread / serial work queue by leveraging
ThreadLikeAssertion. Previously, the code would only distinguish main
thread vs non-main thread. I have also bumped the ASSERT to be an
ASSERT_WITH_SECURITY_IMPLICATION.

* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/RefCountDebugger.h:
(WTF::RefCountDebugger::initAsThreadSafe):
(WTF::RefCountDebugger::disableThreadingChecks):
(WTF::RefCountDebugger::enableThreadingChecksGlobally):
(WTF::RefCountDebugger::applyRefDerefThreadingCheck const):
(WTF::RefCountDebugger::RefCountDebugger): Deleted.
* Source/WTF/wtf/SizeLimits.cpp:
* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
* Source/WebCore/PAL/pal/text/TextCodec.h:
* Source/WebCore/html/parser/HTMLSrcsetParser.h:
* Source/WebCore/page/WebKitPoint.h:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
* Source/WebKit/UIProcess/API/glib/WebKitScriptDialogPrivate.h:
* Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp:
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp:

Canonical link: <a href="https://commits.webkit.org/308390@main">https://commits.webkit.org/308390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdb9453acc6084f26ba49ba5a12022e145d73667

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147370 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100785 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48337ac5-0648-495a-bbae-4d351da62892) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113587 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81004 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab270b52-1d7b-49f1-8042-8d7e6920b93c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dcae936-6c8b-49a2-8f5f-471f5175ea9a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14982 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12766 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3493 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158384 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8158 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121615 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121815 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31198 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75844 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8847 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178687 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83231 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45760 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19350 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->