### PR TITLE
[JSC] Limit element entry count to 10,000,000 per spec

### DIFF
--- a/JSTests/wasm/js-api/too-many-elem-entries.js
+++ b/JSTests/wasm/js-api/too-many-elem-entries.js
@@ -1,0 +1,28 @@
+import * as assert from "../assert.js";
+
+function testElemSegmentLimit() {
+  // (module
+  //   (type (;0;) (func))
+  //   (type (;1;) (func (result i32)))
+  //   (table (;0;) 10 funcref)
+  //   (export "run" (func 1))
+  //   (elem (;0;) func 0 ... (; repeated 10_000_001 times ;) )
+  //   (func (;0;) (type 0))
+  //   (func (;1;) (type 1) (result i32)
+  //     i32.const 42
+  //   )
+  // )
+  let bytes = [0,97,115,109,1,0,0,0,1,8,2,96,0,0,96,0,1,127,3,3,2,0,1,4,4,1,112,0,10,7,7,1,3,114,117,110,0,1,9,136,173,226,4,1,1,0,129,173,226,4];
+  const count = 10_000_001;
+  for (let i = 0; i < count; i++) {
+    bytes.push(0);
+  }
+  bytes.push(...[10,9,2,2,0,11,4,0,65,42,11]);
+  assert.throws(
+      () => new WebAssembly.Module(new Uint8Array(bytes)),
+      WebAssembly.CompileError,
+      "WebAssembly.Module doesn't parse at byte 50: Element section's 0th index count of 10000001 is too big, maximum 10000000"
+  );
+}
+
+testElemSegmentLimit();

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -60,6 +60,7 @@ constexpr size_t maxFunctionParams = 1000;
 constexpr size_t maxFunctionReturns = 1000;
 
 constexpr size_t maxTableEntries = 10000000;
+constexpr size_t maxTableInitializationEntries = 10000000;
 constexpr unsigned maxTables = 1000000;
 
 // Limit of GC arrays in bytes. This is not included in the limits in the

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1206,9 +1206,11 @@ auto SectionParser::parseElementKind(uint8_t& resultElementKind) -> PartialResul
 
 auto SectionParser::parseIndexCountForElementSection(uint32_t& resultIndexCount, const unsigned elementNum) -> PartialResult
 {
+    static_assert(maxTableInitializationEntries < std::numeric_limits<uint32_t>::max());
+
     uint32_t indexCount;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(indexCount), "can't get "_s, elementNum, "th index count for Element section"_s);
-    WASM_PARSER_FAIL_IF(indexCount == std::numeric_limits<uint32_t>::max(), "Element section's "_s, elementNum, "th index count is too big "_s, indexCount);
+    WASM_PARSER_FAIL_IF(indexCount > maxTableInitializationEntries, "Element section's "_s, elementNum, "th index count of "_s, indexCount, " is too big, maximum "_s, maxTableInitializationEntries);
     resultIndexCount = indexCount;
 
     return { };


### PR DESCRIPTION
#### 3e5413522e4c86bc53e117891ad9635b428cf454
<pre>
[JSC] Limit element entry count to 10,000,000 per spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=308792">https://bugs.webkit.org/show_bug.cgi?id=308792</a>
<a href="https://rdar.apple.com/problem/171324747">rdar://problem/171324747</a>

Reviewed by Yusuke Suzuki.

For better interop, respect the limit for elem entry count per
<a href="https://webassembly.github.io/spec/js-api/#limits">https://webassembly.github.io/spec/js-api/#limits</a>:

  The maximum number of table entries in any table initialization is 10,000,000

Test: JSTests/wasm/js-api/too-many-elem-entries.js
* JSTests/wasm/js-api/too-many-elem-entries.js: Added.
(testElemSegmentLimit):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseIndexCountForElementSection):

Canonical link: <a href="https://commits.webkit.org/308473@main">https://commits.webkit.org/308473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e14799b1e1fa661e4fa63bbed9681969c9c1ebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100784 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d42d6e76-3f4f-47c7-8bc6-92ea2c062fbb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81002 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f0c15c2-3695-4c25-822f-eae7a1d98822) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94342 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12764 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3492 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139339 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158383 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8157 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121610 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31252 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75843 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8844 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178686 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19468 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83230 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45759 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19198 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->