### PR TITLE
Fix CSSOM dimension properties for HTML tables with box-sizing: content-box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/td-box-sizing-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/td-box-sizing-002-expected.txt
@@ -27,41 +27,17 @@ Same tests, but tables are inline.
 
 PASS .t 1
 PASS .t 2
-FAIL .t 3 assert_equals:
-<table class="t" style="box-sizing:content-box;border-collapse: separate" data-expected-width="180" data-expected-height="180">
-  <tbody>
-    <tr><td></td>
-  </tr></tbody>
-</table>
-width expected 180 but got 100
+PASS .t 3
 PASS .t 4
 PASS .t 5
-FAIL .t 6 assert_equals:
-<table class="t" style="box-sizing:content-box;border-collapse: collapse" data-expected-width="130" data-expected-height="130">
-  <tbody>
-    <tr><td></td>
-  </tr></tbody>
-</table>
-width expected 130 but got 100
+PASS .t 6
 PASS .t 7
 PASS .t 8
 PASS .t 9
 PASS .t 10
-FAIL .t 11 assert_equals:
-<table class="t inline" style="box-sizing:content-box;border-collapse: separate" data-expected-width="180" data-expected-height="180">
-  <tbody>
-    <tr><td></td>
-  </tr></tbody>
-</table>
-width expected 180 but got 100
+PASS .t 11
 PASS .t 12
-FAIL .t 13 assert_equals:
-<table class="t inline" style="box-sizing:content-box;border-collapse: collapse" data-expected-width="130" data-expected-height="130">
-  <tbody>
-    <tr><td></td>
-  </tr></tbody>
-</table>
-width expected 130 but got 100
+PASS .t 13
 PASS .t 14
 PASS .t 15
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt
@@ -6,10 +6,10 @@ PASS Table and narrower caption
 PASS Table and wider caption
 PASS Table with padding
 PASS Table with padding and content-box sizing
-FAIL Table with separated border assert_equals: Table with separated border clientWidth expected 26 but got 20
-FAIL Table with collapsed border assert_equals: Table with collapsed border clientWidth expected 26 but got 20
-FAIL Flex-level table with separated border assert_equals: Flex-level table with separated border clientWidth expected 26 but got 20
-FAIL Flex-level table with collapsed border assert_equals: Flex-level table with collapsed border clientWidth expected 26 but got 20
+PASS Table with separated border
+PASS Table with collapsed border
+PASS Flex-level table with separated border
+PASS Flex-level table with collapsed border
 PASS Caption with padding
 PASS Caption with border
 PASS Caption with margin

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-offset-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-offset-props-expected.txt
@@ -5,9 +5,9 @@ PASS Basic caption
 PASS Table and narrower caption
 PASS Table and wider caption
 PASS Table with padding
-FAIL Table with padding and content-box sizing assert_equals: Table with padding and content-box sizing offsetWidth expected 26 but got 20
-FAIL Table with separated border assert_equals: Table with separated border offsetWidth expected 26 but got 20
-FAIL Table with collapsed border assert_equals: Table with collapsed border offsetWidth expected 26 but got 20
+PASS Table with padding and content-box sizing
+PASS Table with separated border
+PASS Table with collapsed border
 PASS Caption with padding
 PASS Caption with border
 PASS Caption with margin

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-scroll-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-scroll-props-expected.txt
@@ -5,9 +5,9 @@ PASS Basic caption
 PASS Table and narrower caption
 PASS Table and wider caption
 PASS Table with padding
-FAIL Table with padding and content-box sizing assert_equals: Table with padding and content-box sizing scrollWidth expected 26 but got 20
-FAIL Table with separated border assert_equals: Table with separated border scrollWidth expected 26 but got 14
-FAIL Table with collapsed border assert_equals: Table with collapsed border scrollWidth expected 26 but got 14
+PASS Table with padding and content-box sizing
+PASS Table with separated border
+PASS Table with collapsed border
 PASS Caption with padding
 PASS Caption with border
 PASS Caption with margin


### PR DESCRIPTION
#### 9ebc2b43305c400c89506033b6ed503a55f2860d
<pre>
Fix CSSOM dimension properties for HTML tables with box-sizing: content-box
<a href="https://bugs.webkit.org/show_bug.cgi?id=308867">https://bugs.webkit.org/show_bug.cgi?id=308867</a>
<a href="https://rdar.apple.com/171412144">rdar://171412144</a>

Reviewed by NOBODY (OOPS!).

RenderTable::convertStyleLogicalWidthToComputedWidth intentionally skips
adding border and padding to the stored width/height for HTML &lt;table&gt;
elements, assuming the UA stylesheet&apos;s box-sizing: border-box default.
When a page explicitly sets box-sizing: content-box on a table, width()
and height() end up holding only the raw CSS values, causing offsetWidth,
clientWidth, scrollWidth, and their height equivalents to return values
that are too small.

Additionally, clientLeft and clientTop returned the table grid box&apos;s
border instead of 0. Per the CSS table model the border belongs to the
grid box, not the wrapper box; since WebKit has no wrapper box,
clientLeft/clientTop should always be 0 for tables.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::offsetWidth):
(WebCore::Element::offsetHeight):
(WebCore::Element::clientLeft):
(WebCore::Element::clientTop):
(WebCore::Element::clientWidth):
(WebCore::Element::clientHeight):
(WebCore::Element::scrollWidth):
(WebCore::Element::scrollHeight):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/td-box-sizing-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-client-props-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-offset-props-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/table-scroll-props-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ebc2b43305c400c89506033b6ed503a55f2860d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100820 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b1aad04-8033-40cb-b057-868a0b33a284) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19990 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113607 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/position-absolute-table-001.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81015 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5404b6d0-0282-400c-b2b5-dfc5348bcb7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94367 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06ded938-55d9-4a55-ad39-95428cc9fefd) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15003 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/position-absolute-table-001.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12788 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1557 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11780 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/position-absolute-table-001.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121636 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/position-absolute-table-001.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19889 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16690 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/position-absolute-table-001.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75882 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17369 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8869 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/position-absolute-table-001.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19504 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83266 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19234 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->