### PR TITLE
[iOS] WebKitTestRunner should migrate to the UIKit scene-based life cycle

### DIFF
--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -58,17 +58,15 @@ static Vector<WebKitTestRunnerWindow *> allWindows;
 @implementation WebKitTestRunnerWindow
 @synthesize platformWebView = _platformWebView;
 
-ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithWindowScene:(UIWindowScene *)windowScene
 {
     allWindows.append(self);
 
-    if ((self = [super initWithFrame:frame]))
+    if ((self = [super initWithWindowScene:windowScene]))
         _initialized = YES;
 
     return self;
 }
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)becomeKeyWindow
 {
@@ -209,6 +207,16 @@ static CGRect viewRectForWindowRect(CGRect, PlatformWebView::WebViewSizingMode);
 
 namespace WTR {
 
+static UIWindowScene *windowScene()
+{
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if ([scene isKindOfClass:UIWindowScene.class])
+            return (UIWindowScene *)scene;
+    }
+
+    return nil;
+}
+
 static CGRect viewRectForWindowRect(CGRect windowRect, PlatformWebView::WebViewSizingMode mode)
 {
     CGFloat statusBarBottom = CGRectGetMaxY([[UIApplication sharedApplication] statusBarFrame]);
@@ -221,7 +229,8 @@ PlatformWebView::PlatformWebView(WKPageConfigurationRef configuration, const Tes
 {
     CGRect rect = CGRectMake(0, 0, options.viewWidth(), options.viewHeight());
 
-    m_window = [[WebKitTestRunnerWindow alloc] initWithFrame:rect];
+    m_window = [[WebKitTestRunnerWindow alloc] initWithWindowScene:windowScene()];
+    m_window.frame = rect;
     m_window.backgroundColor = [UIColor lightGrayColor];
     m_window.platformWebView = this;
 

--- a/Tools/WebKitTestRunner/ios/mainIOS.mm
+++ b/Tools/WebKitTestRunner/ios/mainIOS.mm
@@ -29,9 +29,34 @@
 #import "TestController.h"
 #import "UIKitSPIForTesting.h"
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <wtf/RetainPtr.h>
 
 static int _argc;
 static const char **_argv;
+
+static NSString * const sceneConfigurationName = @"Default Configuration";
+
+@interface WebKitTestRunnerSceneDelegate : NSObject <UIWindowSceneDelegate>
+@end
+
+@implementation WebKitTestRunnerSceneDelegate
+
+- (void)_runTestController
+{
+    WTR::TestController controller(_argc, _argv);
+}
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    [self performSelectorOnMainThread:@selector(_runTestController) withObject:nil waitUntilDone:NO];
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+@end
 
 @interface WebKitTestRunnerApp : UIApplication {
     UIBackgroundTaskIdentifier backgroundTaskIdentifier;
@@ -40,19 +65,11 @@ static const char **_argv;
 
 @implementation WebKitTestRunnerApp
 
-- (void)_runTestController
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options
 {
-    WTR::TestController controller(_argc, _argv);
-}
-
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
-{
-    [self performSelectorOnMainThread:@selector(_runTestController) withObject:nil waitUntilDone:NO];
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    RELEASE_ASSERT_NOT_REACHED();
+    RetainPtr configuration = adoptNS([[UISceneConfiguration alloc] initWithName:sceneConfigurationName sessionRole:connectingSceneSession.role]);
+    [configuration setDelegateClass:WebKitTestRunnerSceneDelegate.class];
+    return configuration.autorelease();
 }
 
 - (void)_handleHIDEvent:(IOHIDEventRef)event


### PR DESCRIPTION
#### c9c92c88a384337106deae20137c89bb6568a216
<pre>
[iOS] WebKitTestRunner should migrate to the UIKit scene-based life cycle
<a href="https://bugs.webkit.org/show_bug.cgi?id=308862">https://bugs.webkit.org/show_bug.cgi?id=308862</a>
<a href="https://rdar.apple.com/171175362">rdar://171175362</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

UIKit will soon require apps to adopt the scene-based life cycle. Non-adoption
will result in a fatal assertion.

An app can opt-in to the life cycle by implementing the `UIApplicationDelegate`
method `-application:configurationForConnectingSceneSession:options:`.

Implement the delegate method and make other necessary changes to support
the scene-based life cycle.

* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(-[WebKitTestRunnerWindow initWithFrame:]): Deleted.
(-[WebKitTestRunnerWindow initWithWindowScene:]):

Use the correct `UIWindow` initializer under the scene-based life cycle.

(WTR::windowScene):

Obtain a window scene from the connected scenes.

At most one window scene is expected, since WebKitTestRunner does not support
multiple scenes, and is not expected to run in any configurations where the
system would create additional scenes.

(WTR::PlatformWebView::PlatformWebView):
* Tools/WebKitTestRunner/ios/mainIOS.mm:
(-[WebKitTestRunnerSceneDelegate scene:willConnectToSession:options:]):

Run the tests once a scene is connected. `applicationDidFinishLaunching:` is not
called before scenes are connected, and is no longer a suitable entry point to
start running tests.

(-[WebKitTestRunnerSceneDelegate sceneDidEnterBackground:]):

`applicationDidEnterBackground:` is not called under the scene-based life cycle.
WebKitTestRunner&apos;s window scene is never expected to be backgrounded. Migrate the
assertion.

(-[WebKitTestRunnerApp application:configurationForConnectingSceneSession:options:]):
(-[WebKitTestRunnerApp _runTestController]): Deleted.
(-[WebKitTestRunnerApp applicationDidFinishLaunching:]): Deleted.
(-[WebKitTestRunnerApp applicationDidEnterBackground:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/308475@main">https://commits.webkit.org/308475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/942e16b77adf76b414b722772ee9b401072053e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100793 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85e0b14a-9121-437f-aa92-f206d92b63bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113590 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81007 "Exiting early after 60 failures. 15429 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cbdbf37-453f-42ec-9f0a-d59d50e2b0e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09d234a4-e32b-4d9c-8718-fbcb99dae73a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14987 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12771 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3501 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158392 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121618 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121818 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75852 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8850 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19477 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->