### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in Source/WebKit

### DIFF
--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -84,7 +84,7 @@ public:
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess); }
 
     IPC::Connection& connection() { return m_connection.get(); }
-    IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
+    IPC::MessageReceiverMap& messageReceiverMap() LIFETIME_BOUND { return m_messageReceiverMap; }
     ModelProcess& modelProcess() { return m_modelProcess.get(); }
     WebCore::ProcessIdentifier webProcessIdentifier() const { return m_webProcessIdentifier; }
 
@@ -94,7 +94,7 @@ public:
 
     Logger& NODELETE logger();
 
-    const WebCore::ProcessIdentity& webProcessIdentity() const { return m_webProcessIdentity; }
+    const WebCore::ProcessIdentity& webProcessIdentity() const LIFETIME_BOUND { return m_webProcessIdentity; }
 
     void didUnloadModelPlayer(WebCore::ModelPlayerIdentifier);
     bool allowsExitUnderMemoryPressure() const;

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -76,7 +76,7 @@ public:
 
     void tryExitIfUnusedAndUnderMemoryPressure();
 
-    const String& applicationVisibleName() const { return m_applicationVisibleName; }
+    const String& applicationVisibleName() const LIFETIME_BOUND { return m_applicationVisibleName; }
 
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS)
     void requestSharedSimulationConnection(WebCore::ProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&&);

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -89,7 +89,7 @@ public:
     virtual void connectionReceivedEvent(xpc_object_t) = 0;
 #endif
 
-    const CString& machServiceName() const { return m_machServiceName; }
+    const CString& machServiceName() const LIFETIME_BOUND { return m_machServiceName; }
 
 protected:
     explicit ConnectionToMachService(CString&& machServiceName)

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -178,14 +178,14 @@ public:
     }
 
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
-    AllowedClassHashSet& allowedClasses() { return m_allowedClasses; }
+    AllowedClassHashSet& allowedClasses() LIFETIME_BOUND { return m_allowedClasses; }
 #endif // !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 #endif // __OBJC__
 
     std::optional<Attachment> takeLastAttachment();
 
     void addIndexOfDecodingFailure(uint32_t indexOfObjectFailingDecoding) { m_indicesOfObjectsFailingDecoding.append(indexOfObjectFailingDecoding); }
-    const Vector<uint32_t>& indicesOfObjectsFailingDecoding() const { return m_indicesOfObjectsFailingDecoding; }
+    const Vector<uint32_t>& indicesOfObjectsFailingDecoding() const LIFETIME_BOUND { return m_indicesOfObjectsFailingDecoding; }
 
 private:
     Decoder(std::span<const uint8_t> buffer, BufferDeallocator&&, Vector<Attachment>&&);

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -49,7 +49,7 @@ public:
     void removeStreamConnection(StreamServerConnection&);
     void stopAndWaitForCompletion(NOESCAPE WTF::Function<void()>&& cleanupFunction = nullptr);
     void wakeUp();
-    Semaphore& wakeUpSemaphore() { return m_wakeUpSemaphore; }
+    Semaphore& wakeUpSemaphore() LIFETIME_BOUND { return m_wakeUpSemaphore; }
 
     // SerialFunctionDispatcher
     void dispatch(WTF::Function<void()>&&) final;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -121,7 +121,7 @@ public:
     template<typename T, typename... Arguments>
     void sendAsyncReply(AsyncReplyID, Arguments&&...);
 
-    Semaphore& clientWaitSemaphore() { return m_clientWaitSemaphore; }
+    Semaphore& clientWaitSemaphore() LIFETIME_BOUND { return m_clientWaitSemaphore; }
 
 private:
     StreamServerConnection(Ref<Connection>, StreamServerConnectionBuffer&&);

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -134,8 +134,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             fastFree(m_body.data());
     }
 
-    const Vector<Attachment>& attachments() const { return m_attachments; }
-    MessageInfo& messageInfo() { return m_messageInfo; }
+    const Vector<Attachment>& attachments() const LIFETIME_BOUND { return m_attachments; }
+    MessageInfo& messageInfo() LIFETIME_BOUND { return m_messageInfo; }
 
     std::span<uint8_t> body() const { return m_body; }
     size_t bodySize() const  { return m_messageInfo.bodySize(); }

--- a/Source/WebKit/Platform/cocoa/AssertionCapability.h
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.h
@@ -38,8 +38,8 @@ class AssertionCapability final : public ExtensionCapability {
 public:
     AssertionCapability(String environmentIdentifier, String domain, String name, Function<void()>&& willInvalidateFunction = nullptr, Function<void()>&& didInvalidateFunction = nullptr);
 
-    const String& domain() const { return m_domain; }
-    const String& name() const { return m_name; }
+    const String& domain() const LIFETIME_BOUND { return m_domain; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
     // ExtensionCapability
     String environmentIdentifier() const final { return m_environmentIdentifier; }

--- a/Source/WebKit/Platform/cocoa/ExtensionCapability.h
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapability.h
@@ -40,7 +40,7 @@ class ExtensionCapability {
 public:
     virtual ~ExtensionCapability() = default;
     virtual String environmentIdentifier() const = 0;
-    const PlatformCapability& platformCapability() const { return m_platformCapability; }
+    const PlatformCapability& platformCapability() const LIFETIME_BOUND { return m_platformCapability; }
 
     bool hasPlatformCapability() const { return platformCapabilityIsValid(m_platformCapability); }
 

--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h
@@ -47,7 +47,7 @@ public:
     ExtensionCapabilityGrant& operator=(ExtensionCapabilityGrant&&) = default;
     ExtensionCapabilityGrant isolatedCopy() &&;
 
-    const String& environmentIdentifier() const { return m_environmentIdentifier; }
+    const String& environmentIdentifier() const LIFETIME_BOUND { return m_environmentIdentifier; }
     bool isEmpty() const;
     bool isValid() const;
 

--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -68,7 +68,7 @@ public:
     void setState(State state) { m_state = state; }
     bool isActivatingOrActive() const;
 
-    const URL& webPageURL() const { return m_webPageURL; }
+    const URL& webPageURL() const LIFETIME_BOUND { return m_webPageURL; }
 
     // ExtensionCapability
     String environmentIdentifier() const final;

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h
@@ -38,7 +38,7 @@ public:
 
     ~MediaPlaybackTargetSerialized();
 
-    const MediaPlaybackTargetContextSerialized& context() const { return m_context; }
+    const MediaPlaybackTargetContextSerialized& context() const LIFETIME_BOUND { return m_context; }
 
 private:
     explicit MediaPlaybackTargetSerialized(MediaPlaybackTargetContextSerialized&&);

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -94,8 +94,8 @@ public:
     virtual void present(UIViewController *, CompletionHandler<void(bool)>&&) = 0;
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
     virtual void presentInScene(const String& sceneIdentifier, const String& bundleIdentifier, CompletionHandler<void(bool)>&&) = 0;
-    const String& sceneIdentifier() const { return m_sceneIdentifier; }
-    const String& bundleIdentifier() const { return m_bundleIdentifier; }
+    const String& sceneIdentifier() const LIFETIME_BOUND { return m_sceneIdentifier; }
+    const String& bundleIdentifier() const LIFETIME_BOUND { return m_bundleIdentifier; }
 #endif
 #endif
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -123,7 +123,7 @@ public:
         });
     }
 
-    const BackingDataType& cachedListData() const { return m_cachedListData; }
+    const BackingDataType& cachedListData() const LIFETIME_BOUND { return m_cachedListData; }
 
 protected:
     friend class NeverDestroyed<DerivedType, MainRunLoopAccessTraits>;

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
@@ -48,7 +48,7 @@ public:
     std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
     WebCore::HTMLMediaElementIdentifier mediaElementIdentifier() const { return m_mediaElementIdentifier; }
     std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
-    const WebCore::VideoReceiverEndpoint& endpoint() const { return m_endpoint; }
+    const WebCore::VideoReceiverEndpoint& endpoint() const LIFETIME_BOUND { return m_endpoint; }
     WebCore::VideoReceiverEndpointIdentifier endpointIdentifier() const { return m_endpointIdentifier; }
 
 private:

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -82,13 +82,13 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     std::optional<WebCore::PushSubscriptionSetIdentifier> subscriptionSetIdentifierForOrigin(const WebCore::SecurityOriginData&) const;
-    const String& hostAppCodeSigningIdentifier() const { return m_hostAppCodeSigningIdentifier; }
+    const String& hostAppCodeSigningIdentifier() const LIFETIME_BOUND { return m_hostAppCodeSigningIdentifier; }
     bool hostAppHasPushInjectEntitlement() const { return m_hostAppHasPushInjectEntitlement; };
     std::optional<WTF::UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
     bool declarativeWebPushEnabled() const { return m_declarativeWebPushEnabled; }
 
     // You almost certainly do not want to use this and should probably use subscriptionSetIdentifierForOrigin instead.
-    const String& pushPartitionIfExists() const { return m_pushPartitionString; }
+    const String& pushPartitionIfExists() const LIFETIME_BOUND { return m_pushPartitionString; }
 
     String debugDescription() const;
 

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -90,7 +90,7 @@ public:
     void handleIncomingPush(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
 
 #if PLATFORM(IOS)
-    WebClipCache& ensureWebClipCache();
+    WebClipCache& ensureWebClipCache() LIFETIME_BOUND;
 #endif
 
     // Message handlers


### PR DESCRIPTION
#### 92d46f7506c61bfcdb73d36c2f5dffc87844eeea
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=308883">https://bugs.webkit.org/show_bug.cgi?id=308883</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
(WebKit::ModelConnectionToWebProcess::messageReceiverMap): Deleted.
(WebKit::ModelConnectionToWebProcess::webProcessIdentity const): Deleted.
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/Platform/IPC/DaemonConnection.h:
(WebKit::Daemon::ConnectionToMachService::machServiceName const): Deleted.
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::allowedClasses): Deleted.
(IPC::Decoder::indicesOfObjectsFailingDecoding const): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
(IPC::UnixMessage::attachments const): Deleted.
(IPC::UnixMessage::messageInfo): Deleted.
* Source/WebKit/Platform/cocoa/AssertionCapability.h:
* Source/WebKit/Platform/cocoa/ExtensionCapability.h:
(WebKit::ExtensionCapability::platformCapability const): Deleted.
* Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h:
(WebKit::ExtensionCapabilityGrant::environmentIdentifier const): Deleted.
* Source/WebKit/Platform/cocoa/MediaCapability.h:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetSerialized.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
(WebKit::PaymentAuthorizationPresenter::sceneIdentifier const): Deleted.
(WebKit::PaymentAuthorizationPresenter::bundleIdentifier const): Deleted.
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
(WebKit::ListDataController::cachedListData const): Deleted.
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h:
(WebKit::VideoReceiverEndpointMessage::endpoint const): Deleted.
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::PushClientConnection::hostAppCodeSigningIdentifier const): Deleted.
(WebPushD::PushClientConnection::pushPartitionIfExists const): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:

Canonical link: <a href="https://commits.webkit.org/308418@main">https://commits.webkit.org/308418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96e22aa64be9e035d6bbc85729f67ce4e96dc835

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100890 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3df2d82d-08c7-482a-ba33-8f53885515cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113666 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81063 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/517b21c6-4c77-4ff7-bb3e-9db92db17157) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94426 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dca4e95-a7f7-4d46-b0fd-1730cfc26549) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15065 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12854 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3598 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124661 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158490 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1627 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121694 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31214 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75999 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8936 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83337 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19362 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->