### PR TITLE
Gracefully handle StringBuffer overflow in RegExp replace operator

### DIFF
--- a/JSTests/stress/string-regexp-replace-oom.js
+++ b/JSTests/stress/string-regexp-replace-oom.js
@@ -1,0 +1,22 @@
+//@ skip if $memoryLimited or $addressBits <= 32
+//@ runDefault()
+
+Object.__proto__.__proto__[Symbol.replace] = () => {};
+
+function __f_0(__v_5, __v_6) {
+  while (__v_5.length < __v_6) {
+    __v_5 += __v_5;
+  }
+  return __v_5.substring(0, __v_6);
+}
+
+var __v_2 = __f_0("1", 1 << 20);
+var __v_3 = __f_0("$1", 1 << 16);
+var flag = false;
+try {
+  __v_2.replace(/(.+)/g, __v_3);
+} catch(e) {
+  flag = true;
+}
+
+if(!flag) throw new Error("expected an exception");

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -833,7 +833,7 @@ static inline String getSubstitution(JSGlobalObject* globalObject, const String&
     size_t tailPos = position + matchLength;
     size_t nCaptures = captures.size();
     size_t replacementLength = replacement.length();
-    StringBuilder result;
+    StringBuilder result(OverflowPolicy::RecordOverflow); // overflow should gracefully throw an exception, not crash
     size_t lastStart = 0;
 
     for (; start != notFound; lastStart = start, start = replacement.find('$', lastStart)) {


### PR DESCRIPTION
#### e3c1c1295f4a6af842514d78eed4a1f92df2c0aa
<pre>
Gracefully handle StringBuffer overflow in RegExp replace operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=308836">https://bugs.webkit.org/show_bug.cgi?id=308836</a>
<a href="https://rdar.apple.com/171058069">rdar://171058069</a>

Reviewed by Marcus Plutowski.

When the RegExp replace operator is called, if the output string
overflows the maximum legal length of a javascript string it is
supposed to throw an out-of-memory error, rather than triggering a
controlled crash.

Test: JSTests/stress/string-regexp-replace-oom.js

* JSTests/stress/string-regexp-replace-oom.js: Added.
(Object.__proto__.__proto__.Symbol.replace):
(catch):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::getSubstitution):

Canonical link: <a href="https://commits.webkit.org/308478@main">https://commits.webkit.org/308478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f4c502a5770c19945614da343a10121da476c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156359 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c55d535-e93f-4f89-a0ae-4606b359bb99) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113841 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55351c62-ea70-4b49-a14f-5a3806f7e9b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/120f6291-987c-4202-9429-a01298f9f453) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15245 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13029 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3800 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139647 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124841 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158693 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8465 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121867 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31258 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132335 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76287 "The change is no longer eligible for processing.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9113 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179099 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83539 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45900 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19506 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->