### PR TITLE
Make assorted class members const Ref[Ptr] in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -90,7 +90,7 @@ public:
     // is deleted (that's the part prevented by this RefPtr).
     // 3. Another class is created at the same address.
     // 4. When it is used, the old context data is found in VM and used.
-    RefPtr<OpaqueJSClass> m_class;
+    const RefPtr<OpaqueJSClass> m_class;
 
     OpaqueJSClassStaticValuesTable staticValues;
     OpaqueJSClassStaticFunctionsTable staticFunctions;

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -108,7 +108,6 @@ wasm/WasmBBQJIT.cpp
 wasm/WasmBBQJIT64.cpp
 wasm/WasmBBQPlan.cpp
 wasm/WasmCallee.cpp
-wasm/WasmConstExprGenerator.cpp
 wasm/WasmFaultSignalHandler.cpp
 [ iOS ] wasm/WasmFormat.h
 wasm/WasmFunctionParser.h

--- a/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
@@ -82,7 +82,7 @@ protected:
 
     int32_t m_targetHeapType;
     OptionSet<WasmRefTypeCheckFlag> m_flags;
-    RefPtr<const Wasm::RTT> m_targetRTT;
+    const RefPtr<const Wasm::RTT> m_targetRTT;
 };
 
 } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3WasmStructFieldValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructFieldValue.h
@@ -63,7 +63,7 @@ protected:
     {
     }
 
-    Ref<const Wasm::RTT> m_rtt;
+    const Ref<const Wasm::RTT> m_rtt;
     SUPPRESS_UNCOUNTED_MEMBER const Wasm::StructType* m_structType;
     Wasm::StructFieldCount m_fieldIndex;
     uint64_t m_fieldHeapKey;

--- a/Source/JavaScriptCore/b3/B3WasmStructNewValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructNewValue.h
@@ -74,7 +74,7 @@ private:
     {
     }
 
-    Ref<const Wasm::RTT> m_rtt;
+    const Ref<const Wasm::RTT> m_rtt;
     SUPPRESS_UNCOUNTED_MEMBER const Wasm::StructType* m_structType;
     uint32_t m_typeIndex;
     int32_t m_allocatorsBaseOffset;

--- a/Source/JavaScriptCore/bytecode/ProxyableAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ProxyableAccessCase.h
@@ -47,7 +47,7 @@ protected:
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
 
 private:
-    RefPtr<WatchpointSet> m_additionalSet;
+    const RefPtr<WatchpointSet> m_additionalSet;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecompiler/LabelScope.h
+++ b/Source/JavaScriptCore/bytecompiler/LabelScope.h
@@ -80,7 +80,7 @@ private:
     const Identifier* m_name;
     int m_scopeDepth;
     const Ref<Label> m_breakTarget;
-    RefPtr<Label> m_continueTarget;
+    const RefPtr<Label> m_continueTarget;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -611,8 +611,8 @@ public:
     const ClassInfo* currentlyDestructingCallbackObjectClassInfo { nullptr };
 
     AtomStringTable* m_atomStringTable;
-    UniqueRef<SymbolRegistry> m_symbolRegistry;
-    UniqueRef<SymbolRegistry> m_privateSymbolRegistry;
+    const UniqueRef<SymbolRegistry> m_symbolRegistry;
+    const UniqueRef<SymbolRegistry> m_privateSymbolRegistry;
     CommonIdentifiers* propertyNames { nullptr };
     const ArgList* emptyList;
     SmallStrings smallStrings;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -385,7 +385,7 @@ private:
     Stack m_expressionStack;
     ControlStack m_controlStack;
     Vector<Type, 16> m_locals;
-    Ref<const TypeDefinition> m_signature;
+    const Ref<const TypeDefinition> m_signature;
     const ModuleInformation& m_info;
 
     Vector<uint32_t> m_localInitStack;

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -117,7 +117,7 @@ private:
 
     Wasm::Type m_type;
     // If m_type came from a TypeDefinition, the following retains the definition to prevent a dangling m_type.
-    RefPtr<const Wasm::TypeDefinition> m_typeDefinition;
+    const RefPtr<const Wasm::TypeDefinition> m_typeDefinition;
     Wasm::Mutability m_mutability;
     JSWebAssemblyGlobal* m_owner { nullptr };
     Value m_value;

--- a/Source/JavaScriptCore/wasm/WasmTag.h
+++ b/Source/JavaScriptCore/wasm/WasmTag.h
@@ -66,7 +66,7 @@ private:
         ASSERT(m_type->is<FunctionSignature>());
     }
 
-    Ref<const TypeDefinition> m_type;
+    const Ref<const TypeDefinition> m_type;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -84,8 +84,8 @@ private:
     WebAssemblyGCStructure(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&& unexpandedType, Ref<const Wasm::TypeDefinition>&& expandedType, Ref<const Wasm::RTT>&&);
     WebAssemblyGCStructure(VM&, WebAssemblyGCStructure* previous);
 
-    Ref<const Wasm::RTT> m_rtt;
-    Ref<const Wasm::TypeDefinition> m_type;
+    const Ref<const Wasm::RTT> m_rtt;
+    const Ref<const Wasm::TypeDefinition> m_type;
     WebAssemblyGCStructureTypeDependencies m_typeDependencies;
 };
 


### PR DESCRIPTION
#### 125b0ed306b468f9c98d2bc32b5db82d4539af82
<pre>
Make assorted class members const Ref[Ptr] in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=308878">https://bugs.webkit.org/show_bug.cgi?id=308878</a>

Reviewed by Chris Dumez.

Helps reduce unsafeness.

Canonical link: <a href="https://commits.webkit.org/308406@main">https://commits.webkit.org/308406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4391849070aebcdaa1b8717e13c1b4488e07e33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20119 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100849 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20019 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/156116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139404 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8222 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1586 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/158448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/16715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/158448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19929 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75919 "Failed to checkout and rebase branch from PR 59644") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22727 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83296 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19263 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->