### PR TITLE
Web Inspector: Color Picker should show contrast information when editing background color properties

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -255,6 +255,7 @@ localizedStrings["Average: %s"] = "Average: %s";
 localizedStrings["Axis value outside of supported range: %s – %s"] = "Axis value outside of supported range: %s – %s";
 localizedStrings["BMP"] = "BMP";
 localizedStrings["Back (%s)"] = "Back (%s)";
+localizedStrings["Background Color"] = "Background Color";
 localizedStrings["Backtrace"] = "Backtrace";
 /* Label for navigation item that controls what badges are shown in the main DOM tree. */
 localizedStrings["Badges @ Elements Tab"] = "Badges";
@@ -1754,6 +1755,7 @@ localizedStrings["Template Content"] = "Template Content";
 /* Dropdown option inside the popover used to creating an audit test case. */
 localizedStrings["Test Case @ Audit Tab Navigation Sidebar"] = "Test Case";
 localizedStrings["Text"] = "Text";
+localizedStrings["Text Color"] = "Text Color";
 localizedStrings["Text Frame"] = "Text Frame";
 localizedStrings["Text Node"] = "Text Node";
 localizedStrings["The Inspector Bootstrap Script is guaranteed to be the first script evaluated in any page, as well as any sub-frames."] = "The Inspector Bootstrap Script is guaranteed to be the first script evaluated in any page, as well as any sub-frames.";

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.js
@@ -33,8 +33,8 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         this._contrastInfo = contrastInfo || null;
 
         this._colorSquare = new WI.ColorSquare(this, 200);
-        if (this._contrastInfo?.backgroundColor) {
-            this._colorSquare.contrastBackgroundColor = this._contrastInfo.backgroundColor;
+        if (this._contrastInfo?.contrastColor) {
+            this._colorSquare.contrastColor = this._contrastInfo.contrastColor;
             this._colorSquare.isLargeText = !!this._contrastInfo.isLargeText;
         }
 
@@ -98,7 +98,7 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         }
 
         this._contrastInfoElement = null;
-        if (this._contrastInfo?.backgroundColor)
+        if (this._contrastInfo?.contrastColor)
             this._createContrastInfoSection();
 
         this._opacity = 0;
@@ -527,18 +527,19 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         separatorElement.classList.add("contrast-separator");
         separatorElement.textContent = WI.UIString("vs", "vs @ Color Picker Contrast", "Separator between foreground and background colors in contrast info");
 
-        let backgroundSwatch = new WI.InlineSwatch(WI.InlineSwatch.Type.Color, this._contrastInfo.backgroundColor, {readOnly: true, tooltip: WI.UIString("Background Color")});
-        this._contrastInfoElement.appendChild(backgroundSwatch.element);
+        let swatchTooltip = this._contrastInfo.isBackgroundColor ? WI.UIString("Text Color") : WI.UIString("Background Color");
+        let contrastSwatch = new WI.InlineSwatch(WI.InlineSwatch.Type.Color, this._contrastInfo.contrastColor, {readOnly: true, tooltip: swatchTooltip});
+        this._contrastInfoElement.appendChild(contrastSwatch.element);
     }
 
     _updateContrastInfo()
     {
-        if (!this._contrastInfo?.backgroundColor || !this._contrastInfoElement)
+        if (!this._contrastInfo?.contrastColor || !this._contrastInfoElement)
             return;
 
-        let effectiveForeground = this._color.blendOverBackground(this._contrastInfo.backgroundColor);
+        let effectiveForeground = this._color.blendOverBackground(this._contrastInfo.contrastColor);
 
-        let ratio = effectiveForeground.contrastRatio(this._contrastInfo.backgroundColor);
+        let ratio = effectiveForeground.contrastRatio(this._contrastInfo.contrastColor);
         let isLargeText = !!this._contrastInfo.isLargeText;
         let compliance = WI.Color.contrastComplianceForRatio(ratio, {isLargeText});
 

--- a/Source/WebInspectorUI/UserInterface/Views/ColorSquare.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorSquare.js
@@ -34,7 +34,7 @@ WI.ColorSquare = class ColorSquare
         this._y = 0;
         this._gamut = null;
         this._crosshairPosition = null;
-        this._contrastBackgroundColor = null;
+        this._contrastColor = null;
 
         this._element = document.createElement("div");
         this._element.className = "color-square";
@@ -93,15 +93,15 @@ WI.ColorSquare = class ColorSquare
         this._updateBaseColor();
     }
 
-    get contrastBackgroundColor()
+    get contrastColor()
     {
-        return this._contrastBackgroundColor;
+        return this._contrastColor;
     }
 
-    set contrastBackgroundColor(color)
+    set contrastColor(color)
     {
         console.assert(!color || color instanceof WI.Color, color);
-        this._contrastBackgroundColor = color || null;
+        this._contrastColor = color || null;
         this._drawContrastLines();
     }
 
@@ -287,7 +287,7 @@ WI.ColorSquare = class ColorSquare
         if (this._gamut === WI.Color.Gamut.DisplayP3)
             this._drawSRGBOutline();
 
-        if (this._contrastBackgroundColor)
+        if (this._contrastColor)
             this._drawContrastLines();
     }
 
@@ -355,7 +355,7 @@ WI.ColorSquare = class ColorSquare
 
     _drawContrastLines()
     {
-        if (!this._contrastBackgroundColor) {
+        if (!this._contrastColor) {
             if (this._contrastSVGElement) {
                 this._contrastSVGElement.hidden = true;
                 this._contrastAALabelElement.hidden = true;
@@ -396,23 +396,23 @@ WI.ColorSquare = class ColorSquare
             ? WI.UIString("WCAG AAA enhanced contrast for large text (4.5:1)", "WCAG AAA enhanced contrast for large text (4.5:1) @ Tooltip for AAA contrast line in color picker", "Tooltip for AAA contrast line in color picker for large text")
             : WI.UIString("WCAG AAA enhanced contrast (7:1)", "WCAG AAA enhanced contrast (7:1) @ Tooltip for AAA contrast line in color picker", "Tooltip for AAA contrast line in color picker");
 
-        let backgroundLuminance = this._contrastBackgroundColor.relativeLuminance();
+        let referenceLuminance = this._contrastColor.relativeLuminance();
 
-        let aaPoints = this._calculateContrastLinePoints(aaThreshold, backgroundLuminance);
+        let aaPoints = this._calculateContrastLinePoints(aaThreshold, referenceLuminance);
         this._updatePolylinePoints(this._contrastAAPolylineElement, aaPoints);
-        this._updateContrastLabel(this._contrastAALabelElement, aaPoints, backgroundLuminance);
+        this._updateContrastLabel(this._contrastAALabelElement, aaPoints, referenceLuminance);
 
-        let aaaPoints = this._calculateContrastLinePoints(aaaThreshold, backgroundLuminance);
+        let aaaPoints = this._calculateContrastLinePoints(aaaThreshold, referenceLuminance);
         this._updatePolylinePoints(this._contrastAAAPolylineElement, aaaPoints);
-        this._updateContrastLabel(this._contrastAAALabelElement, aaaPoints, backgroundLuminance);
+        this._updateContrastLabel(this._contrastAAALabelElement, aaaPoints, referenceLuminance);
     }
 
-    _calculateContrastLinePoints(targetRatio, backgroundLuminance)
+    _calculateContrastLinePoints(targetRatio, referenceLuminance)
     {
-        if (backgroundLuminance >= 0.5)
+        if (referenceLuminance >= 0.5)
             targetRatio = 1 / targetRatio;
 
-        let targetLuminance = ((backgroundLuminance + 0.05) * targetRatio) - 0.05;
+        let targetLuminance = ((referenceLuminance + 0.05) * targetRatio) - 0.05;
 
         if (targetLuminance < 0 || targetLuminance > 1)
             return [];
@@ -444,8 +444,8 @@ WI.ColorSquare = class ColorSquare
             let color = new WI.Color(WI.Color.Format.ColorFunction, rgb.concat(this._opacity));
 
             let effectiveColor = color;
-            if (this._opacity < 1 && this._contrastBackgroundColor)
-                effectiveColor = color.blendOverBackground(this._contrastBackgroundColor);
+            if (this._opacity < 1 && this._contrastColor)
+                effectiveColor = color.blendOverBackground(this._contrastColor);
 
             let luminance = effectiveColor.relativeLuminance();
 
@@ -484,7 +484,7 @@ WI.ColorSquare = class ColorSquare
         }
     }
 
-    _updateContrastLabel(labelElement, points, backgroundLuminance)
+    _updateContrastLabel(labelElement, points, referenceLuminance)
     {
         if (points.length === 0) {
             labelElement.hidden = true;
@@ -508,7 +508,7 @@ WI.ColorSquare = class ColorSquare
         }
 
         let labelHeight = 16;
-        let yOffset = backgroundLuminance < 0.5 ? -labelHeight : 4;
+        let yOffset = referenceLuminance < 0.5 ? -labelHeight : 4;
         labelElement.style.top = `${Math.max(0, Math.min(this._dimension - labelHeight, point.y + yOffset))}px`;
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -494,20 +494,22 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
     {
         let propertyName = this._property.name.toLowerCase();
         let isTextColorProperty = propertyName === "color" || propertyName === "-webkit-text-fill-color" || propertyName === "-webkit-text-stroke-color";
+        let isBackgroundColor = propertyName === "background-color" || propertyName === "background";
 
-        if (!isTextColorProperty)
+        if (!isTextColorProperty && !isBackgroundColor)
             return null;
 
         let computedStyle = this._property.ownerStyle.nodeStyles?.computedStyle;
         if (!computedStyle)
             return null;
 
-        let backgroundColor = WI.Color.fromString(computedStyle.propertyForName("background-color")?.value ?? "");
-        if (!backgroundColor)
+        let contrastPropertyName = isTextColorProperty ? "background-color" : "color";
+        let contrastColor = WI.Color.fromString(computedStyle.propertyForName(contrastPropertyName)?.value ?? "");
+        if (!contrastColor)
             return null;
 
-        if (backgroundColor.alpha < 1)
-            backgroundColor = backgroundColor.blendOverBackground(WI.Color.fromString("white"));
+        if (contrastColor.alpha < 1)
+            contrastColor = contrastColor.blendOverBackground(WI.Color.fromString("white"));
 
         let fontSizeInPt = parseFloat(computedStyle.propertyForName("font-size")?.value) * 0.75;
         let isLargeText = fontSizeInPt >= 18;
@@ -516,7 +518,7 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
             isLargeText = fontWeight >= 700;
         }
 
-        return {backgroundColor, isLargeText};
+        return {contrastColor, isLargeText, isBackgroundColor};
     }
 
     // Private


### PR DESCRIPTION
#### 36be7c4d1319d8851a67c5f3aa0abd9f60b3d02e
<pre>
Web Inspector: Color Picker should show contrast information when editing background color properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=308800">https://bugs.webkit.org/show_bug.cgi?id=308800</a>
<a href="https://rdar.apple.com/171332734">rdar://171332734</a>

Reviewed by Devin Rousso.

Since contrast ratio is symmetric, the same contrast UI works for
background color properties by using the computed text color as the
reference instead of the computed background color.

Renamed contrast variables throughout the chain from &quot;backgroundColor&quot;
to &quot;contrastColor&quot;/&quot;contrastReferenceColor&quot; so the naming is accurate
regardless of which direction the contrast is being measured. The &quot;vs&quot;
swatch tooltip now shows &quot;Text Color&quot; or &quot;Background Color&quot; depending
on which property is being edited.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:
(WI.ColorPicker.prototype.async colorInputsWrapperElement):
(WI.ColorPicker.prototype._createContrastInfoSection):
(WI.ColorPicker.prototype._updateContrastInfo):
(WI.ColorPicker):
* Source/WebInspectorUI/UserInterface/Views/ColorSquare.js:
(WI.ColorSquare):
(WI.ColorSquare.prototype.get contrastColor):
(WI.ColorSquare.prototype.set contrastColor):
(WI.ColorSquare.prototype._updateBaseColor):
(WI.ColorSquare.prototype._drawContrastLines):
(WI.ColorSquare.prototype._calculateContrastLinePoints):
(WI.ColorSquare.prototype._findBrightnessForLuminance):
(WI.ColorSquare.prototype._updateContrastLabel):
(WI.ColorSquare.prototype.get contrastBackgroundColor): Deleted.
(WI.ColorSquare.prototype.set contrastBackgroundColor): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype.inlineSwatchGetContrastInfo):

Canonical link: <a href="https://commits.webkit.org/308653@main">https://commits.webkit.org/308653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c605a4249d10d815beb8028be7651ae2774e63b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156802 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114189 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e45f136d-114b-4262-b04b-11d4685bd83b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28b21170-493d-4b6b-9e24-c1323930d710) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4239 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159135 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2269 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122220 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122435 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31378 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76759 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9475 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83979 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19950 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20097 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->