### PR TITLE
REGRESSION(308215@main?): [macOS] TestWebKitAPI.ScrollingCoordinatorTests.ScrollingTreeAfterDetachReattach is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm
@@ -80,6 +80,9 @@ static NSString *scrollingTreeElidingLastCommittedScrollPosition(NSString *scrol
 
 TEST(ScrollingCoordinatorTests, ScrollingTreeAfterDetachReattach)
 {
+    [[NSUserDefaults standardUserDefaults] setObject:@"Scrolling" forKey:@"WebCoreLogging"];
+    [[NSUserDefaults standardUserDefaults] setObject:@"Scrolling" forKey:@"WebKit2Logging"];
+
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration addToWindow:YES]);
     
@@ -121,6 +124,9 @@ TEST(ScrollingCoordinatorTests, ScrollingTreeAfterDetachReattach)
         [webView wheelEventAtPoint:eventLocationInWindow wheelDelta:CGSizeMake(0, -101)];
     });
     EXPECT_EQ(scrollY, 301);
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"WebCoreLogging"];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"WebKit2Logging"];
 }
 
 TEST(ScrollingCoordinatorTests, SetContentOffset)


### PR DESCRIPTION
#### 77a6468588cc2cfd8435227e0dc50695c091a09a
<pre>
REGRESSION(308215@main?): [macOS] TestWebKitAPI.ScrollingCoordinatorTests.ScrollingTreeAfterDetachReattach is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=308786">https://bugs.webkit.org/show_bug.cgi?id=308786</a>
<a href="https://rdar.apple.com/171316019">rdar://171316019</a>

Reviewed by Abrar Rahman Protyasha.

Temporarily turn on Scrolling logging for an API test to diagnose timeouts.

* Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm:
(TestWebKitAPI::TEST(ScrollingCoordinatorTests, ScrollingTreeAfterDetachReattach)):

Canonical link: <a href="https://commits.webkit.org/308411@main">https://commits.webkit.org/308411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22615129187e79035292b48cb5665555f66e1df4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100722 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52fcf40c-b467-4a39-b356-81da60a63430) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113534 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80974 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8d808e7-3beb-45cc-a75a-47d9e87b2259) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94290 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcaae89f-992e-4300-896c-a3ca8a919877) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14930 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12719 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3430 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158321 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121561 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31209 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75778 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8793 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19406 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->