### PR TITLE
TestWebKitAPI.CaptionPreferenceTests.NullProfileNameShouldYieldEmptyStyleSheet is constant failure on Sequoia

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -711,7 +711,7 @@ TEST_F(CaptionPreferenceTests, ReceievedDidOpenWhenHighlighted)
 
 TEST_F(CaptionPreferenceTests, NullProfileNameShouldYieldEmptyStyleSheet)
 {
-    if (!canLoad_MediaAccessibility_MACaptionAppearanceIsCustomized())
+    if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
 
     MediaAccessibilityShim shim;


### PR DESCRIPTION
#### 138f5c1adfe62c5109d983ed307a6830f79f62ba
<pre>
TestWebKitAPI.CaptionPreferenceTests.NullProfileNameShouldYieldEmptyStyleSheet is constant failure on Sequoia
<a href="https://bugs.webkit.org/show_bug.cgi?id=308829">https://bugs.webkit.org/show_bug.cgi?id=308829</a>
<a href="https://rdar.apple.com/171312744">rdar://171312744</a>

Reviewed by Jer Noble.

Change canLoad_MediaAccessibility_MACaptionAppearanceIsCustomized() to
CaptionUserPreferencesMediaAF::canSetActiveProfileID() to correctly check that
Media Accessibility MACaptionAppearanceSetActiveProfileID() API is available.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:
(TestWebKitAPI::TEST_F(CaptionPreferenceTests, NullProfileNameShouldYieldEmptyStyleSheet)):

Canonical link: <a href="https://commits.webkit.org/308435@main">https://commits.webkit.org/308435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46983408fe3c7f04e722cef2f0a1e911e5f4c226

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100692 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a811791-ada0-41a9-9fde-da13208bfb76) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80960 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d796ae4d-6d6a-4559-b0f6-b7bd84b3c0b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150239 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15734 "Found 1 new test failure: fast/forms/ios/select-option-removed-update.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94269 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/092dedad-09da-4366-bd7c-52d022e70fef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12701 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3400 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158291 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121541 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75742 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22738 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8774 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19376 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->