### PR TITLE
[MacOS debug] fast/scrolling/latching/scroll-div-no-latching.html is a flaky text failure.

### DIFF
--- a/LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html
@@ -54,7 +54,7 @@ body {
         var startPosY = divTarget.offsetTop + (divTarget.clientHeight / 2); // One wheel turn before end.
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
 
-        await UIHelper.ensurePresentationUpdate();
+        await UIHelper.startMonitoringWheelEvents();
 
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 1, 'none', 'none');
@@ -70,6 +70,8 @@ body {
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
 
+        await UIHelper.waitForScrollCompletion();
+        // Extra rendering updates to ensure scroll position is synchronized
         await UIHelper.renderingUpdate();
         await UIHelper.renderingUpdate();
         checkForScroll();

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2495,7 +2495,5 @@ tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html [ Skip ]
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html [ Skip ]
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html [ Skip ]
 
-webkit.org/b/308845 [ Debug arm64 ] fast/scrolling/latching/scroll-div-no-latching.html [ Failure Pass ]
-
 webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html [ Failure Pass ]
 


### PR DESCRIPTION
#### 24d3f73887689543ae3dcc4917cfdde3d4caf631
<pre>
[MacOS debug] fast/scrolling/latching/scroll-div-no-latching.html is a flaky text failure.
<a href="https://rdar.apple.com/171379964">rdar://171379964</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308845">https://bugs.webkit.org/show_bug.cgi?id=308845</a>

Reviewed by Jonathan Bedard.

This patch resovles a flaky failure caused by insufficient waiting for scoll completion.

 - Replaced UIHelper.ensurePresentationUpdate() with UIHelper.startMonitoringWheelEvents() - This sets
 up proper wheel event monitoring which is necessary for waitForScrollCompletion to work correctly
 - Replaced the two renderingUpdate() calls with waitForScrollCompletion() plus two additional
  renderingUpdate() calls - The waitForScrollCompletion uses eventSender.callAfterScrollingCompletes()
  which properly waits for scroll events to be processed. The additional rendering updates ensure the
  scroll position is synchronized before checking.

* LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308665@main">https://commits.webkit.org/308665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/129b2ba8a4f066b0b46248a8bb4c354b486190cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101516 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81409 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13350 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159119 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122209 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122424 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76743 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9468 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20204 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19934 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->