### PR TITLE
Give WebPopupMenuProxyMac a delegate for testing purposes

### DIFF
--- a/LayoutTests/fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur.html
@@ -31,9 +31,9 @@ function log(text) {
 }
 
 function clickOnSelectElement() {
-    const event = document.createEvent("MouseEvent");
-    event.initMouseEvent("mousedown", true, true, document.defaultView, 1, select.offsetLeft + 5, select.offsetTop + 5, select.offsetLeft + 5, select.offsetTop + 5, false, false, false, false, 0, document);
-    select.dispatchEvent(event);
+    eventSender.mouseMoveTo(select.offsetLeft + 5, select.offsetTop + 5);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
 }
 
 function roundTripToUIProcess() {

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
@@ -33,6 +33,8 @@
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSPopUpButtonCell;
+OBJC_CLASS NSView;
+OBJC_CLASS WKPopupMenuDelegate;
 OBJC_CLASS WKView;
 
 namespace WebKit {
@@ -54,6 +56,8 @@ public:
     NSPopUpButtonCell *NODELETE popup() const;
     bool isVisible() const { return m_isVisible; }
 
+    void didFinishShowingPopupMenu();
+
 private:
     WebPopupMenuProxyMac(NSView *, WebPopupMenuProxy::Client&);
 
@@ -63,6 +67,8 @@ private:
 
     RetainPtr<NSPopUpButtonCell> m_popup;
     WeakObjCPtr<NSView> m_webView;
+    RetainPtr<WKPopupMenuDelegate> m_menuDelegate;
+    RetainPtr<NSView> m_dummyView;
     bool m_wasCanceled { false };
     bool m_isVisible { false };
 };

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -38,8 +38,43 @@
 #import <pal/system/mac/PopupMenu.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/ProcessPrivilege.h>
-#import <wtf/SetForScope.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+
+@interface WKPopupMenuDelegate : NSObject <NSMenuDelegate> {
+    RefPtr<WebKit::WebPopupMenuProxyMac> _menuProxy;
+    bool _menuDidClose;
+    bool _popUpMenuReturned;
+}
+- (instancetype)initWithMenuProxy:(WebKit::WebPopupMenuProxyMac&)menuProxy;
+- (void)popUpMenuReturned;
+@end
+
+@implementation WKPopupMenuDelegate
+
+- (instancetype)initWithMenuProxy:(WebKit::WebPopupMenuProxyMac&)menuProxy
+{
+    self = [super init];
+    if (!self)
+        return nil;
+    _menuProxy = &menuProxy;
+    return self;
+}
+
+- (void)menuDidClose:(NSMenu *)menu
+{
+    _menuDidClose = true;
+    if (_popUpMenuReturned)
+        _menuProxy->didFinishShowingPopupMenu();
+}
+
+- (void)popUpMenuReturned
+{
+    _popUpMenuReturned = true;
+    if (_menuDidClose)
+        _menuProxy->didFinishShowingPopupMenu();
+}
+
+@end
 
 namespace WebKit {
 using namespace WebCore;
@@ -52,8 +87,10 @@ WebPopupMenuProxyMac::WebPopupMenuProxyMac(NSView *webView, WebPopupMenuProxy::C
 
 WebPopupMenuProxyMac::~WebPopupMenuProxyMac()
 {
-    if (m_popup)
+    if (m_popup) {
+        [[m_popup menu] setDelegate:nil];
         [m_popup setControlView:nil];
+    }
 }
 
 void WebPopupMenuProxyMac::populate(const Vector<WebPopupItem>& items, NSFont *font, TextDirection menuTextDirection)
@@ -154,10 +191,11 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
         else
             location = NSMakePoint(NSMaxX(rect) - popUnderHorizontalAdjust, NSMaxY(rect) + popUnderVerticalAdjust);
     }
-    RetainPtr<NSView> dummyView = adoptNS([[NSView alloc] initWithFrame:rect]);
-    [dummyView.get() setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
-    [m_webView.get() addSubview:dummyView.get()];
-    location = [dummyView convertPoint:location fromView:m_webView.get().get()];
+    m_isVisible = true;
+    m_dummyView = adoptNS([[NSView alloc] initWithFrame:rect]);
+    [m_dummyView setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
+    [m_webView.get() addSubview:m_dummyView.get()];
+    location = [m_dummyView convertPoint:location fromView:m_webView.get().get()];
 
     NSControlSize controlSize;
     switch (data.menuSize) {
@@ -175,24 +213,33 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
         break;
     }
 
-    SetForScope visibleScope { m_isVisible, true };
+    m_menuDelegate = adoptNS([[WKPopupMenuDelegate alloc] initWithMenuProxy:*this]);
+    [menu setDelegate:m_menuDelegate.get()];
 
-    Ref<WebPopupMenuProxyMac> protect(*this);
-    PAL::popUpMenu(menu.get(), location, roundf(NSWidth(rect)), dummyView.get(), selectedIndex, bridge_cast(font.get()), controlSize, data.hideArrows);
+    PAL::popUpMenu(menu.get(), location, roundf(NSWidth(rect)), m_dummyView.get(), selectedIndex, bridge_cast(font.get()), controlSize, data.hideArrows);
 
+    [m_menuDelegate popUpMenuReturned];
+}
+
+void WebPopupMenuProxyMac::didFinishShowingPopupMenu()
+{
     [m_popup dismissPopUp];
-    [dummyView removeFromSuperview];
-    
+    [m_dummyView removeFromSuperview];
+    m_dummyView = nil;
+    [[m_popup menu] setDelegate:nil];
+    m_menuDelegate = nil;
+    m_isVisible = false;
+
     CheckedPtr client = this->client();
     if (!client || m_wasCanceled)
         return;
-    
+
     client->valueChangedForPopupMenu(this, [m_popup indexOfSelectedItem]);
-    
+
     // <https://bugs.webkit.org/show_bug.cgi?id=57904> This code is adopted from EventHandler::sendFakeEventsAfterWidgetTracking().
     if (!client->currentlyProcessedMouseDownEvent())
         return;
-    
+
     RetainPtr initiatingNSEvent = client->currentlyProcessedMouseDownEvent()->nativeEvent();
     if ([initiatingNSEvent type] != NSEventTypeLeftMouseDown)
         return;


### PR DESCRIPTION
#### 1d73c09705ab777b1baba357553977a82eba96bd
<pre>
Give WebPopupMenuProxyMac a delegate for testing purposes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308821">https://bugs.webkit.org/show_bug.cgi?id=308821</a>

Reviewed by NOBODY (OOPS!).

At the moment you cannot open a &lt;select&gt; on macOS from WebKitTestRunner
without it immediately closing due to how NSMenu is swizzled in
TestController::platformInitialize().

With this new delegate cleanup (didFinishShowingPopupMenu()) doesn&apos;t
run immediately, but only after cancelTracking.

Without these changes we could not change
fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur.html
the way we did without it starting to fail.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d73c09705ab777b1baba357553977a82eba96bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0396e55e-7570-43bb-92d4-fa8c708131d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80943 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7beb1ec1-c05d-4e49-8851-6a4acb5a790d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94241 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f5aba51-6eaa-4e83-a331-4ddbe7104fba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12682 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3370 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158258 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1406 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11638 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/open-pseudo.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121506 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19727 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16566 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/open-pseudo.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121709 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75703 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17246 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8750 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/open-pseudo.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19343 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83117 "Found 2 new failures in UIProcess/mac/WebPopupMenuProxyMac.mm") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19073 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->