### PR TITLE
[Table] Table does not reach CSS specified height when <td> has HTML height attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-with-td-height-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-with-td-height-attribute-expected.txt
@@ -1,0 +1,18 @@
+Table with CSS height should reach specified height regardless of td height attribute
+
+td with no height attribute
+td with height=1px attribute
+td with height=1px attribute, explicit border-spacing: 2px
+td with height=1px attribute, border-spacing: 0px
+td with height=1px attribute, border-spacing: 10px
+td with height=50px attribute
+two rows, both with td height=1px attribute
+
+PASS table 1
+PASS table 2
+PASS table 3
+PASS table 4
+PASS table 5
+PASS table 6
+PASS table 7
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-with-td-height-attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-with-td-height-attribute.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<title>TABLE height with td height attribute</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src="/resources/check-layout-th.js"></script>
+<link rel='stylesheet' href='../support/base.css' />
+<link rel='stylesheet' href='./support/table-tentative.css' />
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#row-layout" />
+<style>
+  main table {
+    height: 100px;
+    width: 100px;
+    background: green;
+  }
+  main td {
+    padding: 0;
+  }
+</style>
+<main>
+<h1>Table with CSS height should reach specified height regardless of td height attribute</h1>
+
+<p class="testdesc">td with no height attribute</p>
+<table data-expected-height=100>
+  <tr><td></td></tr>
+</table>
+
+<p class="testdesc">td with height=1px attribute</p>
+<table data-expected-height=100>
+  <tr><td height=1px></td></tr>
+</table>
+
+<p class="testdesc">td with height=1px attribute, explicit border-spacing: 2px</p>
+<table style="border-spacing: 2px" data-expected-height=100>
+  <tr><td height=1px></td></tr>
+</table>
+
+<p class="testdesc">td with height=1px attribute, border-spacing: 0px</p>
+<table style="border-spacing: 0px" data-expected-height=100>
+  <tr><td height=1px></td></tr>
+</table>
+
+<p class="testdesc">td with height=1px attribute, border-spacing: 10px</p>
+<table style="border-spacing: 10px" data-expected-height=100>
+  <tr><td height=1px></td></tr>
+</table>
+
+<p class="testdesc">td with height=50px attribute</p>
+<table data-expected-height=100>
+  <tr><td height=50px></td></tr>
+</table>
+
+<p class="testdesc">two rows, both with td height=1px attribute</p>
+<table data-expected-height=100>
+  <tr><td height=1px></td></tr>
+  <tr><td height=1px></td></tr>
+</table>
+
+</main>
+
+<script>
+  checkLayout("table");
+</script>

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug120364-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug120364-expected.txt
@@ -1,21 +1,21 @@
-layer at (0,0) size 785x1814
+layer at (0,0) size 785x1828
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1814
-  RenderBlock {HTML} at (0,0) size 785x1815
+layer at (0,0) size 785x1828
+  RenderBlock {HTML} at (0,0) size 785x1828
     RenderBody {BODY} at (8,8) size 769x584
       RenderText {#text} at (0,0) size 22x18
         text run at (0,0) width 22: "foo"
-      RenderTable {TABLE} at (653,0) size 116x1807
-        RenderTableSection {TBODY} at (0,0) size 116x1807
-          RenderTableRow {TR} at (0,2) size 116x999
+      RenderTable {TABLE} at (653,0) size 116x1820
+        RenderTableSection {TBODY} at (0,0) size 116x1820
+          RenderTableRow {TR} at (0,2) size 116x1007
             RenderTableCell {TD} at (2,2) size 112x74 [r=0 c=0 rs=1 cs=1]
               RenderBR {BR} at (1,1) size 0x18
               RenderText {#text} at (1,19) size 103x54
                 text run at (1,19) width 85: "Create a cool"
                 text run at (1,37) width 103: "home page with"
                 text run at (1,55) width 20: "the"
-          RenderTableRow {TR} at (0,1002) size 116x803
-            RenderTableCell {TD} at (2,1002) size 112x57 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,1010) size 116x808
+            RenderTableCell {TD} at (2,1010) size 112x57 [r=1 c=0 rs=1 cs=1]
               RenderBR {BR} at (1,1) size 0x18
               RenderText {#text} at (1,19) size 96x36
                 text run at (1,19) width 90: "Get organized"

--- a/LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x4336
+layer at (0,0) size 785x4338
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x4336
-  RenderBlock {HTML} at (0,0) size 785x4337
-    RenderBody {BODY} at (8,8) size 769x4321
+layer at (0,0) size 785x4338
+  RenderBlock {HTML} at (0,0) size 785x4338
+    RenderBody {BODY} at (8,8) size 769x4322
       RenderTable {TABLE} at (0,0) size 40x584 [bgcolor=#0000FF] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 38x582
           RenderTableRow {TR} at (0,2) size 38x115
@@ -111,18 +111,18 @@ layer at (0,0) size 785x4336
                 text run at (2,2) width 24: "200"
       RenderBlock (anonymous) at (0,2476) size 769x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,2494) size 62x199 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 60x197
-          RenderTableRow {TR} at (0,2) size 60x193
-            RenderTableCell {TD} at (2,87) size 34x23 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,87) size 30x19
+      RenderTable {TABLE} at (0,2494) size 62x200 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 60x198
+          RenderTableRow {TR} at (0,2) size 60x194
+            RenderTableCell {TD} at (2,88) size 34x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,88) size 30x18
                 text run at (2,2) width 30: "50%"
-            RenderTableCell {TD} at (37,87) size 21x23 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,87) size 16x19
+            RenderTableCell {TD} at (37,88) size 21x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (2,88) size 16x18
                 text run at (2,2) width 16: "20"
-      RenderBlock (anonymous) at (0,2692) size 769x19
+      RenderBlock (anonymous) at (0,2694) size 769x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,2710) size 40x585 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,2712) size 40x584 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 38x582
           RenderTableRow {TR} at (0,2) size 38x500
             RenderTableCell {TD} at (2,241) size 34x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -132,9 +132,9 @@ layer at (0,0) size 785x4336
             RenderTableCell {TD} at (2,531) size 34x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,29) size 30x18
                 text run at (2,2) width 30: "80%"
-      RenderBlock (anonymous) at (0,3294) size 769x19
+      RenderBlock (anonymous) at (0,3296) size 769x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,3312) size 105x585 [bgcolor=#FF0000] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,3314) size 105x584 [bgcolor=#FF0000] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 103x582
           RenderTableRow {TR} at (0,2) size 103x40
             RenderTableCell {TD} at (2,259) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
@@ -157,9 +157,9 @@ layer at (0,0) size 785x4336
             RenderTableCell {TD} at (35,549) size 33x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (2,11) size 28x18
                 text run at (2,2) width 28: "auto"
-      RenderBlock (anonymous) at (0,3896) size 769x19
+      RenderBlock (anonymous) at (0,3898) size 769x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,3914) size 54x407 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,3916) size 54x406 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 52x404
           RenderTableRow {TR} at (0,2) size 52x400
             RenderTableCell {TD} at (2,2) size 48x400 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2018 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
@@ -460,8 +460,7 @@ void RenderTableSection::distributeRemainingExtraLogicalHeight(LayoutUnit& extra
     if (extraLogicalHeight <= 0 || !m_rowPos[totalRows])
         return;
 
-    // FIXME: m_rowPos[totalRows] - m_rowPos[0] is the total rows' size.
-    LayoutUnit totalRowSize = m_rowPos[totalRows];
+    LayoutUnit totalRowSize = m_rowPos[totalRows] - m_rowPos[0];
     LayoutUnit totalLogicalHeightAdded;
     LayoutUnit previousRowPosition = m_rowPos[0];
     for (unsigned r = 0; r < totalRows; r++) {


### PR DESCRIPTION
#### e737f72ae47e35ff6fe588b6fdd7616e22818533
<pre>
[Table] Table does not reach CSS specified height when &lt;td&gt; has HTML height attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=226002">https://bugs.webkit.org/show_bug.cgi?id=226002</a>
<a href="https://rdar.apple.com/78549188">rdar://78549188</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When a table has a CSS height (e.g. 100px) and contains a &lt;td height=1px&gt;,
the table renders shorter than specified. This is because
distributeRemainingExtraLogicalHeight() uses m_rowPos[totalRows] as the
denominator for proportional distribution, but this includes the initial
border-spacing stored in m_rowPos[0]. The result is that a fraction of the
extra height is never distributed.

Fix by subtracting m_rowPos[0] from the denominator so proportional
distribution is based on actual row sizes. The code already had a FIXME
comment identifying this exact issue.

* LayoutTests/platform/mac/tables/mozilla/bugs/bug120364-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::distributeRemainingExtraLogicalHeight):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e737f72ae47e35ff6fe588b6fdd7616e22818533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100663 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3024417-3c5e-4f73-b900-e306201d5353) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19831 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113484 "Found 4 new test failures: fast/repaint/table-two-pass-layout-overpaint.html tables/mozilla/bugs/bug11944.html tables/mozilla/bugs/bug120364.html tables/mozilla/core/cell_heights.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80947 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150211 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15698 "Found 3 new test failures: tables/mozilla/bugs/bug11944.html tables/mozilla/bugs/bug120364.html tables/mozilla/core/cell_heights.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94245 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d6c96d6-db41-4859-b133-98802d79c1ab) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12683 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3374 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158262 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1409 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11657 "Found 1 new test failure: fast/repaint/table-two-pass-layout-overpaint.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121509 "Found 4 new test failures: fast/repaint/table-two-pass-layout-overpaint.html tables/mozilla/bugs/bug11944.html tables/mozilla/bugs/bug120364.html tables/mozilla/core/cell_heights.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19731 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16567 "Found 1 new test failure: fast/repaint/table-two-pass-layout-overpaint.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121712 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75708 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17243 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8754 "Found 1 new test failure: fast/repaint/table-two-pass-layout-overpaint.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19077 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->