### PR TITLE
REGRESSION(308337@main): Internal macOS engineering build broken with StrictMemorySafety error

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1352,6 +1352,16 @@ extension WKBridgeBlendShapeData {
             weights += Array(repeating: debugWeights[i], count: positionCount)
         }
 
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let blendWeightsBuffer = unsafe device.makeBuffer(
+            bytes: weights,
+            length: weights.count * MemoryLayout<Float>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let blendWeightsBuffer = device.makeBuffer(
@@ -1359,6 +1369,7 @@ extension WKBridgeBlendShapeData {
             length: weights.count * MemoryLayout<Float>.size,
             options: .storageModeShared
         )!
+        #endif
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let blendWeightsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1369,6 +1380,16 @@ extension WKBridgeBlendShapeData {
         )!
 
         let positionOffsets = debugPositionOffsets.flatMap(\.self)
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let positionOffsetsBuffer = unsafe device.makeBuffer(
+            bytes: positionOffsets,
+            length: positionOffsets.count * MemoryLayout<SIMD3<Float>>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let positionOffsetsBuffer = device.makeBuffer(
@@ -1376,6 +1397,7 @@ extension WKBridgeBlendShapeData {
             length: positionOffsets.count * MemoryLayout<SIMD3<Float>>.size,
             options: .storageModeShared
         )!
+        #endif
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let positionOffsetsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1401,6 +1423,16 @@ extension WKBridgeBlendShapeData {
 extension WKBridgeRenormalizationData {
     func makeDeformerDescription(device: MTLDevice) throws -> _Proto_LowLevelDeformerDescription_v1 {
         // Create adjacency buffer
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let adjacenciesMetalBuffer = unsafe device.makeBuffer(
+            bytes: vertexAdjacencies,
+            length: vertexAdjacencies.count * MemoryLayout<UInt32>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacenciesMetalBuffer = device.makeBuffer(
@@ -1408,6 +1440,7 @@ extension WKBridgeRenormalizationData {
             length: vertexAdjacencies.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
+        #endif
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacenciesBuffer = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1418,6 +1451,16 @@ extension WKBridgeRenormalizationData {
         )!
 
         // Create adjacency end indices buffer
+        // FIXME: (rdar://164559261) understand/document/remove unsafety
+        #if compiler(>=6.2)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        let adjacencyEndIndicesMetalBuffer = unsafe device.makeBuffer(
+            bytes: vertexAdjacencyEndIndices,
+            length: vertexAdjacencyEndIndices.count * MemoryLayout<UInt32>.size,
+            options: .storageModeShared
+        )!
+        #else
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacencyEndIndicesMetalBuffer = device.makeBuffer(
@@ -1425,6 +1468,7 @@ extension WKBridgeRenormalizationData {
             length: vertexAdjacencyEndIndices.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
+        #endif
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacencyEndIndicesBuffer = _Proto_LowLevelDeformationDescription_v1.Buffer.make(


### PR DESCRIPTION
#### 519ac545ddce757bafe4f16d3453005b3613788a
<pre>
REGRESSION(308337@main): Internal macOS engineering build broken with StrictMemorySafety error
<a href="https://bugs.webkit.org/show_bug.cgi?id=308839">https://bugs.webkit.org/show_bug.cgi?id=308839</a>
<a href="https://rdar.apple.com/171376078">rdar://171376078</a>

Unreviewed build fix.

This patch expands on the mitigations applied in 308337@main to yet more
`MTLDevice.makeBuffer` calls.

* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(WKBridgeBlendShapeData.makeDeformerDescription(_:)):
(WKBridgeRenormalizationData.makeDeformerDescription(_:)):

Canonical link: <a href="https://commits.webkit.org/308358@main">https://commits.webkit.org/308358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bf284b728611c0aa3fbb1d0821c2accd8e64438

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147296 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/19981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/155978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150258 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/13572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/158310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75767 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22701 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/19395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->