### PR TITLE
[AutoFill Debugging] Add a way for clients to extract only plain text while maintaining DOM structure

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -98,7 +98,7 @@ root
                 <button>Update Status</button>
             </div>
             <textarea uid=…>This is a text box</textarea>
-            <div uid=… role='textbox'> contenteditable
+            <div uid=… role='textbox' contenteditable>
                 <sub>
                     WebKit home page:
                     <a>webkit.org</a>

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -52,9 +52,8 @@ using TextExtractionVersion = unsigned;
 enum class TextExtractionOptionFlag : uint8_t {
     IncludeURLs          = 1 << 0,
     IncludeRects         = 1 << 1,
-    OnlyIncludeText      = 1 << 2,
-    ShortenURLs          = 1 << 3,
-    IncludeSelectOptions = 1 << 4,
+    ShortenURLs          = 1 << 2,
+    IncludeSelectOptions = 1 << 3,
 };
 
 enum class TextExtractionOutputFormat : uint8_t {
@@ -62,6 +61,7 @@ enum class TextExtractionOutputFormat : uint8_t {
     HTMLMarkup,
     Markdown,
     MinifiedJSON,
+    PlainText,
 };
 
 using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6820,6 +6820,8 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         return WebKit::TextExtractionOutputFormat::Markdown;
     case _WKTextExtractionOutputFormatJSON:
         return WebKit::TextExtractionOutputFormat::MinifiedJSON;
+    case _WKTextExtractionOutputFormatPlainText:
+        return WebKit::TextExtractionOutputFormat::PlainText;
     default:
         ASSERT_NOT_REACHED();
         return WebKit::TextExtractionOutputFormat::TextTree;
@@ -6933,7 +6935,6 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         includeURLs = configuration.includeURLs,
         includeRects = configuration.includeRects,
         includeSelectOptions = configuration.includeSelectOptions,
-        onlyIncludeText = configuration.onlyIncludeVisibleText,
         applyDiscretionaryWordLimit = configuration.maxWordsPerParagraphPolicy == _WKTextExtractionWordLimitPolicyDiscretionary,
         shortenURLs = configuration.shortenURLs,
         maxWordsPerParagraph = WTF::move(maxWordsPerParagraph),
@@ -7060,8 +7061,6 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             optionFlags.add(IncludeURLs);
         if (includeRects)
             optionFlags.add(IncludeRects);
-        if (onlyIncludeText)
-            optionFlags.add(OnlyIncludeText);
         if (shortenURLs)
             optionFlags.add(ShortenURLs);
         if (includeSelectOptions)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -53,6 +53,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
     _WKTextExtractionOutputFormatHTML,
     _WKTextExtractionOutputFormatMarkdown,
     _WKTextExtractionOutputFormatJSON,
+    _WKTextExtractionOutputFormatPlainText,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 #define WK_TEXT_EXTRACTION_HAS_EVENT_LISTENER_CATEGORIES 1
@@ -86,7 +87,15 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionWordLimitPolicy) {
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
-@property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly NS_SWIFT_NAME(visibleTextOnly);
+@property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly WK_API_DEPRECATED_WITH_REPLACEMENT("_WKTextExtractionOutputFormatPlainText", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA)) NS_SWIFT_NAME(visibleTextOnly);
+
+/*!
+ Disables all optional metadata in the extraction output: URLs, bounding rects,
+ node identifiers, event listeners, and accessibility attributes.
+ The output format and other structural configuration (e.g. `targetRect`, `targetNode`)
+ are left unchanged. Individual flags can still be re-enabled after calling this method.
+ */
+- (void)configureForMinimalOutput;
 
 /*!
  Output format to use when collating extracted elements into the final text output.
@@ -157,7 +166,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 /*!
  Include context around password fields, including those outside of `targetRect`.
- The default value is `false`.
+ The default value is `NO`.
  */
 @property (nonatomic) BOOL includeOffscreenPasswordFields;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -51,13 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)forEachClientNodeAttribute:(void(^)(NSString *attribute, NSString *value, _WKJSHandle *))block;
 
-/*!
- Only include visible text content, excluding all DOM attributes and element types.
- Takes precedence over `includeURLs`, `includeRects`, etc.
- Defaults to `NO`.
- */
-@property (nonatomic) BOOL onlyIncludeVisibleText;
-
 @end
 
 @interface _WKTextExtractionResult ()


### PR DESCRIPTION
#### d9fb21138389734dcd9e38f4729d55333ba13562
<pre>
[AutoFill Debugging] Add a way for clients to extract only plain text while maintaining DOM structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=308832">https://bugs.webkit.org/show_bug.cgi?id=308832</a>
<a href="https://rdar.apple.com/171240021">rdar://171240021</a>

Reviewed by Abrar Rahman Protyasha.

Make some adjustments to the `_WKTextExtraction` SPI surface; see below for more details.

Test: TextExtractionTests.MinimalHTMLOutput

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::addResult):
(WebKit::TextExtractionAggregator::includeRects const):
(WebKit::TextExtractionAggregator::includeURLs const):
(WebKit::TextExtractionAggregator::usePlainTextOutput const):
(WebKit::TextExtractionAggregator::addNativeMenuItemsIfNeeded):

Rename several helper methods, in light of the new plain text output type.

(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
(WebKit::TextExtractionAggregator::onlyIncludeText const): Deleted.
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(textExtractionOutputFormat):
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:

Deprecate `+configurationForVisibleTextOnly`, and replace it with a new enum value which represents
only plain text: `_WKTextExtractionOutputFormatPlainText`. Previously, making a new configuration
with `configurationForVisibleTextOnly` would yield a configuration that only supported _some_ of
the relevant configuration options. However, this is inconsistent with how the rest of the
extraction formatting options work, such as markdown — configuration flags that don&apos;t make sense for
the output format are simply ignored.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]):
(+[_WKTextExtractionConfiguration configurationForVisibleTextOnly]):
(-[_WKTextExtractionConfiguration configureForMinimalOutput]):

Add a convenience method to reset all extraction configuration parameters back to values that ensure
minimal output text. For clients that need to ensure minimal output, but still might want to
preserve specific types of data, they can use `-configureForMinimalOutput` and then enable only what
they need.

In the future, we should consider making the default initialized `_WKTextExtractionConfiguration`
start at this minimal output, rather than defaulting to text tree (with various bits of information
included, such as bounding rects and URLs).

(-[_WKTextExtractionConfiguration setIncludeEventListeners:]):
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]): Deleted.
(-[_WKTextExtractionConfiguration setIncludeURLs:]): Deleted.
(-[_WKTextExtractionConfiguration setIncludeRects:]): Deleted.
(-[_WKTextExtractionConfiguration setNodeIdentifierInclusion:]): Deleted.
(-[_WKTextExtractionConfiguration setEventListenerCategories:]): Deleted.
(-[_WKTextExtractionConfiguration setIncludeAccessibilityAttributes:]): Deleted.
(-[_WKTextExtractionConfiguration setIncludeTextInAutoFilledControls:]): Deleted.
(-[_WKTextExtractionConfiguration setOutputFormat:]): Deleted.
(-[_WKTextExtractionConfiguration setShortenURLs:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, VisibleTextOnly)):
(TestWebKitAPI::TEST(TextExtractionTests, MinimalHTMLOutput)):

Canonical link: <a href="https://commits.webkit.org/308380@main">https://commits.webkit.org/308380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9988d285a604f4a5e01d0f466d02e95f1f59e01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100740 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21a0afba-55d0-48f0-ad13-2aca99cf93fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113547 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80980 "Exiting early after 60 failures. 15370 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/303f37a8-02ba-4867-aafe-1dcf1f240c93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94305 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99de13ad-4367-4b40-beb1-05d703016603) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14947 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3448 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158339 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1477 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121575 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121774 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31191 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75798 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8809 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->