### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in the NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsMemoryStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsMemoryStore.h
@@ -50,7 +50,7 @@ public:
     bool isEmpty() const override;
 
     Vector<ITPThirdPartyData> aggregatedThirdPartyData() const override;
-    const HashMap<RegistrableDomain, UniqueRef<WebCore::ResourceLoadStatistics>>& data() const { return m_resourceStatisticsMap; }
+    const HashMap<RegistrableDomain, UniqueRef<WebCore::ResourceLoadStatistics>>& data() const LIFETIME_BOUND { return m_resourceStatisticsMap; }
 
     std::unique_ptr<WebCore::KeyedEncoder> createEncoderFromData() const;
     void mergeWithDataFromDecoder(WebCore::KeyedDecoder&);

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.h
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.h
@@ -59,7 +59,7 @@ protected:
     virtual void destroyStatements() = 0;
     virtual String getDomainStringFromDomainID(unsigned) const = 0;
     virtual bool needsUpdatedSchema() = 0;
-    virtual const MemoryCompactLookupOnlyRobinHoodHashMap<String, TableAndIndexPair>& expectedTableAndIndexQueries() = 0;
+    virtual const MemoryCompactLookupOnlyRobinHoodHashMap<String, TableAndIndexPair>& expectedTableAndIndexQueries() LIFETIME_BOUND = 0;
     virtual std::span<const ASCIILiteral> sortedTables() = 0;
     TableAndIndexPair currentTableAndIndexQueries(const String&);
     String stripIndexQueryToMatchStoredValue(const char* originalQuery);

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -73,7 +73,7 @@ public:
         return adoptRef(*new NetworkCORSPreflightChecker(networkProcess, networkResourceLoader, WTF::move(parameters), shouldCaptureExtraNetworkLoadMetrics, WTF::move(completionCallback)));
     }
     ~NetworkCORSPreflightChecker();
-    const WebCore::ResourceRequest& originalRequest() const { return m_parameters.originalRequest; }
+    const WebCore::ResourceRequest& originalRequest() const LIFETIME_BOUND { return m_parameters.originalRequest; }
 
     void startPreflight();
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -258,7 +258,7 @@ public:
     void broadcastConsoleMessage(JSC::MessageSource, JSC::MessageLevel, const String& message);
     RefPtr<NetworkResourceLoader> takeNetworkResourceLoader(WebCore::ResourceLoaderIdentifier);
 
-    NetworkOriginAccessPatterns& originAccessPatterns() { return m_originAccessPatterns.get(); }
+    NetworkOriginAccessPatterns& originAccessPatterns() LIFETIME_BOUND { return m_originAccessPatterns.get(); }
 
 #if ENABLE(CONTENT_FILTERING)
     void installMockContentFilter(WebCore::MockContentFilterSettings&&);

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -127,13 +127,13 @@ public:
     void setPendingDownload(PendingDownload&);
 
     virtual void setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&&, bool /*allowOverwrite*/) { m_pendingDownloadLocation = filename; }
-    const String& pendingDownloadLocation() const { return m_pendingDownloadLocation; }
+    const String& pendingDownloadLocation() const LIFETIME_BOUND { return m_pendingDownloadLocation; }
     bool isDownload() const { return !!m_pendingDownloadID; }
 
-    const WebCore::ResourceRequest& firstRequest() const { return m_firstRequest; }
+    const WebCore::ResourceRequest& firstRequest() const LIFETIME_BOUND { return m_firstRequest; }
     virtual String suggestedFilename() const { return String(); }
     void setSuggestedFilename(const String& suggestedName) { m_suggestedFilename = suggestedName; }
-    const String& partition() { return m_partition; }
+    const String& partition() LIFETIME_BOUND { return m_partition; }
 
     bool isTopLevelNavigation() const { return m_dataTaskIsForMainFrameNavigation; }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -67,12 +67,12 @@ public:
 
     bool isAllowedToAskUserForCredentials() const;
 
-    const WebCore::ResourceRequest& currentRequest() const { return m_currentRequest; }
+    const WebCore::ResourceRequest& currentRequest() const LIFETIME_BOUND { return m_currentRequest; }
     void updateRequestAfterRedirection(WebCore::ResourceRequest&) const;
     void reprioritizeRequest(WebCore::ResourceLoadPriority);
 
-    const NetworkLoadParameters& parameters() const { return m_parameters; }
-    const URL& url() const { return parameters().request.url(); }
+    const NetworkLoadParameters& parameters() const LIFETIME_BOUND { return m_parameters; }
+    const URL& url() const LIFETIME_BOUND { return parameters().request.url(); }
     String attributedBundleIdentifier(WebPageProxyIdentifier);
 
     void convertTaskToDownload(PendingDownload&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, ResponseCompletionHandler&&);

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -107,7 +107,7 @@ public:
 
     NetworkProcess& networkProcess() { return m_networkProcess; }
 
-    const URL& url() const { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const { return m_storedCredentialsPolicy; }
 
     WebCore::NetworkLoadInformation takeNetworkLoadInformation() { return WTF::move(m_loadInformation); }
@@ -118,7 +118,7 @@ public:
     RefPtr<WebCore::SecurityOrigin> origin() const { return m_origin; }
     RefPtr<WebCore::SecurityOrigin> topOrigin() const { return m_topOrigin; }
 
-    const WebCore::FetchOptions& options() const { return m_options; }
+    const WebCore::FetchOptions& options() const LIFETIME_BOUND { return m_options; }
 
     bool timingAllowFailedFlag() const { return m_timingAllowFailedFlag; }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -214,7 +214,7 @@ public:
 
     CacheModel cacheModel() const { return m_cacheModel; }
 
-    const HashSet<String>& localhostAliasesForTesting() const { return m_localhostAliasesForTesting; }
+    const HashSet<String>& localhostAliasesForTesting() const LIFETIME_BOUND { return m_localhostAliasesForTesting; }
 
     // Diagnostic messages logging.
     void logDiagnosticMessage(WebPageProxyIdentifier, const String& message, const String& description, WebCore::ShouldSample);
@@ -342,7 +342,7 @@ public:
     void connectionToWebProcessClosed(IPC::Connection&, PAL::SessionID);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    NetworkContentRuleListManager& networkContentRuleListManager() { return m_networkContentRuleListManager; }
+    NetworkContentRuleListManager& networkContentRuleListManager() LIFETIME_BOUND { return m_networkContentRuleListManager; }
 #endif
 
     void syncLocalStorage(CompletionHandler<void()>&&);
@@ -367,7 +367,7 @@ public:
     bool parentProcessHasServiceWorkerEntitlement() const { return true; }
 #endif
 
-    const String& uiProcessBundleIdentifier() const;
+    const String& uiProcessBundleIdentifier() const LIFETIME_BOUND;
 
     void ref() const final { ThreadSafeRefCounted<NetworkProcess>::ref(); }
     void deref() const final { ThreadSafeRefCounted<NetworkProcess>::deref(); }
@@ -392,7 +392,7 @@ public:
     void addKeptAliveLoad(Ref<NetworkResourceLoader>&&);
     void removeKeptAliveLoad(NetworkResourceLoader&);
 
-    const OptionSet<NetworkCache::CacheOption>& cacheOptions() const { return m_cacheOptions; }
+    const OptionSet<NetworkCache::CacheOption>& cacheOptions() const LIFETIME_BOUND { return m_cacheOptions; }
 
     NetworkConnectionToWebProcess* webProcessConnection(WebCore::ProcessIdentifier) const;
     NetworkConnectionToWebProcess* webProcessConnection(const IPC::Connection&) const;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -100,7 +100,7 @@ public:
     }
     virtual ~NetworkResourceLoader();
 
-    const WebCore::ResourceRequest& originalRequest() const { return m_parameters.request; }
+    const WebCore::ResourceRequest& originalRequest() const LIFETIME_BOUND { return m_parameters.request; }
 
     NetworkLoad* networkLoad() const { return m_networkLoad.get(); }
 
@@ -115,7 +115,7 @@ public:
     void continueWillSendRequest(WebCore::ResourceRequest&&, bool isAllowedToAskUserForCredentials, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
 
     void setResponse(WebCore::ResourceResponse&& response) { m_response = WTF::move(response); }
-    const WebCore::ResourceResponse& response() const { return m_response; }
+    const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_response; }
 
     NetworkConnectionToWebProcess& connectionToWebProcess() const { return m_connection; }
     PAL::SessionID sessionID() const { return m_connection->sessionID(); }
@@ -123,9 +123,9 @@ public:
     WebCore::FrameIdentifier frameID() const { return m_parameters.webFrameID; }
     WebCore::PageIdentifier pageID() const { return m_parameters.webPageID; }
     WebPageProxyIdentifier webPageProxyID() const { return m_parameters.webPageProxyID; }
-    const NetworkResourceLoadParameters& parameters() const { return m_parameters; }
+    const NetworkResourceLoadParameters& parameters() const LIFETIME_BOUND { return m_parameters; }
     NetworkResourceLoadIdentifier identifier() const { return m_resourceLoadID; }
-    const URL& firstResponseURL() const { return m_firstResponseURL; }
+    const URL& firstResponseURL() const LIFETIME_BOUND { return m_firstResponseURL; }
 
     NetworkCache::GlobalFrameID globalFrameID() { return { webPageProxyID(), pageID(), frameID() }; }
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -208,7 +208,7 @@ public:
     virtual void removeWebSocketTask(SessionSet&, WebSocketTask&) { }
     virtual void addWebSocketTask(WebPageProxyIdentifier, WebSocketTask&) { }
 
-    WebCore::BlobRegistryImpl& blobRegistry() { return m_blobRegistry; }
+    WebCore::BlobRegistryImpl& blobRegistry() LIFETIME_BOUND { return m_blobRegistry; }
     NetworkBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry; }
 
     unsigned testSpeedMultiplier() const { return m_testSpeedMultiplier; }
@@ -257,7 +257,7 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    AppPrivacyReportTestingData& appPrivacyReportTestingData() { return m_appPrivacyReportTestingData; }
+    AppPrivacyReportTestingData& appPrivacyReportTestingData() LIFETIME_BOUND { return m_appPrivacyReportTestingData; }
 #endif
 
     virtual void removeNetworkWebsiteData(std::optional<WallTime>, std::optional<HashSet<WebCore::RegistrableDomain>>&&, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
@@ -316,7 +316,7 @@ protected:
     NetworkSession(NetworkProcess&, const NetworkSessionCreationParameters&);
 
     void forwardResourceLoadStatisticsSettings();
-    WebSWOriginStore* NODELETE swOriginStore() const;
+    WebSWOriginStore* NODELETE swOriginStore() const LIFETIME_BOUND;
 
     // SWServerDelegate
     void softUpdate(WebCore::ServiceWorkerJobData&&, bool shouldRefreshCache, WebCore::ResourceRequest&&, CompletionHandler<void(WebCore::WorkerFetchResult&&)>&&) final;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -62,9 +62,9 @@ public:
     using BodyCallback = Function<void(RefPtr<const WebCore::FragmentedSharedBuffer>&&)>;
     void waitForBody(BodyCallback&&);
 
-    const WebCore::ResourceError& error() const { return m_error; }
-    const WebCore::ResourceResponse& response() const { return m_response; }
-    const WebCore::NetworkLoadMetrics& networkLoadMetrics() const { return m_networkLoadMetrics; }
+    const WebCore::ResourceError& error() const LIFETIME_BOUND { return m_error; }
+    const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_response; }
+    const WebCore::NetworkLoadMetrics& networkLoadMetrics() const LIFETIME_BOUND { return m_networkLoadMetrics; }
     bool isServiceWorkerNavigationPreloadEnabled() const { return m_state.enabled; }
     bool didReceiveResponseOrError() const { return m_didReceiveResponseOrError; }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -231,7 +231,7 @@ public:
 
     NetworkProcess& networkProcess() { return m_networkProcess.get(); }
     PAL::SessionID sessionID() const { return m_sessionID; }
-    const String& storageDirectory() const { return m_storageDirectory; }
+    const String& storageDirectory() const LIFETIME_BOUND { return m_storageDirectory; }
     void fetchData(bool shouldComputeSize, CompletionHandler<void(Vector<WebsiteData::Entry>&&)>&&);
     void deleteData(const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&&);
     void deleteDataForRegistrableDomains(const Vector<WebCore::RegistrableDomain>&, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -53,13 +53,13 @@ public:
     static std::unique_ptr<Entry> decodeStorageRecord(const Storage::Record&);
 
     PrivateRelayed privateRelayed() const { return m_privateRelayed; }
-    const Key& key() const { return m_key; }
+    const Key& key() const LIFETIME_BOUND { return m_key; }
     WallTime timeStamp() const { return m_timeStamp; }
-    const WebCore::ResourceResponse& response() const { return m_response; }
-    const Vector<std::pair<String, String>>& varyingRequestHeaders() const { return m_varyingRequestHeaders; }
+    const WebCore::ResourceResponse& response() const LIFETIME_BOUND { return m_response; }
+    const Vector<std::pair<String, String>>& varyingRequestHeaders() const LIFETIME_BOUND { return m_varyingRequestHeaders; }
 
     WebCore::FragmentedSharedBuffer* buffer() const;
-    const std::optional<WebCore::ResourceRequest>& redirectRequest() const { return m_redirectRequest; }
+    const std::optional<WebCore::ResourceRequest>& redirectRequest() const LIFETIME_BOUND { return m_redirectRequest; }
 
 #if ENABLE(SHAREABLE_RESOURCE)
     std::optional<WebCore::ShareableResource::Handle> shareableResourceHandle() const;
@@ -68,7 +68,7 @@ public:
     bool needsValidation() const;
     void NODELETE setNeedsValidation(bool);
 
-    const Storage::Record& sourceStorageRecord() const { return m_sourceStorageRecord; }
+    const Storage::Record& sourceStorageRecord() const LIFETIME_BOUND { return m_sourceStorageRecord; }
 
     void asJSON(StringBuilder&, const Storage::RecordInfo&) const;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -71,13 +71,13 @@ public:
 
     bool isNull() const { return m_identifier.isNull(); }
 
-    const String& partition() const { return m_partition; }
-    const String& identifier() const { return m_identifier; }
-    const String& type() const { return m_type; }
-    const String& range() const { return m_range; }
+    const String& partition() const LIFETIME_BOUND { return m_partition; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const String& type() const LIFETIME_BOUND { return m_type; }
+    const String& range() const LIFETIME_BOUND { return m_range; }
 
-    const HashType& hash() const { return m_hash; }
-    const HashType& partitionHash() const { return m_partitionHash; }
+    const HashType& hash() const LIFETIME_BOUND { return m_hash; }
+    const HashType& partitionHash() const LIFETIME_BOUND { return m_partitionHash; }
 
     static bool NODELETE stringToHash(const String&, HashType&);
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h
@@ -58,7 +58,7 @@ public:
 
     virtual ~SpeculativeLoad();
 
-    const WebCore::ResourceRequest& originalRequest() const { return m_originalRequest; }
+    const WebCore::ResourceRequest& originalRequest() const LIFETIME_BOUND { return m_originalRequest; }
 
     void cancel();
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -135,7 +135,7 @@ public:
     String versionPath() const;
     String recordsPathIsolatedCopy() const;
 
-    const Salt& salt() const { return m_salt; }
+    const Salt& salt() const LIFETIME_BOUND { return m_salt; }
 
     ~Storage();
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -78,7 +78,7 @@ public:
     void setPendingDownloadLocation(const String&, SandboxExtension::Handle&&, bool /*allowOverwrite*/) override;
     String suggestedFilename() const override;
 
-    WebCore::NetworkLoadMetrics& networkLoadMetrics() { return m_networkLoadMetrics; }
+    WebCore::NetworkLoadMetrics& networkLoadMetrics() LIFETIME_BOUND { return m_networkLoadMetrics; }
 
     std::optional<WebCore::FrameIdentifier> frameID() const final { return m_frameID; }
     std::optional<WebCore::PageIdentifier> pageID() const final { return m_pageID; }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -124,11 +124,11 @@ public:
 
     SessionWrapper& initializeEphemeralStatelessSessionIfNeeded(std::optional<WebPageProxyIdentifier>, NavigatingToAppBoundDomain);
 
-    const String& boundInterfaceIdentifier() const;
-    const String& sourceApplicationBundleIdentifier() const;
-    const String& sourceApplicationSecondaryIdentifier() const;
+    const String& boundInterfaceIdentifier() const LIFETIME_BOUND { return m_boundInterfaceIdentifier; }
+    const String& sourceApplicationBundleIdentifier() const LIFETIME_BOUND { return m_sourceApplicationBundleIdentifier; }
+    const String& sourceApplicationSecondaryIdentifier() const LIFETIME_BOUND { return m_sourceApplicationSecondaryIdentifier; }
 #if PLATFORM(IOS_FAMILY)
-    const String& dataConnectionServiceType() const;
+    const String& dataConnectionServiceType() const LIFETIME_BOUND { return m_dataConnectionServiceType; }
 #endif
 
     void setClientAuditToken(const WebCore::AuthenticationChallenge&);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1048,28 +1048,6 @@ NSURLCredentialStorage *NetworkSessionCocoa::nsCredentialStorage() const
 {
     return m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration.URLCredentialStorage;
 }
-    
-const String& NetworkSessionCocoa::boundInterfaceIdentifier() const
-{
-    return m_boundInterfaceIdentifier;
-}
-
-const String& NetworkSessionCocoa::sourceApplicationBundleIdentifier() const
-{
-    return m_sourceApplicationBundleIdentifier;
-}
-
-const String& NetworkSessionCocoa::sourceApplicationSecondaryIdentifier() const
-{
-    return m_sourceApplicationSecondaryIdentifier;
-}
-
-#if PLATFORM(IOS_FAMILY)
-const String& NetworkSessionCocoa::dataConnectionServiceType() const
-{
-    return m_dataConnectionServiceType;
-}
-#endif
 
 std::unique_ptr<NetworkSession> NetworkSessionCocoa::create(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
 {

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -83,28 +83,28 @@ std::optional<SharedPreferencesForWebProcess> NetworkConnectionToWebProcess::sha
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorBoundInterfaceIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    if (CheckedPtr session = downcast<NetworkSessionCocoa>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->boundInterfaceIdentifier();
     return emptyString();
 }
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&)
 {
-    if (CheckedPtr session = downcast<NetworkSessionCocoa>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->dataConnectionServiceType();
     return emptyString();
 }
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationBundleIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    if (CheckedPtr session = downcast<NetworkSessionCocoa>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->sourceApplicationBundleIdentifier();
     return emptyString();
 }
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationSecondaryIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    if (CheckedPtr session = downcast<NetworkSessionCocoa>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->sourceApplicationSecondaryIdentifier();
     return emptyString();
 }

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -72,7 +72,7 @@ private:
     void connectionClosedForLocalStorageArea(IPC::Connection::UniqueID);
     void connectionClosedForTransientStorageArea(IPC::Connection::UniqueID);
 
-    StorageAreaBase& ensureLocalStorageArea(const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
+    StorageAreaBase& ensureLocalStorageArea(const WebCore::ClientOrigin&, Ref<WorkQueue>&&) LIFETIME_BOUND;
     MemoryStorageArea& ensureTransientLocalStorageArea(const WebCore::ClientOrigin&);
 
     String m_path;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -68,20 +68,20 @@ public:
 
     void connectionClosed(IPC::Connection::UniqueID);
     WebCore::StorageEstimate estimate();
-    const String& path() const { return m_path; }
+    const String& path() const LIFETIME_BOUND { return m_path; }
     OriginQuotaManager& NODELETE quotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);
     FileSystemStorageManager* existingFileSystemStorageManager();
-    LocalStorageManager& localStorageManager(StorageAreaRegistry&);
-    LocalStorageManager* existingLocalStorageManager();
-    SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
-    SessionStorageManager* existingSessionStorageManager();
+    LocalStorageManager& localStorageManager(StorageAreaRegistry&) LIFETIME_BOUND;
+    LocalStorageManager* existingLocalStorageManager() LIFETIME_BOUND;
+    SessionStorageManager& sessionStorageManager(StorageAreaRegistry&) LIFETIME_BOUND;
+    SessionStorageManager* existingSessionStorageManager() LIFETIME_BOUND;
     IDBStorageManager& idbStorageManager(IDBStorageRegistry&, bool useSQLiteMemoryBackingStore);
     IDBStorageManager* existingIDBStorageManager();
     CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
     CacheStorageManager* existingCacheStorageManager();
     BackgroundFetchStoreManager& backgroundFetchManager(Ref<WTF::WorkQueue>&&);
-    ServiceWorkerStorageManager& serviceWorkerStorageManager();
+    ServiceWorkerStorageManager& serviceWorkerStorageManager() LIFETIME_BOUND;
     uint64_t cacheStorageSize();
     void closeCacheStorageManager();
     String resolvedPath(WebsiteDataType);
@@ -104,7 +104,7 @@ private:
     Ref<OriginQuotaManager> createQuotaManager(OriginQuotaManager::Parameters&&);
     enum class StorageBucketMode : bool;
     class StorageBucket;
-    StorageBucket& defaultBucket();
+    StorageBucket& defaultBucket() LIFETIME_BOUND;
 
     std::unique_ptr<StorageBucket> m_defaultBucket;
     String m_path;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -61,8 +61,8 @@ public:
 
     void onNetworksChanged(const Vector<RTCNetwork>&, const RTCNetwork::IPAddress&, const RTCNetwork::IPAddress&);
 
-    const RTCNetwork::IPAddress& ipv4() const;
-    const RTCNetwork::IPAddress& ipv6()  const;
+    const RTCNetwork::IPAddress& ipv4() const LIFETIME_BOUND;
+    const RTCNetwork::IPAddress& ipv6()  const LIFETIME_BOUND;
 
     void NODELETE ref();
     void deref();


### PR DESCRIPTION
#### e35a0c2c6a948c357427c5e91d75e00499fd53c3
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in the NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=308871">https://bugs.webkit.org/show_bug.cgi?id=308871</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsMemoryStore.h:
* Source/WebKit/NetworkProcess/DatabaseUtilities.h:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::pendingDownloadLocation const): Deleted.
(WebKit::NetworkDataTask::firstRequest const): Deleted.
(WebKit::NetworkDataTask::partition): Deleted.
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::url const): Deleted.
(WebKit::NetworkLoadChecker::options const): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::blobRegistry): Deleted.
(WebKit::NetworkSession::appPrivacyReportTestingData): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
(WebKit::NetworkCache::Cache::storageDirectory const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
(WebKit::NetworkCache::Entry::key const): Deleted.
(WebKit::NetworkCache::Entry::response const): Deleted.
(WebKit::NetworkCache::Entry::varyingRequestHeaders const): Deleted.
(WebKit::NetworkCache::Entry::redirectRequest const): Deleted.
(WebKit::NetworkCache::Entry::sourceStorageRecord const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WebKit::NetworkCache::Key::partition const): Deleted.
(WebKit::NetworkCache::Key::identifier const): Deleted.
(WebKit::NetworkCache::Key::type const): Deleted.
(WebKit::NetworkCache::Key::range const): Deleted.
(WebKit::NetworkCache::Key::hash const): Deleted.
(WebKit::NetworkCache::Key::partitionHash const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
(WebKit::NetworkCache::Storage::salt const): Deleted.
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::nsCredentialStorage const):
(WebKit::NetworkSessionCocoa::boundInterfaceIdentifier const): Deleted.
(WebKit::NetworkSessionCocoa::sourceApplicationBundleIdentifier const): Deleted.
(WebKit::NetworkSessionCocoa::sourceApplicationSecondaryIdentifier const): Deleted.
(WebKit::NetworkSessionCocoa::dataConnectionServiceType const): Deleted.
* Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm:
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorBoundInterfaceIdentifier):
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorCTDataConnectionServiceType):
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationBundleIdentifier):
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationSecondaryIdentifier):
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:

Canonical link: <a href="https://commits.webkit.org/308401@main">https://commits.webkit.org/308401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/597d4456b56838e7484d2c62bcf46def9507a155

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156096 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113614 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75f3bc63-e0ae-4389-935f-13937095a9e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f39dc464-1c6e-43bc-9312-e9c5e7f694c8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15006 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12793 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124602 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158428 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121643 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121842 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31202 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75891 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8878 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19513 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83275 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19243 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19394 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->