### PR TITLE
WebKit is slow at opening very big HTML files

### DIFF
--- a/PerformanceTests/Parser/pending-text-buffer-parser.html
+++ b/PerformanceTests/Parser/pending-text-buffer-parser.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+
+var segmentSize = 64;
+var fillerSize = segmentSize - 2;
+var totalSize = 16 * 1024 * 1024;
+
+var filler = "";
+for (var i = 0; i < fillerSize; i++)
+    filler += "A";
+var segment = filler + "<1";
+
+var text = segment;
+while (text.length < totalSize)
+    text = text + text;
+text = text.substring(0, totalSize);
+
+var source = "<!DOCTYPE html><html><body>" + text + "</body></html>";
+text = null;
+
+var blob = new Blob([source], {type: "text/html"});
+source = null;
+var blobURL = URL.createObjectURL(blob);
+
+var iframe = document.createElement("iframe");
+iframe.style.display = "none";
+iframe.sandbox = "";
+document.body.appendChild(iframe);
+
+PerfTestRunner.prepareToMeasureValuesAsync({done: onCompletedRun, unit: "ms"});
+
+iframe.onload = function() {
+    var now = PerfTestRunner.now();
+    if (PerfTestRunner.measureValueAsync(now - then))
+        startNextRun();
+};
+
+function startNextRun() {
+    iframe.onload = function() {
+        iframe.onload = function() {
+            var now = PerfTestRunner.now();
+            if (PerfTestRunner.measureValueAsync(now - then))
+                startNextRun();
+        };
+        then = PerfTestRunner.now();
+        iframe.src = blobURL;
+    };
+    iframe.src = "about:blank";
+}
+
+var then = PerfTestRunner.now();
+iframe.src = blobURL;
+
+function onCompletedRun() {
+    iframe.onload = null;
+    document.body.removeChild(iframe);
+    URL.revokeObjectURL(blobURL);
+}
+
+</script>
+</body>

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -93,27 +93,32 @@ static ContainerNode::ChildChange NODELETE makeChildChange(CharacterData& charac
     };
 }
 
-void CharacterData::parserAppendData(StringView string)
+void CharacterData::parserAppendData(StringView string, StringBuilder& buffer)
 {
     auto childChange = makeChildChange(*this, ContainerNode::ChildChange::Source::Parser);
     std::optional<Style::ChildChangeInvalidation> styleInvalidation;
     if (RefPtr parent = parentNode())
         styleInvalidation.emplace(*parent, childChange);
 
-    String oldData = m_data;
-    m_data = makeString(m_data, string);
+    unsigned oldLength = length();
+
+    if (buffer.isEmpty() && !m_data.isEmpty())
+        buffer.append(m_data);
+
+    buffer.append(string);
+    m_data = buffer.toStringPreserveCapacity();
 
     clearStateFlag(StateFlag::ContainsOnlyASCIIWhitespaceIsValid);
 
     ASSERT(!renderer() || is<Text>(*this));
     if (auto text = dynamicDowncast<Text>(*this))
-        text->updateRendererAfterContentChange(oldData.length(), 0);
+        text->updateRendererAfterContentChange(oldLength, 0);
 
     notifyParentAfterChange(childChange);
 
     auto mutationRecipients = MutationObserverInterestGroup::createForCharacterDataMutation(*this);
     if (mutationRecipients) [[unlikely]]
-        mutationRecipients->enqueueMutationRecord(MutationRecord::createCharacterData(*this, oldData));
+        mutationRecipients->enqueueMutationRecord(MutationRecord::createCharacterData(*this, m_data.left(oldLength)));
 }
 
 void CharacterData::appendData(const String& data)

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -48,7 +48,8 @@ public:
     bool containsOnlyASCIIWhitespace() const;
 
     // Like appendData, but optimized for the parser (e.g., no mutation events).
-    void parserAppendData(StringView);
+    // Using the same StringBuilder across calls avoids O(n^2) behavior.
+    void parserAppendData(StringView, StringBuilder&);
 
 protected:
     CharacterData(Document& document, String&& text, NodeType type, OptionSet<TypeFlag> typeFlags = { })

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -461,6 +461,8 @@ void HTMLConstructionSite::setCompatibilityModeFromDoctype(const AtomString& nam
 
 void HTMLConstructionSite::finishedParsing()
 {
+    m_textNodeBuffer = nullptr;
+    m_currentTextNode = nullptr;
     protect(m_document)->finishedParsing();
 }
 
@@ -709,7 +711,14 @@ void HTMLConstructionSite::insertTextNode(const String& characters)
         // FIXME: We're only supposed to append to this text node if it was the last text node inserted by the parser.
         unsigned proposedBreakIndex = std::min(characters.length(), lengthLimit - previousTextChild->length());
         if (unsigned breakIndex = findBreakIndex(characters, 0, proposedBreakIndex)) {
-            previousTextChild->parserAppendData(StringView(characters).left(breakIndex));
+            if (previousTextChild != m_currentTextNode) {
+                if (!m_textNodeBuffer)
+                    m_textNodeBuffer = makeUnique<StringBuilder>();
+                else
+                    m_textNodeBuffer->clear();
+                m_currentTextNode = previousTextChild;
+            }
+            previousTextChild->parserAppendData(StringView(characters).left(breakIndex), *m_textNodeBuffer);
             currentPosition = breakIndex;
         }
     }

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -241,6 +241,9 @@ private:
     unsigned m_maximumDOMTreeDepth;
 
     bool m_inQuirksMode;
+
+    std::unique_ptr<StringBuilder> m_textNodeBuffer;
+    RefPtr<Text> m_currentTextNode;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -162,9 +162,10 @@ bool XMLDocumentParser::updateLeafTextNode()
     if (!m_leafTextNode)
         return true;
 
-    if (isXHTMLDocument())
-        protect(m_leafTextNode)->parserAppendData(String::fromUTF8(m_bufferedText.span()));
-    else {
+    if (isXHTMLDocument()) {
+        StringBuilder buffer;
+        protect(m_leafTextNode)->parserAppendData(String::fromUTF8(m_bufferedText.span()), buffer);
+    } else {
         // This operation might fire mutation event, see below.
         protect(m_leafTextNode)->appendData(String::fromUTF8(m_bufferedText.span()));
     }


### PR DESCRIPTION
#### 3ce7856bc424d5194a4fb8325b57d8e1a7cb2fed
<pre>
WebKit is slow at opening very big HTML files
<a href="https://bugs.webkit.org/show_bug.cgi?id=308852">https://bugs.webkit.org/show_bug.cgi?id=308852</a>
<a href="https://rdar.apple.com/144245503">rdar://144245503</a>

Reviewed by Ryosuke Niwa.

CharacterData::parserAppendData() previously called makeString() on
every chunk the HTML parser received, which copies all previously
accumulated text on each receipt, making total work occur in
polynomial time O(n^2) for large text nodes.

This change makes parserAppendData() take a StringBuilder&amp;, which lives
in HTMLConstructionSite that is lazily heap allocated before the first
parserAppendData() call, avoiding polynomial time complexity via
StringBuilder&apos;s exponential growth. This StringBuilder is only
created when text nodes are split across multiple chunks.

The included microbenchmark is progressed from ~240 ms/run to ~110 ms/run.
This patch does not cause any behavior change.

* PerformanceTests/Parser/pending-text-buffer-parser.html: Added.
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::parserAppendData):
* Source/WebCore/dom/CharacterData.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::finishedParsing):
(WebCore::HTMLConstructionSite::insertTextNode):
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::updateLeafTextNode):

Canonical link: <a href="https://commits.webkit.org/308781@main">https://commits.webkit.org/308781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a13b8c242b85249ca8ae5262f92c69da75d07109

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4448 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159344 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122391 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76973 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9653 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84214 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->