### PR TITLE
git-webkit conflict should tell me which files had conflict markers added

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py
@@ -23,6 +23,7 @@
 import sys
 
 from webkitbugspy import Tracker, radar
+from webkitcorepy import run
 from .command import Command
 from .. import local
 from ..commit import Commit
@@ -103,6 +104,16 @@ class Conflict(Command):
         full_branch = '{}:{}'.format(conflict_pr._metadata['full_name'], conflict_pr.head)
         print('Found conflict branch {}'.format(full_branch))
         checkout_response = repository.checkout(full_branch)
+
+        grep_result = run(
+            [local.Git.executable(), 'grep', '-l', '^<<<<<<<'],
+            capture_output=True, encoding='utf-8', cwd=repository.root_path,
+        )
+        if grep_result.returncode == 0 and grep_result.stdout.strip():
+            conflicted_files = grep_result.stdout.strip().splitlines()
+            print('\nFiles with conflict markers:')
+            for f in conflicted_files:
+                print('  {}'.format(f))
 
         msg = "\n\n-------------------------------------------------------"
         msg += "\nYou are now checked out into the conflict branch.\n"


### PR DESCRIPTION
#### a478e8d1c6c106c41623814a27799a22cdc43b38
<pre>
git-webkit conflict should tell me which files had conflict markers added
<a href="https://bugs.webkit.org/show_bug.cgi?id=308831">https://bugs.webkit.org/show_bug.cgi?id=308831</a>
<a href="https://rdar.apple.com/171287934">rdar://171287934</a>

Uses git grep to find file names with conflict markers present when running the conflict
command.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/conflict.py:
(Conflict.main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a478e8d1c6c106c41623814a27799a22cdc43b38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100703 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/635dd69e-820b-4b66-b374-eb7552dcd368) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80965 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/681463c4-f97b-4a11-9cc3-59342793b6c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d9db522-e30e-46f3-b812-c0247a7b2021) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/146610 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14923 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12708 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3411 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158302 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121549 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/146689 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131989 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75759 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19387 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19117 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->