### PR TITLE
[macOS] imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html
@@ -17,8 +17,7 @@
     const inner = outer.firstChild;
 
     // First request fullscreen for the outer element.
-    await trusted_request(outer);
-    await fullScreenChange();
+    await Promise.all([fullScreenChange(), trusted_request(outer)]);
     assert_equals(document.fullscreenElement, outer);
     assert_true(
       outer.matches(":fullscreen"),

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2490,8 +2490,6 @@ webkit.org/b/308334 [ Tahoe Debug ] http/tests/webgpu/webgpu/api/validation/gpu_
 
 webkit.org/b/308494 media/remote-control-command-is-user-gesture.html [ Timeout Pass ]
 
-webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
-
 webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure ]
 
 webkit.org/b/308601 [ Release ] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html [ Failure Pass ]

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -24,7 +24,7 @@
 internal import Metal
 import WebKit
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_weakLinked internal import USDKit
@@ -253,7 +253,6 @@ func decodeValues<T>(from data: Data) -> [T] {
         return []
     }
 
-    #if compiler(>=6.2)
     return unsafe data.withUnsafeBytes { rawBufferPointer in
         guard let baseAddress = rawBufferPointer.baseAddress else {
             return []
@@ -263,17 +262,6 @@ func decodeValues<T>(from data: Data) -> [T] {
         let pointer = unsafe baseAddress.assumingMemoryBound(to: T.self)
         return (0..<count).map { unsafe pointer[$0] }
     }
-    #else
-    return data.withUnsafeBytes { rawBufferPointer in
-        guard let baseAddress = rawBufferPointer.baseAddress else {
-            return []
-        }
-
-        let count = rawBufferPointer.count / stride
-        let pointer = baseAddress.assumingMemoryBound(to: T.self)
-        return (0..<count).map { pointer[$0] }
-    }
-    #endif
 }
 
 extension WKBridgeBlendShapeData {
@@ -855,16 +843,10 @@ extension WKBridgeLiteral {
 #if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
 
 internal func toData<T>(_ input: [T]) -> Data {
-    #if compiler(>=6.2)
     // FIXME: (rdar://164559261) understand/document/remove unsafety
     unsafe input.withUnsafeBytes { bufferPointer in
         unsafe Data(bufferPointer)
     }
-    #else
-    input.withUnsafeBytes { bufferPointer in
-        Data(bufferPointer)
-    }
-    #endif
 }
 
 private func toDataArray<T>(_ input: [[T]]) -> [Data] {
@@ -939,7 +921,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -948,16 +929,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<jointTransformsCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
-            return (0..<jointTransformsCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     var inverseBindPoses: [simd_float4x4] {
@@ -978,7 +949,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -987,16 +957,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<inverseBindPosesCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
-            return (0..<inverseBindPosesCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     var influenceJointIndices: [UInt32] {
@@ -1017,7 +977,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -1026,16 +985,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: UInt32.self)
             return (0..<influenceJointIndicesCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: UInt32.self)
-            return (0..<influenceJointIndicesCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     var influenceWeights: [Float] {
@@ -1056,7 +1005,6 @@ extension WKBridgeSkinningData {
             return []
         }
 
-        #if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -1065,16 +1013,6 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: Float.self)
             return (0..<influenceWeightsCount).map { unsafe matrices[$0] }
         }
-        #else
-        return data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = baseAddress.assumingMemoryBound(to: Float.self)
-            return (0..<influenceWeightsCount).map { matrices[$0] }
-        }
-        #endif
     }
 
     @nonobjc

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 internal import Metal
 @_weakLinked internal import USDKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 @_weakLinked internal import USDKit
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 internal import QuartzCore
 @_weakLinked internal import USDKit
@@ -47,8 +47,9 @@ nonisolated class Renderer {
     }
     var pose: _Proto_Pose_v1
     var modelDistance: Float = 1.0
+    let memoryOwner: task_id_token_t
 
-    init(device: MTLDevice) throws {
+    init(device: MTLDevice, memoryOwner: task_id_token_t) throws {
         guard let commandQueue = device.makeCommandQueue() else {
             fatalError("Failed to create command queue.")
         }
@@ -57,10 +58,16 @@ nonisolated class Renderer {
         self.device = device
         self.commandQueue = commandQueue
         self.pose = .init(translation: [0, 0, 1], rotation: .init(ix: 0, iy: 0, iz: 0, r: 1))
+        self.memoryOwner = memoryOwner
     }
 
     func createMaterialCompiler(colorPixelFormat: MTLPixelFormat, rasterSampleCount: Int, colorSpace: CGColorSpace? = nil) async throws {
+        #if canImport(RealityCoreRenderer, _version: 9999)
         var configuration = _Proto_LowLevelRenderContextStandaloneConfiguration_v1(device: device)
+        configuration.memoryOwner = self.memoryOwner
+        #else
+        var configuration = _Proto_LowLevelRenderContextStandaloneConfiguration_v1(device: device)
+        #endif
         configuration.residencySetBehavior = _Proto_LowLevelRenderContextStandaloneConfiguration_v1.ResidencySetBehavior.disable
         let renderContext = try await _Proto_makeLowLevelRenderContextStandalone_v1(configuration: configuration)
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 
 @_weakLinked internal import DirectResource
 internal import Metal

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -26,7 +26,7 @@ import OSLog
 import WebKit
 import simd
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreRenderer, _version: 11) && compiler(>=6.2)
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_weakLinked @_spi(RealityCoreTextureProcessingAPI) internal import RealityCoreTextureProcessing
@@ -78,6 +78,7 @@ private func makeMTLTextureFromImageAsset(
     _ imageAsset: WKBridgeImageAsset,
     device: MTLDevice,
     generateMips: Bool,
+    memoryOwner: task_id_token_t,
     overridePixelFormat: Bool = false
 ) -> MTLTexture? {
     guard let imageAssetData = imageAsset.data else {
@@ -130,11 +131,11 @@ private func makeMTLTextureFromImageAsset(
         logError("failed to device.makeTexture")
         return nil
     }
+    mtlTexture.__setOwnerWithIdentity(memoryOwner)
 
     let bytesPerRow = imageAsset.width * imageAsset.bytesPerPixel
     let bytesPerImage = bytesPerRow * imageAsset.height
 
-    #if compiler(>=6.2)
     unsafe imageAssetData.bytes.withUnsafeBytes { textureBytes in
         guard let textureBytesBaseAddress = textureBytes.baseAddress else {
             return
@@ -153,26 +154,6 @@ private func makeMTLTextureFromImageAsset(
             )
         }
     }
-    #else
-    imageAssetData.bytes.withUnsafeBytes { textureBytes in
-        guard let textureBytesBaseAddress = textureBytes.baseAddress else {
-            return
-        }
-        for face in 0..<sliceCount {
-            let offset = face * bytesPerImage
-            let facePointer = textureBytesBaseAddress.advanced(by: offset)
-
-            mtlTexture.replace(
-                region: MTLRegionMake2D(0, 0, imageAsset.width, imageAsset.height),
-                mipmapLevel: 0,
-                slice: face,
-                withBytes: facePointer,
-                bytesPerRow: bytesPerRow,
-                bytesPerImage: bytesPerImage
-            )
-        }
-    }
-    #endif
 
     return mtlTexture
 }
@@ -183,6 +164,7 @@ private func makeTextureFromImageAsset(
     renderContext: _Proto_LowLevelRenderContext_v1,
     commandQueue: MTLCommandQueue,
     generateMips: Bool,
+    memoryOwner: task_id_token_t,
     overridePixelFormat: Bool,
     swizzle: MTLTextureSwizzleChannels = .init(red: .red, green: .green, blue: .blue, alpha: .alpha)
 ) -> _Proto_LowLevelTextureResource_v1? {
@@ -191,6 +173,7 @@ private func makeTextureFromImageAsset(
             imageAsset,
             device: device,
             generateMips: generateMips,
+            memoryOwner: memoryOwner,
             overridePixelFormat: overridePixelFormat
         )
     else {
@@ -314,11 +297,11 @@ extension WKBridgeUSDConfiguration {
         get { appRenderer.renderTargetDescriptor }
     }
 
-    @objc(initWithDevice:)
-    init(device: MTLDevice) {
+    @objc
+    init(device: MTLDevice, memoryOwner: task_id_token_t) {
         self.device = device
         do {
-            self.appRenderer = try Renderer(device: device)
+            self.appRenderer = try Renderer(device: device, memoryOwner: memoryOwner)
         } catch {
             fatalError("Exception creating renderer \(error)")
         }
@@ -410,6 +393,13 @@ extension WKBridgeReceiver {
     @nonobjc
     fileprivate var dontCaptureAgain: Bool = false
 
+    @nonobjc
+    fileprivate final var memoryOwner: mach_port_t {
+        get {
+            appRenderer.memoryOwner
+        }
+    }
+
     init(
         configuration: WKBridgeUSDConfiguration,
         diffuseAsset: WKBridgeImageAsset,
@@ -434,6 +424,7 @@ extension WKBridgeReceiver {
                 renderContext: renderContext,
                 commandQueue: configuration.commandQueue,
                 generateMips: true,
+                memoryOwner: configuration.appRenderer.memoryOwner,
                 overridePixelFormat: false,
                 swizzle: .init(red: .red, green: .red, blue: .red, alpha: .one)
             )
@@ -447,6 +438,7 @@ extension WKBridgeReceiver {
                 renderContext: renderContext,
                 commandQueue: configuration.commandQueue,
                 generateMips: true,
+                memoryOwner: configuration.appRenderer.memoryOwner,
                 overridePixelFormat: false,
                 swizzle: .init(red: .red, green: .red, blue: .red, alpha: .one)
             )
@@ -546,6 +538,7 @@ extension WKBridgeReceiver {
             renderContext: renderContext,
             commandQueue: commandQueue,
             generateMips: true,
+            memoryOwner: self.memoryOwner,
             overridePixelFormat: false
         ) {
             textureResources[textureHash] = textureResource
@@ -752,7 +745,14 @@ extension WKBridgeReceiver {
     @objc
     func setEnvironmentMap(_ imageAsset: WKBridgeImageAsset) {
         do {
-            guard let mtlTextureEquirectangular = makeMTLTextureFromImageAsset(imageAsset, device: device, generateMips: true) else {
+            guard
+                let mtlTextureEquirectangular = makeMTLTextureFromImageAsset(
+                    imageAsset,
+                    device: device,
+                    generateMips: true,
+                    memoryOwner: self.memoryOwner
+                )
+            else {
                 fatalError("Could not make metal texture from environment asset data")
             }
 
@@ -762,6 +762,7 @@ extension WKBridgeReceiver {
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
             let cubeMTLTexture = self.device.makeTexture(descriptor: cubeMTLTextureDescriptor)!
+            cubeMTLTexture.__setOwnerWithIdentity(self.memoryOwner)
 
             let diffuseMTLTextureDescriptor = try self.textureProcessingContext.createImageBasedLightDiffuseDescriptor(
                 fromCube: cubeMTLTexture
@@ -1016,11 +1017,7 @@ extension WKBridgeModelLoader {
         self.loader = USDModelLoader(objcInstance: self)
     }
 
-    @objc(
-        setCallbacksWithModelUpdatedCallback:
-        textureUpdatedCallback:
-        materialUpdatedCallback:
-    )
+    @objc
     func setCallbacksWithModelUpdatedCallback(
         _ modelUpdatedCallback: @escaping ((WKBridgeUpdateMesh) -> (Void)),
         textureUpdatedCallback: @escaping ((WKBridgeUpdateTexture) -> (Void)),
@@ -1089,7 +1086,6 @@ extension WKBridgeModelLoader {
     }
 }
 
-
 extension WKBridgeReceiver {
     internal func configureDeformation(
         identifier: _Proto_ResourceId,
@@ -1099,13 +1095,13 @@ extension WKBridgeReceiver {
         var deformers: [_Proto_LowLevelDeformerDescription_v1] = []
 
         if let skinningData = deformationData.skinningData {
-            let skinningDeformer = skinningData.makeDeformerDescription(device: self.device)
+            let skinningDeformer = skinningData.makeDeformerDescription(device: self.device, memoryOwner: self.memoryOwner)
             deformers.append(skinningDeformer)
         }
 
         if let blendShapeData = deformationData.blendShapeData {
             do {
-                let blendShapeDeformer = try blendShapeData.makeDeformerDescription(device: self.device)
+                let blendShapeDeformer = try blendShapeData.makeDeformerDescription(device: self.device, memoryOwner: self.memoryOwner)
                 deformers.append(blendShapeDeformer)
             } catch {
                 logError("Error creating blend shape deformer for \(identifier): \(error.localizedDescription)")
@@ -1115,7 +1111,7 @@ extension WKBridgeReceiver {
         // TODO: add tangent frame data to input
         // if let renormalizationData = deformationData.renormalizationData {
         //     do {
-        //         let renormalization = try renormalizationData.makeDeformerDescription(device: self.device)
+        //         let renormalization = try renormalizationData.makeDeformerDescription(device: self.device, memoryOwner: self.memoryOwner)
         //         deformers.append(renormalization)
         //     } catch {
         //         logError("Error creating renormalization deformer for \(identifier): \(error.localizedDescription)")
@@ -1133,7 +1129,8 @@ extension WKBridgeReceiver {
             let vertexPositionsBuffer = meshResource.readVertices(at: 1, using: commandBuffer)!
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
-            let inputPositionsBuffer = device.makeBuffer(length: vertexPositionsBuffer.length, options: .storageModeShared)!
+            let inputPositionsBuffer = unsafe device.makeBuffer(length: vertexPositionsBuffer.length, options: .storageModeShared)!
+            inputPositionsBuffer.__setOwnerWithIdentity(self.memoryOwner)
 
             // Copy data from vertexPositionsBuffer to inputPositionsBuffer
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -1215,9 +1212,7 @@ extension WKBridgeReceiver {
 }
 
 extension WKBridgeSkinningData {
-    fileprivate func makeDeformerDescription(device: MTLDevice) -> _Proto_LowLevelDeformerDescription_v1 {
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
+    fileprivate func makeDeformerDescription(device: MTLDevice, memoryOwner: mach_port_t) -> _Proto_LowLevelDeformerDescription_v1 {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointTransformsBuffer = unsafe device.makeBuffer(
@@ -1225,15 +1220,7 @@ extension WKBridgeSkinningData {
             length: self.jointTransforms.count * MemoryLayout<simd_float4x4>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let jointTransformsBuffer = device.makeBuffer(
-            bytes: self.jointTransforms,
-            length: self.jointTransforms.count * MemoryLayout<simd_float4x4>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        jointTransformsBuffer.__setOwnerWithIdentity(memoryOwner)
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -1244,8 +1231,6 @@ extension WKBridgeSkinningData {
             elementType: .float4x4
         )!
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let inverseBindPosesBuffer = unsafe device.makeBuffer(
@@ -1253,15 +1238,7 @@ extension WKBridgeSkinningData {
             length: self.inverseBindPoses.count * MemoryLayout<simd_float4x4>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let inverseBindPosesBuffer = device.makeBuffer(
-            bytes: self.inverseBindPoses,
-            length: self.inverseBindPoses.count * MemoryLayout<simd_float4x4>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        inverseBindPosesBuffer.__setOwnerWithIdentity(memoryOwner)
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -1272,8 +1249,6 @@ extension WKBridgeSkinningData {
             elementType: .float4x4
         )!
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointIndicesBuffer = unsafe device.makeBuffer(
@@ -1281,15 +1256,8 @@ extension WKBridgeSkinningData {
             length: self.influenceJointIndices.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let jointIndicesBuffer = device.makeBuffer(
-            bytes: self.influenceJointIndices,
-            length: self.influenceJointIndices.count * MemoryLayout<UInt32>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        jointIndicesBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let jointIndicesDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1299,8 +1267,6 @@ extension WKBridgeSkinningData {
             elementType: .uint
         )!
 
-        // FIXME: (rdar://164559261) understand/document/remove unsafety
-        #if compiler(>=6.2)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let influenceWeightsBuffer = unsafe device.makeBuffer(
@@ -1308,15 +1274,8 @@ extension WKBridgeSkinningData {
             length: self.influenceWeights.count * MemoryLayout<Float>.size,
             options: .storageModeShared
         )!
-        #else
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        let influenceWeightsBuffer = device.makeBuffer(
-            bytes: self.influenceWeights,
-            length: self.influenceWeights.count * MemoryLayout<Float>.size,
-            options: .storageModeShared
-        )!
-        #endif
+        influenceWeightsBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let influenceWeightsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1340,7 +1299,7 @@ extension WKBridgeSkinningData {
 }
 
 extension WKBridgeBlendShapeData {
-    func makeDeformerDescription(device: MTLDevice) throws -> _Proto_LowLevelDeformerDescription_v1 {
+    func makeDeformerDescription(device: MTLDevice, memoryOwner: task_id_token_t) throws -> _Proto_LowLevelDeformerDescription_v1 {
         var weights: [Float] = []
 
         var debugWeights = self.weights
@@ -1354,11 +1313,13 @@ extension WKBridgeBlendShapeData {
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
-        let blendWeightsBuffer = device.makeBuffer(
+        let blendWeightsBuffer = unsafe device.makeBuffer(
             bytes: weights,
             length: weights.count * MemoryLayout<Float>.size,
             options: .storageModeShared
         )!
+        blendWeightsBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let blendWeightsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1371,11 +1332,13 @@ extension WKBridgeBlendShapeData {
         let positionOffsets = debugPositionOffsets.flatMap(\.self)
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
-        let positionOffsetsBuffer = device.makeBuffer(
+        let positionOffsetsBuffer = unsafe device.makeBuffer(
             bytes: positionOffsets,
             length: positionOffsets.count * MemoryLayout<SIMD3<Float>>.size,
             options: .storageModeShared
         )!
+        positionOffsetsBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let positionOffsetsDescription = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1399,15 +1362,17 @@ extension WKBridgeBlendShapeData {
 }
 
 extension WKBridgeRenormalizationData {
-    func makeDeformerDescription(device: MTLDevice) throws -> _Proto_LowLevelDeformerDescription_v1 {
+    func makeDeformerDescription(device: MTLDevice, memoryOwner: task_id_token_t) throws -> _Proto_LowLevelDeformerDescription_v1 {
         // Create adjacency buffer
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
-        let adjacenciesMetalBuffer = device.makeBuffer(
+        let adjacenciesMetalBuffer = unsafe device.makeBuffer(
             bytes: vertexAdjacencies,
             length: vertexAdjacencies.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
+        adjacenciesMetalBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacenciesBuffer = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1420,11 +1385,13 @@ extension WKBridgeRenormalizationData {
         // Create adjacency end indices buffer
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
-        let adjacencyEndIndicesMetalBuffer = device.makeBuffer(
+        let adjacencyEndIndicesMetalBuffer = unsafe device.makeBuffer(
             bytes: vertexAdjacencyEndIndices,
             length: vertexAdjacencyEndIndices.count * MemoryLayout<UInt32>.size,
             options: .storageModeShared
         )!
+        adjacencyEndIndicesMetalBuffer.__setOwnerWithIdentity(memoryOwner)
+
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         let adjacencyEndIndicesBuffer = _Proto_LowLevelDeformationDescription_v1.Buffer.make(
@@ -1450,7 +1417,7 @@ extension WKBridgeRenormalizationData {
 @objc
 @implementation
 extension WKBridgeUSDConfiguration {
-    init(device: MTLDevice) {
+    init(device: MTLDevice, memoryOwner: task_id_token_t) {
     }
 
     @objc(createMaterialCompiler:)

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -27,13 +27,15 @@
 #import "WebKitMesh.h"
 
 #import "ModelTypes.h"
-#import "WebKitSwiftSoftLink.h"
 
+#import <WebCore/ProcessIdentity.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/MathExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/spi/cocoa/IOSurfaceSPI.h>
 #import <wtf/threads/BinarySemaphore.h>
+
+#import "WebKitSwiftSoftLink.h"
 
 namespace WebModel {
 
@@ -328,7 +330,8 @@ WebMesh::WebMesh(const WebModelCreateMeshDescriptor& descriptor)
     WKBridgeImageAsset *specularAsset = WebModel::convert(descriptor.specularTexture);
     if (configuration) {
         BinarySemaphore completion;
-        [configuration createMaterialCompiler:[&completion] mutable {
+        task_id_token_t memoryOwner = descriptor.processIdentity ? descriptor.processIdentity->taskIdToken() : 0;
+        [configuration createMaterialCompiler:memoryOwner completionHandler:[&completion] mutable {
             completion.signal();
         }];
         completion.wait();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -289,12 +289,14 @@ static Vector<UniqueRef<WebCore::IOSurface>> createIOSurfaces(unsigned width, un
 #endif
 
 #if ENABLE(GPU_PROCESS_MODEL)
-static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback, const WebCore::ProcessIdentity& processIdentity)
 {
     auto ioSurfaceVector = createIOSurfaces(width, height);
     Vector<RetainPtr<IOSurfaceRef>> ioSurfaces;
-    for (UniqueRef<WebCore::IOSurface>& ioSurface : ioSurfaceVector)
+    for (UniqueRef<WebCore::IOSurface>& ioSurface : ioSurfaceVector) {
         ioSurfaces.append(ioSurface->surface());
+        ioSurface->setOwnershipIdentity(processIdentity);
+    }
 
     WebModelCreateMeshDescriptor backingDescriptor {
         .width = width,
@@ -302,6 +304,7 @@ static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned 
         .ioSurfaces = WTF::move(ioSurfaces),
         .diffuseTexture = diffuseTexture,
         .specularTexture = specularTexture,
+        .processIdentity = &processIdentity
     };
 
     auto mesh = WebKit::MeshImpl::create(WebMesh::create(backingDescriptor), WTF::move(ioSurfaceVector));
@@ -318,7 +321,10 @@ void RemoteGPU::createModelBacking(unsigned width, unsigned height, const WebMod
     Ref objectHeap = m_modelObjectHeap.get();
 
     RefPtr gpu = m_backing.get();
-    auto mesh = createModelBackingInternal(width, height, diffuseTexture, specularTexture, WTF::move(callback));
+    auto gpuProcessConnection = m_gpuConnectionToWebProcess.get();
+    MESSAGE_CHECK(gpuProcessConnection);
+
+    auto mesh = createModelBackingInternal(width, height, diffuseTexture, specularTexture, WTF::move(callback), gpuProcessConnection->webProcessIdentity());
     auto remoteMesh = RemoteMesh::create(*m_gpuConnectionToWebProcess.get(), *this, *mesh, objectHeap, Ref { *m_streamConnection }, identifier);
     objectHeap->addObject(identifier, remoteMesh);
 #else


### PR DESCRIPTION
#### 525709033934c532baac13f64daedf0a18a22f0b
<pre>
[macOS] imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html is a flaky text failure
<a href="https://rdar.apple.com/171112681">rdar://171112681</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308586">https://bugs.webkit.org/show_bug.cgi?id=308586</a>

Reviewed by Tim Nguyen.

The test was intermittently timing out because the fullscreenchange
event listener was registered after the event had already fired.

The sequential awaits:
    await trusted_request(outer);
    await fullScreenChange();
caused the fullscreenchange event to fire while waiting for
requestFullscreen() to resolve, before the listener in
fullScreenChange() was registered.

Using Promise.all() ensures the listener is registered synchronously
before the fullscreen transition completes:
await Promise.all([trusted_request(outer), fullScreenChange()]);

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308351@main">https://commits.webkit.org/308351@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/525709033934c532baac13f64daedf0a18a22f0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147306 "Failed to checkout and rebase branch from PR 59602") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/19991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/155988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150268 "Failed to checkout and rebase branch from PR 59602") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/155988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8094 "Build is in progress. Recent messages:") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/158320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/19405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->