### PR TITLE
WKTR: use nested event loop for PopUpMenu

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -664,6 +664,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html [ Skip ]
 
 # List boxes/<select multiple>.
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-listbox/ [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
@@ -3,5 +3,5 @@ details
 
 PASS The dialog element should support :open.
 PASS The details element should support :open.
-FAIL The select element should support :open. assert_true: :open should match when the select is open. expected true got false
+PASS The select element should support :open.
 

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -67,8 +67,12 @@
 
 namespace WTR {
 
+static __weak NSMenu *gCurrentPopUpMenu;
+
 void TestController::notifyDone()
 {
+    if (RetainPtr menu = gCurrentPopUpMenu)
+        [menu cancelTracking];
 }
 
 static PlatformWindow wtr_NSApplication_keyWindow(id self, SEL _cmd)
@@ -87,7 +91,6 @@ static Class menuImplClassSingleton()
     return menuImplClass;
 }
 
-static __weak NSMenu *gCurrentPopUpMenu = nil;
 static void setSwizzledPopUpMenu(NSMenu *menu)
 {
     if (gCurrentPopUpMenu == menu)
@@ -112,6 +115,9 @@ static void swizzledPopUpContextMenu(Class, SEL, NSMenu *menu, NSEvent *event, N
 static void swizzledPopUpMenu(id, SEL, NSMenu *menu, NSPoint, CGFloat, NSView *, NSInteger, NSFont *, NSUInteger, NSDictionary *)
 {
     setSwizzledPopUpMenu(menu);
+
+    while (gCurrentPopUpMenu)
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
 }
 
 static void swizzledCancelTracking(NSMenu *menu, SEL)
@@ -182,6 +188,9 @@ void TestController::initializeTestPluginDirectory()
 
 bool TestController::platformResetStateToConsistentValues(const TestOptions& options)
 {
+    if (RetainPtr menu = gCurrentPopUpMenu)
+        [menu cancelTracking];
+
     cocoaResetStateToConsistentValues(options);
 
     if (RetainPtr webView = m_mainWebView ? m_mainWebView->platformView() : nil) {


### PR DESCRIPTION
#### 001d79b4c01575fa85c20ae474abba67571f4034
<pre>
WKTR: use nested event loop for PopUpMenu
<a href="https://bugs.webkit.org/show_bug.cgi?id=308884">https://bugs.webkit.org/show_bug.cgi?id=308884</a>
<a href="https://rdar.apple.com/171980750">rdar://171980750</a>

Reviewed by Charlie Wolfe.

At the moment you cannot open a &lt;select&gt; on macOS from WebKitTestRunner
without it immediately closing due to how NSMenu is swizzled in
TestController::platformInitialize().

We adjust this implementation with a nested event loop, similar to how
it&apos;s handled in the browser. This works because of 308928@main,
308970@main, and 309000@main paving the way.

This also exposes an assert in
imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html
and progresses
/imported/w3c/web-platform-tests/css/selectors/open-pseudo.html.

Canonical link: <a href="https://commits.webkit.org/309039@main">https://commits.webkit.org/309039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32ed4a4369683ff9fc615f5f9d582f2ee7c8790d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157967 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f8ba2e5-16fe-4c1a-9fd2-eff62e3471aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115092 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9e285d3-2f13-4eb8-b353-819f75fe106b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17249 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95841 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5817 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160452 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13411 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123358 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133675 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18589 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21400 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21281 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->