### PR TITLE
[AutoFill Debugging] Surface text with `text-decoration: line-through;` as ~~strikethrough text~~ when producing markdown

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -8,3 +8,7 @@ This is a list:
 - baz
 On [sale](https://webkit.org/) for
 £10.99 This ~~text~~ has a ~~line through it~~. The price ~~was \~\~$50~~
+~~CSS linethrough~~ normal text
+~~Linethrough also linethrough~~
+~~both semantic and CSS~~
+~~[A link](https://www.apple.com/)~~

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -8,6 +8,10 @@
 body.done {
     white-space: pre-wrap;
 }
+
+.linethrough {
+    text-decoration: line-through;
+}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -29,6 +33,10 @@ On <a href="https://webkit.org">sale</a> for
     <sup>99</sup>
     This <strike>text</strike> has a <del>line through it</del>. The price <s>was ~~$50</s>
 </p>
+<p><span class="linethrough">CSS linethrough</span> normal text</p>
+<p class="linethrough">Linethrough <span>also linethrough</span></p>
+<p><del class="linethrough">both semantic and CSS</del></p>
+<p class="linethrough"><a href="https://www.apple.com">A link</a></p>
 <script>
 addEventListener("load", async () => {
     if (!window.testRunner)

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -86,6 +86,7 @@
 #include "SimpleRange.h"
 #include "StaticRange.h"
 #include "StringEntropyHelpers.h"
+#include "StyleTextDecorationLine.h"
 #include "Text.h"
 #include "TextIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
@@ -354,6 +355,9 @@ static inline bool canMerge(const TraversalContext& context, const Item& destina
         return false;
 
     if (!std::holds_alternative<TextItemData>(destinationItem.data) || !std::holds_alternative<TextItemData>(sourceItem.data))
+        return false;
+
+    if (destinationItem.hasLineThrough != sourceItem.hasLineThrough)
         return false;
 
     // Don't merge adjacent text runs if they represent two different editable roots.
@@ -972,6 +976,9 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         }
         context.onlyCollectTextAndLinksCount++;
     }
+
+    if (CheckedPtr renderer = node.renderer(); renderer && item)
+        item->hasLineThrough = renderer->style().textDecorationLineInEffect().hasLineThrough();
 
     ASSERT_IMPLIES(isScrollable, item);
 

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -214,6 +214,7 @@ struct Item {
     String title;
     HashMap<String, String> clientAttributes;
     unsigned enclosingBlockNumber { 0 };
+    bool hasLineThrough { false };
 
     template<typename T> bool hasData() const
     {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7115,6 +7115,7 @@ header: <WebCore/TextExtractionTypes.h>
     String title;
     HashMap<String, String> clientAttributes;
     unsigned enclosingBlockNumber;
+    bool hasLineThrough;
 };
 
 header: <WebCore/TextExtractionTypes.h>


### PR DESCRIPTION
#### edc7e77a2687660864223656c612565300fb13d0
<pre>
[AutoFill Debugging] Surface text with `text-decoration: line-through;` as ~~strikethrough text~~ when producing markdown
<a href="https://bugs.webkit.org/show_bug.cgi?id=308863">https://bugs.webkit.org/show_bug.cgi?id=308863</a>
<a href="https://rdar.apple.com/171355896">rdar://171355896</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Add plumbing to handle text with `text-decoration: line-through;` in the same way as text underneath
`del` and `s` elements, by surrounding the text with `~~`.

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html:

Add several more test cases to the markdown output format.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::canMerge):
(WebCore::TextExtraction::extractRecursive):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Add `hasLineThrough` on each item to track whether or not the element has a `line-through` style.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForText):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/308413@main">https://commits.webkit.org/308413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2648e741208f2b670871cf0154fae9070719239

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100861 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e9201b6-f1e3-4bf6-86ee-14d200d9eba5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113643 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81042 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88870614-19d9-4bbc-9d60-cdd5133422d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94403 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48eec0a7-7b5d-4fdb-a0b6-8cfef8dd3d86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15039 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158460 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121670 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121869 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31211 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75960 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8908 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83308 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19275 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19426 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19333 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->