### PR TITLE
[YARR] JIT FixedCount parentheses should restore index on backtrack

### DIFF
--- a/JSTests/stress/regexp-fixedcount-simple-backtrack-index-restore.js
+++ b/JSTests/stress/regexp-fixedcount-simple-backtrack-index-restore.js
@@ -1,0 +1,56 @@
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: " + JSON.stringify(actual) + " expected: " + JSON.stringify(expected));
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe("xza".match(/(?:xz){2}|./), ["x"]);
+    shouldBe("xz".match(/(?:xz){2}|./), ["x"]);
+    shouldBe("xyzxyz".match(/(?:xyz){3}|(?:xyz){2}/), ["xyzxyz"]);
+    shouldBe("abab".match(/(?:ab){3}|./g), ["a", "b", "a", "b"]);
+    shouldBe("\uD83D\uDE00a".match(/(?:\u{1F600}){2}|./u), ["\uD83D\uDE00"]);
+    shouldBe("abc".match(/(?:ab){2}|./y), ["a"]);
+    shouldBe("xzxza".match(/(?:xz){3}|./), ["x"]);
+    shouldBe("xzxzxz".match(/(?:xz){3}|./), ["xzxzxz"]);
+    shouldBe("xzxz".match(/(?:xz){2}|./), ["xzxz"]);
+    shouldBe("a".match(/(?:xz){2}|./), ["a"]);
+    shouldBe("xza".match(/(?:(?:xz){2}|.)/), ["x"]);
+    shouldBe("xza".match(/^(?:(?:xz){2}|.)$/), null);
+    shouldBe("aBx".match(/(?:(?i:ab)){2}|./), ["a"]);
+    shouldBe("xzx".match(/(?:xz){2}|x/g), ["x", "x"]);
+    shouldBe("xyza".match(/(?:(xy)z){2}|./), ["x", undefined]);
+    shouldBe("xyzxyza".match(/(?:(xy)z){2}|./), ["xyzxyz", "xy"]);
+    shouldBe("xzxzxza".match(/(?:xz){4}|(?:xz){3}/), ["xzxzxz"]);
+    shouldBe("xzxza".match(/(?:xz){4}|(?:xz){3}|./), ["x"]);
+
+    shouldBe("xzxzb".match(/(?:xz){2}a|./), ["x"]);
+    shouldBe("xzxzb".match(/(?:xz){2}a/), null);
+    shouldBe("xzxza".match(/(?:xz){2}a|./), ["xzxza"]);
+    shouldBe("xzxzxzb".match(/(?:xz){3}a|./), ["x"]);
+
+    shouldBe("xyzxya".match(/(?:(xy)z){2}|./), ["x", undefined]);
+    shouldBe("xyzxyz".match(/(?:(xy)z){2}|./), ["xyzxyz", "xy"]);
+    shouldBe("xyzxyzb".match(/(?:(xy)z){2}a|./), ["x", undefined]);
+    shouldBe("xyzxyza".match(/(?:(xy)z){2}a|./), ["xyzxyza", "xy"]);
+
+    shouldBe("xxa".match(/(?:(?:x){2}){2}|./), ["x"]);
+    shouldBe("xxxx".match(/(?:(?:x){2}){2}|./), ["xxxx"]);
+    shouldBe("xxxa".match(/(?:(?:x){2}){2}|./), ["x"]);
+    shouldBe("xyxya".match(/(?:(?:(x)y){2}){2}|./), ["x", undefined]);
+
+    shouldBe("x".match(/(?:xz){2}|./), ["x"]);
+    shouldBe("".match(/(?:xz){2}|./), null);
+
+    shouldBe("xzxzxz".match(/(?:xz){2}|./g), ["xzxz", "x", "z"]);
+    shouldBe("xzaxz".match(/(?:xz){2}|./g), ["x", "z", "a", "x", "z"]);
+}
+
+{
+    let re = /(?:xz){2}|./y;
+    for (let i = 0; i < testLoopCount; ++i) {
+        re.lastIndex = 1;
+        let m = re.exec("axza");
+        shouldBe(m, ["x"]);
+        shouldBe(re.lastIndex, 2);
+    }
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3971,6 +3971,11 @@ class YarrGenerator final : public YarrJITInfo {
                 PatternTerm* term = op.m_term;
                 unsigned parenthesesFrameLocation = term->frameLocation;
 
+                // Save the initial index so we can restore it on backtrack.
+                // The beginIndex slot is reused per-iteration for empty match detection,
+                // so we use returnAddressIndex (unused in this single-alt, non-ParenContext path).
+                storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
+
                 // Initialize the match count to 0.
                 storeToFrame(MacroAssembler::TrustedImm32(0), parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
 
@@ -4793,13 +4798,27 @@ class YarrGenerator final : public YarrJITInfo {
             // For non-capturing FixedCount parentheses, any failure means the entire
             // pattern fails. There's no partial backtracking - we either match
             // exactly N times or we fail completely.
-            case YarrOpCode::ParenthesesSubpatternFixedCountBegin:
+            case YarrOpCode::ParenthesesSubpatternFixedCountBegin: {
                 // Any backtrack to Begin means we failed to match the required count.
-                // First link any pending backtrack state from the content inside,
+                // Link any pending backtrack state from the content inside, restore
+                // the index to the position when we entered the group (since one or
+                // more iterations may have advanced it), clear any nested captures,
                 // then propagate the failure upward.
+                PatternTerm* term = op.m_term;
+                unsigned parenthesesFrameLocation = term->frameLocation;
+
                 m_backtrackingState.link(*this, op);
+
+                loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex(), m_regs.index);
+
+                if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
+                    for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                        clearSubpattern(subpattern);
+                }
+
                 m_backtrackingState.fallthrough();
                 break;
+            }
             case YarrOpCode::ParenthesesSubpatternFixedCountEnd:
                 // Backtracking into the End means something after the parentheses failed.
                 // For FixedCount, we don't try alternative counts, so just fail.


### PR DESCRIPTION
#### fbd2a11004f46e9ace6f44ba52ab7863d547e8db
<pre>
[YARR] JIT FixedCount parentheses should restore index on backtrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=308825">https://bugs.webkit.org/show_bug.cgi?id=308825</a>

Reviewed by Yusuke Suzuki.

The simple FixedCount path (ParenthesesSubpatternFixedCountBegin/End) did
not restore the input index when backtracking out of the group. Each
successful iteration advances index by checkAdjust (the alternative&apos;s
minimum size), but on failure only the last iteration&apos;s checkAdjust was
subtracted, leaving the index ahead of where the group was entered. This
caused outer alternatives to match from the wrong position.

This is a regression from 306402@main which introduced this path.

The fix saves the initial index into the unused returnAddressIndex frame
slot before the loop, and restores it on backtrack. Nested captures are
also cleared to avoid leaking into subsequent alternatives.

Test: JSTests/stress/regexp-fixedcount-simple-backtrack-index-restore.js

* JSTests/stress/regexp-fixedcount-simple-backtrack-index-restore.js: Added.
(shouldBe):
(i.shouldBe.string_appeared_here.match):
(shouldBe.string_appeared_here.match):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/308509@main">https://commits.webkit.org/308509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a0e6c17345687ace4f0211e65dc1ac4d87cb2e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113504 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14904 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3388 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139243 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158277 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8062 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121532 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121725 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31283 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19754 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75723 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8766 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178582 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19361 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83126 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45740 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19091 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->