### PR TITLE
[macOS debug] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html is a flaky text failure.

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers_wsh.py
@@ -12,7 +12,14 @@ def web_socket_do_extra_handshake(request):
     message += b'Sec-WebSocket-Accept: '
     message += compute_accept_from_unicode(request.headers_in['Sec-WebSocket-Key'])
     message += b'\r\n\r\n'
-    request.connection.write(message)
+    close_body = stream.create_closing_handshake_body(1000, '')
+    close_frame = stream.create_close_frame(close_body)
+    request.connection.write(message + close_frame)
+    MASK_LENGTH = 4
+    try:
+        request.connection.read(len(close_frame) + MASK_LENGTH)
+    except Exception:
+        pass
     raise handshake.AbortedByUserException('Abort the connection') # Prevents pywebsocket from sending its own handshake message.
 
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2495,5 +2495,3 @@ webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-con
 webkit.org/b/308601 [ Release ] imported/w3c/web-platform-tests/media-source/SourceBuffer-abort-updating.html [ Failure Pass ]
 
 webkit.org/b/308845 [ Debug arm64 ] fast/scrolling/latching/scroll-div-no-latching.html [ Failure Pass ]
-
-webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html [ Failure Pass ]


### PR DESCRIPTION
#### 56804f31f0e0705ba24ba3c8500af081cdad077d
<pre>
[macOS debug] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html is a flaky text failure.
<a href="https://rdar.apple.com/171394530">rdar://171394530</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308856">https://bugs.webkit.org/show_bug.cgi?id=308856</a>

Reviewed by NOBODY (OOPS!).

The test was flaky because the WebSocket handler abruptly closed the connection
after sending the handshake response by raising AbortedByUserException without
sending a proper WebSocket close frame. This caused a race condition where the
client would sometimes log &quot;The network connection was lost&quot; before the test
finished, causing output mismatch.

Fix by sending a proper WebSocket close frame (code 1000) after the handshake
and waiting for the client&apos;s close frame response before aborting.

* LayoutTests/http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers_wsh.py:
(web_socket_do_extra_handshake):
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56804f31f0e0705ba24ba3c8500af081cdad077d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113595 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81009 "Exiting early after 60 failures. 15397 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158397 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121622 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75857 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8855 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19482 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->