### PR TITLE
Fix UI control overlap when viewing narrow vertical video in element fullscreen on visionOS

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -185,12 +185,16 @@ private:
     RetainPtr<UIViewController> _environmentPickerButtonViewController;
     RetainPtr<UIStackView> _centeredStackView;
     RetainPtr<UIButton> _enterVideoFullscreenButton;
+    RetainPtr<NSLayoutConstraint> _centeredStackViewCenterXConstraint;
+    RetainPtr<NSLayoutConstraint> _centeredStackViewTrailingConstraint;
+    BOOL _isImmersiveVideo;
     enum ButtonState {
         EnvironmentPicker = 1 << 0,
         FullscreenVideo = 1 << 1
     };
     OptionSet<ButtonState> _buttonState;
     BOOL _viewDidAppear;
+    BOOL _isUsingCompactVideoButtonLayout;
 #endif
 }
 
@@ -218,6 +222,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didEndInteractionWithSystemChrome:) name:_MRUIWindowSceneDidEndRepositioningNotification object:windowScene];
 #endif
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
+#endif
     _secheuristic.setParameters(WebKit::FullscreenTouchSecheuristicParameters::iosParameters());
     self._webView = webView;
 
@@ -233,6 +240,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     _viewDidAppear = NO;
+    _isUsingCompactVideoButtonLayout = NO;
 #endif
 
     return self;
@@ -464,6 +472,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
+- (void)_contentSizeCategoryDidChange:(NSNotification *)notification
+{
+    if (_buttonState.contains(FullscreenVideo) && [_enterVideoFullscreenButton superview])
+        [self configureEnvironmentPickerOrFullscreenVideoButtonView];
+}
+
 - (void)_setTopButtonLabel:(const String&)label
 {
     UIButtonConfiguration *fullscreenButtonConfiguration = [UIButtonConfiguration filledButtonConfiguration];
@@ -471,9 +485,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     fullscreenButtonConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(12, 18, 12, 22);
     fullscreenButtonConfiguration.titleLineBreakMode = NSLineBreakByClipping;
 
-    RetainPtr imageConfiguration = [[UIImageSymbolConfiguration configurationWithTextStyle:UIFontTextStyleBody] configurationByApplyingConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightMedium]];
+    RetainPtr dynamicImageConfiguration = [[UIImageSymbolConfiguration configurationWithTextStyle:UIFontTextStyleBody] configurationByApplyingConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightMedium]];
+    RetainPtr fixedImageConfiguration = [[UIImageSymbolConfiguration configurationWithPointSize:17 weight:UIImageSymbolWeightMedium] configurationByApplyingConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightMedium]];
+    NSString *symbolName = _isImmersiveVideo ? @"pano" : @"cube";
+    fullscreenButtonConfiguration.image = [[UIImage systemImageNamed:symbolName withConfiguration:dynamicImageConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
 
-    fullscreenButtonConfiguration.image = [[UIImage systemImageNamed:@"cube" withConfiguration:imageConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    static constexpr CGFloat kMinimumSpacing = 24;
 
     RetainPtr descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
     descriptor = [descriptor fontDescriptorByAddingAttributes:@{
@@ -484,7 +501,49 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }]);
     fullscreenButtonConfiguration.attributedTitle = buttonTitle.get();
     [_enterVideoFullscreenButton setConfiguration:fullscreenButtonConfiguration];
+    [_enterVideoFullscreenButton invalidateIntrinsicContentSize];
+    CGSize fullButtonSize = [_enterVideoFullscreenButton intrinsicContentSize];
+
+    CGFloat availableWidth = self.view.bounds.size.width;
+    CGFloat centerX = availableWidth / 2;
+    CGFloat fullButtonLeadingEdge = centerX - (fullButtonSize.width / 2);
+
+    CGRect stackViewFrame = [_stackView convertRect:_stackView.get().bounds toView:self.view];
+    CGFloat leftStackTrailingEdge = CGRectGetMaxX(stackViewFrame);
+
+    CGFloat actualSpacing = fullButtonLeadingEdge - leftStackTrailingEdge;
+    BOOL shouldUseCompactLayout = actualSpacing < kMinimumSpacing;
+
+    if (shouldUseCompactLayout) {
+        fullscreenButtonConfiguration.image = [[UIImage systemImageNamed:symbolName withConfiguration:fixedImageConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        fullscreenButtonConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(12, 12, 12, 12);
+        fullscreenButtonConfiguration.attributedTitle = nil;
+
+        [_enterVideoFullscreenButton setConfiguration:fullscreenButtonConfiguration];
+        [_enterVideoFullscreenButton invalidateIntrinsicContentSize];
+    }
+
     [_enterVideoFullscreenButton sizeToFit];
+
+    _isUsingCompactVideoButtonLayout = shouldUseCompactLayout;
+    [self _updateVideoButtonLayout];
+}
+
+- (void)_updateVideoButtonLayout
+{
+    if (!self.view)
+        return;
+
+    if (!_centeredStackView)
+        return;
+
+    if (_isUsingCompactVideoButtonLayout) {
+        [_centeredStackViewCenterXConstraint setActive:NO];
+        [_centeredStackViewTrailingConstraint setActive:YES];
+    } else {
+        [_centeredStackViewTrailingConstraint setActive:NO];
+        [_centeredStackViewCenterXConstraint setActive:YES];
+    }
 }
 
 - (void)configureEnvironmentPickerOrFullscreenVideoButtonView
@@ -512,7 +571,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self.delegate fullScreenViewController:self bestVideoPresentationInterfaceDidChange:videoPresentationInterface.get()];
 
     if (RetainPtr mediaPlayer = playbackSessionInterface->linearMediaPlayer(); [mediaPlayer spatialVideoMetadata] || [mediaPlayer isImmersiveVideo]) {
-        [self _setTopButtonLabel:[mediaPlayer isImmersiveVideo] ? WebCore::fullscreenControllerViewImmersive() : WebCore::fullscreenControllerViewSpatial()];
+        _isImmersiveVideo = [mediaPlayer isImmersiveVideo];
+        [self _setTopButtonLabel:_isImmersiveVideo ? WebCore::fullscreenControllerViewImmersive() : WebCore::fullscreenControllerViewSpatial()];
         if (!_buttonState.contains(FullscreenVideo)) {
             [_centeredStackView addArrangedSubview:_enterVideoFullscreenButton.get()];
             _buttonState.add(FullscreenVideo);
@@ -869,6 +929,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     else
         stackViewToTopGuideConstraint = [[_stackView topAnchor] constraintEqualToAnchor:topAnchor];
     _topConstraint = [topAnchor constraintEqualToAnchor:safeArea.topAnchor];
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    _centeredStackViewCenterXConstraint = [[_centeredStackView centerXAnchor] constraintEqualToAnchor:[_animatingView centerXAnchor]];
+    _centeredStackViewTrailingConstraint = [[_centeredStackView trailingAnchor] constraintEqualToAnchor:margins.trailingAnchor];
+#endif
     [NSLayoutConstraint activateConstraints:@[
         _topConstraint.get(),
         stackViewToTopGuideConstraint,
@@ -880,7 +944,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(LINEAR_MEDIA_PLAYER)
         // Align stack view's top anchor to the other stack view and to the middle of its superview.
         [[_centeredStackView topAnchor] constraintEqualToAnchor:[_stackView topAnchor]],
-        [[_centeredStackView centerXAnchor] constraintEqualToAnchor:[_animatingView centerXAnchor]],
 #endif
     ]];
 


### PR DESCRIPTION
#### fc34d2c7231c210487f92c2036c22a16b7eab086
<pre>
Fix UI control overlap when viewing narrow vertical video in element fullscreen on visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=308843">https://bugs.webkit.org/show_bug.cgi?id=308843</a>
<a href="https://rdar.apple.com/162804362">rdar://162804362</a>

Reviewed by Andy Estes.

The fix makes the button(view immersive/view spatial) responsive to available space. When there is
sufficient width, the button displays centered with both symbol and text, maintaining a minimum
24pt spacing from the left-sidebuttons. When space is insufficient,the button switches to a compact
symbol-only variant aligned to the trailing edge.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController _contentSizeCategoryDidChange:]):
(-[WKFullScreenViewController _setTopButtonLabel:]):
(-[WKFullScreenViewController _updateVideoButtonLayout]):
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):
(-[WKFullScreenViewController loadView]):

Canonical link: <a href="https://commits.webkit.org/308494@main">https://commits.webkit.org/308494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e8e15f2197d84def7de13db16d6136772a81271

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/773a887f-4c66-435e-9c20-aff16eb6ab1f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113858 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94618 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdfefaf9-42ff-4490-9faa-d7325abf2bdf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15277 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13047 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3825 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124872 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158719 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122086 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31274 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76312 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9130 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19802 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19531 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19682 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->