### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in Source/WebKit/WebProcess

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -49,7 +49,7 @@ public:
     void invokeListenersWithArgument(id argument1, id argument2, id argument3);
 #endif
 
-    const ListenerVector& listeners() const { return m_listeners; }
+    const ListenerVector& listeners() const LIFETIME_BOUND { return m_listeners; }
 
     void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
     void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
@@ -54,7 +54,7 @@ public:
 
     double actionMenuTopLevelLimit() const { return webExtensionActionMenuItemTopLevelLimit; }
 
-    const ClickHandlerMap& clickHandlers() const { return m_clickHandlerMap; }
+    const ClickHandlerMap& clickHandlers() const LIFETIME_BOUND { return m_clickHandlerMap; }
 
 private:
     enum class ForUpdate : bool { No, Yes };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -79,7 +79,7 @@ public:
     WebExtensionContextProxy& extensionContext() const { return *m_extensionContext; }
     bool hasExtensionContext() const { return !!m_extensionContext; }
 
-    const String& propertyPath() const { return m_propertyPath; }
+    const String& propertyPath() const LIFETIME_BOUND { return m_propertyPath; }
     void setPropertyPath(const String& propertyName, const WebExtensionAPIObject* parentObject = nullptr)
     {
         ASSERT(!propertyName.isEmpty());

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -53,7 +53,7 @@ public:
     WebExtensionContentWorldType targetContentWorldType() const { return m_targetContentWorldType; }
     WebExtensionPortChannelIdentifier channelIdentifier() const { return *m_channelIdentifier; }
     std::optional<WebPageProxyIdentifier> owningPageProxyIdentifier() const { return m_owningPageProxyIdentifier; }
-    const std::optional<WebExtensionMessageSenderParameters>& senderParameters() const { return m_senderParameters; }
+    const std::optional<WebExtensionMessageSenderParameters>& senderParameters() const LIFETIME_BOUND { return m_senderParameters; }
 
     void postMessage(WebFrame&, const String&, NSString **outExceptionString);
     void disconnect();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -50,7 +50,7 @@ public:
 
     void invokeListenersWithArgument(id argument, NSURL *targetURL);
 
-    const ListenerVector& listeners() const { return m_listeners; }
+    const ListenerVector& listeners() const LIFETIME_BOUND { return m_listeners; }
 #endif
 
     void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -53,7 +53,7 @@ public:
 
     using ListenerVector = Vector<Listener>;
 
-    const ListenerVector& listeners() const { return m_listeners; }
+    const ListenerVector& listeners() const LIFETIME_BOUND { return m_listeners; }
 
     void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSArray *extraInfo, NSString **outExceptionString);
     void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -49,7 +49,7 @@ public:
     void invokeListenersWithArgument(id argument, OptionSet<WindowTypeFilter>);
 #endif
 
-    const ListenerVector& listeners() const { return m_listeners; }
+    const ListenerVector& listeners() const LIFETIME_BOUND { return m_listeners; }
 
     void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
     void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -81,8 +81,8 @@ public:
 
     bool operator==(const WebExtensionContextProxy& other) const { return (this == &other); }
 
-    const URL& baseURL() const { return m_baseURL; }
-    const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
+    const URL& baseURL() const LIFETIME_BOUND { return m_baseURL; }
+    const String& uniqueIdentifier() const LIFETIME_BOUND { return m_uniqueIdentifier; }
 
 #if PLATFORM(COCOA)
     NSDictionary *manifest() const { return m_manifest.get(); }

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -80,7 +80,7 @@ public:
     RefPtr<WebExtensionContextProxy> extensionContext(WebFrame&, WebCore::DOMWrapperWorld&) const;
 
     bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
-    const WebExtensionContextProxySet& extensionContexts() const { return m_extensionContexts; }
+    const WebExtensionContextProxySet& extensionContexts() const LIFETIME_BOUND { return m_extensionContexts; }
 
 private:
     explicit WebExtensionControllerProxy(const WebExtensionControllerParameters&);

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -82,7 +82,7 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     IPC::Connection& connection() { return m_connection.get(); }
-    IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
+    IPC::MessageReceiverMap& messageReceiverMap() LIFETIME_BOUND { return m_messageReceiverMap; }
 
     void didBecomeUnresponsive();
 #if HAVE(AUDIT_TOKEN)
@@ -90,7 +90,7 @@ public:
 #endif
     Ref<RemoteSharedResourceCacheProxy> sharedResourceCache();
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    SampleBufferDisplayLayerManager& sampleBufferDisplayLayerManager();
+    SampleBufferDisplayLayerManager& sampleBufferDisplayLayerManager() LIFETIME_BOUND;
     void resetAudioMediaStreamTrackRendererInternalUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
 #endif
 #if ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.h
@@ -43,7 +43,7 @@ class InjectedBundleHitTestResult : public API::ObjectImpl<API::Object::Type::Bu
 public:
     static Ref<InjectedBundleHitTestResult> create(const WebCore::HitTestResult&);
 
-    const WebCore::HitTestResult& coreHitTestResult() const { return m_hitTestResult; }
+    const WebCore::HitTestResult& coreHitTestResult() const LIFETIME_BOUND { return m_hitTestResult; }
 
     RefPtr<InjectedBundleNodeHandle> nodeHandle() const;
     RefPtr<InjectedBundleNodeHandle> urlElementHandle() const;

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
@@ -48,7 +48,7 @@ public:
 
     static ASCIILiteral supplementName();
 
-    const String& mediaKeyStorageDirectory() const { return m_mediaKeyStorageDirectory; }
+    const String& mediaKeyStorageDirectory() const LIFETIME_BOUND { return m_mediaKeyStorageDirectory; }
     String mediaKeyStorageDirectoryForOrigin(const WebCore::SecurityOriginData&);
 
     Vector<WebCore::SecurityOriginData> getMediaKeyOrigins();

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
@@ -58,7 +58,7 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     IPC::Connection& connection() { return m_connection.get(); }
-    IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
+    IPC::MessageReceiverMap& messageReceiverMap() LIFETIME_BOUND { return m_messageReceiverMap; }
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return WebProcess::singleton().sharedPreferencesForWebProcess(); }
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return WebProcess::singleton().sharedPreferencesForWebProcessValue(); }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -53,7 +53,7 @@ public:
     void networkProcessCrashed() final;
     void setAsActive() final;
 
-    WebRTCMonitor& monitor() { return m_webNetworkMonitor; }
+    WebRTCMonitor& monitor() LIFETIME_BOUND { return m_webNetworkMonitor; }
     LibWebRTCSocketFactory& socketFactory() { return m_socketFactory; }
 
     void disableNonLocalhostConnections() { socketFactory().disableNonLocalhostConnections(); }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -58,8 +58,8 @@ public:
     ~LibWebRTCSocket();
 
     WebCore::ScriptExecutionContextIdentifier contextIdentifier() const { return m_contextIdentifier; }
-    const webrtc::SocketAddress& localAddress() const { return m_localAddress; }
-    const webrtc::SocketAddress& remoteAddress() const { return m_remoteAddress; }
+    const webrtc::SocketAddress& localAddress() const LIFETIME_BOUND { return m_localAddress; }
+    const webrtc::SocketAddress& remoteAddress() const LIFETIME_BOUND { return m_remoteAddress; }
 
     void setError(int error) { m_error = error; }
     void setState(State state) { m_state = state; }

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
@@ -67,9 +67,9 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     bool didReceiveNetworkList() const { return m_didReceiveNetworkList; }
-    const Vector<RTCNetwork>& networkList() const { return m_networkList; }
-    const RTCNetwork::IPAddress& ipv4() const { return m_ipv4; }
-    const RTCNetwork::IPAddress& ipv6() const { return m_ipv6; }
+    const Vector<RTCNetwork>& networkList() const LIFETIME_BOUND { return m_networkList; }
+    const RTCNetwork::IPAddress& ipv4() const LIFETIME_BOUND { return m_ipv4; }
+    const RTCNetwork::IPAddress& ipv6() const LIFETIME_BOUND { return m_ipv6; }
 
 private:
     void networksChanged(Vector<RTCNetwork>&&, RTCNetwork::IPAddress&&, RTCNetwork::IPAddress&&);

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h
@@ -50,7 +50,7 @@ public:
     virtual void setAsActive();
     bool isActive() const { return m_isActive; }
 
-    WebMDNSRegister& mdnsRegister() { return m_mdnsRegister; }
+    WebMDNSRegister& mdnsRegister() LIFETIME_BOUND { return m_mdnsRegister; }
 
 private:
     const CheckedRef<WebProcess> m_webProcess;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -91,7 +91,7 @@ public:
     void layerHostingStrategyDidChange() final;
 
     WebCore::HTMLPlugInElement& pluginElement() const { return m_pluginElement; }
-    const URL& mainResourceURL() const { return m_mainResourceURL; }
+    const URL& mainResourceURL() const LIFETIME_BOUND { return m_mainResourceURL; }
 
     void didBeginMagnificationGesture();
     void didEndMagnificationGesture();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -372,7 +372,7 @@ private:
         Type type() const { return m_type; }
         bool resize(const WebCore::IntSize&);
         bool handleBufferFormatChangeIfNeeded();
-        const WebCore::IntSize& size() const { return m_size; }
+        const WebCore::IntSize& size() const LIFETIME_BOUND { return m_size; }
         RenderTarget* nextTarget();
         void releaseTarget(uint64_t, UnixFileDescriptor&& releaseFence);
         void reset();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.h
@@ -140,7 +140,7 @@ private:
 
         Type type() const { return m_type; }
         bool resize(const WebCore::IntSize&);
-        const WebCore::IntSize& size() const { return m_size; }
+        const WebCore::IntSize& size() const LIFETIME_BOUND { return m_size; }
         RenderTarget* nextTarget();
         void releaseTarget(uint64_t, UnixFileDescriptor&& releaseFence);
         void reset();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingRunLoop.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingRunLoop.h
@@ -63,7 +63,7 @@ public:
     void suspend();
     void resume();
 
-    Lock& stateLock() { return m_state.lock; }
+    Lock& stateLock() LIFETIME_BOUND { return m_state.lock; }
 
     void scheduleUpdate();
     void stopUpdates();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -55,7 +55,7 @@ public:
     bool flush();
     void invalidate();
 
-    const HashSet<Ref<WebCore::CoordinatedPlatformLayer>>& committedLayers();
+    const HashSet<Ref<WebCore::CoordinatedPlatformLayer>>& committedLayers() LIFETIME_BOUND;
     void invalidateCommittedLayers();
 
     bool layersDidChange() const { return m_didChangeLayers; }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -93,7 +93,7 @@ public:
     WebPage& webPage() const { return m_webPage; }
     CoordinatedSceneState& sceneState() const { return m_sceneState.get(); }
 
-    const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
+    const LayerTreeContext& layerTreeContext() const LIFETIME_BOUND { return m_layerTreeContext; }
     void setLayerTreeStateIsFrozen(bool);
 
     void scheduleRenderingUpdate();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -59,7 +59,7 @@ public:
     explicit LayerTreeHost(WebPage&);
     ~LayerTreeHost();
 
-    const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
+    const LayerTreeContext& layerTreeContext() const LIFETIME_BOUND { return m_layerTreeContext; }
     void setLayerTreeStateIsFrozen(bool);
     void setShouldNotifyAfterNextScheduledLayerFlush(bool);
     void scheduleRenderingUpdate();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -127,7 +127,7 @@ public:
     using KeyframeValue = PlatformCAAnimationRemoteProperties::KeyframeValue;
     using Properties = PlatformCAAnimationRemoteProperties;
 
-    const Properties& properties() const { return m_properties; }
+    const Properties& properties() const LIFETIME_BOUND { return m_properties; }
 
     typedef Vector<std::pair<String, Properties>> AnimationsList;
     static void updateLayerAnimations(CALayer *, RemoteLayerTreeHost*, const AnimationsList& animationsToAdd, const HashSet<String>& animationsToRemove);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -265,8 +265,8 @@ public:
 
     void setClonedLayer(const PlatformCALayer*);
 
-    LayerProperties& properties() { return m_properties; }
-    const LayerProperties& properties() const { return m_properties; }
+    LayerProperties& properties() LIFETIME_BOUND { return m_properties; }
+    const LayerProperties& properties() const LIFETIME_BOUND { return m_properties; }
 
     void didCommit();
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -93,7 +93,7 @@ public:
 
     void willStartAnimationOnLayer(PlatformCALayerRemote&);
 
-    RemoteLayerBackingStoreCollection& backingStoreCollection() { return m_backingStoreCollection; }
+    RemoteLayerBackingStoreCollection& backingStoreCollection() LIFETIME_BOUND { return m_backingStoreCollection; }
 
     void adoptLayersFromContext(RemoteLayerTreeContext&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -628,7 +628,7 @@ public:
     bool usesEphemeralSession() const;
 
     void setSize(const WebCore::IntSize&);
-    const WebCore::IntSize& size() const { return m_viewSize; }
+    const WebCore::IntSize& size() const LIFETIME_BOUND { return m_viewSize; }
     inline WebCore::IntRect bounds() const;
 
     DrawingArea* drawingArea() const { return m_drawingArea.get(); }
@@ -638,7 +638,7 @@ public:
 #endif
 
 #if HAVE(NSVIEW_CORNER_CONFIGURATION)
-    const WebCore::CornerRadii& scrollbarAvoidanceCornerRadii() const { return m_scrollbarAvoidanceCornerRadii; }
+    const WebCore::CornerRadii& scrollbarAvoidanceCornerRadii() const LIFETIME_BOUND { return m_scrollbarAvoidanceCornerRadii; }
 #endif
 
     WebPageGroupProxy* pageGroup() const { return m_pageGroup.get(); }
@@ -773,7 +773,7 @@ public:
 
     void animationDidFinishForElement(const WebCore::Element&);
 
-    const String& overrideContentSecurityPolicy() const { return m_overrideContentSecurityPolicy; }
+    const String& overrideContentSecurityPolicy() const LIFETIME_BOUND { return m_overrideContentSecurityPolicy; }
 
     WebUndoStep* webUndoStep(WebUndoStepID);
     void addWebUndoStep(WebUndoStepID, Ref<WebUndoStep>&&);
@@ -819,13 +819,13 @@ public:
     void setInjectedBundleUIClient(std::unique_ptr<API::InjectedBundle::PageUIClient>&&);
 
 #if ENABLE(CONTEXT_MENUS)
-    API::InjectedBundle::PageContextMenuClient& injectedBundleContextMenuClient() { return *m_contextMenuClient; }
+    API::InjectedBundle::PageContextMenuClient& injectedBundleContextMenuClient() LIFETIME_BOUND { return *m_contextMenuClient; }
 #endif
-    API::InjectedBundle::EditorClient& injectedBundleEditorClient() { return *m_editorClient; }
-    API::InjectedBundle::FormClient& injectedBundleFormClient() { return *m_formClient; }
-    API::InjectedBundle::PageLoaderClient& injectedBundleLoaderClient() { return *m_loaderClient; }
-    API::InjectedBundle::ResourceLoadClient& injectedBundleResourceLoadClient() { return *m_resourceLoadClient; }
-    API::InjectedBundle::PageUIClient& injectedBundleUIClient() { return *m_uiClient; }
+    API::InjectedBundle::EditorClient& injectedBundleEditorClient() LIFETIME_BOUND { return *m_editorClient; }
+    API::InjectedBundle::FormClient& injectedBundleFormClient() LIFETIME_BOUND { return *m_formClient; }
+    API::InjectedBundle::PageLoaderClient& injectedBundleLoaderClient() LIFETIME_BOUND { return *m_loaderClient; }
+    API::InjectedBundle::ResourceLoadClient& injectedBundleResourceLoadClient() LIFETIME_BOUND { return *m_resourceLoadClient; }
+    API::InjectedBundle::PageUIClient& injectedBundleUIClient() LIFETIME_BOUND { return *m_uiClient; }
 
     void replaceStringMatchesFromInjectedBundle(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly);
 
@@ -963,8 +963,8 @@ public:
 
 #if PLATFORM(COCOA)
     void updatePluginsActiveAndFocusedState();
-    const WebCore::FloatRect& windowFrameInUnflippedScreenCoordinates() const { return m_windowFrameInUnflippedScreenCoordinates; }
-    const WebCore::FloatRect& viewFrameInWindowCoordinates() const { return m_viewFrameInWindowCoordinates; }
+    const WebCore::FloatRect& windowFrameInUnflippedScreenCoordinates() const LIFETIME_BOUND { return m_windowFrameInUnflippedScreenCoordinates; }
+    const WebCore::FloatRect& viewFrameInWindowCoordinates() const LIFETIME_BOUND { return m_viewFrameInWindowCoordinates; }
 
     bool hasCachedWindowFrame() const { return m_hasCachedWindowFrame; }
 
@@ -1030,11 +1030,11 @@ public:
 
     static const WebEvent* NODELETE currentEvent();
 
-    FindController& findController() { return m_findController.get(); }
-    WebFoundTextRangeController& foundTextRangeController() { return m_foundTextRangeController.get(); }
+    FindController& findController() LIFETIME_BOUND { return m_findController.get(); }
+    WebFoundTextRangeController& foundTextRangeController() LIFETIME_BOUND { return m_foundTextRangeController.get(); }
 
 #if ENABLE(GEOLOCATION)
-    GeolocationPermissionRequestManager& geolocationPermissionRequestManager() { return m_geolocationPermissionRequestManager.get(); }
+    GeolocationPermissionRequestManager& geolocationPermissionRequestManager() LIFETIME_BOUND { return m_geolocationPermissionRequestManager.get(); }
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -1043,14 +1043,14 @@ public:
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-    UserMediaPermissionRequestManager& userMediaPermissionRequestManager() { return m_userMediaPermissionRequestManager; }
+    UserMediaPermissionRequestManager& userMediaPermissionRequestManager() LIFETIME_BOUND { return m_userMediaPermissionRequestManager; }
     void captureDevicesChanged();
     void updateCaptureState(const WebCore::Document&, bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
     void voiceActivityDetected();
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    MediaKeySystemPermissionRequestManager& mediaKeySystemPermissionRequestManager() { return m_mediaKeySystemPermissionRequestManager; }
+    MediaKeySystemPermissionRequestManager& mediaKeySystemPermissionRequestManager() LIFETIME_BOUND { return m_mediaKeySystemPermissionRequestManager; }
 #endif
 
     void copyLinkWithHighlight();
@@ -1279,7 +1279,7 @@ public:
         RefPtr<SandboxExtension> m_committedSandboxExtension;
     };
 
-    SandboxExtensionTracker& sandboxExtensionTracker() { return m_sandboxExtensionTracker; }
+    SandboxExtensionTracker& sandboxExtensionTracker() LIFETIME_BOUND { return m_sandboxExtensionTracker; }
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void cancelComposition(const String& text);
@@ -1318,7 +1318,7 @@ public:
 #endif
     NSObject *accessibilityObjectForMainFramePlugin();
     bool shouldFallbackToWebContentAXObjectForMainFramePlugin() const;
-    const WebCore::FloatPoint& accessibilityPosition() const { return m_accessibilityPosition; }
+    const WebCore::FloatPoint& accessibilityPosition() const LIFETIME_BOUND { return m_accessibilityPosition; }
 
     void setTextAsync(const String&);
     void insertTextAsync(const String& text, const EditingRange& replacementRange, InsertTextOptions&&);
@@ -1552,7 +1552,7 @@ public:
 #if ENABLE(META_VIEWPORT)
     void setViewportConfigurationViewLayoutSize(const WebCore::FloatSize&, double layoutSizeScaleFactorFromClient, double minimumEffectiveDeviceWidth);
     void setOverrideViewportArguments(const std::optional<WebCore::ViewportArguments>&);
-    const WebCore::ViewportConfiguration& viewportConfiguration() const { return m_viewportConfiguration; }
+    const WebCore::ViewportConfiguration& viewportConfiguration() const LIFETIME_BOUND { return m_viewportConfiguration; }
 
     void setUseTestingViewportConfiguration(bool useTestingViewport) { m_useTestingViewportConfiguration = useTestingViewport; }
     bool isUsingTestingViewportConfiguration() const { return m_useTestingViewportConfiguration; }
@@ -1820,7 +1820,7 @@ public:
     WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const String& originIdentifier);
     WebCore::IntRect rectForElementAtInteractionLocation() const;
 
-    const std::optional<WebCore::Color>& backgroundColor() const { return m_backgroundColor; }
+    const std::optional<WebCore::Color>& backgroundColor() const LIFETIME_BOUND { return m_backgroundColor; }
 
     void suspendAllMediaBuffering();
     void resumeAllMediaBuffering();
@@ -1838,7 +1838,7 @@ public:
 #endif
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
-    TextCheckingControllerProxy& textCheckingController() { return m_textCheckingControllerProxy.get(); }
+    TextCheckingControllerProxy& textCheckingController() LIFETIME_BOUND { return m_textCheckingControllerProxy.get(); }
 #endif
 
 #if PLATFORM(COCOA)
@@ -1884,7 +1884,7 @@ public:
     void requestPasswordForQuickLookDocumentInMainFrame(const String& fileName, CompletionHandler<void(const String&)>&&);
 #endif
 
-    const AtomString& overriddenMediaType() const { return m_overriddenMediaType; }
+    const AtomString& overriddenMediaType() const LIFETIME_BOUND { return m_overriddenMediaType; }
     void setOverriddenMediaType(const String&);
 
     void updateCORSDisablingPatterns(Vector<String>&&);
@@ -1994,7 +1994,7 @@ public:
 #endif
 
 #if ENABLE(WEBXR)
-    PlatformXRSystemProxy& NODELETE xrSystemProxy();
+    PlatformXRSystemProxy& NODELETE xrSystemProxy() LIFETIME_BOUND;
 #endif
 
     void prepareToRunModalJavaScriptDialog();
@@ -2070,13 +2070,13 @@ public:
     uint64_t NODELETE logIdentifier() const;
 
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && (USE(GBM) || OS(ANDROID))
-    const Vector<RendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
+    const Vector<RendererBufferFormat>& preferredBufferFormats() const LIFETIME_BOUND { return m_preferredBufferFormats; }
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    const String& mediaPlaybackEnvironment() const { return m_mediaPlaybackEnvironment; }
+    const String& mediaPlaybackEnvironment() const LIFETIME_BOUND { return m_mediaPlaybackEnvironment; }
     void setMediaPlaybackEnvironment(const String&);
-    const String& displayCaptureEnvironment() const { return m_displayCaptureEnvironment; }
+    const String& displayCaptureEnvironment() const LIFETIME_BOUND { return m_displayCaptureEnvironment; }
     void setDisplayCaptureEnvironment(const String&);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
@@ -87,7 +87,7 @@ public:
     void clear();
 
     WebCore::PageOverlay* coreOverlay() const { return m_overlay.get(); }
-    Client& client() const { return *m_client; }
+    Client& client() const LIFETIME_BOUND { return *m_client; }
 
 #if PLATFORM(MAC)
     struct ActionContext {

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
@@ -49,7 +49,7 @@ public:
         return adoptRef(*new WebURLSchemeTaskProxy(handler, loader, webFrame));
     }
     
-    const WebCore::ResourceRequest& request() const { return m_request; }
+    const WebCore::ResourceRequest& request() const LIFETIME_BOUND { return m_request; }
 
     void startLoading();
     void stopLoading();

--- a/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h
@@ -47,7 +47,7 @@ public:
         void addDirtyRect(const WebCore::IntRect&);
         void clearDirtyRect();
         bool hasDirtyRect() const;
-        WebCore::IntRect& dirtyRect() { return m_dirtyRect; }
+        WebCore::IntRect& dirtyRect() LIFETIME_BOUND { return m_dirtyRect; }
 
     private:
         bool m_willRemove { false };
@@ -59,7 +59,7 @@ public:
     void addDirtyRect(const WebCore::IntRect&);
     void clearDirtyRects();
     bool setCoverageRect(const WebCore::IntRect&);
-    auto& tiles() { return m_tiles; }
+    auto& tiles() LIFETIME_BOUND { return m_tiles; }
     WebCore::IntSize tilePixelSize() const;
 
 private:

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -284,13 +284,13 @@ public:
     OptionSet<TextCheckerState> textCheckerState() const { return m_textCheckerState; }
     void setTextCheckerState(OptionSet<TextCheckerState>);
 
-    EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
+    EventDispatcher& eventDispatcher() LIFETIME_BOUND { return m_eventDispatcher; }
 
     NetworkProcessConnection& ensureNetworkProcessConnection();
 
     void networkProcessConnectionClosed(NetworkProcessConnection*);
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
-    WebLoaderStrategy& NODELETE webLoaderStrategy();
+    WebLoaderStrategy& NODELETE webLoaderStrategy() LIFETIME_BOUND;
     WebFileSystemStorageConnection& fileSystemStorageConnection();
 
     RefPtr<WebTransportSession> webTransportSession(WebTransportSessionIdentifier);
@@ -298,7 +298,7 @@ public:
     void removeWebTransportSession(WebTransportSessionIdentifier);
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
-    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return m_sharedPreferencesForWebProcess; }
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const LIFETIME_BOUND { return m_sharedPreferencesForWebProcess; }
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess); }
 
 #if USE(LIBRICE)
@@ -366,7 +366,7 @@ public:
     void releaseSystemMallocMemory();
 #endif
 
-    const String& uiProcessBundleIdentifier() const { return m_uiProcessBundleIdentifier; }
+    const String& uiProcessBundleIdentifier() const LIFETIME_BOUND { return m_uiProcessBundleIdentifier; }
 
     void updateActivePages(const String& overrideDisplayName);
     void getActivePagesOriginsForTesting(CompletionHandler<void(Vector<String>&&)>&&);
@@ -397,7 +397,7 @@ public:
 
     void prefetchDNS(const String&);
 
-    WebAutomationSessionProxy* automationSessionProxy() { return m_automationSessionProxy.get(); }
+    WebAutomationSessionProxy* automationSessionProxy() LIFETIME_BOUND { return m_automationSessionProxy.get(); }
 #if ENABLE(MODEL_PROCESS)
     ModelProcessModelPlayerManager& modelProcessModelPlayerManager() { return m_modelProcessModelPlayerManager.get(); }
 #endif
@@ -411,7 +411,7 @@ public:
 #endif
     WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }
-    WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
+    WebSocketChannelManager& webSocketChannelManager() LIFETIME_BOUND { return m_webSocketChannelManager; }
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     float backlightLevel() const { return m_backlightLevel; }
@@ -512,9 +512,9 @@ public:
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    const OptionSet<RendererBufferTransportMode>& rendererBufferTransportMode() const { return m_rendererBufferTransportMode; }
+    const OptionSet<RendererBufferTransportMode>& rendererBufferTransportMode() const LIFETIME_BOUND { return m_rendererBufferTransportMode; }
     void initializePlatformDisplayIfNeeded() const;
-    const OptionSet<AvailableInputDevices>& availableInputDevices() const { return m_availableInputDevices; }
+    const OptionSet<AvailableInputDevices>& availableInputDevices() const LIFETIME_BOUND { return m_availableInputDevices; }
     std::optional<AvailableInputDevices> primaryPointingDevice() const;
     void setAvailableInputDevices(OptionSet<AvailableInputDevices>);
 #endif // PLATFORM(WPE)
@@ -526,7 +526,7 @@ public:
     void updateCachedCookiesEnabled();
     void enableMediaPlayback();
 #if ENABLE(ROUTING_ARBITRATION)
-    AudioSessionRoutingArbitrator* audioSessionRoutingArbitrator() const { return m_routingArbitrator.get(); }
+    AudioSessionRoutingArbitrator* audioSessionRoutingArbitrator() const LIFETIME_BOUND { return m_routingArbitrator.get(); }
 #endif
 
     bool mediaPlaybackEnabled() const { return m_mediaPlaybackEnabled; }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -68,13 +68,13 @@ protected:
     RemoteRealtimeMediaSource(RemoteRealtimeMediaSourceProxy&&, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, std::optional<WebCore::PageIdentifier>);
     void createRemoteMediaSource();
 
-    RemoteRealtimeMediaSourceProxy& proxy() { return m_proxy; }
+    RemoteRealtimeMediaSourceProxy& proxy() LIFETIME_BOUND { return m_proxy; }
     inline UserMediaCaptureManager& manager(); // Defined in RemoteRealtimeMediaSourceInlines.h.
 
     void setCapabilities(WebCore::RealtimeMediaSourceCapabilities&&);
 
-    const WebCore::RealtimeMediaSourceSettings& settings() final { return m_settings; }
-    const WebCore::RealtimeMediaSourceCapabilities& capabilities() final { return m_capabilities; }
+    const WebCore::RealtimeMediaSourceSettings& settings() LIFETIME_BOUND final { return m_settings; }
+    const WebCore::RealtimeMediaSourceCapabilities& capabilities() LIFETIME_BOUND final { return m_capabilities; }
 
     Ref<TakePhotoNativePromise> takePhoto(WebCore::PhotoSettings&&) final;
     Ref<PhotoCapabilitiesNativePromise> getPhotoCapabilities() final;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -54,7 +54,7 @@ public:
     IPC::Connection& connection() { return m_connection.get(); }
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_identifier; }
     WebCore::CaptureDevice::DeviceType deviceType() const { return m_device.type(); }
-    const WebCore::CaptureDevice& device() const { return m_device; }
+    const WebCore::CaptureDevice& device() const LIFETIME_BOUND { return m_device; }
     bool shouldCaptureInGPUProcess() const { return m_shouldCaptureInGPUProcess; }
 
     using CreateCallback = CompletionHandler<void(WebCore::CaptureSourceError&&, WebCore::RealtimeMediaSourceSettings&&, WebCore::RealtimeMediaSourceCapabilities&&)>;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -78,7 +78,7 @@ public:
     void addSource(Ref<RemoteRealtimeVideoSource>&&);
     void removeSource(WebCore::RealtimeMediaSourceIdentifier);
 
-    RemoteCaptureSampleManager& remoteCaptureSampleManager() { return m_remoteCaptureSampleManager; }
+    RemoteCaptureSampleManager& remoteCaptureSampleManager() LIFETIME_BOUND { return m_remoteCaptureSampleManager; }
     bool shouldUseGPUProcessRemoteFrames() const { return m_shouldUseGPUProcessRemoteFrames; }
 
 private:

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -80,7 +80,7 @@ public:
     }
     virtual ~VideoPresentationInterfaceContext();
 
-    LayerHostingContext* layerHostingContext() { return m_layerHostingContext.get(); }
+    LayerHostingContext* layerHostingContext() LIFETIME_BOUND { return m_layerHostingContext.get(); }
     void setLayerHostingContext(std::unique_ptr<LayerHostingContext>&&);
 
     enum class AnimationType { None, IntoFullscreen, FromFullscreen };


### PR DESCRIPTION
#### 93c988d656bbd9fd9e3a3203a84da7a053a6ceb9
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in Source/WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=308882">https://bugs.webkit.org/show_bug.cgi?id=308882</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
(WebKit::WebExtensionAPIEvent::listeners const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h:
(WebKit::WebExtensionAPIMenus::clickHandlers const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::propertyPath const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
(WebKit::WebExtensionAPIPort::senderParameters const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
(WebKit::WebExtensionAPIWebNavigationEvent::listeners const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
(WebKit::WebExtensionAPIWebRequestEvent::listeners const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
(WebKit::WebExtensionAPIWindowsEvent::listeners const): Deleted.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
(WebKit::GPUProcessConnection::messageReceiverMap): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.h:
(WebKit::InjectedBundleHitTestResult::coreHitTestResult const): Deleted.
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h:
(WebKit::WebMediaKeyStorageManager::mediaKeyStorageDirectory const): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessConnection.h:
(WebKit::ModelProcessConnection::messageReceiverMap): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h:
(WebKit::WebRTCMonitor::networkList const): Deleted.
(WebKit::WebRTCMonitor::ipv4 const): Deleted.
(WebKit::WebRTCMonitor::ipv6 const): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h:
(WebKit::WebRTCNetworkBase::mdnsRegister): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingRunLoop.h:
(WebKit::CompositingRunLoop::stateLock): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
(WebKit::PlatformCALayerRemote::properties): Deleted.
(WebKit::PlatformCALayerRemote::properties const): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::backingStoreCollection): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.h:
(WebKit::WebPageOverlay::client const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h:
(WebKit::WebURLSchemeTaskProxy::request const): Deleted.
* Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h:
(WebKit::WCTileGrid::Tile::dirtyRect): Deleted.
(WebKit::WCTileGrid::tiles): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
(WebKit::RemoteRealtimeMediaSource::proxy): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:
(WebKit::RemoteRealtimeMediaSourceProxy::device const): Deleted.
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:

Canonical link: <a href="https://commits.webkit.org/308407@main">https://commits.webkit.org/308407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c86e24e087ca6dfa5d3bf1b6d67239d700a20e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78a68d5b-89cc-4e84-a49f-94ae4ccedb5c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113629 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81028 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd8d0467-9959-44b1-a71a-5f1db6c9862e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94389 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19ee1694-f17c-49e4-9be4-7fb90ca9a779) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15026 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3556 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124622 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158447 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121657 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121856 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31206 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75920 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8895 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83295 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19262 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19413 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->