### PR TITLE
[iOS] Playback rate and position are not restored when MediaDeviceRoute activates

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/remote-playback-configuration-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/remote-playback-configuration-expected.txt
@@ -1,0 +1,15 @@
+
+Test that the wireless playback media engine is configured with a video's current time, playback rate, and playing state when a MediaDeviceRoute activates.
+
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.currentTime = 3)
+RUN(video.playbackRate = 0.25)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(route.timeRange = { start: 0, duration: 6 })
+RUN(route.ready = true)
+EVENT(playing)
+EXPECTED (route.currentPlaybackPosition >= '3') OK
+EXPECTED (route.playbackRate == '0.25') OK
+EXPECTED (route.playing == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/remote-playback-configuration.html
+++ b/LayoutTests/media/wireless-playback-media-player/remote-playback-configuration.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.currentTime = 3`);
+                run(`video.playbackRate = 0.25`);
+                await video.play();
+
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await urlPromise;
+
+                run(`route.timeRange = { start: 0, duration: 6 }`);
+                run(`route.ready = true`);
+                await waitFor(video, 'playing');
+
+                testExpected('route.currentPlaybackPosition', 3, '>=');
+                testExpected('route.playbackRate', 0.25);
+                testExpected('route.playing', true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the wireless playback media engine is configured with a video's current time, playback rate, and playing state when a MediaDeviceRoute activates.</p> 
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1353,6 +1353,8 @@ bool HTMLMediaElement::hasEverNotifiedAboutPlaying() const
 
 void HTMLMediaElement::checkPlaybackTargetCompatibility()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     Ref player = *m_player;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -1824,6 +1826,8 @@ void HTMLMediaElement::selectMediaResource()
 
 void HTMLMediaElement::loadNextSourceChild()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     ContentType contentType;
     auto mediaURL = selectNextSourceChild(&contentType, InvalidURLAction::Complain);
     if (!mediaURL.isValid()) {
@@ -3250,7 +3254,7 @@ void HTMLMediaElement::setReadyState(MediaPlayer::ReadyState state)
 
     m_tracksAreReady = tracksAreReady;
 
-    HTMLMEDIAELEMENT_RELEASE_LOG(SETREADYSTATE, convertEnumerationToString(state).utf8(), convertEnumerationToString(m_readyState).utf8());
+    HTMLMEDIAELEMENT_RELEASE_LOG(SETREADYSTATE, convertEnumerationToString(state).utf8(), convertEnumerationToString(m_readyState).utf8(), tracksAreReady);
 
     if (tracksAreReady)
         m_readyState = newState;
@@ -10311,6 +10315,8 @@ static ContentType inferredContentTypeFromURL(const URL& url)
 
 void HTMLMediaElement::rebuildMediaEngineForWirelessPlayback()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
+
     setReadyState(MediaPlayer::ReadyState::HaveNothing);
 
     switch (m_loadState) {

--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -147,7 +147,7 @@ HTMLMEDIAELEMENT_SETAUTOPLAYEVENTPLAYBACKSTATE, "HTMLMediaElement::setAutoplayEv
 HTMLMEDIAELEMENT_SETMUTEDINTERNAL, "HTMLMediaElement::setMutedInternal(%" PRIX64 ") %d", (uint64_t, int), DEFAULT, Media
 HTMLMEDIAELEMENT_SETNETWORKSTATE, "HTMLMediaElement::setNetworkState(%" PRIX64 ") new state = %s, current state = %s", (uint64_t, CString, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_SETPLAYBACKRATE, "HTMLMediaElement::setPlaybackRate(%" PRIX64 ") %f", (uint64_t, double), DEFAULT, Media
-HTMLMEDIAELEMENT_SETREADYSTATE, "HTMLMediaElement::setReadyState(%" PRIX64 ") new state = %s, current state = %s", (uint64_t, CString, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_SETREADYSTATE, "HTMLMediaElement::setReadyState(%" PRIX64 ") new state = %s, current state = %s, tracks ready = %d", (uint64_t, CString, CString, bool), DEFAULT, Media
 HTMLMEDIAELEMENT_SETSHOWPOSTERFLAG, "HTMLMediaElement::setShowPosterFlag(%" PRIX64 ") %d", (uint64_t, int), DEFAULT, Media
 HTMLMEDIAELEMENT_SETVOLUME, "HTMLMediaElement::setVolume(%" PRIX64 ") %f", (uint64_t, double), DEFAULT, Media
 

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -31,6 +31,8 @@
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <wtf/TZoneMallocInlines.h>
 
+#import <pal/cf/CoreMediaSoftLink.h>
+
 #define FOR_EACH_READONLY_KEY_PATH(Macro) \
     Macro(timeRange, TimeRange, MediaTimeRange) \
     Macro(ready, Ready, bool) \
@@ -53,7 +55,7 @@
 \
 
 #define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_mediaSource addObserver:self forKeyPath:@#KeyPath options:0 context:WebMediaSourceObserverContext]; \
+    [_mediaSource addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebMediaSourceObserverContext]; \
 \
 
 #define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
@@ -92,6 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSObject (Staging_169033633)
 @property (nonatomic) CMTime currentPlaybackPosition;
+@property (nonatomic) CMTime currentValue;
 @end
 
 static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
@@ -125,9 +128,14 @@ static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
 - (void)setMediaSource:(AVMediaSource * _Nullable)mediaSource
 {
     FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
+    REMOVE_OBSERVER(currentPlaybackPosition, CurrentPlaybackPosition, CMTime)
+    REMOVE_OBSERVER(currentValue, CurrentValue, CMTime)
+
     _mediaSource = mediaSource;
+
     FOR_EACH_KEY_PATH(ADD_OBSERVER)
-    FOR_EACH_KEY_PATH(NOTIFY_CLIENT)
+    ADD_OBSERVER(currentPlaybackPosition, CurrentPlaybackPosition, CMTime)
+    ADD_OBSERVER(currentValue, CurrentValue, CMTime)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
@@ -65,6 +65,7 @@ public:
 
     WEBCORE_EXPORT bool activateRoute(WebMediaDevicePlatformRoute *);
     WEBCORE_EXPORT bool deactivateRoute(WebMediaDevicePlatformRoute *);
+    WEBCORE_EXPORT void deactivateAllRoutes();
 
 private:
     MediaDeviceRouteController();
@@ -77,11 +78,9 @@ private:
 #endif
 };
 
+WEBCORE_EXPORT void setMockMediaDeviceRouteControllerEnabled(bool);
+WEBCORE_EXPORT bool mockMediaDeviceRouteControllerEnabled();
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-
-namespace WebCore {
-WEBCORE_EXPORT void setMockMediaDeviceRouteControllerEnabled(bool);
-WEBCORE_EXPORT bool mockMediaDeviceRouteControllerEnabled();
-}

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
@@ -29,6 +29,7 @@
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
 #import "MediaDeviceRoute.h"
+#import "MediaSessionHelperIOS.h"
 #import "MediaStrategy.h"
 #import "PlatformStrategies.h"
 #import <WebKitAdditions/MediaDeviceRouteControllerAdditions.mm>
@@ -96,11 +97,13 @@ bool MediaDeviceRouteController::deactivateRoute(WebMediaDevicePlatformRoute *pl
     return true;
 }
 
-} // namespace WebCore
+void MediaDeviceRouteController::deactivateAllRoutes()
+{
+    m_activeRoutes.clear();
 
-#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-
-namespace WebCore {
+    if (RefPtr client = m_client.get())
+        client->activeRoutesDidChange(*this);
+}
 
 static bool& mockMediaDeviceRouteControllerEnabledValue()
 {
@@ -110,17 +113,21 @@ static bool& mockMediaDeviceRouteControllerEnabledValue()
 
 void setMockMediaDeviceRouteControllerEnabled(bool isEnabled)
 {
+    MediaDeviceRouteController::singleton().deactivateAllRoutes();
+    MediaDeviceRouteController::singleton().setClient(isEnabled ? &MediaSessionHelper::sharedHelper() : nullptr);
+
     if (mockMediaDeviceRouteControllerEnabledValue() == isEnabled)
         return;
 
     mockMediaDeviceRouteControllerEnabledValue() = isEnabled;
-#if ENABLE(VIDEO)
     platformStrategies()->mediaStrategy()->resetMediaEngines();
-#endif
 }
+
 bool mockMediaDeviceRouteControllerEnabled()
 {
     return mockMediaDeviceRouteControllerEnabledValue();
 }
 
 } // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -750,7 +750,6 @@ void Internals::resetToConsistentState(Page& page)
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    MediaDeviceRouteController::singleton().setClient(nullptr);
     setMockMediaDeviceRouteControllerEnabled(false);
 #endif
 }

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -41,6 +41,11 @@ namespace WebCore {
 class MockMediaDeviceRoute : public RefCounted<MockMediaDeviceRoute> {
     WTF_MAKE_TZONE_ALLOCATED(MockMediaDeviceRoute);
 public:
+    struct TimeRange {
+        double start;
+        double duration;
+    };
+
     static Ref<MockMediaDeviceRoute> create();
 
     WebMediaDevicePlatformRoute *platformRoute() const;
@@ -53,8 +58,20 @@ public:
     bool ready() const;
     void setReady(bool);
 
+    bool playing() const;
+    void setPlaying(bool);
+
     bool hasPlaybackError() const;
     void setHasPlaybackError(bool);
+
+    float playbackRate() const;
+    void setPlaybackRate(float);
+
+    float currentPlaybackPosition() const;
+    void setCurrentPlaybackPosition(float);
+
+    TimeRange timeRange() const;
+    void setTimeRange(const TimeRange&);
 
 private:
     MockMediaDeviceRoute();

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -32,5 +32,18 @@
 
     attribute DOMString deviceName;
     attribute boolean ready;
+    attribute boolean playing;
     attribute boolean hasPlaybackError;
+    attribute float playbackRate;
+    attribute float currentPlaybackPosition;
+    attribute MockMediaDeviceRouteTimeRange timeRange;
+};
+
+[
+    Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary MockMediaDeviceRouteTimeRange {
+    required double start;
+    required double duration;
 };

--- a/Source/WebCore/testing/MockMediaDeviceRouteController.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRouteController.mm
@@ -51,7 +51,6 @@ bool MockMediaDeviceRouteController::enabled() const
 
 void MockMediaDeviceRouteController::setEnabled(bool enabled)
 {
-    MediaDeviceRouteController::singleton().setClient(enabled ? &MediaSessionHelper::sharedHelper() : nullptr);
     setMockMediaDeviceRouteControllerEnabled(enabled);
 }
 

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -32,7 +32,7 @@
 typedef NS_ENUM(NSInteger, WebMockMediaDeviceRouteErrorCode) {
     WebMockMediaDeviceRouteErrorCodeInvalidState,
     WebMockMediaDeviceRouteErrorCodeUnsupportedURL,
-    WebMockMediaDeviceRouteErrorPlaybackError,
+    WebMockMediaDeviceRouteErrorCodePlaybackError,
 };
 
 namespace WebCore {
@@ -48,6 +48,7 @@ extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
 @property (copy) NSString *routeDisplayName;
 @property (nonatomic, getter=isReady) BOOL ready;
 @property (nonatomic, strong, nullable) NSError *playbackError;
+@property (nonatomic) CMTimeRange timeRange;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 361b188ab57dbd2dac9657296e21ad48aca31a8b
<pre>
[iOS] Playback rate and position are not restored when MediaDeviceRoute activates
<a href="https://bugs.webkit.org/show_bug.cgi?id=308851">https://bugs.webkit.org/show_bug.cgi?id=308851</a>
<a href="https://rdar.apple.com/171388113">rdar://171388113</a>

Reviewed by Jer Noble.

When HTMLMediaElement switches media engines for wireless playback it stores the current time,
payback rate, and paused state in m_remotePlaybackConfiguration. Later, when the new media engine
reaches the HAVE_FUTURE_DATA ready state, this configuration is applied to the media engine. This
ensures that a video continues playing to the wireless route at the same position and rate.
MediaPlayerPrivateWirelessPlayback needed to be taught how to accept this stored configuration and
configure the MediaDeviceRoute accordingly. This change makes it so.

Test: media/wireless-playback-media-player/remote-playback-configuration.html

* LayoutTests/media/wireless-playback-media-player/remote-playback-configuration-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/remote-playback-configuration.html: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::checkPlaybackTargetCompatibility):
(WebCore::HTMLMediaElement::loadNextSourceChild):
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::rebuildMediaEngineForWirelessPlayback):
* Source/WebCore/platform/LogMessages.in:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebMediaSourceObserver setMediaSource:]):
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm:
(WebCore::MediaDeviceRouteController::deactivateAllRoutes):
(WebCore::setMockMediaDeviceRouteControllerEnabled):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::load):
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTarget const):
(WebCore::MediaPlayerPrivateWirelessPlayback::route const):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded):
(WebCore::MediaPlayerPrivateWirelessPlayback::play):
(WebCore::MediaPlayerPrivateWirelessPlayback::pause):
(WebCore::MediaPlayerPrivateWirelessPlayback::hasAudio const):
(WebCore::MediaPlayerPrivateWirelessPlayback::seekToTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::paused const):
(WebCore::MediaPlayerPrivateWirelessPlayback::startTime const):
(WebCore::MediaPlayerPrivateWirelessPlayback::duration const):
(WebCore::MediaPlayerPrivateWirelessPlayback::currentTime const):
(WebCore::MediaPlayerPrivateWirelessPlayback::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateWirelessPlayback::minTimeSeekable const):
(WebCore::MediaPlayerPrivateWirelessPlayback::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayerPrivateWirelessPlayback::setRate):
(WebCore::MediaPlayerPrivateWirelessPlayback::rate const):
(WebCore::MediaPlayerPrivateWirelessPlayback::timeRangeDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::playing const):
(WebCore::MockMediaDeviceRoute::setPlaying):
(WebCore::MockMediaDeviceRoute::setHasPlaybackError):
(WebCore::MockMediaDeviceRoute::playbackRate const):
(WebCore::MockMediaDeviceRoute::setPlaybackRate):
(WebCore::MockMediaDeviceRoute::currentPlaybackPosition const):
(WebCore::MockMediaDeviceRoute::setCurrentPlaybackPosition):
(WebCore::MockMediaDeviceRoute::timeRange const):
(WebCore::MockMediaDeviceRoute::setTimeRange):
* Source/WebCore/testing/MockMediaDeviceRouteController.mm:
(WebCore::MockMediaDeviceRouteController::setEnabled):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute currentPlaybackPosition]):
(-[WebMockMediaDeviceRoute setCurrentPlaybackPosition:]):
(-[WebMockMediaDeviceRoute currentValue]):
(-[WebMockMediaDeviceRoute setCurrentValue:]):
(-[WebMockMediaDeviceRoute startWithURL:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/308391@main">https://commits.webkit.org/308391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c06711b74ca6d6d2be3a03f32b2af0c0224d009

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/147403 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/20088 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156085 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/149276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20545 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/156085 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/150365 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20545 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156085 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20545 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3526 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20545 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158417 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1555 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/158417 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/19887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158417 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/31197 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19898 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22719 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/13679 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/19502 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83264 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19232 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19383 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19290 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->