### PR TITLE
Make assorted class members const RefPtr in WebCore

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.h
@@ -58,7 +58,7 @@ private:
     MediaKeyMessageEvent(const AtomString&, const MediaKeyMessageEventInit&, IsTrusted);
 
     MediaKeyMessageType m_messageType;
-    RefPtr<JSC::ArrayBuffer> m_message;
+    const RefPtr<JSC::ArrayBuffer> m_message;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h
@@ -60,7 +60,7 @@ private:
     WebKitMediaKeyMessageEvent(const AtomString& type, Uint8Array* message, const String& destinationURL);
     WebKitMediaKeyMessageEvent(const AtomString& type, Init&&, IsTrusted);
 
-    RefPtr<Uint8Array> m_message;
+    const RefPtr<Uint8Array> m_message;
     String m_destinationURL;
 };
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h
@@ -57,7 +57,7 @@ private:
     WebKitMediaKeyNeededEvent(const AtomString& type, Uint8Array* initData);
     WebKitMediaKeyNeededEvent(const AtomString& type, Init&&, IsTrusted);
 
-    RefPtr<Uint8Array> m_initData;
+    const RefPtr<Uint8Array> m_initData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.h
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.h
@@ -60,8 +60,8 @@ private:
     BufferedChangeEvent(RefPtr<TimeRanges>&& added, RefPtr<TimeRanges>&& removed);
     BufferedChangeEvent(const AtomString& type, Init&&);
 
-    RefPtr<TimeRanges> m_added;
-    RefPtr<TimeRanges> m_removed;
+    const RefPtr<TimeRanges> m_added;
+    const RefPtr<TimeRanges> m_removed;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h
@@ -69,7 +69,7 @@ private:
     {
     }
 
-    RefPtr<OverconstrainedError> m_error;
+    const RefPtr<OverconstrainedError> m_error;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
@@ -51,7 +51,7 @@ public:
 private:
     RTCPeerConnectionIceEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<RTCIceCandidate>&&, String&& serverURL);
 
-    RefPtr<RTCIceCandidate> m_candidate;
+    const RefPtr<RTCIceCandidate> m_candidate;
     String m_url;
 };
 

--- a/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h
@@ -43,8 +43,8 @@ public:
 private:
     PushSubscriptionChangeEvent(const AtomString&, ExtendableEventInit&&, RefPtr<PushSubscription>&& newSubscription, RefPtr<PushSubscription>&& oldSubscription, IsTrusted);
 
-    RefPtr<PushSubscription> m_newSubscription;
-    RefPtr<PushSubscription> m_oldSubscription;
+    const RefPtr<PushSubscription> m_newSubscription;
+    const RefPtr<PushSubscription> m_oldSubscription;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioProcessingEvent.h
+++ b/Source/WebCore/Modules/webaudio/AudioProcessingEvent.h
@@ -53,8 +53,8 @@ private:
     AudioProcessingEvent(RefPtr<AudioBuffer>&& inputBuffer, RefPtr<AudioBuffer>&& outputBuffer, double playbackTime);
     AudioProcessingEvent(const AtomString&, AudioProcessingEventInit&&);
 
-    RefPtr<AudioBuffer> m_inputBuffer;
-    RefPtr<AudioBuffer> m_outputBuffer;
+    const RefPtr<AudioBuffer> m_inputBuffer;
+    const RefPtr<AudioBuffer> m_outputBuffer;
     double m_playbackTime;
 };
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -152,29 +152,22 @@ css/CSSCursorImageValue.cpp
 css/CSSFontFace.cpp
 css/CSSFontFaceRule.cpp
 css/CSSFontValue.cpp
-css/CSSGridLineValue.cpp
 css/CSSGroupingRule.cpp
 css/CSSImageSetOptionValue.cpp
 css/CSSImageValue.h
 css/CSSKeyframeRule.cpp
 css/CSSKeyframesRule.cpp
 css/CSSNestedDeclarations.cpp
-css/CSSOffsetRotateValue.cpp
-css/CSSOffsetRotateValue.h
 css/CSSPageRule.cpp
 css/CSSProperty.h
 css/CSSPropertyRule.cpp
 css/CSSRuleList.h
-css/CSSScrollValue.cpp
-css/CSSScrollValue.h
 css/CSSSelector.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
 css/CSSStyleSheetObservableArray.cpp
 css/CSSValueList.cpp
-css/CSSViewValue.cpp
-css/CSSViewValue.h
 css/DOMMatrixReadOnly.cpp
 css/DeprecatedCSSOMPrimitiveValue.h
 [ macOS ] css/DeprecatedCSSOMRGBColor.h
@@ -556,7 +549,6 @@ platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
 platform/mock/MockRealtimeVideoSource.cpp
-platform/mock/RTCNotifiersMock.cpp
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
 plugins/PluginData.cpp

--- a/Source/WebCore/css/CSSAttrValue.h
+++ b/Source/WebCore/css/CSSAttrValue.h
@@ -50,7 +50,7 @@ private:
     }
 
     String m_attributeName;
-    RefPtr<CSSValue> m_fallback;
+    const RefPtr<CSSValue> m_fallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridLineValue.h
+++ b/Source/WebCore/css/CSSGridLineValue.h
@@ -43,9 +43,9 @@ public:
 
 private:
     explicit CSSGridLineValue(RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&);
-    RefPtr<CSSPrimitiveValue> m_spanValue;
-    RefPtr<CSSPrimitiveValue> m_numericValue;
-    RefPtr<CSSPrimitiveValue> m_gridLineName;
+    const RefPtr<CSSPrimitiveValue> m_spanValue;
+    const RefPtr<CSSPrimitiveValue> m_numericValue;
+    const RefPtr<CSSPrimitiveValue> m_gridLineName;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSOffsetRotateValue.h
+++ b/Source/WebCore/css/CSSOffsetRotateValue.h
@@ -74,8 +74,8 @@ private:
             ASSERT(m_angle->isAngle());
     }
 
-    RefPtr<CSSPrimitiveValue> m_modifier;
-    RefPtr<CSSPrimitiveValue> m_angle;
+    const RefPtr<CSSPrimitiveValue> m_modifier;
+    const RefPtr<CSSPrimitiveValue> m_angle;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -49,8 +49,8 @@ public:
 
     String customCSSText(const CSS::SerializationContext&) const;
 
-    const RefPtr<CSSValue>& scroller() const { return m_scroller; }
-    const RefPtr<CSSValue>& axis() const { return m_axis; }
+    CSSValue* scroller() const { return m_scroller; }
+    CSSValue* axis() const { return m_axis; }
 
     bool equals(const CSSScrollValue&) const;
 
@@ -75,8 +75,8 @@ private:
     {
     }
 
-    RefPtr<CSSValue> m_scroller;
-    RefPtr<CSSValue> m_axis;
+    const RefPtr<CSSValue> m_scroller;
+    const RefPtr<CSSValue> m_axis;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -49,9 +49,9 @@ public:
 
     String customCSSText(const CSS::SerializationContext&) const;
 
-    const RefPtr<CSSValue>& axis() const { return m_axis; }
-    const RefPtr<CSSValue>& startInset() const { return m_startInset; }
-    const RefPtr<CSSValue>& endInset() const { return m_endInset; }
+    CSSValue* axis() const { return m_axis; }
+    CSSValue* startInset() const { return m_startInset; }
+    CSSValue* endInset() const { return m_endInset; }
 
     bool equals(const CSSViewValue&) const;
 
@@ -82,9 +82,9 @@ private:
     {
     }
 
-    RefPtr<CSSValue> m_axis;
-    RefPtr<CSSValue> m_startInset;
-    RefPtr<CSSValue> m_endInset;
+    const RefPtr<CSSValue> m_axis;
+    const RefPtr<CSSValue> m_startInset;
+    const RefPtr<CSSValue> m_endInset;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceMotionData.h
+++ b/Source/WebCore/dom/DeviceMotionData.h
@@ -104,9 +104,9 @@ private:
     DeviceMotionData() = default;
     DeviceMotionData(RefPtr<Acceleration>&&, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&&, std::optional<double> interval);
 
-    RefPtr<Acceleration> m_acceleration;
-    RefPtr<Acceleration> m_accelerationIncludingGravity;
-    RefPtr<RotationRate> m_rotationRate;
+    const RefPtr<Acceleration> m_acceleration;
+    const RefPtr<Acceleration> m_accelerationIncludingGravity;
+    const RefPtr<RotationRate> m_rotationRate;
     std::optional<double> m_interval;
 };
 

--- a/Source/WebCore/html/MediaEncryptedEvent.h
+++ b/Source/WebCore/html/MediaEncryptedEvent.h
@@ -58,7 +58,7 @@ private:
     MediaEncryptedEvent(const AtomString&, const MediaEncryptedEventInit&, IsTrusted);
 
     String m_initDataType;
-    RefPtr<JSC::ArrayBuffer> m_initData;
+    const RefPtr<JSC::ArrayBuffer> m_initData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/HRTFPanner.h
+++ b/Source/WebCore/platform/audio/HRTFPanner.h
@@ -57,7 +57,7 @@ private:
     // and azimuthBlend which is an interpolation value from 0 -> 1.
     int calculateDesiredAzimuthIndexAndBlend(double azimuth, double& azimuthBlend);
 
-    RefPtr<HRTFDatabaseLoader> m_databaseLoader;
+    const RefPtr<HRTFDatabaseLoader> m_databaseLoader;
 
     float m_sampleRate;
 

--- a/Source/WebCore/platform/mock/RTCNotifiersMock.h
+++ b/Source/WebCore/platform/mock/RTCNotifiersMock.h
@@ -47,8 +47,8 @@ public:
     void fire() override;
 
 private:
-    RefPtr<RTCSessionDescriptionRequest> m_request;
-    RefPtr<RTCSessionDescriptionDescriptor> m_descriptor;
+    const RefPtr<RTCSessionDescriptionRequest> m_request;
+    const RefPtr<RTCSessionDescriptionDescriptor> m_descriptor;
     String m_errorName;
 };
 
@@ -59,7 +59,7 @@ public:
     void fire() override;
 
 private:
-    RefPtr<RTCVoidRequest> m_request;
+    const RefPtr<RTCVoidRequest> m_request;
     bool m_success;
     String m_errorName;
 };


### PR DESCRIPTION
#### 6ab6e33c193527aa3a3a4ab8145f3180a3c74d79
<pre>
Make assorted class members const RefPtr in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=308870">https://bugs.webkit.org/show_bug.cgi?id=308870</a>

Reviewed by Chris Dumez.

Also correct trivial getters on CSSScrollValue and CSSViewValue to
return a pointer instead of const RefPtr&amp;.

Helps reduce unsafeness.

Canonical link: <a href="https://commits.webkit.org/308403@main">https://commits.webkit.org/308403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c3655867cae3d16075f32c950973508dfed506a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156102 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75619f92-e7c3-4bc5-9966-4d764e85da82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113622 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a431d160-26e1-42a5-acf6-ff47e1b8fcb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150382 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34e30e24-40ad-4c04-bafa-215658268b4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15017 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12801 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3543 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158434 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1572 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121650 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121849 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75899 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8880 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83282 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->