### PR TITLE
draft: just test ews

### DIFF
--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -63,7 +63,7 @@ VisibleSelection::VisibleSelection(const Position& anchor, const Position& focus
     , m_affinity(affinity)
     , m_directionality(directionality)
 {
-    validate();
+    // validate();
 }
 
 VisibleSelection::VisibleSelection(const Position& position, Affinity affinity, Directionality directionality)


### PR DESCRIPTION
#### 251fc22c52781398604634bb9d2a3b0f19e2f4d4
<pre>
draft: just test ews
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/251fc22c52781398604634bb9d2a3b0f19e2f4d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100770 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19940 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113572 "Failure limit exceed. At least found 500 new test failures: css3/color-filters/color-filter-caret-color.html cssom/cssvalue-comparison.html editing/async-clipboard/clipboard-write-in-copy-event-handler-in-subframe.html editing/caret/caret-color.html editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/caret/emoji.html editing/caret/insert-paragraph-does-not-paint-stale-carets.html editing/deleting/25322-1.html editing/deleting/25322-2.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80998 "Exiting early after 60 failures. 2435 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/176e13f1-cc15-4cc3-81e3-302e3f8be830) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150317 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15819 "Found 60 new test failures: accessibility/insert-newline.html accessibility/ios-simulator/resolved-text-editing.html accessibility/ios-simulator/selected-text.html accessibility/misspelling-range.html accessibility/set-selected-text-range-after-newline.html css3/text-decoration/text-decoration-line-grammar-error-1.html css3/text-decoration/text-decoration-line-grammar-error-3.html css3/text-decoration/text-decoration-line-spelling-error-1.html css3/text-decoration/text-decoration-line-spelling-error-3.html cssom/cssvalue-comparison.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132351 "Found 263 new API test failures: TestWebKitAPI.WKAttachmentTests.CustomFileWrapperSubclass, TestWebKitAPI.WritingTools.CompositionWithList, TestWebKitAPI.WKAttachmentTests.InsertPastedAttributedStringContainingMultipleAttachments, TestWebKitAPI.PasteWebArchive.PreservesPictureInsideSpan, TestWebKitAPI.WKWebViewDisableSelection.DoubleClickDoesNotSelectWhenTextInteractionsAreDisabled, TestWebKitAPI.ImmediateActionTests.ImmediateActionOverImageOverlay, TestWebKitAPI.WebKitLegacy.AccessingImageInPastedWebArchive, TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContentDuringOutdent, TestWebKitAPI.WebKitLegacy.WebViewCanPasteURL, TestWebKitAPI.WritingTools.CompositionWithMultipleUndoAfterEndingAfterShowOriginalAndRewritten ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94331 "Found 5 new API test failures: WPE/TestWebKitFindController:/webkit/WebKitFindController/next, WPE/TestWebKitWebView:/webkit/WebKitWebView/snapshot, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, WPE/TestEditor:/webkit/WebKitWebEditor/selection-changed, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e96c3a48-8fa6-4b68-b82b-dec028015347) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14993 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-011.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-012.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-text-fragment.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-priority-painting.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-decorations.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-dynamic.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-replace.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12754 "Found 284 new API test failures: TestWebKitAPI.WKAttachmentTests.CustomFileWrapperSubclass, TestWebKitAPI.WritingTools.CompositionWithList, TestWebKitAPI.WKAttachmentTests.InsertPastedAttributedStringContainingMultipleAttachments, TestWebKitAPI.PasteWebArchive.PreservesPictureInsideSpan, TestWebKitAPI.WKWebViewDisableSelection.DoubleClickDoesNotSelectWhenTextInteractionsAreDisabled, TestWebKitAPI.ImmediateActionTests.ImmediateActionOverImageOverlay, TestWebKitAPI.WebKitLegacy.AccessingImageInPastedWebArchive, TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContentDuringOutdent, TestWebKitAPI.WebKitLegacy.WebViewCanPasteURL, TestWebKitAPI.WritingTools.CompositionWithMultipleUndoAfterEndingAfterShowOriginalAndRewritten ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3478 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124589 "Found 362 new API test failures: TestWebKitAPI.WKAttachmentTests.CustomFileWrapperSubclass, TestWebKitAPI.DocumentEditingContext.SpatialAndCurrentSelectionRequest_RectAfterCaretSelection, TestWebKitAPI.WritingTools.CompositionWithList, TestWebKitAPI.WKAttachmentTests.InsertPastedAttributedStringContainingMultipleAttachments, TestWebKitAPI.DocumentEditingContext.RequestLastTwoLines, TestWebKitAPI.DragAndDropTests.DataTransferSetDataUnescapedURL, TestWebKitAPI.DragAndDropTests.DataTransferTypesOnDragStartForTextSelection, TestWebKitAPI.DragAndDropTests.ExternalSourceFileURL, TestWebKitAPI.iOSMouseSupport.ShowingContextMenuSelectsNonEditableText, TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContentDuringOutdent ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10287 "Found 60 new test failures: accessibility/mac/attributed-string/attributed-string-for-range-with-options.html editing/input/reveal-contenteditable-on-input-vertically.html editing/input/setting-input-value-cancel-ime-composition.html editing/inserting/break-blockquote-after-delete.html editing/mac/attributed-string/attrib-string-range-with-color-filter.html editing/mac/attributed-string/attributed-string-for-typing-with-color-filter.html editing/mac/attributed-string/attributed-string-for-typing.html editing/mac/input/5576619.html editing/mac/input/NSBackgroundColor-transparent.html editing/mac/input/bold-node.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158369 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1507 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11735 "Found 60 new test failures: accessibility/mac/attributed-string-with-image.html accessibility/mac/attributed-string/attributed-string-for-range-with-options.html accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html accessibility/mac/select-text/select-text-135546.html accessibility/mac/select-text/select-text-135575.html accessibility/mac/select-text/select-text-3.html accessibility/mac/select-text/select-text-4.html accessibility/mac/select-text/select-text-7.html accessibility/mac/select-text/select-text-8.html accessibility/mac/select-text/select-text-9.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121600 "Failure limit exceed. At least found 498 new test failures: accessibility/gtk/caret-browsing-select-focus.html accessibility/gtk/caret-offsets-and-extraneous-white-spaces.html accessibility/gtk/text-in-span-block-in-a-block.html css3/text-decoration/text-decoration-line-spelling-error-1.html css3/text-decoration/text-decoration-line-spelling-error-3.html cssom/cssvalue-comparison.html editing/async-clipboard/clipboard-write-in-copy-event-handler-in-subframe.html editing/caret/caret-color.html editing/caret/caret-position-vertical-rl.html editing/caret/emoji.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16643 "Found 60 new test failures: accessibility/mac/attributed-string-with-image.html accessibility/mac/attributed-string/attributed-string-for-range-with-options.html accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html accessibility/mac/search-text/search-text.html accessibility/mac/select-text/select-text-135546.html accessibility/mac/select-text/select-text-135575.html accessibility/mac/select-text/select-text-3.html accessibility/mac/select-text/select-text-4.html accessibility/mac/select-text/select-text-7.html accessibility/mac/select-text/select-text-8.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121799 "Found 12 new API test failures: WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editor-state/typing-attributes, WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/link, WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable, WebKitGTK/TestEditor:/webkit/WebKitWebEditor/selection-changed, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/image ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75828 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17329 "Found 4 new test failures: interaction-region/text-input-focused-edited-empty.html interaction-region/text-input-focused-edited.html interaction-region/textarea-focused-edited-empty.html interaction-region/textarea-focused-edited.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8831 "Found 60 new test failures: accessibility/mac/attributed-string/attributed-string-for-range-with-options.html accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html accessibility/mac/select-text/select-text-135546.html accessibility/mac/select-text/select-text-135575.html accessibility/mac/select-text/select-text-3.html accessibility/mac/select-text/select-text-4.html accessibility/mac/select-text/select-text-7.html accessibility/mac/select-text/select-text-8.html accessibility/mac/select-text/select-text-9.html css3/color-filters/color-filter-caret-color.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19454 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83216 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19184 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->