### PR TITLE
Reducing ShapedTextCache memory footprint

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -71,7 +71,7 @@ namespace ShapedTextCacheDefaults {
 static constexpr int initialInterval = -3; // Cache immediately, no countdown
 static constexpr int minInterval = -3; // After a hit, cache the next 3 attempts
 static constexpr int maxInterval = -3; // Never ramp up sampling, stay aggressive
-static constexpr unsigned maxSize = 500000; // Same as default cache size
+static constexpr unsigned maxSize = 3000; // Shaped text entries are large due to GlyphBuffer
 static constexpr unsigned maxTextLength = 128; // Larger than default to cache longer canvas text
 }
 

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -43,6 +43,7 @@
 namespace WebCore {
 
 static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
+static constexpr unsigned glyphBufferInlineCapacity = 64;
 
 class Font;
 
@@ -262,11 +263,11 @@ private:
         std::swap(m_offsetsInString[index1], m_offsetsInString[index2]);
     }
 
-    Vector<const Font*, 1024> m_fonts;
-    Vector<GlyphBufferGlyph, 1024> m_glyphs;
-    Vector<GlyphBufferAdvance, 1024> m_advances;
-    Vector<GlyphBufferOrigin, 1024> m_origins;
-    Vector<GlyphBufferStringOffset, 1024> m_offsetsInString;
+    Vector<const Font*, glyphBufferInlineCapacity> m_fonts;
+    Vector<GlyphBufferGlyph, glyphBufferInlineCapacity> m_glyphs;
+    Vector<GlyphBufferAdvance, glyphBufferInlineCapacity> m_advances;
+    Vector<GlyphBufferOrigin, glyphBufferInlineCapacity> m_origins;
+    Vector<GlyphBufferStringOffset, glyphBufferInlineCapacity> m_offsetsInString;
     GlyphBufferAdvance m_initialAdvance { makeGlyphBufferAdvance() };
 };
 


### PR DESCRIPTION
#### b67480a52340e2c07e67cc1db655a0f7b0699995
<pre>
Reducing ShapedTextCache memory footprint
<a href="https://bugs.webkit.org/show_bug.cgi?id=308850">https://bugs.webkit.org/show_bug.cgi?id=308850</a>

Reviewed by Sammy Gill.

* Source/WebCore/platform/graphics/GlyphBuffer.h:

Canonical link: <a href="https://commits.webkit.org/308462@main">https://commits.webkit.org/308462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bff35cd58e68976730ab6d51886b47be7587957a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f18a1a5-d622-4dba-9222-a534a8e8f1e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113653 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81051 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7367a25a-e675-430f-89b3-cd8cd7e97e41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94413 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15048 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3581 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158473 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121680 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31244 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75973 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19557 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83320 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->