### PR TITLE
Disable top background extensions when banner view overlay is present

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -128,6 +128,7 @@ pdf [ Skip ]
 ipc/mac [ Skip ]
 ipc/restrictedendpoints/mac [ Skip ]
 webanimations/threaded-animations [ Skip ]
+tiled-drawing/mac [ Skip ]
 
 # Requires async overflow scrolling
 compositing/shared-backing/overflow-scroll [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2494,6 +2494,10 @@ webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-con
 
 webkit.org/b/308601 [ Release ] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html [ Failure Pass ]
 
+tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html [ Skip ]
+tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html [ Skip ]
+tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html [ Skip ]
+
 webkit.org/b/308845 [ Debug arm64 ] fast/scrolling/latching/scroll-div-no-latching.html [ Failure Pass ]
 
 webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html [ Failure Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2502,3 +2502,7 @@ webkit.org/b/304523 inspector/unit-tests/iterableweakset.html [ Pass Failure ]
 # webkit.org/b/297276 4x New Test(292044@main): [ macOS ] 4x imported/w3c/web-platform-tests/css/css-text-decor/ (layout-tests) tests are constant image failures
 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-left-001.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-right-001.xht [ ImageOnlyFailure ]
+
+tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html [ Skip ]
+tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html [ Skip ]
+tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html [ Skip ]

--- a/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-expected.txt
+++ b/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-expected.txt
@@ -1,0 +1,72 @@
+Without banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect -392.50, -512.00 1570.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage -512, -512 2048 x 2048)
+      (tile size 512 x 512)
+      (top left tile -1, -1 tiles grid 4 x 4)
+      (in window 1)
+    )
+  )
+)
+
+With banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect -392.50, 0.00 1570.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage -512, 0 2048 x 2048)
+      (tile size 512 x 512)
+      (top left tile -1, 0 tiles grid 4 x 4)
+      (in window 1)
+    )
+  )
+)
+
+After removing banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect -392.50, -512.00 1570.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage -512, -512 2048 x 2048)
+      (tile size 512 x 512)
+      (top left tile -1, -1 tiles grid 4 x 4)
+      (in window 1)
+    )
+  )
+)
+

--- a/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x-expected.txt
+++ b/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x-expected.txt
@@ -1,0 +1,72 @@
+Without banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect -392.50, 0.00 1570.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage -512, 0 2048 x 2021)
+      (tile size 512 x 512)
+      (top left tile -1, 0 tiles grid 4 x 4)
+      (in window 1)
+    )
+  )
+)
+
+With banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect -392.50, 0.00 1570.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage -512, 0 2048 x 2021)
+      (tile size 512 x 512)
+      (top left tile -1, 0 tiles grid 4 x 4)
+      (in window 1)
+    )
+  )
+)
+
+After removing banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect -392.50, 0.00 1570.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage -512, 0 2048 x 2021)
+      (tile size 512 x 512)
+      (top left tile -1, 0 tiles grid 4 x 4)
+      (in window 1)
+    )
+  )
+)
+

--- a/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html
+++ b/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            width: 1200px;
+            height: 2000px;
+            /* The setBackgroundShouldExtendBeyondPage setting will only create margin tiles for documents
+               that have background images. */
+            background-image: url(resources/greenbox.png);
+            background-repeat: repeat-x;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function promiseNextFrame() {
+          return new Promise(resolve => {
+            requestAnimationFrame(resolve);
+          });
+        }
+
+        async function doTest()
+        {
+            if (!window.internals)
+                return;
+
+            internals.settings.setBackgroundShouldExtendBeyondPage(true);
+            internals.setSpeculativeTilingDelayDisabledForTesting(true);
+
+            await promiseNextFrame();
+
+            var output = '';
+
+            output += 'Without banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            internals.setPageHasBannerViewOverlayForTesting(true);
+            await promiseNextFrame();
+
+            output += '\nWith banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            internals.setPageHasBannerViewOverlayForTesting(false);
+            await promiseNextFrame();
+
+            output += '\nAfter removing banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            document.getElementById('layers').innerText = output;
+            testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+<pre id="layers">Layer tree goes here</pre>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y-expected.txt
+++ b/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y-expected.txt
@@ -1,0 +1,72 @@
+Without banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect 0.00, -512.00 1208.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage 0, -512 1208 x 2048)
+      (tile size 512 x 512)
+      (top left tile 0, -1 tiles grid 3 x 4)
+      (in window 1)
+    )
+  )
+)
+
+With banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect 0.00, 0.00 1208.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage 0, 0 1208 x 2048)
+      (tile size 512 x 512)
+      (top left tile 0, 0 tiles grid 3 x 4)
+      (in window 1)
+    )
+  )
+)
+
+After removing banner view overlay:
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1208.00 2021.00)
+  (visible rect 0.00, 0.00 785.00 x 585.00)
+  (coverage rect 0.00, 0.00 785.00 x 585.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1208.00 2021.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 585.00)
+      (coverage rect 0.00, -512.00 1208.00 x 1755.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (tile cache coverage 0, -512 1208 x 2048)
+      (tile size 512 x 512)
+      (top left tile 0, -1 tiles grid 3 x 4)
+      (in window 1)
+    )
+  )
+)
+

--- a/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html
+++ b/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            width: 1200px;
+            height: 2000px;
+            /* The setBackgroundShouldExtendBeyondPage setting will only create margin tiles for documents
+               that have background images. */
+            background-image: url(resources/greenbox.png);
+            background-repeat: repeat-y;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function promiseNextFrame() {
+          return new Promise(resolve => {
+            requestAnimationFrame(resolve);
+          });
+        }
+
+        async function doTest()
+        {
+            if (!window.internals)
+                return;
+
+            internals.settings.setBackgroundShouldExtendBeyondPage(true);
+            internals.setSpeculativeTilingDelayDisabledForTesting(true);
+
+            await promiseNextFrame();
+
+            var output = '';
+
+            output += 'Without banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            internals.setPageHasBannerViewOverlayForTesting(true);
+            await promiseNextFrame();
+
+            output += '\nWith banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            internals.setPageHasBannerViewOverlayForTesting(false);
+            await promiseNextFrame();
+
+            output += '\nAfter removing banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            document.getElementById('layers').innerText = output;
+            testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+<pre id="layers">Layer tree goes here</pre>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html
+++ b/LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            width: 1200px;
+            height: 2000px;
+            /* The setBackgroundShouldExtendBeyondPage setting will only create margin tiles for documents
+               that have background images. */
+            background-image: url(resources/greenbox.png);
+            background-repeat: repeat;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function promiseNextFrame() {
+          return new Promise(resolve => {
+            requestAnimationFrame(resolve);
+          });
+        }
+
+        async function doTest()
+        {
+            if (!window.internals)
+                return;
+
+            internals.settings.setBackgroundShouldExtendBeyondPage(true);
+            internals.setSpeculativeTilingDelayDisabledForTesting(true);
+
+            await promiseNextFrame();
+
+            var output = '';
+
+            output += 'Without banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            internals.setPageHasBannerViewOverlayForTesting(true);
+            await promiseNextFrame();
+
+            output += '\nWith banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            internals.setPageHasBannerViewOverlayForTesting(false);
+            await promiseNextFrame();
+
+            output += '\nAfter removing banner view overlay:\n';
+            output += internals.layerTreeAsText(document,
+                internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+
+            document.getElementById('layers').innerText = output;
+            testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+<pre id="layers">Layer tree goes here</pre>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/AdjustViewSize.h>
+#include <WebCore/BoxSides.h>
 #include <WebCore/Color.h>
 #include <WebCore/FrameView.h>
 #include <WebCore/LayoutMilestone.h>
@@ -217,13 +218,7 @@ public:
     WEBCORE_EXPORT void setBaseBackgroundColor(const Color&);
     WEBCORE_EXPORT void updateBackgroundRecursively(const std::optional<Color>& backgroundColor);
 
-    enum ExtendedBackgroundModeFlags {
-        ExtendedBackgroundModeNone          = 0,
-        ExtendedBackgroundModeVertical      = 1 << 0,
-        ExtendedBackgroundModeHorizontal    = 1 << 1,
-        ExtendedBackgroundModeAll           = ExtendedBackgroundModeVertical | ExtendedBackgroundModeHorizontal,
-    };
-    typedef unsigned ExtendedBackgroundMode;
+    using ExtendedBackgroundMode = BoxSideSet;
 
     void updateExtendBackgroundIfNecessary();
     void updateTilesForExtendedBackgroundMode(ExtendedBackgroundMode);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1946,6 +1946,20 @@ void Page::setShouldSuppressScrollbarAnimations(bool suppressAnimations)
     m_suppressScrollbarAnimations = suppressAnimations;
 }
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+void Page::setHasBannerViewOverlay(bool hasBannerViewOverlay)
+{
+    if (m_hasBannerViewOverlay == hasBannerViewOverlay)
+        return;
+
+    m_hasBannerViewOverlay = hasBannerViewOverlay;
+
+    RefPtr localMainFrame = this->localMainFrame();
+    if (RefPtr view = localMainFrame ? localMainFrame->view() : nullptr)
+        view->updateExtendBackgroundIfNecessary();
+}
+#endif
+
 void Page::lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars)
 {
     RefPtr view = protect(mainFrame())->virtualView();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -669,6 +669,11 @@ public:
     const FloatBoxExtent& obscuredContentInsets() const { return m_obscuredContentInsets; }
     WEBCORE_EXPORT void setObscuredContentInsets(const FloatBoxExtent&);
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool hasBannerViewOverlay() const { return m_hasBannerViewOverlay; }
+    WEBCORE_EXPORT void setHasBannerViewOverlay(bool);
+#endif
+
     WEBCORE_EXPORT void useSystemAppearanceChanged();
 
     WEBCORE_EXPORT bool useDarkAppearance() const;
@@ -1548,7 +1553,10 @@ private:
     float m_initialScaleIgnoringContentSize { 1.0f };
     
     bool m_suppressScrollbarAnimations { false };
-    
+
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool m_hasBannerViewOverlay { false };
+#endif
     ScrollElasticity m_verticalScrollElasticity { ScrollElasticity::Allowed };
     ScrollElasticity m_horizontalScrollElasticity { ScrollElasticity::Allowed };
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -530,12 +530,12 @@ void RenderLayerBacking::adjustTiledBackingCoverage()
     }
 }
 
-void RenderLayerBacking::setTiledBackingHasMargins(bool hasExtendedBackgroundOnLeftAndRight, bool hasExtendedBackgroundOnTopAndBottom)
+void RenderLayerBacking::setTiledBackingHasMargins(BoxSideSet margins)
 {
     if (!m_isFrameLayerWithTiledBacking)
         return;
 
-    tiledBacking()->setHasMargins(hasExtendedBackgroundOnTopAndBottom, hasExtendedBackgroundOnTopAndBottom, hasExtendedBackgroundOnLeftAndRight, hasExtendedBackgroundOnLeftAndRight);
+    tiledBacking()->setHasMargins(margins.contains(BoxSide::Top), margins.contains(BoxSide::Bottom), margins.contains(BoxSide::Left), margins.contains(BoxSide::Right));
 }
 
 void RenderLayerBacking::updateDebugIndicators(bool showBorder, bool showRepaintCounter)

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/BoxSides.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatPoint3D.h>
 #include <WebCore/GraphicsLayerClient.h>
@@ -232,7 +233,7 @@ public:
 
     WEBCORE_EXPORT TiledBacking* tiledBacking() const;
     void adjustTiledBackingCoverage();
-    void setTiledBackingHasMargins(bool hasExtendedBackgroundOnLeftAndRight, bool hasExtendedBackgroundOnTopAndBottom);
+    void setTiledBackingHasMargins(BoxSideSet);
     
     void updateDebugIndicators(bool showBorder, bool showRepaintCounter);
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -624,6 +624,9 @@ void Internals::resetToConsistentState(Page& page)
         page.setHeaderHeight(0);
         page.setFooterHeight(0);
         page.setObscuredContentInsets({ });
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+        page.setHasBannerViewOverlay(false);
+#endif
         mainFrameView->setUseFixedLayout(false);
         mainFrameView->setFixedLayoutSize(IntSize());
         mainFrameView->enableFixedWidthAutoSizeMode(false, { });
@@ -6058,6 +6061,21 @@ float Internals::pageMediaVolume()
 
     return page->mediaVolume();
 }
+
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+void Internals::setPageHasBannerViewOverlayForTesting(bool hasBannerViewOverlay)
+{
+    RefPtr document = contextDocument();
+    if (!document)
+        return;
+
+    RefPtr page = document->page();
+    if (!page)
+        return;
+
+    page->setHasBannerViewOverlay(hasBannerViewOverlay);
+}
+#endif
 
 #if !PLATFORM(COCOA)
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -977,6 +977,10 @@ public:
     float pageMediaVolume();
     void setPageMediaVolume(float);
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    void setPageHasBannerViewOverlayForTesting(bool);
+#endif
+
     String userVisibleString(const DOMURL&);
     void setShowAllPlugins(bool);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1151,6 +1151,8 @@ enum ContentsFormat {
     float pageMediaVolume();
     undefined setPageMediaVolume(float volume);
 
+    [Conditional=BANNER_VIEW_OVERLAYS] undefined setPageHasBannerViewOverlayForTesting(boolean hasFakeBannerViewOverlay);
+
     undefined setShowAllPlugins(boolean showAll);
 
     [CallWith=CurrentGlobalObject] any cloneArrayBuffer(any buffer, any srcByteOffset, any byteLength);

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -163,7 +163,10 @@ struct WebPageCreationParameters {
     double pageZoomFactor { 1 };
 
     WebCore::FloatBoxExtent obscuredContentInsets { };
-    
+
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool hasBannerViewOverlay { false };
+#endif
     float mediaVolume { 0 };
     WebCore::MediaProducerMutedStateFlags muted { };
     bool openedByDOM { false };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -80,6 +80,10 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     WebCore::FloatBoxExtent obscuredContentInsets;
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool hasBannerViewOverlay;
+#endif
+
     float mediaVolume;
     WebCore::MediaProducerMutedStateFlags muted;
     bool openedByDOM;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2912,6 +2912,21 @@ const WebCore::FloatBoxExtent& WebPageProxy::obscuredContentInsets() const
     return m_internals->obscuredContentInsets;
 }
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+void WebPageProxy::setHasBannerViewOverlay(bool hasBannerViewOverlay)
+{
+    if (m_internals->hasBannerViewOverlay == hasBannerViewOverlay)
+        return;
+
+    m_internals->hasBannerViewOverlay = hasBannerViewOverlay;
+
+    if (!hasRunningProcess())
+        return;
+
+    send(Messages::WebPage::SetHasBannerViewOverlay(hasBannerViewOverlay));
+}
+#endif
+
 Color WebPageProxy::underlayColor() const
 {
     return internals().underlayColor;
@@ -12578,6 +12593,9 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.textZoomFactor = m_textZoomFactor;
     parameters.pageZoomFactor = m_pageZoomFactor;
     parameters.obscuredContentInsets = m_internals->obscuredContentInsets;
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    parameters.hasBannerViewOverlay = m_internals->hasBannerViewOverlay;
+#endif
     parameters.mediaVolume = m_mediaVolume;
     parameters.muted = internals().mutedState;
     parameters.openedByDOM = m_openedByDOM;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1041,6 +1041,10 @@ public:
     const WebCore::FloatBoxExtent& NODELETE obscuredContentInsets() const LIFETIME_BOUND;
     void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    void setHasBannerViewOverlay(bool);
+#endif
+
 #if PLATFORM(MAC)
     void setObscuredContentInsetsAsync(const WebCore::FloatBoxExtent&);
     WebCore::FloatBoxExtent pendingOrActualObscuredContentInsets() const;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -302,6 +302,9 @@ public:
     WebCore::IntSize sizeToContentAutoSizeMaximumSize;
     WebCore::Color themeColor;
     WebCore::FloatBoxExtent obscuredContentInsets;
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool hasBannerViewOverlay { false };
+#endif
 #if PLATFORM(MAC)
     std::optional<WebCore::FloatBoxExtent> pendingObscuredContentInsets;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1115,6 +1115,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     setObscuredContentInsets(parameters.obscuredContentInsets);
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    setHasBannerViewOverlay(parameters.hasBannerViewOverlay);
+#endif
+
     m_userAgent = WTF::move(parameters.userAgent);
 
     setMediaVolume(parameters.mediaVolume);
@@ -4241,6 +4245,13 @@ void WebPage::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInse
         pluginView->obscuredContentInsetsDidChange();
 #endif
 }
+
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+void WebPage::setHasBannerViewOverlay(bool hasBannerViewOverlay)
+{
+    m_page->setHasBannerViewOverlay(hasBannerViewOverlay);
+}
+#endif
 
 void WebPage::viewWillStartLiveResize()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2123,6 +2123,10 @@ public:
 
     void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    void setHasBannerViewOverlay(bool);
+#endif
+
     void updateOpener(WebCore::FrameIdentifier, std::optional<WebCore::FrameIdentifier>);
     void setFramePrinting(WebCore::FrameIdentifier, bool printing, WebCore::FloatSize pageSize, WebCore::FloatSize originalPageSize, float maximumShrinkRatio, WebCore::AdjustViewSize shouldAdjustViewSize);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -48,6 +48,10 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     [DeferSendingIfSuspended] SetShouldSuppressHDR(bool shouldSuppressHDR)
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    SetHasBannerViewOverlay(bool hasBannerViewOverlay)
+#endif
+
     SetUnderlayColor(WebCore::Color color)
     SetUnderPageBackgroundColorOverride(WebCore::Color underPageBackgroundColorOverride)
 


### PR DESCRIPTION
#### 52f0b08b88716f2815358ca25d2ff67c0b760f57
<pre>
Disable top background extensions when banner view overlay is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=308857">https://bugs.webkit.org/show_bug.cgi?id=308857</a>
<a href="https://rdar.apple.com/171391429">rdar://171391429</a>

Reviewed by Abrar Rahman Protyasha.

When a banner view overlay is present, content in the scroll stretch area
will be partially obscured by the overlay, making the background and background
extension discontiguous.

To avoid this, disable the top background extension when a banner view overlay
is present. The UI process now notifies the Page when an overlay is present,
and we adjust accordingly in LocalFrameView::calculateExtendedBackgroundMode().

Since the extended background modes are now more complex than simply both axes,
no axes, x-axis, and y-axis, we used `BoxSideSet` for the extended background
mode instead of an enum. When a banner view is present, we simply remove the top
extension from the set.

Add `setPageHasFakeBannerViewOverlay` to Internals to allow for a layout test to
behave similarly to if it had a banner view overlay installed.

Existing tests: tiled-drawing/simple-document-with-margin-tiles.html

New tests: tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html
           tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html
           tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-expected.txt: Added.
* LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x-expected.txt: Added.
* LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html: Added.
* LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y-expected.txt: Added.
* LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html: Added.
* LayoutTests/tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateExtendBackgroundIfNecessary):
(WebCore::LocalFrameView::calculateExtendedBackgroundMode const):
(WebCore::LocalFrameView::updateTilesForExtendedBackgroundMode):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setHasBannerViewOverlay):
* Source/WebCore/page/Page.h:
(WebCore::Page::hasBannerViewOverlay const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::setTiledBackingHasMargins):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::setPageHasBannerViewOverlayForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setHasBannerViewOverlay):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):
(WebKit::WebPage::setHasBannerViewOverlay):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/308399@main">https://commits.webkit.org/308399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df6d753d68e1761a42345104221dd2870bc8014a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100804 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9adc948-6251-4f8c-b389-f9ae84e2c84a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113598 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81011 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa0c2edf-2311-4d7a-ac08-b3a6ff02816e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9cd01252-db5f-4206-add3-861a93ff901f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12779 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3512 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158403 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121625 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121825 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75863 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8859 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19218 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->