### PR TITLE
Table cell nowrap minimum width calculation quirk should be quirks-mode only

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/quirks/table-cell-nowrap-minimum-width-calculation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/quirks/table-cell-nowrap-minimum-width-calculation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The table cell nowrap minimum width calculation quirk, basic assert_equals: quirks mode expected "10px" but got "2px"
+PASS The table cell nowrap minimum width calculation quirk, basic
 

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug57828-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug57828-expected.txt
@@ -30,10 +30,10 @@ layer at (0,0) size 800x600
                 text run at (45,2) width 174: "NOWRAP cell, width=100"
       RenderBlock (anonymous) at (0,198) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,216) size 188x54 [border: (3px outset #000000)]
-        RenderTableSection {TBODY} at (3,3) size 182x48
-          RenderTableRow {TR} at (0,2) size 182x44
-            RenderTableCell {TD} at (2,2) size 178x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,216) size 314x54 [border: (3px outset #000000)]
+        RenderTableSection {TBODY} at (3,3) size 308x48
+          RenderTableRow {TR} at (0,2) size 308x44
+            RenderTableCell {TD} at (2,2) size 304x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (2,2) size 40x40
               RenderText {#text} at (45,2) size 174x18
                 text run at (45,2) width 174: "NOWRAP cell, width=300"

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug78162-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug78162-expected.txt
@@ -3,31 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584 [bgcolor=#FFFFFF]
-      RenderTable {TABLE} at (0,0) size 634x172 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 632x170
-          RenderTableRow {TR} at (0,2) size 632x166
+      RenderTable {TABLE} at (0,0) size 646x172 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 644x170
+          RenderTableRow {TR} at (0,2) size 644x166
             RenderTableCell {TD} at (2,80) size 124x10 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (2,80) size 120x6
                 RenderTableSection {TBODY} at (0,0) size 120x6
                   RenderTableRow {TR} at (0,2) size 120x2
                     RenderTableCell {TD} at (2,2) size 116x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (128,2) size 502x166 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 498x162 [border: (1px outset #000000)]
-                RenderTableSection {TBODY} at (1,1) size 496x160
-                  RenderTableRow {TR} at (0,2) size 496x156
-                    RenderTableCell {TD} at (2,2) size 492x156 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                      RenderTable {TABLE} at (2,2) size 488x80
-                        RenderTableSection {TBODY} at (0,0) size 488x80
-                          RenderTableRow {TR} at (0,10) size 488x60
-                            RenderTableCell {TD} at (10,10) size 468x60 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (128,2) size 514x166 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 510x162 [border: (1px outset #000000)]
+                RenderTableSection {TBODY} at (1,1) size 508x160
+                  RenderTableRow {TR} at (0,2) size 508x156
+                    RenderTableCell {TD} at (2,2) size 504x156 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                      RenderTable {TABLE} at (2,2) size 500x80
+                        RenderTableSection {TBODY} at (0,0) size 500x80
+                          RenderTableRow {TR} at (0,10) size 500x60
+                            RenderTableCell {TD} at (10,10) size 480x60 [r=0 c=0 rs=1 cs=1]
                               RenderInline {A} at (0,46) size 468x17 [color=#0000EE]
                                 RenderImage {IMG} at (0,0) size 468x60
-                      RenderBlock (anonymous) at (2,82) size 488x72
-                        RenderText {#text} at (0,0) size 480x72
+                      RenderBlock (anonymous) at (2,82) size 500x72
+                        RenderText {#text} at (0,0) size 499x72
                           text run at (0,0) width 295: "Your donation to protect our wildlife was paid "
-                          text run at (294,0) width 167: "for by the sponsors on this"
-                          text run at (0,18) width 109: "page, so it's free. "
-                          text run at (109,18) width 371: "100% of each donation is distributed through organizations"
-                          text run at (0,36) width 352: "working hard to protect our wildlife. You can view live "
-                          text run at (351,36) width 109: "donation totals in"
-                          text run at (0,54) width 207: "support of this cause by clicking."
+                          text run at (294,0) width 205: "for by the sponsors on this page,"
+                          text run at (0,18) width 71: "so it's free. "
+                          text run at (71,18) width 375: "100% of each donation is distributed through organizations "
+                          text run at (445,18) width 54: "working"
+                          text run at (0,36) width 295: "hard to protect our wildlife. You can view live "
+                          text run at (294,36) width 203: "donation totals in support of this"
+                          text run at (0,54) width 113: "cause by clicking."

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug57828-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug57828-expected.txt
@@ -30,10 +30,10 @@ layer at (0,0) size 800x600
                 text run at (45,2) width 174: "NOWRAP cell, width=100"
       RenderBlock (anonymous) at (0,202) size 784x20
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,222) size 188x54 [border: (3px outset #000000)]
-        RenderTableSection {TBODY} at (3,3) size 182x48
-          RenderTableRow {TR} at (0,2) size 182x44
-            RenderTableCell {TD} at (2,2) size 178x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,222) size 314x54 [border: (3px outset #000000)]
+        RenderTableSection {TBODY} at (3,3) size 308x48
+          RenderTableRow {TR} at (0,2) size 308x44
+            RenderTableCell {TD} at (2,2) size 304x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (2,2) size 40x40
               RenderText {#text} at (45,2) size 174x20
                 text run at (45,2) width 174: "NOWRAP cell, width=300"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug78162-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug78162-expected.txt
@@ -3,31 +3,31 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584 [bgcolor=#FFFFFF]
-      RenderTable {TABLE} at (0,0) size 634x180 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 632x178
-          RenderTableRow {TR} at (0,2) size 632x174
+      RenderTable {TABLE} at (0,0) size 646x180 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 644x178
+          RenderTableRow {TR} at (0,2) size 644x174
             RenderTableCell {TD} at (2,84) size 124x10 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (2,84) size 120x6
                 RenderTableSection {TBODY} at (0,0) size 120x6
                   RenderTableRow {TR} at (0,2) size 120x2
                     RenderTableCell {TD} at (2,2) size 116x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (128,2) size 502x174 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 498x170 [border: (1px outset #000000)]
-                RenderTableSection {TBODY} at (1,1) size 496x168
-                  RenderTableRow {TR} at (0,2) size 496x164
-                    RenderTableCell {TD} at (2,2) size 492x164 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                      RenderTable {TABLE} at (2,2) size 488x80
-                        RenderTableSection {TBODY} at (0,0) size 488x80
-                          RenderTableRow {TR} at (0,10) size 488x60
-                            RenderTableCell {TD} at (10,10) size 468x60 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (128,2) size 514x174 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 510x170 [border: (1px outset #000000)]
+                RenderTableSection {TBODY} at (1,1) size 508x168
+                  RenderTableRow {TR} at (0,2) size 508x164
+                    RenderTableCell {TD} at (2,2) size 504x164 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                      RenderTable {TABLE} at (2,2) size 500x80
+                        RenderTableSection {TBODY} at (0,0) size 500x80
+                          RenderTableRow {TR} at (0,10) size 500x60
+                            RenderTableCell {TD} at (10,10) size 480x60 [r=0 c=0 rs=1 cs=1]
                               RenderInline {A} at (0,45) size 468x19 [color=#0000EE]
                                 RenderImage {IMG} at (0,0) size 468x60
-                      RenderBlock (anonymous) at (2,82) size 488x80
-                        RenderText {#text} at (0,0) size 469x80
+                      RenderBlock (anonymous) at (2,82) size 500x80
+                        RenderText {#text} at (0,0) size 491x80
                           text run at (0,0) width 300: "Your donation to protect our wildlife was paid "
                           text run at (299,0) width 170: "for by the sponsors on this"
                           text run at (0,20) width 112: "page, so it's free. "
-                          text run at (111,20) width 290: "100% of each donation is distributed through"
-                          text run at (0,40) width 90: "organizations "
-                          text run at (89,40) width 354: "working hard to protect our wildlife. You can view live"
-                          text run at (0,60) width 327: "donation totals in support of this cause by clicking."
+                          text run at (111,20) width 380: "100% of each donation is distributed through organizations"
+                          text run at (0,40) width 357: "working hard to protect our wildlife. You can view live "
+                          text run at (356,40) width 113: "donation totals in"
+                          text run at (0,60) width 212: "support of this cause by clicking."

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug57828-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug57828-expected.txt
@@ -30,10 +30,10 @@ layer at (0,0) size 800x600
                 text run at (45,2) width 174: "NOWRAP cell, width=100"
       RenderBlock (anonymous) at (0,198) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,216) size 188x54 [border: (3px outset #000000)]
-        RenderTableSection {TBODY} at (3,3) size 182x48
-          RenderTableRow {TR} at (0,2) size 182x44
-            RenderTableCell {TD} at (2,2) size 178x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,216) size 314x54 [border: (3px outset #000000)]
+        RenderTableSection {TBODY} at (3,3) size 308x48
+          RenderTableRow {TR} at (0,2) size 308x44
+            RenderTableCell {TD} at (2,2) size 304x44 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderImage {IMG} at (2,2) size 40x40
               RenderText {#text} at (45,2) size 174x18
                 text run at (45,2) width 174: "NOWRAP cell, width=300"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug78162-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug78162-expected.txt
@@ -3,31 +3,31 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584 [bgcolor=#FFFFFF]
-      RenderTable {TABLE} at (0,0) size 634x172 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 632x170
-          RenderTableRow {TR} at (0,2) size 632x166
+      RenderTable {TABLE} at (0,0) size 646x172 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 644x170
+          RenderTableRow {TR} at (0,2) size 644x166
             RenderTableCell {TD} at (2,80) size 124x10 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderTable {TABLE} at (2,80) size 120x6
                 RenderTableSection {TBODY} at (0,0) size 120x6
                   RenderTableRow {TR} at (0,2) size 120x2
                     RenderTableCell {TD} at (2,2) size 116x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (128,2) size 502x166 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 498x162 [border: (1px outset #000000)]
-                RenderTableSection {TBODY} at (1,1) size 496x160
-                  RenderTableRow {TR} at (0,2) size 496x156
-                    RenderTableCell {TD} at (2,2) size 492x156 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                      RenderTable {TABLE} at (2,2) size 488x80
-                        RenderTableSection {TBODY} at (0,0) size 488x80
-                          RenderTableRow {TR} at (0,10) size 488x60
-                            RenderTableCell {TD} at (10,10) size 468x60 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (128,2) size 514x166 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 510x162 [border: (1px outset #000000)]
+                RenderTableSection {TBODY} at (1,1) size 508x160
+                  RenderTableRow {TR} at (0,2) size 508x156
+                    RenderTableCell {TD} at (2,2) size 504x156 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                      RenderTable {TABLE} at (2,2) size 500x80
+                        RenderTableSection {TBODY} at (0,0) size 500x80
+                          RenderTableRow {TR} at (0,10) size 500x60
+                            RenderTableCell {TD} at (10,10) size 480x60 [r=0 c=0 rs=1 cs=1]
                               RenderInline {A} at (0,46) size 468x18 [color=#0000EE]
                                 RenderImage {IMG} at (0,0) size 468x60
-                      RenderBlock (anonymous) at (2,82) size 488x72
-                        RenderText {#text} at (0,0) size 469x72
+                      RenderBlock (anonymous) at (2,82) size 500x72
+                        RenderText {#text} at (0,0) size 491x72
                           text run at (0,0) width 300: "Your donation to protect our wildlife was paid "
                           text run at (299,0) width 170: "for by the sponsors on this"
                           text run at (0,18) width 112: "page, so it's free. "
-                          text run at (111,18) width 290: "100% of each donation is distributed through"
-                          text run at (0,36) width 90: "organizations "
-                          text run at (89,36) width 354: "working hard to protect our wildlife. You can view live"
-                          text run at (0,54) width 327: "donation totals in support of this cause by clicking."
+                          text run at (111,18) width 380: "100% of each donation is distributed through organizations"
+                          text run at (0,36) width 357: "working hard to protect our wildlife. You can view live "
+                          text run at (356,36) width 113: "donation totals in"
+                          text run at (0,54) width 212: "support of this cause by clicking."

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -245,17 +245,15 @@ void RenderTableCell::computePreferredLogicalWidths()
     if (overridingLogicalHeight)
         setOverridingBorderBoxLogicalHeight(*overridingLogicalHeight);
 
-    if (!element() || style().textWrapMode() == TextWrapMode::NoWrap || !element()->hasAttributeWithoutSynchronization(nowrapAttr))
+    if (!element() || !document().inQuirksMode() || !element()->hasAttributeWithoutSynchronization(nowrapAttr))
         return;
 
     auto [ logicalWidth, usedZoom ] = styleOrColLogicalWidth();
     if (auto fixedLogicalWidth = logicalWidth.tryFixed()) {
-        // Nowrap is set, but we didn't actually use it because of the
-        // fixed width set on the cell. Even so, it is a WinIE/Moz trait
-        // to make the minwidth of the cell into the fixed width. They do this
-        // even in strict mode, so do not make this a quirk. Affected the top
+        // In quirks mode, when nowrap is set on a cell that also has an explicit fixed width,
+        // WinIE/Moz treat the fixed width as the minimum width of the cell. Affected the top
         // of hiptop.com.
-        m_minPreferredLogicalWidth = std::max(LayoutUnit(fixedLogicalWidth->resolveZoom(usedZoom)), m_minPreferredLogicalWidth);
+        m_minPreferredLogicalWidth = std::max(adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit(fixedLogicalWidth->resolveZoom(usedZoom))), m_minPreferredLogicalWidth);
     }
 }
 


### PR DESCRIPTION
#### 07bb7826eccd31959a9310bc51fc5922fdec558b
<pre>
Table cell nowrap minimum width calculation quirk should be quirks-mode only
<a href="https://bugs.webkit.org/show_bug.cgi?id=308866">https://bugs.webkit.org/show_bug.cgi?id=308866</a>
<a href="https://rdar.apple.com/171410252">rdar://171410252</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The old guard `!element() || textWrapMode() == NoWrap || !nowrapAttr` was
broken in the common case: when only the nowrap attribute is present,
textWrapMode() is already NoWrap (the attribute maps to white-space:nowrap),
so the second sub-expression is true and we early-return — skipping the
quirk entirely. In the edge case where CSS overrides wrapping
(&lt;td nowrap style=&quot;white-space:normal&quot;&gt;), all three sub-expressions are
false, so the quirk fires even though CSS explicitly opted out of nowrap.

Fix by gating on document().inQuirksMode() instead of textWrapMode(), and
wrapping the resolved width in adjustBorderBoxLogicalWidthForBoxSizing()
before the comparison (the old code compared a content-box CSS width against
m_minPreferredLogicalWidth which is a border-box value).

Cases                                          | Old guard          | New guard          | Quirk
-----------------------------------------------+--------------------+--------------------+--------
&lt;td nowrap&gt;              (quirks mode)         | early return (bug) | fall through       | applied
&lt;td nowrap&gt;              (standards mode)      | early return       | early return       | skipped
&lt;td&gt;                     (any mode)            | early return       | early return       | skipped
&lt;td nowrap style=&quot;white-space:normal&quot;&gt; (quirks)| fall through       | fall through       | applied
&lt;td style=&quot;white-space:nowrap&quot;&gt;        (quirks)| early return       | early return       | skipped

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::computePreferredLogicalWidths):
* LayoutTests/imported/w3c/web-platform-tests/quirks/table-cell-nowrap-minimum-width-calculation-expected.txt: Progression

&gt; Rebaselines: (match other browsers)
* LayoutTests/platform/glib/tables/mozilla/bugs/bug57828-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug78162-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug57828-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug78162-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug57828-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug78162-expected.txt:

Canonical link: <a href="https://commits.webkit.org/310195@main">https://commits.webkit.org/310195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c9eaad5fd35cc1fe41d03d89515f7ba16b42179

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106411 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118216 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83702 "3 flakes 5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98929 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17459 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164173 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7309 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126278 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34322 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82160 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21385 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13762 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89439 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24904 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->