### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in Source/WebKit/Shared

### DIFF
--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -53,8 +53,8 @@ public:
     Object* at(size_t i) const { return m_elements[i].get(); }
     size_t size() const { return m_elements.size(); }
 
-    const Vector<RefPtr<Object>>& elements() const { return m_elements; }
-    Vector<RefPtr<Object>>& elements() { return m_elements; }
+    const Vector<RefPtr<Object>>& elements() const LIFETIME_BOUND { return m_elements; }
+    Vector<RefPtr<Object>>& elements() LIFETIME_BOUND { return m_elements; }
 
     template<typename T>
     decltype(auto) elementsOfType() const

--- a/Source/WebKit/Shared/API/APIClient.h
+++ b/Source/WebKit/Shared/API/APIClient.h
@@ -77,7 +77,7 @@ public:
         }
     }
 
-    const LatestClientInterface& client() const { return m_client; }
+    const LatestClientInterface& client() const LIFETIME_BOUND { return m_client; }
 
 protected:
     LatestClientInterface m_client;

--- a/Source/WebKit/Shared/API/APIDictionary.h
+++ b/Source/WebKit/Shared/API/APIDictionary.h
@@ -75,7 +75,7 @@ public:
 
     size_t size() const { return m_map.size(); }
 
-    const MapType& map() const { return m_map; }
+    const MapType& map() const LIFETIME_BOUND { return m_map; }
 
 private:
     explicit Dictionary(MapType&&);

--- a/Source/WebKit/Shared/API/APIError.h
+++ b/Source/WebKit/Shared/API/APIError.h
@@ -99,12 +99,12 @@ public:
     static const WTF::String& webKitPrintErrorDomain();
 #endif
 
-    const WTF::String& domain() const { return m_platformError.domain(); }
+    const WTF::String& domain() const LIFETIME_BOUND { return m_platformError.domain(); }
     int errorCode() const { return m_platformError.errorCode(); }
-    const WTF::String& failingURL() const { return m_platformError.failingURL().string(); }
-    const WTF::String& localizedDescription() const { return m_platformError.localizedDescription(); }
+    const WTF::String& failingURL() const LIFETIME_BOUND { return m_platformError.failingURL().string(); }
+    const WTF::String& localizedDescription() const LIFETIME_BOUND { return m_platformError.localizedDescription(); }
 
-    const WebCore::ResourceError& platformError() const { return m_platformError; }
+    const WebCore::ResourceError& platformError() const LIFETIME_BOUND { return m_platformError; }
     const RefPtr<Error> underlyingError() const { return m_underlyingError; }
 
 private:

--- a/Source/WebKit/Shared/API/APIGeometry.h
+++ b/Source/WebKit/Shared/API/APIGeometry.h
@@ -41,7 +41,7 @@ public:
         return create(WKSizeMake(width, height));
     }
 
-    const WKSize& size() const { return m_size; }
+    const WKSize& size() const LIFETIME_BOUND { return m_size; }
 
 private:
     explicit Size(const WKSize& size)
@@ -63,7 +63,7 @@ public:
         return adoptRef(*new Point(WKPointMake(x, y)));
     }
 
-    const WKPoint& point() const { return m_point; }
+    const WKPoint& point() const LIFETIME_BOUND { return m_point; }
 
 private:
     explicit Point(const WKPoint& point)
@@ -84,7 +84,7 @@ public:
         return create(WKRectMake(x, y, width, height));
     }
 
-    const WKRect& rect() const { return m_rect; }
+    const WKRect& rect() const LIFETIME_BOUND { return m_rect; }
 
 private:
     explicit Rect(const WKRect& rect)

--- a/Source/WebKit/Shared/API/APIURL.h
+++ b/Source/WebKit/Shared/API/APIURL.h
@@ -52,7 +52,7 @@ public:
     bool isNull() const { return m_string.isNull(); }
     bool isEmpty() const { return m_string.isEmpty(); }
 
-    const WTF::String& string() const { return m_string; }
+    const WTF::String& string() const LIFETIME_BOUND { return m_string; }
 
     static bool equals(const API::URL& a, const API::URL& b)
     {
@@ -95,7 +95,7 @@ private:
     {
     }
 
-    const WTF::URL& url() const
+    const WTF::URL& url() const LIFETIME_BOUND
     {
         parseURLIfNecessary();
         return *m_parsedURL;

--- a/Source/WebKit/Shared/API/APIURLRequest.h
+++ b/Source/WebKit/Shared/API/APIURLRequest.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new URLRequest(request));
     }
 
-    const WebCore::ResourceRequest& resourceRequest() const { return m_request; }
+    const WebCore::ResourceRequest& resourceRequest() const LIFETIME_BOUND { return m_request; }
 
     static double defaultTimeoutInterval(); // May return 0 when using platform default.
     static void setDefaultTimeoutInterval(double);

--- a/Source/WebKit/Shared/API/APIURLResponse.h
+++ b/Source/WebKit/Shared/API/APIURLResponse.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new URLResponse(response));
     }
 
-    const WebCore::ResourceResponse& resourceResponse() const { return m_response; }
+    const WebCore::ResourceResponse& resourceResponse() const LIFETIME_BOUND { return m_response; }
 
 private:
     explicit URLResponse(const WebCore::ResourceResponse& response)

--- a/Source/WebKit/Shared/API/APIUserContentURLPattern.h
+++ b/Source/WebKit/Shared/API/APIUserContentURLPattern.h
@@ -39,13 +39,13 @@ public:
         return adoptRef(*new UserContentURLPattern(pattern));
     }
 
-    const WTF::String& host() const { return m_pattern.host(); }
-    const WTF::String& scheme() const { return m_pattern.scheme(); }
+    const WTF::String& host() const LIFETIME_BOUND { return m_pattern.host(); }
+    const WTF::String& scheme() const LIFETIME_BOUND { return m_pattern.scheme(); }
     bool isValid() const { return m_pattern.isValid(); };
     bool matchesURL(const WTF::String& url) const { return m_pattern.matches(WTF::URL({ }, url)); }
     bool matchesSubdomains() const { return m_pattern.matchSubdomains(); }
 
-    const WTF::String& patternString() const { return m_patternString; }
+    const WTF::String& patternString() const LIFETIME_BOUND { return m_patternString; }
 
 private:
     explicit UserContentURLPattern(const WTF::String& pattern)

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
@@ -54,9 +54,9 @@ public:
     RemoteObjectInvocation();
     RemoteObjectInvocation(const String& interfaceIdentifier, RefPtr<API::Dictionary>&& encodedInvocation, std::unique_ptr<ReplyInfo>&&);
 
-    const String& interfaceIdentifier() const { return m_interfaceIdentifier; }
-    const RefPtr<API::Dictionary>& encodedInvocation() const { return m_encodedInvocation; }
-    const std::unique_ptr<ReplyInfo>& replyInfo() const { return m_replyInfo; }
+    const String& interfaceIdentifier() const LIFETIME_BOUND { return m_interfaceIdentifier; }
+    const RefPtr<API::Dictionary>& encodedInvocation() const LIFETIME_BOUND { return m_encodedInvocation; }
+    const std::unique_ptr<ReplyInfo>& replyInfo() const LIFETIME_BOUND { return m_replyInfo; }
 
 private:
     String m_interfaceIdentifier;

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -101,7 +101,7 @@ public:
 
     IPC::Connection* parentProcessConnection() const { return m_connection.get(); }
 
-    IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
+    IPC::MessageReceiverMap& messageReceiverMap() LIFETIME_BOUND { return m_messageReceiverMap; }
 
 #if PLATFORM(COCOA)
     static bool isSystemWebKit();

--- a/Source/WebKit/Shared/Cocoa/RevealItem.h
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.h
@@ -55,8 +55,8 @@ public:
     RevealItem() = default;
     RevealItem(const String& text, RevealItemRange selectedRange);
 
-    const String& text() const { return m_text; }
-    const RevealItemRange& selectedRange() const { return m_selectedRange; }
+    const String& text() const LIFETIME_BOUND { return m_text; }
+    const RevealItemRange& selectedRange() const LIFETIME_BOUND { return m_selectedRange; }
     NSRange highlightRange() const;
 
     RVItem *item() const;

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -82,12 +82,12 @@ public:
     );
 
     Type type() const { return m_type; }
-    const WebCore::IntPoint& menuLocation() const { return m_menuLocation; }
+    const WebCore::IntPoint& menuLocation() const LIFETIME_BOUND { return m_menuLocation; }
     void setMenuLocation(WebCore::IntPoint menuLocation) { m_menuLocation = menuLocation; }
-    const Vector<WebKit::WebContextMenuItemData>& menuItems() const { return m_menuItems; }
+    const Vector<WebKit::WebContextMenuItemData>& menuItems() const LIFETIME_BOUND { return m_menuItems; }
 
-    const std::optional<WebHitTestResultData>& webHitTestResultData() const { return m_webHitTestResultData; }
-    const String& selectedText() const { return m_selectedText; }
+    const std::optional<WebHitTestResultData>& webHitTestResultData() const LIFETIME_BOUND { return m_webHitTestResultData; }
+    const String& selectedText() const LIFETIME_BOUND { return m_selectedText; }
 
     bool hasEntireImage() const { return m_hasEntireImage; }
     bool allowsFollowingLink() const { return m_allowsFollowingLink; }
@@ -118,8 +118,8 @@ public:
     WebCore::ShareableBitmap* controlledImage() const { return m_controlledImage.get(); }
     std::optional<WebCore::ShareableBitmap::Handle> createControlledImageReadOnlyHandle() const;
 
-    const WebCore::AttributedString& controlledSelection() const { return m_controlledSelection; }
-    const Vector<String>& selectedTelephoneNumbers() const { return m_selectedTelephoneNumbers; }
+    const WebCore::AttributedString& controlledSelection() const LIFETIME_BOUND { return m_controlledSelection; }
+    const Vector<String>& selectedTelephoneNumbers() const LIFETIME_BOUND { return m_selectedTelephoneNumbers; }
 
     bool selectionIsEditable() const { return m_selectionIsEditable; }
 
@@ -137,7 +137,7 @@ public:
     WebCore::ShareableBitmap* potentialQRCodeViewportSnapshotImage() const { return m_potentialQRCodeViewportSnapshotImage.get(); }
     std::optional<WebCore::ShareableBitmap::Handle> createPotentialQRCodeViewportSnapshotImageReadOnlyHandle() const;
 
-    const String& qrCodePayloadString() const { return m_qrCodePayloadString; }
+    const String& qrCodePayloadString() const LIFETIME_BOUND { return m_qrCodePayloadString; }
     void setQRCodePayloadString(const String& string) { m_qrCodePayloadString = string; }
 #endif
 

--- a/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h
+++ b/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h
@@ -52,8 +52,8 @@ public:
     WebIDBResult(WebIDBResult&&) = default;
     WebIDBResult& operator=(WebIDBResult&&) = default;
 
-    const WebCore::IDBResultData& resultData() const { return m_resultData; }
-    const Vector<SandboxExtension::Handle>& handles() const { return m_handles; }
+    const WebCore::IDBResultData& resultData() const LIFETIME_BOUND { return m_resultData; }
+    const Vector<SandboxExtension::Handle>& handles() const LIFETIME_BOUND { return m_handles; }
 
 private:
     friend struct IPC::ArgumentCoder<WebIDBResult>;

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
@@ -47,7 +47,7 @@ public:
         return adoptRef(*new WebExtensionLocalization(std::forward<Args>(args)...));
     }
 
-    const String& uniqueIdentifier() { return m_uniqueIdentifier; };
+    const String& uniqueIdentifier() LIFETIME_BOUND { return m_uniqueIdentifier; };
     RefPtr<JSON::Object> localizationJSON() { return m_localizationJSON; };
 
     RefPtr<JSON::Object> localizedJSONforJSON(RefPtr<JSON::Object>);

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -85,7 +85,7 @@ public:
 
     int close();
 
-    sqlite3* sqlite3Handle() const { return m_db; };
+    sqlite3* sqlite3Handle() const LIFETIME_BOUND { return m_db; };
     void NODELETE assertQueue();
     WorkQueue& queue() const { return m_queue; };
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp
@@ -39,9 +39,9 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteRow);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteRowEnumerator);
 
-WebExtensionSQLiteRow::WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement> statement)
-    : m_statement(statement)
-    , m_handle(statement->handle())
+WebExtensionSQLiteRow::WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement>&& statement)
+    : m_statement(WTF::move(statement))
+    , m_handle(m_statement->handle())
 {
     m_statement->database()->assertQueue();
 }
@@ -97,8 +97,8 @@ bool WebExtensionSQLiteRow::isNullAtIndex(int index)
     return sqlite3_column_type(m_handle, index) == SQLITE_NULL;
 }
 
-WebExtensionSQLiteRowEnumerator::WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement> statement)
-    : m_statement(statement)
+WebExtensionSQLiteRowEnumerator::WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement>&& statement)
+    : m_statement(WTF::move(statement))
 {
     m_statement->database()->assertQueue();
 }
@@ -110,7 +110,7 @@ RefPtr<WebExtensionSQLiteRow> WebExtensionSQLiteRowEnumerator::next()
     switch (sqlite3_step(m_statement->handle())) {
     case SQLITE_ROW:
         if (!m_row)
-            m_row = WebExtensionSQLiteRow::create(m_statement);
+            m_row = WebExtensionSQLiteRow::create(Ref { m_statement });
         return m_row;
 
     default:

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h
@@ -56,7 +56,7 @@ public:
     RefPtr<API::Data> getData(int index);
 
 private:
-    explicit WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement>);
+    explicit WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement>&&);
 
     bool isNullAtIndex(int index);
 
@@ -79,7 +79,7 @@ public:
     Ref<WebExtensionSQLiteStatement> statement() { return m_statement; };
 
 private:
-    explicit WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement>);
+    explicit WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement>&&);
 
     Ref<WebExtensionSQLiteStatement> m_statement;
     RefPtr<WebExtensionSQLiteRow> m_row;

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
@@ -70,7 +70,7 @@ public:
     void invalidate();
 
     Ref<WebExtensionSQLiteDatabase> database() { return m_db; };
-    sqlite3_stmt* handle() { return m_handle; };
+    sqlite3_stmt* handle() LIFETIME_BOUND { return m_handle; };
     bool isValid() { return !!m_handle; };
 
     Vector<String> columnNames();

--- a/Source/WebKit/Shared/Gamepad/GamepadData.h
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.h
@@ -43,11 +43,11 @@ public:
 
     MonotonicTime lastUpdateTime() const { return m_lastUpdateTime; }
     unsigned index() const { return m_index; }
-    const String& id() const { return m_id; }
-    const String& mapping() const { return m_mapping; }
-    const Vector<double>& axisValues() const { return m_axisValues; }
-    const Vector<double>& buttonValues() const { return m_buttonValues; }
-    const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes() const { return m_supportedEffectTypes; }
+    const String& id() const LIFETIME_BOUND { return m_id; }
+    const String& mapping() const LIFETIME_BOUND { return m_mapping; }
+    const Vector<double>& axisValues() const LIFETIME_BOUND { return m_axisValues; }
+    const Vector<double>& buttonValues() const LIFETIME_BOUND { return m_buttonValues; }
+    const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes() const LIFETIME_BOUND { return m_supportedEffectTypes; }
 
 private:
     unsigned m_index;

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -58,7 +58,7 @@ private:
     IPCStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&, bool ignoreInvalidMessageForTesting);
     ~IPCStreamTester();
     void initialize();
-    IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
+    IPC::StreamConnectionWorkQueue& workQueue() const LIFETIME_BOUND { return m_workQueue; }
 
     // IPC::StreamServerConnection::Client overrides.
     void didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::MessageName, const Vector<uint32_t>&) final;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -81,7 +81,7 @@ public:
     ~JavaScriptEvaluationResult();
 
     JSObjectID root() const { return m_root; }
-    const Map& map() const { return m_map; }
+    const Map& map() const LIFETIME_BOUND { return m_map; }
 
     String toString() const;
 

--- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
+++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
@@ -101,8 +101,8 @@ public:
 #elif PLATFORM(IOS_FAMILY)
     ::WebEvent* nativeEvent() const { return m_nativeEvent.get(); }
 #elif PLATFORM(WIN)
-    const MSG* nativeEvent() const { return &m_nativeEvent; }
-    const Vector<MSG>& pendingCharEvents() const { return m_pendingCharEvents; }
+    const MSG* nativeEvent() const LIFETIME_BOUND { return &m_nativeEvent; }
+    const Vector<MSG>& pendingCharEvents() const LIFETIME_BOUND { return m_pendingCharEvents; }
 #else
     const void* nativeEvent() const { return nullptr; }
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
@@ -49,7 +49,7 @@ class DynamicContentScalingBifurcatedImageBuffer : public WebCore::ImageBuffer {
 public:
     DynamicContentScalingBifurcatedImageBuffer(WebCore::ImageBufferParameters, const WebCore::ImageBufferBackend::Info&, const WebCore::ImageBufferCreationContext&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
 
-    WebCore::GraphicsContext& NODELETE context() const final;
+    WebCore::GraphicsContext& NODELETE context() const LIFETIME_BOUND final;
 
 protected:
     std::optional<WebCore::DynamicContentScalingDisplayList> dynamicContentScalingDisplayList() final;

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
@@ -45,7 +45,7 @@ public:
     DynamicContentScalingImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
     ~DynamicContentScalingImageBufferBackend();
 
-    WebCore::GraphicsContext& NODELETE context() final;
+    WebCore::GraphicsContext& NODELETE context() LIFETIME_BOUND final;
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;
 
     void releaseGraphicsContext() final;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -160,7 +160,7 @@ public:
         SecondaryBack
     };
 
-    const WebCore::Region& dirtyRegion() { return m_dirtyRegion; }
+    const WebCore::Region& dirtyRegion() LIFETIME_BOUND { return m_dirtyRegion; }
     bool hasEmptyDirtyRegion() const { return m_dirtyRegion.isEmpty() || m_parameters.size.isEmpty(); }
 
     MonotonicTime lastDisplayTime() const { return m_lastDisplayTime; }
@@ -179,7 +179,7 @@ public:
     void markFrontBufferVolatileForTesting();
 
 protected:
-    RemoteLayerBackingStoreCollection* NODELETE backingStoreCollection() const;
+    RemoteLayerBackingStoreCollection* NODELETE backingStoreCollection() const LIFETIME_BOUND;
 
     void drawInContext(WebCore::GraphicsContext&);
 
@@ -225,7 +225,7 @@ public:
 
     void applyBackingStoreToNode(RemoteLayerTreeNode&, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView* hostingView);
 
-    const std::optional<ImageBufferBackendHandle>& bufferHandle() const { return m_bufferHandle; };
+    const std::optional<ImageBufferBackendHandle>& bufferHandle() const LIFETIME_BOUND { return m_bufferHandle; };
 
     struct LayerContentsBufferInfo {
         RetainPtr<id> buffer;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -147,14 +147,14 @@ public:
     
     bool NODELETE hasAnyLayerChanges() const;
 
-    const Vector<LayerCreationProperties>& createdLayers() const { return m_createdLayers; }
-    const Vector<WebCore::PlatformLayerIdentifier>& destroyedLayers() const { return m_destroyedLayerIDs; }
-    const Vector<WebCore::PlatformLayerIdentifier>& layerIDsWithNewlyUnreachableBackingStore() const { return m_layerIDsWithNewlyUnreachableBackingStore; }
+    const Vector<LayerCreationProperties>& createdLayers() const LIFETIME_BOUND { return m_createdLayers; }
+    const Vector<WebCore::PlatformLayerIdentifier>& destroyedLayers() const LIFETIME_BOUND { return m_destroyedLayerIDs; }
+    const Vector<WebCore::PlatformLayerIdentifier>& layerIDsWithNewlyUnreachableBackingStore() const LIFETIME_BOUND { return m_layerIDsWithNewlyUnreachableBackingStore; }
 
-    HashSet<Ref<PlatformCALayerRemote>>& NODELETE changedLayers();
+    HashSet<Ref<PlatformCALayerRemote>>& NODELETE changedLayers() LIFETIME_BOUND;
 
-    const LayerPropertiesMap& NODELETE changedLayerProperties() const;
-    LayerPropertiesMap& changedLayerProperties();
+    const LayerPropertiesMap& NODELETE changedLayerProperties() const LIFETIME_BOUND;
+    LayerPropertiesMap& changedLayerProperties() LIFETIME_BOUND;
 
     void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
@@ -172,7 +172,7 @@ public:
     void setScrollPosition(WebCore::IntPoint p) { m_scrollPosition = p; }
 
 #if ENABLE(THREADED_ANIMATIONS)
-    const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate() const { return m_timelinesUpdate; }
+    const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate() const LIFETIME_BOUND { return m_timelinesUpdate; }
     void setTimelinesUpdate(WebCore::AcceleratedTimelinesUpdate&& timelinesUpdate) { m_timelinesUpdate = WTF::move(timelinesUpdate); }
 #endif
 

--- a/Source/WebKit/Shared/SandboxInitializationParameters.h
+++ b/Source/WebKit/Shared/SandboxInitializationParameters.h
@@ -67,7 +67,7 @@ public:
         m_overrideSandboxProfilePathOrSandboxProfile = path;
     }
 
-    const String& overrideSandboxProfilePath() const
+    const String& overrideSandboxProfilePath() const LIFETIME_BOUND
     {
         ASSERT(m_profileSelectionMode == ProfileSelectionMode::UseOverrideSandboxProfilePath);
         return m_overrideSandboxProfilePathOrSandboxProfile;
@@ -79,14 +79,14 @@ public:
         m_overrideSandboxProfilePathOrSandboxProfile = profile;
     }
 
-    const String& sandboxProfile() const
+    const String& sandboxProfile() const LIFETIME_BOUND
     {
         ASSERT(m_profileSelectionMode == ProfileSelectionMode::UseSandboxProfile);
         return m_overrideSandboxProfilePathOrSandboxProfile;
     }
 
     void setUserDirectorySuffix(const String& suffix) { m_userDirectorySuffix = suffix; }
-    const String& userDirectorySuffix() const { return m_userDirectorySuffix; }
+    const String& userDirectorySuffix() const LIFETIME_BOUND { return m_userDirectorySuffix; }
 #endif
 
 private:

--- a/Source/WebKit/Shared/VisibleContentRectUpdateInfo.h
+++ b/Source/WebKit/Shared/VisibleContentRectUpdateInfo.h
@@ -81,14 +81,14 @@ public:
     {
     }
 
-    const WebCore::FloatRect& exposedContentRect() const { return m_exposedContentRect; }
-    const WebCore::FloatRect& unobscuredContentRect() const { return m_unobscuredContentRect; }
-    const WebCore::FloatBoxExtent& contentInsets() const { return m_contentInsets; }
-    const WebCore::FloatRect& unobscuredRectInScrollViewCoordinates() const { return m_unobscuredRectInScrollViewCoordinates; }
-    const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds() const { return m_unobscuredContentRectRespectingInputViewBounds; }
-    const WebCore::FloatRect& layoutViewportRect() const { return m_layoutViewportRect; }
-    const WebCore::FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
-    const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets() const { return m_unobscuredSafeAreaInsets; }
+    const WebCore::FloatRect& exposedContentRect() const LIFETIME_BOUND { return m_exposedContentRect; }
+    const WebCore::FloatRect& unobscuredContentRect() const LIFETIME_BOUND { return m_unobscuredContentRect; }
+    const WebCore::FloatBoxExtent& contentInsets() const LIFETIME_BOUND { return m_contentInsets; }
+    const WebCore::FloatRect& unobscuredRectInScrollViewCoordinates() const LIFETIME_BOUND { return m_unobscuredRectInScrollViewCoordinates; }
+    const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds() const LIFETIME_BOUND { return m_unobscuredContentRectRespectingInputViewBounds; }
+    const WebCore::FloatRect& layoutViewportRect() const LIFETIME_BOUND { return m_layoutViewportRect; }
+    const WebCore::FloatBoxExtent& obscuredInsets() const LIFETIME_BOUND { return m_obscuredInsets; }
+    const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets() const LIFETIME_BOUND { return m_unobscuredSafeAreaInsets; }
 
     double scale() const { return m_scale; }
     bool inStableState() const { return m_viewStability.isEmpty(); }
@@ -97,7 +97,7 @@ public:
     bool allowShrinkToFit() const { return m_allowShrinkToFit; }
     bool enclosedInScrollableAncestorView() const { return m_enclosedInScrollableAncestorView; }
     bool needsScrollend() const { return m_needsScrollend; }
-    const WebCore::VelocityData& scrollVelocity() const { return m_scrollVelocity; }
+    const WebCore::VelocityData& scrollVelocity() const LIFETIME_BOUND { return m_scrollVelocity; }
     TransactionID lastLayerTreeTransactionID() const { return m_lastLayerTreeTransactionID; }
 
     MonotonicTime timestamp() const { return m_scrollVelocity.lastUpdateTime; }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -50,7 +50,7 @@ public:
 
     std::optional<WebCore::FrameIdentifier> NODELETE frameID() const;
     WebCore::BackForwardFrameItemIdentifier identifier() const { return m_identifier; }
-    const String& NODELETE url() const;
+    const String& NODELETE url() const LIFETIME_BOUND;
 
     WebBackForwardListFrameItem* parent() const { return m_parent; }
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -64,12 +64,12 @@ public:
     Ref<FrameState> navigatedFrameState() const;
     Ref<FrameState> mainFrameState() const;
 
-    const String& NODELETE originalURL() const;
-    const String& NODELETE url() const;
-    const String& NODELETE title() const;
+    const String& NODELETE originalURL() const LIFETIME_BOUND;
+    const String& NODELETE url() const LIFETIME_BOUND;
+    const String& NODELETE title() const LIFETIME_BOUND;
     bool wasCreatedByJSWithoutUserInteraction() const;
 
-    const URL& resourceDirectoryURL() const { return m_resourceDirectoryURL; }
+    const URL& resourceDirectoryURL() const LIFETIME_BOUND { return m_resourceDirectoryURL; }
     void setResourceDirectoryURL(URL&& url) { m_resourceDirectoryURL = WTF::move(url); }
     RefPtr<WebsiteDataStore> dataStoreForWebArchive() const { return m_dataStoreForWebArchive; }
     void setDataStoreForWebArchive(WebsiteDataStore* dataStore) { m_dataStoreForWebArchive = dataStore; }

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.h
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.h
@@ -38,7 +38,7 @@ public:
     static RefPtr<WebCompiledContentRuleList> create(WebCompiledContentRuleListData&&);
     virtual ~WebCompiledContentRuleList();
 
-    const WebCompiledContentRuleListData& data() const { return m_data; }
+    const WebCompiledContentRuleListData& data() const LIFETIME_BOUND { return m_data; }
 
 private:
     WebCompiledContentRuleList(WebCompiledContentRuleListData&&);

--- a/Source/WebKit/Shared/WebContextMenuItem.h
+++ b/Source/WebKit/Shared/WebContextMenuItem.h
@@ -56,7 +56,7 @@ public:
     API::Object* NODELETE userData() const;
     void setUserData(API::Object*);
 
-    const WebContextMenuItemData& data() { return m_webContextMenuItemData; }
+    const WebContextMenuItemData& data() LIFETIME_BOUND { return m_webContextMenuItemData; }
 
 private:
     WebContextMenuItem(const WebContextMenuItemData&);

--- a/Source/WebKit/Shared/WebContextMenuItemData.h
+++ b/Source/WebKit/Shared/WebContextMenuItemData.h
@@ -44,12 +44,12 @@ public:
 
     WebCore::ContextMenuItemType type() const { return m_type; }
     WebCore::ContextMenuAction action() const { return m_action; }
-    const String& title() const { return m_title; }
+    const String& title() const LIFETIME_BOUND { return m_title; }
     bool enabled() const { return m_enabled; }
     void setEnabled(bool enabled) { m_enabled = enabled; }
     bool checked() const { return m_checked; }
     unsigned indentationLevel() const { return m_indentationLevel; }
-    const Vector<WebContextMenuItemData>& submenu() const { return m_submenu; }
+    const Vector<WebContextMenuItemData>& submenu() const LIFETIME_BOUND { return m_submenu; }
     
     WebCore::ContextMenuItem core() const;
     

--- a/Source/WebKit/Shared/WebImage.h
+++ b/Source/WebKit/Shared/WebImage.h
@@ -56,11 +56,11 @@ public:
     virtual ~WebImage();
 
     WebCore::IntSize size() const;
-    const WebCore::ImageBufferParameters* NODELETE parameters() const;
+    const WebCore::ImageBufferParameters* NODELETE parameters() const LIFETIME_BOUND;
     std::optional<ParametersAndHandle> parametersAndHandle() const;
     bool isEmpty() const { return !m_buffer; }
 
-    WebCore::GraphicsContext* context() const;
+    WebCore::GraphicsContext* context() const LIFETIME_BOUND;
 
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const;
     RefPtr<WebCore::ShareableBitmap> bitmap() const;


### PR DESCRIPTION
#### db35eacf7ad03851555764d060717f76d19f0b0e
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in Source/WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=308879">https://bugs.webkit.org/show_bug.cgi?id=308879</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/Shared/API/APIArray.h:
* Source/WebKit/Shared/API/APIClient.h:
(API::Client::client const): Deleted.
* Source/WebKit/Shared/API/APIDictionary.h:
* Source/WebKit/Shared/API/APIError.h:
(API::Error::domain const): Deleted.
(API::Error::failingURL const): Deleted.
(API::Error::localizedDescription const): Deleted.
(API::Error::platformError const): Deleted.
* Source/WebKit/Shared/API/APIGeometry.h:
(API::Size::size const): Deleted.
(API::Point::point const): Deleted.
(API::Rect::rect const): Deleted.
* Source/WebKit/Shared/API/APIURL.h:
(API::URL::string const): Deleted.
(API::URL::url const): Deleted.
* Source/WebKit/Shared/API/APIURLRequest.h:
(API::URLRequest::resourceRequest const): Deleted.
* Source/WebKit/Shared/API/APIURLResponse.h:
(API::URLResponse::resourceResponse const): Deleted.
* Source/WebKit/Shared/API/APIUserContentURLPattern.h:
(API::UserContentURLPattern::host const): Deleted.
(API::UserContentURLPattern::scheme const): Deleted.
(API::UserContentURLPattern::patternString const): Deleted.
* Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h:
(WebKit::RemoteObjectInvocation::interfaceIdentifier const): Deleted.
(WebKit::RemoteObjectInvocation::encodedInvocation const): Deleted.
(WebKit::RemoteObjectInvocation::replyInfo const): Deleted.
* Source/WebKit/Shared/AuxiliaryProcess.h:
(WebKit::AuxiliaryProcess::messageReceiverMap): Deleted.
* Source/WebKit/Shared/Cocoa/RevealItem.h:
(WebKit::RevealItem::text const): Deleted.
(WebKit::RevealItem::selectedRange const): Deleted.
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::menuLocation const): Deleted.
(WebKit::ContextMenuContextData::menuItems const): Deleted.
(WebKit::ContextMenuContextData::webHitTestResultData const): Deleted.
(WebKit::ContextMenuContextData::selectedText const): Deleted.
(WebKit::ContextMenuContextData::controlledSelection const): Deleted.
(WebKit::ContextMenuContextData::selectedTelephoneNumbers const): Deleted.
(WebKit::ContextMenuContextData::qrCodePayloadString const): Deleted.
* Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h:
(WebKit::WebIDBResult::resultData const): Deleted.
(WebKit::WebIDBResult::handles const): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionLocalization.h:
(WebKit::WebExtensionLocalization::uniqueIdentifier): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp:
(WebKit::WebExtensionSQLiteRow::WebExtensionSQLiteRow):
(WebKit::WebExtensionSQLiteRowEnumerator::WebExtensionSQLiteRowEnumerator):
(WebKit::WebExtensionSQLiteRowEnumerator::next):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h:
(WebKit::WebExtensionSQLiteStatement::handle): Deleted.
* Source/WebKit/Shared/Gamepad/GamepadData.h:
(WebKit::GamepadData::id const): Deleted.
(WebKit::GamepadData::mapping const): Deleted.
(WebKit::GamepadData::axisValues const): Deleted.
(WebKit::GamepadData::buttonValues const): Deleted.
(WebKit::GamepadData::supportedEffectTypes const): Deleted.
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
(WebKit::JavaScriptEvaluationResult::map const): Deleted.
* Source/WebKit/Shared/NativeWebKeyboardEvent.h:
(WebKit::NativeWebKeyboardEvent::pendingCharEvents const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
(WebKit::RemoteLayerBackingStore::dirtyRegion): Deleted.
(WebKit::RemoteLayerBackingStoreProperties::bufferHandle const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/SandboxInitializationParameters.h:
(WebKit::SandboxInitializationParameters::overrideSandboxProfilePath const): Deleted.
(WebKit::SandboxInitializationParameters::sandboxProfile const): Deleted.
(WebKit::SandboxInitializationParameters::userDirectorySuffix const): Deleted.
* Source/WebKit/Shared/VisibleContentRectUpdateInfo.h:
(WebKit::VisibleContentRectUpdateInfo::exposedContentRect const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::unobscuredContentRect const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::contentInsets const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::unobscuredRectInScrollViewCoordinates const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::unobscuredContentRectRespectingInputViewBounds const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::layoutViewportRect const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::obscuredInsets const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::unobscuredSafeAreaInsets const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::scrollVelocity const): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::resourceDirectoryURL const): Deleted.
* Source/WebKit/Shared/WebCompiledContentRuleList.h:
* Source/WebKit/Shared/WebContextMenuItem.h:
(WebKit::WebContextMenuItem::data): Deleted.
* Source/WebKit/Shared/WebContextMenuItemData.h:
(WebKit::WebContextMenuItemData::title const): Deleted.
(WebKit::WebContextMenuItemData::submenu const): Deleted.
* Source/WebKit/Shared/WebImage.h:

Canonical link: <a href="https://commits.webkit.org/308404@main">https://commits.webkit.org/308404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caae25dd10a209702749e20ccabab01e9c1e376b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100841 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/637bcbc0-d54a-46a6-88cf-08b45bfd6f6d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113625 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81022 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46768a38-e0bf-4f6a-bebe-7491d4c47934) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94385 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af34caac-ed40-41b2-8e01-f03a2ecd2884) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15020 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12805 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124616 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158440 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11797 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121652 "Found 1 new test failure: swipe/swipe-disables-view-transition.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31204 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75907 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8886 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19255 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19406 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19313 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->