### PR TITLE
[WTF] Add RefCountIsThreadSafe as template parameter to RefCountDebugger

### DIFF
--- a/Source/WTF/wtf/RefCountDebugger.cpp
+++ b/Source/WTF/wtf/RefCountDebugger.cpp
@@ -27,7 +27,7 @@
 
 namespace WTF {
 
-bool RefCountDebugger::areThreadingChecksEnabledGlobally { false };
+bool RefCountDebuggerBase::areThreadingChecksEnabledGlobally { false };
 
 // This is a convenience that makes IPC serialization easier.
 static_assert(sizeof(RefCountedBase) == sizeof(ThreadSafeRefCountedBase));
@@ -99,12 +99,12 @@ private:
 std::atomic<size_t> RefLogSingleton::s_end;
 std::array<std::atomic<RefLogStackShot*>, RefLogSingleton::s_size> RefLogSingleton::s_buffer;
 
-void RefCountDebugger::logRefDuringDestruction(const void* ptr)
+void RefCountDebuggerBase::logRefDuringDestruction(const void* ptr)
 {
     RefLogSingleton::append(ptr);
 }
 
-void RefCountDebugger::printRefDuringDestructionLogAndCrash(const void* ptr)
+void RefCountDebuggerBase::printRefDuringDestructionLogAndCrash(const void* ptr)
 {
     WTFLogAlways("Error: Dangling RefPtr: %p", ptr);
     WTFLogAlways("This means that a ref() during destruction was not balanced by a deref() before destruction ended.");

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -40,7 +40,7 @@ class WTF_EMPTY_BASE_CLASS ThreadSafeRefCountedBase {
 public:
     void ref() const
     {
-        m_refCountDebugger.willRef(m_refCount, RefCountIsThreadSafe::Yes);
+        m_refCountDebugger.willRef(m_refCount);
         ++m_refCount;
     }
 
@@ -51,12 +51,11 @@ public:
     void adopted() { m_refCountDebugger.adopted(); }
     void relaxAdoptionRequirement() { m_refCountDebugger.relaxAdoptionRequirement(); }
     void disableThreadingChecks() { m_refCountDebugger.disableThreadingChecks(); }
-    RefCountDebugger& refCountDebugger() { return m_refCountDebugger; }
+    ThreadSafeRefCountDebugger& refCountDebugger() { return m_refCountDebugger; }
 
 protected:
     ThreadSafeRefCountedBase()
     {
-        m_refCountDebugger.initAsThreadSafe();
         // FIXME: Lots of subclasses violate our adoption requirements. Migrate
         // this call into only those subclasses that need it.
         m_refCountDebugger.relaxAdoptionRequirement();
@@ -72,7 +71,7 @@ protected:
     // Returns true if the pointer should be freed.
     bool derefBase() const
     {
-        m_refCountDebugger.willDeref(m_refCount, RefCountIsThreadSafe::Yes);
+        m_refCountDebugger.willDeref(m_refCount);
 
         if (!--m_refCount) [[unlikely]] {
             m_refCountDebugger.willDelete();
@@ -86,7 +85,7 @@ protected:
 
 private:
     mutable std::atomic<uint32_t> m_refCount { 1 };
-    NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
+    NO_UNIQUE_ADDRESS ThreadSafeRefCountDebugger m_refCountDebugger;
 };
 
 template<class T, DestructionThread destructionThread = DestructionThread::Any> class ThreadSafeRefCounted : public ThreadSafeRefCountedBase {

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -42,7 +42,7 @@ class WTF_EMPTY_BASE_CLASS ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBa
 public:
     void refSuppressingSaferCPPChecking() const
     {
-        m_refCountDebugger.willRef(m_refCount, RefCountIsThreadSafe::Yes);
+        m_refCountDebugger.willRef(m_refCount);
         ++m_refCount;
     }
 
@@ -53,12 +53,11 @@ public:
     void adopted() { m_refCountDebugger.adopted(); }
     void relaxAdoptionRequirement() { m_refCountDebugger.relaxAdoptionRequirement(); }
     void disableThreadingChecks() { m_refCountDebugger.disableThreadingChecks(); }
-    RefCountDebugger& refCountDebugger() { return m_refCountDebugger; }
+    ThreadSafeRefCountDebugger& refCountDebugger() { return m_refCountDebugger; }
 
 protected:
     ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
     {
-        m_refCountDebugger.initAsThreadSafe();
         // FIXME: Lots of subclasses violate our adoption requirements. Migrate
         // this call into only those subclasses that need it.
         m_refCountDebugger.relaxAdoptionRequirement();
@@ -74,7 +73,7 @@ protected:
     // Returns true if the pointer should be freed.
     bool derefBase() const
     {
-        m_refCountDebugger.willDeref(m_refCount, RefCountIsThreadSafe::Yes);
+        m_refCountDebugger.willDeref(m_refCount);
 
         if (!--m_refCount) [[unlikely]] {
             m_refCountDebugger.willDelete();
@@ -88,7 +87,7 @@ protected:
 
 private:
     mutable std::atomic<uint32_t> m_refCount { 1 };
-    NO_UNIQUE_ADDRESS RefCountDebugger m_refCountDebugger;
+    NO_UNIQUE_ADDRESS ThreadSafeRefCountDebugger m_refCountDebugger;
 };
 
 template<class T, DestructionThread destructionThread = DestructionThread::Any> class ThreadSafeRefCountedWithSuppressingSaferCPPChecking : public ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase {

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -440,7 +440,7 @@ Node::~Node()
 
 #if ASSERT_ENABLED
     if (m_refCountAndParentBit != s_refCountIncrement)
-        WTF::RefCountDebugger::printRefDuringDestructionLogAndCrash(this);
+        WTF::RefCountDebuggerBase::printRefDuringDestructionLogAndCrash(this);
 #endif
     RELEASE_ASSERT(m_refCountAndParentBit == s_refCountIncrement);
 }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -858,7 +858,7 @@ inline void Node::applyRefDuringDestructionCheck() const
 #if ASSERT_ENABLED
     if (!deletionHasBegun())
         return;
-    WTF::RefCountDebugger::logRefDuringDestruction(this);
+    WTF::RefCountDebuggerBase::logRefDuringDestruction(this);
 #endif
 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1386,7 +1386,7 @@ extension WebGPU.CommandEncoder {
             }
 
             if zeroColorTargets {
-                // FIXME: rdar://170997914 (Invalid render pass usage leads to crashes in the WebGPU Swift backend (308471))
+                // FIXME: rdar://170997914 (Invalid render pass usage leads to crashes in the WebGPU Swift backend (308471)).
                 // swift-format-ignore: NeverForceUnwrap
                 mtlDescriptor.defaultRasterSampleCount = metalDepthStencilTexture!.sampleCount
                 if mtlDescriptor.defaultRasterSampleCount == 0 {

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -47,7 +47,7 @@ extension WebGPU.Queue {
 
         let count = data.count
         let noCopy = data.count >= largeBufferSize
-        // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here
+        // FIXME: 'bufferWithOffset' may extend the lifetime of 'data', but we drop that information here.
         let bufferWithOffset = unsafe newTemporaryBufferWithBytes(WebGPU.SpanUInt8(data), noCopy)
         let temporaryBuffer = unsafe bufferWithOffset.first
         let temporaryBufferOffset = unsafe bufferWithOffset.second

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -85,7 +85,7 @@ void AuxiliaryProcess::initialize(AuxiliaryProcessInitializationParameters&& par
 {
     TraceScope traceScope(ProcessInitializeStart, ProcessInitializeEnd);
 
-    WTF::RefCountDebugger::enableThreadingChecksGlobally();
+    WTF::RefCountDebuggerBase::enableThreadingChecksGlobally();
 
 #if PLATFORM(COCOA)
     // On Cocoa platforms, setAuxiliaryProcessType() is called in XPCServiceInitializer().

--- a/Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm
@@ -65,7 +65,7 @@ static void runInitializationCode(void* = nullptr)
     InitWebCoreThreadSystemInterface();
 #endif
 
-    WTF::RefCountDebugger::enableThreadingChecksGlobally();
+    WTF::RefCountDebuggerBase::enableThreadingChecksGlobally();
 
     WebCore::populateJITOperations();
 }

--- a/Source/WebKit/Shared/WebKit2Initialize.cpp
+++ b/Source/WebKit/Shared/WebKit2Initialize.cpp
@@ -43,7 +43,7 @@ void InitializeWebKit2()
     WTF::initializeMainThread();
     WebCore::initializeCommonAtomStrings();
 
-    WTF::RefCountDebugger::enableThreadingChecksGlobally();
+    WTF::RefCountDebuggerBase::enableThreadingChecksGlobally();
 
     WebCore::populateJITOperations();
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -5027,7 +5027,7 @@ IGNORE_WARNINGS_END
 
     WebCore::initializeMainThreadIfNeeded();
 
-    WTF::RefCountDebugger::enableThreadingChecksGlobally();
+    WTF::RefCountDebuggerBase::enableThreadingChecksGlobally();
 
     WTF::setProcessPrivileges(allPrivileges());
     WebCore::NetworkStorageSession::permitProcessToUseCookieAPI(true);


### PR DESCRIPTION
#### a23c635eab2a21fcfd9d982355297c7cc7e69eae
<pre>
[WTF] Add RefCountIsThreadSafe as template parameter to RefCountDebugger
<a href="https://bugs.webkit.org/show_bug.cgi?id=308880">https://bugs.webkit.org/show_bug.cgi?id=308880</a>

Reviewed by Ryosuke Niwa.

Add RefCountIsThreadSafe as template parameter to RefCountDebugger
instead of passing it dynamically to some of RefCountDebugger&apos;s
functions. The value of RefCountIsThreadSafe doesn&apos;t change. This allows
simplifying the code a bit and leveraging `if constexpr`.

* Source/WTF/wtf/RefCountDebugger.cpp:
(WTF::RefCountDebuggerBase::logRefDuringDestruction):
(WTF::RefCountDebuggerBase::printRefDuringDestructionLogAndCrash):
(WTF::RefCountDebugger::logRefDuringDestruction): Deleted.
(WTF::RefCountDebugger::printRefDuringDestructionLogAndCrash): Deleted.
* Source/WTF/wtf/RefCountDebugger.h:
(WTF::RefCountDebuggerBase::enableThreadingChecksGlobally):
(WTF::RefCountDebuggerImpl::~RefCountDebuggerImpl):
(WTF::RefCountDebuggerImpl::willRef const):
(WTF::RefCountDebuggerImpl::applyRefDerefThreadingCheck const):
(WTF::RefCountDebuggerImpl::willDeref const):
(WTF::RefCountDebuggerImpl::initialOwnerThread):
(WTF::RefCountDebugger::initAsThreadSafe): Deleted.
(WTF::RefCountDebugger::~RefCountDebugger): Deleted.
(WTF::RefCountDebugger::willRef const): Deleted.
(WTF::RefCountDebugger::adopted): Deleted.
(WTF::RefCountDebugger::relaxAdoptionRequirement): Deleted.
(WTF::RefCountDebugger::disableThreadingChecks): Deleted.
(WTF::RefCountDebugger::enableThreadingChecksGlobally): Deleted.
(WTF::RefCountDebugger::applyRefDuringDestructionCheck const): Deleted.
(WTF::RefCountDebugger::applyRefDerefThreadingCheck const): Deleted.
(WTF::RefCountDebugger::willDestroy const): Deleted.
(WTF::RefCountDebugger::willDelete const): Deleted.
(WTF::RefCountDebugger::willDeref const): Deleted.
(WTF::RefCountDebugger::deletionHasBegun const): Deleted.
* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::~Node):
* Source/WebCore/dom/Node.h:
(WebCore::Node::applyRefDuringDestructionCheck const):

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
* Source/WebGPU/WebGPU/Queue.swift:
(WebGPU.writeBuffer(_:bufferOffset:data:)):
Touch the files to work around incremental build issues affecting WebGPU
Swift files.

* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::initialize):
* Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm:
(WebKit::runInitializationCode):
* Source/WebKit/Shared/WebKit2Initialize.cpp:
(WebKit::InitializeWebKit2):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView initialize]):

Canonical link: <a href="https://commits.webkit.org/308415@main">https://commits.webkit.org/308415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8746bad0f6320824a4bc87d4b2528c85d4984d34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100844 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ce6928a-6b3d-4d25-924d-19d68fe15c18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113628 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81024 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/570a279e-0fc9-4d7c-b124-4237a1900e32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/373070ef-b7e2-4f16-886e-b2195bc2b3e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15023 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12808 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3552 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139399 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158443 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8217 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1581 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121655 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31213 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75914 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8891 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178788 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83291 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45767 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->