### PR TITLE
Disable HTTP Enhanced Security usage when developer extras are active.

### DIFF
--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -171,11 +171,12 @@ void EnhancedSecurityTracking::trackSameSiteNavigation(const API::Navigation& na
     }
 }
 
-bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation)
+bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation, bool hasDeveloperExtrasEnabled)
 {
     auto currentRequestURL = navigation.currentRequest().url();
 
     if (currentRequestURL.protocolIs("http"_s)
+        && !hasDeveloperExtrasEnabled
         && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())) {
         enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
         return true;
@@ -200,7 +201,7 @@ void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation
         enableFor(reasonForEnhancedSecurity(priorState), navigation);
 }
 
-void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation, bool hasOpenedPage)
+void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation, bool hasOpenedPage, bool hasDeveloperExtrasEnabled)
 {
     auto lastNavigationAction = navigation.lastNavigationAction();
     if (lastNavigationAction && lastNavigationAction->hasOpener)
@@ -223,7 +224,7 @@ void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation
     if (m_activeState != ActivationState::None && isInitialUIDriven && !isReload)
         reset();
 
-    if (m_activeState != ActivationState::Active && enableIfRequired(navigation))
+    if (m_activeState != ActivationState::Active && enableIfRequired(navigation, hasDeveloperExtrasEnabled))
         return;
 
     if (m_activeState == ActivationState::Active

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
@@ -40,7 +40,7 @@ class EnhancedSecurityTracking final : public CanMakeWeakPtr<EnhancedSecurityTra
 public:
     void initializeWithWebsiteDataStore(WebsiteDataStore&);
 
-    void trackNavigation(const API::Navigation&, bool hasOpenedPage);
+    void trackNavigation(const API::Navigation&, bool hasOpenedPage, bool hasDeveloperExtrasEnabled);
 
     bool isEnhancedSecurityEnabled() const { return isEnhancedSecurityEnabledForState(enhancedSecurityState()); }
     EnhancedSecurity NODELETE enhancedSecurityState() const;
@@ -58,7 +58,7 @@ private:
     void handleBackForwardNavigation(const API::Navigation&);
 
     void enableFor(EnhancedSecurityReason, const API::Navigation&);
-    bool enableIfRequired(const API::Navigation&);
+    bool enableIfRequired(const API::Navigation&, bool hasDeveloperExtrasEnabled);
 
     void trackSameSiteNavigation(const API::Navigation&);
     void trackChangingSiteNavigation();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5208,7 +5208,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         browsingContextGroup = BrowsingContextGroup::create();
 
     if (frame.isMainFrame() && preferences->enhancedSecurityHeuristicsEnabled())
-        internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage());
+        internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage(), preferences->developerExtrasEnabled());
 
     auto enhancedSecurity = currentEnhancedSecurityState(websitePolicies.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -186,6 +186,8 @@ static RetainPtr<TestWKWebView> enhancedSecurityTestConfiguration(
         }
     }
 
+    preferences._developerExtrasEnabled = NO;
+
     auto storeConfiguration = useNonPersistentStore
         ? adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration])
         : adoptNS([_WKWebsiteDataStoreConfiguration new]);
@@ -281,6 +283,21 @@ static void runHttpLoad(bool useSiteIsolation)
     });
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLoad)
+
+static void runHttpLoadWithDeveloperExtrasEnabled(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('insecure-page')</script>"_s } },
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+    [webView configuration].preferences._developerExtrasEnabled = YES;
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLoadWithDeveloperExtrasEnabled)
 
 static void runHttpsLoad(bool useSiteIsolation)
 {


### PR DESCRIPTION
#### deff646e0d423bcdca7b55cc4a5c8f4cc064ea9e
<pre>
Disable HTTP Enhanced Security usage when developer extras are active.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

This change disables the HTTP heuristic for Enhanced Security when the
developer extras are active (e.g. Develop menu in Safari), to prevent
impacting local development against HTTP servers.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::EnhancedSecurityTracking::enableIfRequired):
(WebKit::EnhancedSecurityTracking::trackNavigation):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(enhancedSecurityTestConfiguration):
(runHttpLoadWithDeveloperExtrasEnabled):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deff646e0d423bcdca7b55cc4a5c8f4cc064ea9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100647 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fc8146c-dfaa-4d74-8d96-f1012e5dc275) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80930 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56836f44-0f9d-4a03-8658-ed402ebc0c16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94229 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f17b9524-784c-4bc4-bf6d-96f9d273ebdd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12654 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158246 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121494 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121697 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75686 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8735 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83085 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19061 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->