### PR TITLE
Counters don't work from ::checkmark/::picker-icon pseudo-elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -652,10 +652,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html [ ImageOnlyFailure ]
 
-# Need to use `disclosure-open` counter on ::picker-icon.
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html [ ImageOnlyFailure ]
-
 # Top layer exit animations (remove from implicit anchor/top layer after picker transition finishes).
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html [ ImageOnlyFailure ]
 
@@ -5468,9 +5464,6 @@ imported/w3c/web-platform-tests/css/css-lists/nested-marker-styling.html [ Image
 imported/w3c/web-platform-tests/css/css-lists/counter-list-item-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/counter-list-item-slot-order.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/counter-list-item.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/counter-order-display-contents.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/counter-slot-order-scoping.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/counter-slot-order.html [ ImageOnlyFailure ]
 
 # No support for reversed(<counter-name>) syntax
 imported/w3c/web-platform-tests/css/css-lists/counter-reset-reversed-list-item-start.html [ ImageOnlyFailure ]
@@ -5518,7 +5511,6 @@ webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-typ
 webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-006.html [ ImageOnlyFailure ]
 webkit.org/b/249918 imported/w3c/web-platform-tests/css/css-lists/list-marker-symbol-bidi.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-circle.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-lower-greek.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-lower-latin.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-square.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-style-containment-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-style-containment-001-expected.txt
@@ -1,10 +1,10 @@
 
 PASS content-visibility: visible
-FAIL content-visibility: hidden assert_true: expected true got false
-FAIL content-visibility: auto (far from viewport) assert_true: expected true got false
-FAIL content-visibility: auto (close from viewport) assert_true: expected true got false
+PASS content-visibility: hidden
+PASS content-visibility: auto (far from viewport)
+PASS content-visibility: auto (close from viewport)
 FAIL switching content-visibility from visible to hidden assert_true: expected true got false
-PASS switching content-visibility from hidden to visible
+FAIL switching content-visibility from hidden to visible assert_false: expected false got true
 FAIL switching content-visibility from visible to auto assert_true: expected true got false
-PASS switching content-visibility from auto to visible
+FAIL switching content-visibility from auto to visible assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -2,7 +2,7 @@ button
 SIBLING
 
 FAIL UA styles of base appearance <select>. assert_equals: min-inline-size expected "calc-size(auto, max(size, 24px))" but got "0px"
-FAIL UA styles of base appearance select::picker-icon. assert_equals: content expected "counter(fake-counter-name, disclosure-open)" but got "\"▼\" / \"\""
+PASS UA styles of base appearance select::picker-icon.
 FAIL UA styles of base appearance ::picker(select) assert_equals: position-try-fallbacks expected "start span-end, end span-start, start span-start" but got "block-start span-inline-end, block-end span-inline-start, block-start span-inline-start"
 PASS UA styles of base appearance <option>.
 PASS UA styles of base appearance option::checkmark.

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1126,8 +1126,7 @@ select:not([multiple]):-internal-uses-menulist > button:first-child {
 }
 
 select::picker-icon {
-    /* FIXME: Switch to disclosure-open counter once it works */
-    content: "\25BC" / "";
+    content: counter(fake-counter-name, disclosure-open);
     display: block;
     margin-inline-start: auto;
 }

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -23,15 +23,13 @@
 #include "RenderCounter.h"
 
 #include "CSSCounterStyleRegistry.h"
-#include "ContainerNodeInlines.h"
 #include "CounterDirectives.h"
 #include "CounterNode.h"
 #include "Document.h"
 #include "ElementInlines.h"
-#include "ElementTraversal.h"
 #include "HTMLNames.h"
 #include "HTMLOListElement.h"
-#include "PseudoElement.h"
+#include "RenderChildIterator.h"
 #include "RenderElementStyleInlines.h"
 #include "RenderElementInlines.h"
 #include "RenderListItem.h"
@@ -62,109 +60,92 @@ static CounterMaps& counterMaps()
     return staticCounterMaps;
 }
 
-static Element* ancestorStyleContainmentObject(const Element& element)
+// Descend into a subtree to find its last RenderElement in pre-order, stopping at style containment boundaries.
+static RenderElement* lastDescendantRespectingContainment(RenderElement& start)
 {
-    auto* pseudoElement = dynamicDowncast<PseudoElement>(element);
-    SUPPRESS_UNCOUNTED_LOCAL auto* ancestor = pseudoElement ? pseudoElement->hostElement() : element.parentElement();
-    while (ancestor) {
-        if (auto* style = ancestor->existingComputedStyle()) {
-            // None principal box shouldn't be regarded as style containment object.
-            // https://drafts.csswg.org/css-contain/#containment-style
-            if (style->usedContain().contains(Style::ContainValue::Style) && ancestor->renderer())
-                break;
-        }
-        // FIXME: this should use parentInComposedTree but for now matches the rest of RenderCounter.
-        ancestor = ancestor->parentElement();
+    auto* current = &start;
+    while (!current->shouldApplyStyleContainment()) {
+        auto* lastChild = childrenOfType<RenderElement>(*current).last();
+        if (!lastChild)
+            break;
+        current = lastChild;
     }
-    return ancestor;
+    return current;
 }
 
-// This function processes the renderer tree in the order of the DOM tree
-// including pseudo elements as defined in CSS 2.1. This method will always
-// return either a previous element within the same contain: style scope or nullptr.
+// This function processes the renderer tree in pre-order, returning the previous
+// renderer while respecting contain:style boundaries.
 static RenderElement* previousInPreOrderRespectingContainment(const RenderElement& renderer)
 {
-    ASSERT(renderer.element());
-    RefPtr previous = ElementTraversal::previousIncludingPseudo(*renderer.element());
-    RefPtr styleContainmentAncestor = ancestorStyleContainmentObject(*renderer.element());
-
+    auto* previous = renderer.previousSibling();
     while (previous) {
-        while (previous && !previous->renderer())
-            previous = ElementTraversal::previousIncludingPseudo(*previous, styleContainmentAncestor);
-        if (!previous)
-            break;
-        RefPtr previousStyleContainmentAncestor = ancestorStyleContainmentObject(*previous);
-        // If the candidate's containment ancestor is the same as elements, then
-        // that's a valid candidate.
-        if (previousStyleContainmentAncestor == styleContainmentAncestor)
-            return previous->renderer();
-
-        // If the candidate does have a containment ancestor, it could be
-        // that we entered a new sub-containment. Try again starting from the
-        // contain ancestor.
-        previous = previousStyleContainmentAncestor;
+        if (auto* previousElement = dynamicDowncast<RenderElement>(previous))
+            return lastDescendantRespectingContainment(*previousElement);
+        previous = previous->previousSibling();
     }
-    return nullptr;
-}
-
-static inline Element* NODELETE parentOrPseudoHostElement(const RenderElement& renderer)
-{
-    if (renderer.isPseudoElement())
-        return renderer.generatingElement();
-    return renderer.element() ? renderer.element()->parentElement() : nullptr;
-}
-
-static Element* previousSiblingOrParentElement(const Element& element)
-{
-    if (SUPPRESS_UNCHECKED_LOCAL auto* previous = ElementTraversal::pseudoAwarePreviousSibling(element)) {
-        while (previous && !previous->renderer())
-            previous = ElementTraversal::pseudoAwarePreviousSibling(*previous);
-
-        if (previous)
-            return previous;
-    }
-
-    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element)) {
-        SUPPRESS_UNCOUNTED_LOCAL auto* hostElement = pseudoElement->hostElement();
-        ASSERT(hostElement);
-        if (hostElement->renderer())
-            return hostElement;
-        return previousSiblingOrParentElement(*hostElement);
-    }
-    
-    SUPPRESS_UNCOUNTED_LOCAL auto* parent = element.parentElement();
-    if (parent && !parent->renderer())
-        parent = previousSiblingOrParentElement(*parent);
-    if (parent && parent->renderer() && parent->renderer()->style().usedContain().contains(Style::ContainValue::Style))
+    auto* parent = renderer.parent();
+    if (parent && parent->shouldApplyStyleContainment())
         return nullptr;
     return parent;
 }
 
-// This function processes the renderer tree in the order of the DOM tree
-// including pseudo elements as defined in CSS 2.1.
+// Unwrap anonymous block to find the real element it contains.
+static RenderElement* lastDescendantInAnonymousBlock(RenderElement& anonymousBlock)
+{
+    ASSERT(anonymousBlock.isAnonymous());
+    RenderElement* current = &anonymousBlock;
+    do {
+        current = childrenOfType<RenderElement>(*current).last();
+    } while (current && current->isAnonymous());
+    return current;
+}
+
+static RenderElement* previousSiblingUnwrappingAnonymous(const RenderElement& renderer)
+{
+    for (auto* previous = renderer.previousSibling(); previous; previous = previous->previousSibling()) {
+        if (auto* previousElement = dynamicDowncast<RenderElement>(previous))
+            return previousElement->isAnonymous() ? lastDescendantInAnonymousBlock(*previousElement) : previousElement;
+    }
+    return nullptr;
+}
+
+static RenderElement* previousSiblingOrParentSkippingAnonymous(const RenderElement& renderer)
+{
+    for (auto* parent = renderer.parent(); parent; parent = parent->parent()) {
+        if (!parent->isAnonymous()) {
+            if (parent->shouldApplyStyleContainment())
+                return nullptr;
+            return parent;
+        }
+        if (auto* previous = previousSiblingUnwrappingAnonymous(*parent))
+            return previous;
+    }
+    return nullptr;
+}
+
 static RenderElement* previousSiblingOrParent(const RenderElement& renderer)
 {
-    ASSERT(renderer.element());
+    if (auto* previous = previousSiblingUnwrappingAnonymous(renderer))
+        return previous;
 
-    RefPtr previous = previousSiblingOrParentElement(*renderer.element());
-    return previous ? previous->renderer() : nullptr;
+    return previousSiblingOrParentSkippingAnonymous(renderer);
 }
 
 static inline bool NODELETE areRenderersElementsSiblings(const RenderElement& first, const RenderElement& second)
 {
-    return parentOrPseudoHostElement(first) == parentOrPseudoHostElement(second);
+    return first.firstNonAnonymousAncestor() == second.firstNonAnonymousAncestor();
 }
 
-// This function processes the renderer tree in the order of the DOM tree
-// including pseudo elements as defined in CSS 2.1.
-static RenderElement* nextInPreOrder(const RenderElement& renderer, const Element* stayWithin, bool skipDescendants = false)
+static RenderElement* nextInPreOrder(const RenderElement& renderer, const RenderElement* stayWithin, bool skipDescendants = false)
 {
-    ASSERT(renderer.element());
-    Ref self = *renderer.element();
-    RefPtr next = skipDescendants ? ElementTraversal::nextIncludingPseudoSkippingChildren(self, stayWithin) : ElementTraversal::nextIncludingPseudo(self, stayWithin);
-    while (next && !next->renderer())
-        next = skipDescendants ? ElementTraversal::nextIncludingPseudoSkippingChildren(*next, stayWithin) : ElementTraversal::nextIncludingPseudo(*next, stayWithin);
-    return next ? next->renderer() : nullptr;
+    auto* next = skipDescendants
+        ? renderer.nextInPreOrderAfterChildren(stayWithin)
+        : renderer.nextInPreOrder(stayWithin);
+    for (; next; next = next->nextInPreOrder(stayWithin)) {
+        if (auto* nextElement = dynamicDowncast<RenderElement>(next))
+            return nextElement;
+    }
+    return nullptr;
 }
 
 static CounterDirectives listItemCounterDirectives(RenderElement& renderer)
@@ -207,17 +188,8 @@ static std::optional<CounterPlan> planCounter(RenderElement& renderer, const Ato
         return std::nullopt;
 
     auto& style = renderer.style();
-
-    if (style.pseudoElementType()) {
-        switch (*style.pseudoElementType()) {
-        case PseudoElementType::Before:
-        case PseudoElementType::After:
-            break;
-        default:
-            return std::nullopt; // Counters are forbidden from all other pseudo elements.
-        }
-    } else {
-        // Sometimes elements have more then one renderer. Only the first one gets the counter
+    if (!style.pseudoElementType()) {
+        // Sometimes elements have more than one renderer. Only the first one gets the counter
         // LayoutTests/http/tests/css/counter-crash.html
         if (generatingElement->renderer() != &renderer)
             return std::nullopt;
@@ -253,7 +225,7 @@ static std::optional<CounterPlan> planCounter(RenderElement& renderer, const Ato
     return std::nullopt;
 }
 
-// - Finds the insertion point for the counter described by counterOwner, isReset and 
+// - Finds the insertion point for the counter described by counterOwner, isReset and
 // identifier in the CounterNode tree for identifier and sets parent and
 // previousSibling accordingly.
 // - The function returns true if the counter whose insertion point is searched is NOT
@@ -262,9 +234,9 @@ static std::optional<CounterPlan> planCounter(RenderElement& renderer, const Ato
 // counter with the same identifier.
 // - All the counter references with the same identifier as this one that are in
 // children or subsequent siblings of the renderer that owns the root of the tree
-// form the rest of of the nodes of the tree.
+// form the rest of the nodes of the tree.
 // - The root of the tree is always a reset type reference.
-// - A subtree rooted at any reset node in the tree is equivalent to all counter 
+// - A subtree rooted at any reset node in the tree is equivalent to all counter
 // references that are in the scope of the counter or nested counter defined by that
 // reset node.
 // - Non-reset CounterNodes cannot have descendants.
@@ -278,11 +250,11 @@ static CounterInsertionPoint findPlaceForCounter(RenderElement& counterOwner, co
 {
     // We cannot stop searching for counters with the same identifier before we also
     // check this renderer, because it may affect the positioning in the tree of our counter.
-    RenderElement* searchEndRenderer = previousSiblingOrParent(counterOwner);
+    auto* searchEndRenderer = previousSiblingOrParent(counterOwner);
     // We check renderers in preOrder from the renderer that our counter is attached to
-    // towards the begining of the document for counters with the same identifier as the one
+    // towards the beginning of the document for counters with the same identifier as the one
     // we are trying to find a place for. This is the next renderer to be checked.
-    RenderElement* currentRenderer = previousInPreOrderRespectingContainment(counterOwner);
+    auto* currentRenderer = previousInPreOrderRespectingContainment(counterOwner);
     RefPtr<CounterNode> previousSibling;
 
     // Establish counter nodes previous to currentRenderer in order that calling
@@ -319,7 +291,7 @@ static CounterInsertionPoint findPlaceForCounter(RenderElement& counterOwner, co
                         }
                         // We are not a reset node or the previous reset must be on an ancestor of our owner renderer
                         // hence we must be a child of that reset counter.
-                        // In some cases renders can be reparented (ex. nodes inside a table but not in a column or row).
+                        // In some cases renderers can be reparented (ex. nodes inside a table but not in a column or row).
                         // In these cases the identified previousSibling will be invalid as its parent is different from
                         // our identified parent.
                         if (previousSibling->parent() != currentCounter)
@@ -366,8 +338,7 @@ static CounterInsertionPoint findPlaceForCounter(RenderElement& counterOwner, co
                         previousSibling = currentCounter;
                         // We are no longer interested in previous siblings of the currentRenderer or their children
                         // as counters they may have attached cannot be the previous sibling of the counter we are placing.
-                        auto* parent = parentOrPseudoHostElement(*currentRenderer);
-                        currentRenderer = parent ? parent->renderer() : nullptr;
+                        currentRenderer = currentRenderer->firstNonAnonymousAncestor();
                         continue;
                     }
                 } else
@@ -377,8 +348,8 @@ static CounterInsertionPoint findPlaceForCounter(RenderElement& counterOwner, co
             }
         }
         // This function is designed so that the same test is not done twice in an iteration, except for this one
-        // which may be done twice in some cases. Rearranging the decision points though, to accommodate this 
-        // performance improvement would create more code duplication than is worthwhile in my oppinion and may further
+        // which may be done twice in some cases. Rearranging the decision points though, to accommodate this
+        // performance improvement would create more code duplication than is worthwhile in my opinion and may further
         // impede the readability of this already complex algorithm.
         if (previousSibling)
             currentRenderer = previousSiblingOrParent(*currentRenderer);
@@ -402,9 +373,10 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
 
     auto& maps = counterMaps();
 
-    auto newNode = CounterNode::create(renderer, plan ? plan->type : OptionSet<CounterNode::Type> { }, plan ? plan->value : 0);
+    auto type = plan ? plan->type : OptionSet<CounterNode::Type> { };
+    auto newNode = CounterNode::create(renderer, type, plan ? plan->value : 0);
 
-    auto place = findPlaceForCounter(renderer, identifier, plan ? plan->type : OptionSet<CounterNode::Type> { });
+    auto place = findPlaceForCounter(renderer, identifier, type);
     if (place.parent)
         place.parent->insertAfter(newNode, place.previousSibling.get(), identifier);
 
@@ -416,7 +388,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
 
     // Check if some nodes that were previously root nodes should become children of this node now.
     auto* currentRenderer = &renderer;
-    RefPtr stayWithin = parentOrPseudoHostElement(renderer);
+    auto* stayWithin = renderer.firstNonAnonymousAncestor();
     bool skipDescendants = false;
     while ((currentRenderer = nextInPreOrder(*currentRenderer, stayWithin, skipDescendants))) {
         skipDescendants = currentRenderer->shouldApplyStyleContainment();
@@ -428,7 +400,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
         skipDescendants = true;
         if (currentCounter->parent())
             continue;
-        if (stayWithin == parentOrPseudoHostElement(*currentRenderer) && currentCounter->hasResetType())
+        if (stayWithin == currentRenderer->firstNonAnonymousAncestor() && currentCounter->hasResetType())
             break;
         newNode->insertAfter(*currentCounter, newNode->lastChild(), identifier);
     }
@@ -467,19 +439,19 @@ String RenderCounter::originalText() const
     if (!m_counterNode)
         return emptyString();
 
-    RefPtr child = m_counterNode.get();
-    int value = child->actsAsReset() ? child->value() : child->countInParent();
+    RefPtr counterNode = m_counterNode.get();
+    int value = counterNode->actsAsReset() ? counterNode->value() : counterNode->countInParent();
 
     auto counterText = [&](int value) {
         return counterStyle()->text(value, writingMode());
     };
     auto text = counterText(value);
     if (!m_counter.separator.isNull()) {
-        if (!child->actsAsReset())
-            child = child->parent();
-        while (RefPtr parent = child->parent()) {
-            text = makeString(counterText(child->countInParent()), m_counter.separator, text);
-            child = parent;
+        if (!counterNode->actsAsReset())
+            counterNode = counterNode->parent();
+        while (RefPtr parent = counterNode->parent()) {
+            text = makeString(counterText(counterNode->countInParent()), m_counter.separator, text);
+            counterNode = parent;
         }
     }
 
@@ -489,18 +461,18 @@ String RenderCounter::originalText() const
 void RenderCounter::updateCounter()
 {
     if (!m_counterNode) {
-        RenderElement* beforeAfterContainer = parent();
+        auto* container = parent();
         while (true) {
-            if (!beforeAfterContainer)
+            if (!container)
                 return;
-            if (!beforeAfterContainer->isAnonymous() && !beforeAfterContainer->isPseudoElement())
+            auto pseudoElementType = container->style().pseudoElementType();
+            if (!container->isAnonymous() && !pseudoElementType)
                 return;
-            auto containerStyle = beforeAfterContainer->style().pseudoElementType();
-            if (containerStyle == PseudoElementType::Before || containerStyle == PseudoElementType::After)
+            if (pseudoElementType)
                 break;
-            beforeAfterContainer = beforeAfterContainer->parent();
+            container = container->parent();
         }
-        makeCounterNode(*beforeAfterContainer, m_counter.identifier, true)->addRenderer(const_cast<RenderCounter&>(*this));
+        makeCounterNode(*container, m_counter.identifier, true)->addRenderer(const_cast<RenderCounter&>(*this));
     }
 
     setText(originalText(), true);
@@ -512,8 +484,9 @@ static void destroyCounterNodeWithoutMapRemoval(const AtomString& identifier, Co
     for (RefPtr<CounterNode> child = node.lastDescendant(); child && child != &node; child = WTF::move(previous)) {
         previous = child->previousInPreOrder();
         child->parent()->removeChild(*child);
-        ASSERT(counterMaps().find(child->owner())->value->get(identifier) == child);
-        counterMaps().find(child->owner())->value->remove(identifier);
+        auto& ownerCounterMap = *counterMaps().find(child->owner())->value;
+        ASSERT(ownerCounterMap.get(identifier) == child);
+        ownerCounterMap.remove(identifier);
     }
     if (RefPtr parent = node.parent())
         parent->removeChild(node);
@@ -552,12 +525,12 @@ void RenderCounter::rendererStyleChangedSlowCase(RenderElement& renderer, const 
     if (!element || !element->renderer())
         return; // cannot have generated content or if it can have, it will be handled during attaching
 
-    const CounterDirectiveMap* oldCounterDirectives;
-    if (oldStyle && !(oldCounterDirectives = &oldStyle->usedCounterDirectives())->map.isEmpty()) {
+    if (oldStyle && !oldStyle->usedCounterDirectives().map.isEmpty()) {
+        auto& oldCounterDirectives = oldStyle->usedCounterDirectives();
         if (auto& newCounterDirectives = newStyle.usedCounterDirectives().map; !newCounterDirectives.isEmpty()) {
             for (auto& keyValue : newCounterDirectives) {
-                auto existingEntry = oldCounterDirectives->map.find(keyValue.key);
-                if (existingEntry != oldCounterDirectives->map.end()) {
+                auto existingEntry = oldCounterDirectives.map.find(keyValue.key);
+                if (existingEntry != oldCounterDirectives.map.end()) {
                     if (existingEntry->value == keyValue.value)
                         continue;
                     RenderCounter::destroyCounterNode(renderer, keyValue.key);
@@ -568,7 +541,7 @@ void RenderCounter::rendererStyleChangedSlowCase(RenderElement& renderer, const 
                 makeCounterNode(renderer, keyValue.key, false);
             }
             // Destroying old counters that do not exist in the new counterDirective map.
-            for (auto& key : oldCounterDirectives->map.keys()) {
+            for (auto& key : oldCounterDirectives.map.keys()) {
                 if (!newCounterDirectives.contains(key))
                     RenderCounter::destroyCounterNode(renderer, key);
             }


### PR DESCRIPTION
#### 523a8fb63dc2811c92bea9da2e623e7871f299d5
<pre>
Counters don&apos;t work from ::checkmark/::picker-icon pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307170">https://bugs.webkit.org/show_bug.cgi?id=307170</a>
<a href="https://rdar.apple.com/169804965">rdar://169804965</a>

Reviewed by Darin Adler.

Newer pseudo-elements are not backed by DOM elements, so DOM traversals in RenderCounter would fail to find those.

Use renderer traversals instead of DOM element based-ones.

As a result of using renderer traversals, we also progress tests that expect the flat tree to be used for slots &amp; display: contents.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-style-containment-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt:
* Source/WebCore/css/html.css:
(select::picker-icon):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::lastDescendantRespectingContainment):
(WebCore::previousInPreOrderRespectingContainment):
(WebCore::lastDescendantInAnonymousBlock):
(WebCore::previousSiblingUnwrappingAnonymous):
(WebCore::previousSiblingOrParentSkippingAnonymous):
(WebCore::previousSiblingOrParent):
(WebCore::areRenderersElementsSiblings):
(WebCore::nextInPreOrder):
(WebCore::planCounter):
(WebCore::findPlaceForCounter):
(WebCore::makeCounterNode):
(WebCore::RenderCounter::originalText const):
(WebCore::RenderCounter::updateCounter):
(WebCore::destroyCounterNodeWithoutMapRemoval):
(WebCore::RenderCounter::rendererStyleChangedSlowCase):
(WebCore::ancestorStyleContainmentObject): Deleted.
(WebCore::parentOrPseudoHostElement):
(WebCore::previousSiblingOrParentElement): Deleted.

Canonical link: <a href="https://commits.webkit.org/308563@main">https://commits.webkit.org/308563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f3b1dc2774c19c7f6feb612c3b10140cfdcac7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101001 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113764 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81140 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0475a762-af3f-463e-a9bc-84bd45811bee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27ad0d58-b683-4130-bf7f-d9355ea7614e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12955 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158602 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121788 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121989 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31316 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76178 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9037 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83448 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19415 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->