### PR TITLE
Generalize pseudo-element renderer pointer storage

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4579,7 +4579,7 @@ void Element::removeFromTopLayer()
     // Document::topLayerElements(), since Styleable::fromRenderer() relies on this to
     // find the backdrop's associated element.
     if (CheckedPtr renderer = this->renderer()) {
-        if (CheckedPtr backdrop = renderer->backdropRenderer().get()) {
+        if (CheckedPtr backdrop = renderer->pseudoElementRenderer(PseudoElementType::Backdrop).get()) {
             if (auto styleable = Styleable::fromRenderer(*backdrop))
                 styleable->cancelStyleOriginatedAnimations();
         }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2438,7 +2438,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
             if (!elementRenderer)
                 return std::nullopt;
 
-            auto backdropRenderer = elementRenderer->backdropRenderer();
+            auto backdropRenderer = elementRenderer->pseudoElementRenderer(PseudoElementType::Backdrop);
             if (!backdropRenderer)
                 return std::nullopt;
 
@@ -5459,7 +5459,7 @@ Color LocalFrameView::documentBackgroundColor() const
 
         auto fullscreenElementColor = fullscreenRenderer->style().visitedDependentBackgroundColorApplyingColorFilter();
 
-        WeakPtr backdropRenderer = fullscreenRenderer->backdropRenderer();
+        WeakPtr backdropRenderer = fullscreenRenderer->pseudoElementRenderer(PseudoElementType::Backdrop);
         if (!backdropRenderer)
             return fullscreenElementColor;
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1996,8 +1996,8 @@ Node* RenderBlock::nodeForHitTest() const
             for (auto& element : document().topLayerElements()) {
                 if (!element->renderer())
                     continue;
-                ASSERT(element->renderer()->backdropRenderer());
-                if (element->renderer()->backdropRenderer() == this)
+                ASSERT(element->renderer()->pseudoElementRenderer(PseudoElementType::Backdrop));
+                if (element->renderer()->pseudoElementRenderer(PseudoElementType::Backdrop) == this)
                     return element.ptr();
             }
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2585,24 +2585,26 @@ std::unique_ptr<RenderStyle> RenderElement::animatedStyle()
     return result;
 }
 
-SingleThreadWeakPtr<RenderBlockFlow> RenderElement::backdropRenderer() const
+static constexpr size_t pseudoElementRendererIndex(PseudoElementType type)
 {
-    return hasRareData() ? rareData().backdropRenderer : nullptr;
+    switch (type) {
+    case PseudoElementType::Backdrop:   return 0;
+    case PseudoElementType::Checkmark:  return 1;
+    case PseudoElementType::PickerIcon: return 2;
+    default: WTF_UNREACHABLE();
+    }
 }
 
-void RenderElement::setBackdropRenderer(RenderBlockFlow& renderer)
+SingleThreadWeakPtr<RenderBlockFlow> RenderElement::pseudoElementRenderer(PseudoElementType type) const
 {
-    ensureRareData().backdropRenderer = renderer;
+    if (!hasRareData())
+        return nullptr;
+    return rareData().pseudoElementRenderers[pseudoElementRendererIndex(type)];
 }
 
-SingleThreadWeakPtr<RenderBlockFlow> RenderElement::pickerIconRenderer() const
+void RenderElement::setPseudoElementRenderer(PseudoElementType type, RenderBlockFlow& renderer)
 {
-    return hasRareData() ? rareData().pickerIconRenderer : nullptr;
-}
-
-void RenderElement::setPickerIconRenderer(RenderBlockFlow& renderer)
-{
-    ensureRareData().pickerIconRenderer = renderer;
+    ensureRareData().pseudoElementRenderers[pseudoElementRendererIndex(type)] = renderer;
 }
 
 Overflow RenderElement::effectiveOverflowX() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -290,11 +290,8 @@ public:
     virtual void suspendAnimations(MonotonicTime = MonotonicTime()) { }
     std::unique_ptr<RenderStyle> animatedStyle();
 
-    SingleThreadWeakPtr<RenderBlockFlow> backdropRenderer() const;
-    void setBackdropRenderer(RenderBlockFlow&);
-
-    SingleThreadWeakPtr<RenderBlockFlow> pickerIconRenderer() const;
-    void setPickerIconRenderer(RenderBlockFlow&);
+    SingleThreadWeakPtr<RenderBlockFlow> pseudoElementRenderer(PseudoElementType) const;
+    void setPseudoElementRenderer(PseudoElementType, RenderBlockFlow&);
 
     ReferencedSVGResources& ensureReferencedSVGResources();
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4553,7 +4553,7 @@ Vector<RenderLayer*> RenderLayer::topLayerRenderLayers(const RenderView& renderV
         if (!renderer)
             continue;
 
-        auto backdropRenderer = renderer->backdropRenderer();
+        auto backdropRenderer = renderer->pseudoElementRenderer(PseudoElementType::Backdrop);
         if (backdropRenderer && backdropRenderer->hasLayer() && backdropRenderer->layer()->parent())
             layers.append(backdropRenderer->layer());
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -323,7 +323,7 @@ RenderLayerBacking::RenderLayerBacking(RenderLayer& layer)
         if (!documentFullscreen)
             return false;
         RefPtr fullscreenElement = documentFullscreen->fullscreenElement();
-        if (!fullscreenElement || !fullscreenElement->renderer() || fullscreenElement->renderer()->backdropRenderer() != &renderer)
+        if (!fullscreenElement || !fullscreenElement->renderer() || fullscreenElement->renderer()->pseudoElementRenderer(PseudoElementType::Backdrop) != &renderer)
             return false;
 
         auto rendererRect = box->frameRect();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3331,7 +3331,7 @@ static FullScreenDescendant isDescendantOfFullScreenLayer(const RenderLayer& lay
     if (!fullScreenLayer)
         return FullScreenDescendant::NotApplicable;
 
-    auto backdropRenderer = fullScreenRenderer->backdropRenderer();
+    auto backdropRenderer = fullScreenRenderer->pseudoElementRenderer(PseudoElementType::Backdrop);
     if (backdropRenderer && backdropRenderer.get() == &layer.renderer())
         return FullScreenDescendant::Yes;
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1292,8 +1292,7 @@ private:
 
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;
-        SingleThreadWeakPtr<RenderBlockFlow> backdropRenderer;
-        SingleThreadWeakPtr<RenderBlockFlow> pickerIconRenderer;
+        std::array<SingleThreadWeakPtr<RenderBlockFlow>, 3> pseudoElementRenderers;
 
         // From RenderBox
         RefPtr<ControlPart> controlPart;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -34,7 +34,6 @@
 #include "RenderBlockFlow.h"
 #include "RenderBlockInlines.h"
 #include "RenderButton.h"
-#include "RenderDescendantIterator.h"
 #include "RenderMenuList.h"
 #include "RenderTreeBuilderBlock.h"
 #include "RenderTreeUpdaterGeneratedContent.h"
@@ -111,15 +110,7 @@ void RenderTreeBuilder::FormControls::updateAfterDescendants(RenderElement& rend
 
 void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type, RenderElement& renderer, StyleAppearance usedAppearance, RenderObject* beforeChild)
 {
-    auto existingPseudoElement = [&] -> CheckedPtr<RenderElement> {
-        if (type == PseudoElementType::PickerIcon)
-            return renderer.pickerIconRenderer().get();
-        for (CheckedRef child : childrenOfType<RenderElement>(renderer)) {
-            if (child->style().pseudoElementType() == type)
-                return child;
-        }
-        return nullptr;
-    }();
+    CheckedPtr existingPseudoElement = renderer.pseudoElementRenderer(type).get();
 
     if (usedAppearance != StyleAppearance::Base && !existingPseudoElement)
         return;
@@ -159,8 +150,7 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
     if (pseudoElement->style().content().isData())
         RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, *pseudoElement, pseudoElement->style(), type);
 
-    if (type == PseudoElementType::PickerIcon)
-        renderer.setPickerIconRenderer(*pseudoElement.get());
+    renderer.setPseudoElementRenderer(type, *pseudoElement.get());
 
     m_builder.attach(renderer, WTF::move(pseudoElement), beforeChild);
 }

--- a/Source/WebCore/rendering/updating/RenderTreePosition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.cpp
@@ -130,7 +130,7 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
             // by content."
             // https://drafts.csswg.org/css-forms-1/#picker-icon
             if (CheckedPtr renderer = element->renderer()) {
-                if (auto* pickerIconRenderer = renderer->pickerIconRenderer().get())
+                if (auto* pickerIconRenderer = renderer->pseudoElementRenderer(PseudoElementType::PickerIcon).get())
                     return pickerIconRenderer;
             }
         }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -789,7 +789,7 @@ static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingB
     };
 
     auto repaintBackdropIfApplicable = [&](auto& renderer) {
-        if (auto backdropRenderer = renderer.backdropRenderer())
+        if (auto backdropRenderer = renderer.pseudoElementRenderer(PseudoElementType::Backdrop))
             backdropRenderer->repaint(RenderObject::ForceRepaint::Yes);
     };
 
@@ -929,7 +929,7 @@ void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType te
                         parent->setNeedsPreferredWidthsUpdate();
                     }
                 }
-                if (auto backdropRenderer = renderer->backdropRenderer())
+                if (auto backdropRenderer = renderer->pseudoElementRenderer(PseudoElementType::Backdrop))
                     builder.destroyAndCleanUpAnonymousWrappers(*backdropRenderer, { });
                 builder.destroyAndCleanUpAnonymousWrappers(*renderer, root.renderer());
                 element->setRenderer(nullptr);

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -266,7 +266,7 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
 void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& renderer, Style::DifferenceResult minimalStyleDifference)
 {
     auto destroyBackdropIfNeeded = [&renderer, this]() {
-        if (WeakPtr backdropRenderer = renderer.backdropRenderer())
+        if (WeakPtr backdropRenderer = renderer.pseudoElementRenderer(PseudoElementType::Backdrop))
             m_updater.m_builder.destroy(*backdropRenderer);
     };
 
@@ -283,12 +283,12 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
     }
 
     auto newStyle = RenderStyle::clone(*style);
-    if (auto backdropRenderer = renderer.backdropRenderer())
+    if (auto backdropRenderer = renderer.pseudoElementRenderer(PseudoElementType::Backdrop))
         backdropRenderer->setStyle(WTF::move(newStyle), minimalStyleDifference);
     else {
         auto newBackdropRenderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, renderer.document(), WTF::move(newStyle));
         newBackdropRenderer->initializeStyle();
-        renderer.setBackdropRenderer(*newBackdropRenderer.get());
+        renderer.setPseudoElementRenderer(PseudoElementType::Backdrop, *newBackdropRenderer.get());
         m_updater.m_builder.attach(renderer.view(), WTF::move(newBackdropRenderer));
     }
 }


### PR DESCRIPTION
#### 9f52430ba166973b43555c92a29d55b24bf910c0
<pre>
Generalize pseudo-element renderer pointer storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=308865">https://bugs.webkit.org/show_bug.cgi?id=308865</a>
<a href="https://rdar.apple.com/171407918">rdar://171407918</a>

Reviewed by Simon Fraser.

As we add more pseudo-elements, we&apos;ll want efficient renderer lookups:
- to determine the render tree position (see ::picker-icon usage in RenderTreePosition)
- to find pre-existing renderer for destruction
- to add animation support (see Styleable.cpp usages)

Create a map from PseudoElementType -&gt; SingleThreadedWeakPtr&lt;RenderBlockFlow&gt; and replace the ::backdrop / ::picker-icon pointers.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::removeFromTopLayer):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
(WebCore::LocalFrameView::documentBackgroundColor const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::nodeForHitTest const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::pseudoElementRendererIndex):
(WebCore::RenderElement::pseudoElementRenderer const):
(WebCore::RenderElement::setPseudoElementRenderer):
(WebCore::RenderElement::backdropRenderer const): Deleted.
(WebCore::RenderElement::setBackdropRenderer): Deleted.
(WebCore::RenderElement::pickerIconRenderer const): Deleted.
(WebCore::RenderElement::setPickerIconRenderer): Deleted.
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::isDescendantOfFullScreenLayer):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::updatePseudoElement):
* Source/WebCore/rendering/updating/RenderTreePosition.cpp:
(WebCore::RenderTreePosition::nextSiblingRenderer const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::repaintAndMarkContainingBlockDirtyBeforeTearDown):
(WebCore::RenderTreeUpdater::tearDownRenderersInternal):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):
(WebCore::Styleable::renderer const):

Canonical link: <a href="https://commits.webkit.org/308412@main">https://commits.webkit.org/308412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a6d10dd09577a14024b809ec0242f27721c24d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100813 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113602 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81014 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d823847-7bf0-4ac1-9eb0-96e0520fbb45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94362 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd3ee97c-76e8-4db1-8b10-b6de361dc081) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12782 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158412 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1550 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121630 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31210 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75872 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8863 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19497 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83259 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19227 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19378 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->