### PR TITLE
glance.cx: Home page shows stretched image next to "Employee Workspaces" section.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/keyword-sizes-on-replaced-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/keyword-sizes-on-replaced-element-expected.txt
@@ -96,13 +96,13 @@ height expected 60 but got 110
 PASS .test 71
 FAIL .test 72 assert_equals:
 <canvas width="100" height="100" class="test max-height" style="max-width: 50px; max-height: fit-content" data-expected-width="60" data-expected-height="60"></canvas>
-height expected 60 but got 110
+height expected 60 but got 70
 FAIL .test 73 assert_equals:
 <canvas width="100" height="100" class="test height" style="min-width: 150px; height: fit-content" data-expected-width="160" data-expected-height="160"></canvas>
 height expected 160 but got 110
 FAIL .test 74 assert_equals:
 <canvas width="100" height="100" class="test min-height" style="min-width: 150px; min-height: fit-content" data-expected-width="160" data-expected-height="160"></canvas>
-height expected 160 but got 110
+width expected 160 but got 170
 PASS .test 75
 PASS .test 76
 PASS .test 77
@@ -113,13 +113,13 @@ height expected 60 but got 110
 PASS .test 80
 FAIL .test 81 assert_equals:
 <canvas width="100" height="100" class="test max-height" style="max-width: 50px; max-height: min-content" data-expected-width="60" data-expected-height="60"></canvas>
-height expected 60 but got 110
+height expected 60 but got 70
 FAIL .test 82 assert_equals:
 <canvas width="100" height="100" class="test height" style="min-width: 150px; height: min-content" data-expected-width="160" data-expected-height="160"></canvas>
 height expected 160 but got 110
 FAIL .test 83 assert_equals:
 <canvas width="100" height="100" class="test min-height" style="min-width: 150px; min-height: min-content" data-expected-width="160" data-expected-height="160"></canvas>
-height expected 160 but got 110
+width expected 160 but got 170
 PASS .test 84
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<link rel="match" href="replaced-max-width-with-height-fit-content-ref.html">
+</head>
+<body>
+<img style="max-width: 100px; height: fit-content;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<link rel="match" href="replaced-max-width-with-height-max-content-ref.html">
+</head>
+<body>
+<img style="max-width: 100px; height: max-content;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<link rel="match" href="replaced-max-width-with-height-min-content-ref.html">
+</head>
+<body>
+<img style="max-width: 100px; height: min-content;" src="support/replaced-min-max-2.png">
+</body>
+</html>
+	

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -107,6 +107,7 @@
 #include <math.h>
 #include <wtf/Assertions.h>
 #include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/Scope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -5081,6 +5082,13 @@ std::pair<LayoutUnit, LayoutUnit> RenderBox::computeMinMaxLogicalHeightFromAspec
 {
     LayoutUnit transferredMinSize = LayoutUnit();
     LayoutUnit transferredMaxSize = LayoutUnit::max();
+
+#if ASSERT_ENABLED
+    auto checkMinMaxSizes = makeScopeExit([&transferredMinSize, &transferredMaxSize] {
+        ASSERT(transferredMaxSize >= transferredMinSize);
+    });
+#endif
+
     std::optional<double> aspectRatio = resolveAspectRatio();
     if (!aspectRatio)
         return { transferredMinSize, transferredMaxSize };

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -1330,16 +1330,19 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
             return percentageOrCalculated(calculatedLogicalHeight);
         },
         [&](const CSS::Keyword::FitContent&) -> LayoutUnit {
-            return content();
+            auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
+            return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::WebkitFillAvailable&) -> LayoutUnit {
             return content();
         },
         [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
-            return content();
+            auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
+            return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
-            return content();
+            auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
+            return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::Intrinsic&) -> LayoutUnit {
             return intrinsicLogicalHeight();


### PR DESCRIPTION
#### 99ecafd045f5b8a376a4bb6e453b149f78ab5f92
<pre>
glance.cx: Home page shows stretched image next to &quot;Employee Workspaces&quot; section.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309086">https://bugs.webkit.org/show_bug.cgi?id=309086</a>
<a href="https://rdar.apple.com/168264069">rdar://168264069</a>

Reviewed by Alan Baradlay.

The aforementioned image on the glance.cx homepage has styling with
width: 100%, max-width: 100%, and height: fit-content. We compute the width
of the image to be the same size as other engines, but the height of the
image is much taller compared to the others. In fact, the height of the
image comes from the natural size of it.

We currently see to return the intrinsic size of the image when computing
the fit-content size in RenderReplaced::computeReplacedLogicalHeightUsingGeneric,
which gets from eventually calling into computeIntrinsicLogicalContentHeightUsingGeneric.
This seems to be fine according to the way the intrinsic height is supposed
to be computed according to CSS-Box-Sizing-3, which defers to some language
from CSS2:
<a href="https://www.w3.org/TR/2021/WD-css-sizing-3-20211217/#intrinsic-sizes">https://www.w3.org/TR/2021/WD-css-sizing-3-20211217/#intrinsic-sizes</a>

However, there is an additional note that we do not seem to be taking
into account.
Note: When the box has a preferred aspect ratio, size constraints in the
opposite dimension will transfer through and can affect the auto size in
the considered one.

Essentially, we are not taking into consideration the transferred min/max
size constraints using those properties and the aspect ratio. The spec seems
to imply that we should be doing this since it has some language that says
it’s sized as &quot;if it was a float given an auto size in that axis,&quot; and includes
that note below the text.

So here we just apply those transferred size constraints by using the
computeMinMaxLogicalHeightFromAspectRatio helper that computes them and
clamping the intrinsic size between them. I also went ahead and did this
for the min-content and max-content cases since it was trivial to create
those test cases and it seems like that is what other engines are doing
as well. However, I did not do it for the WebkitFillAvailable since other
engines end up actually using the intrinsic size in that case.

Tests: imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-ref.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-ref.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-ref.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/keyword-sizes-on-replaced-element-expected.txt:
Rebasing this test since we were previously failing it and are still failing
it, but the sizes of the boxes do seem to be much closer to what is expected.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeMinMaxLogicalHeightFromAspectRatio const):
We already make sure that the transferred max size is at least as large
as the min at the end of this function, but I think it would be nice
to have this be a bit more resilient to changes by having a ScopeExit
check for this in debug builds.

Canonical link: <a href="https://commits.webkit.org/308995@main">https://commits.webkit.org/308995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8c536b2bf8e2b7074aaea67f727b4b5738ccd14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14179 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156580 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101313 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72266b30-cafa-4337-bbe6-8f6216fd2c40) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114020 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81309 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c94953a2-1184-46c8-a046-b5d7cc5a9839) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94784 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3ea4fcb-fb49-4192-b7b8-0e145b93e525) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13206 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4020 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158915 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122053 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33500 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132536 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76535 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17745 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9300 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83760 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->