### PR TITLE
[GLIB] Reduce unsafe buffer usage in remote inspector code

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
@@ -135,10 +135,14 @@ void RemoteInspectorProtocolHandler::handleRequest(WebKitURISchemeRequest* reque
     }).iterator->value.get();
     webViewResult.iterator->value = client;
 
-    auto* html = client->buildTargetListPage(RemoteInspectorClient::InspectorType::UI);
-    gsize streamLength = html->len;
-    GRefPtr<GInputStream> stream = adoptGRef(g_memory_input_stream_new_from_data(g_string_free(html, FALSE), streamLength, g_free));
-    webkit_uri_scheme_request_finish(request, stream.get(), streamLength, "text/html");
+    auto html = client->buildTargetListPage(RemoteInspectorClient::InspectorType::UI).toString().utf8();
+    RefPtr buffer = html.buffer();
+    auto span = buffer->span();
+    GRefPtr bytes = adoptGRef(g_bytes_new_with_free_func(span.data(), span.size(), [](void* data) {
+        static_cast<WTF::CStringBuffer*>(data)->deref();
+    }, buffer.leakRef()));
+    GRefPtr stream = adoptGRef(g_memory_input_stream_new_from_bytes(bytes.get()));
+    webkit_uri_scheme_request_finish(request, stream.get(), html.length(), "text/html");
 }
 
 void RemoteInspectorProtocolHandler::inspect(const String& hostAndPort, uint64_t connectionID, uint64_t tatgetID, const String& targetType)
@@ -153,13 +157,12 @@ void RemoteInspectorProtocolHandler::updateTargetList(WebKitWebView* webView)
     if (!clientForWebView)
         return;
 
-    GString* script = g_string_new("document.getElementById('targetlist').innerHTML='");
-    clientForWebView->appendTargetList(script, RemoteInspectorClient::InspectorType::UI, RemoteInspectorClient::ShouldEscapeSingleQuote::Yes);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port
-    g_string_append(script, "';");
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    webkit_web_view_evaluate_javascript(webView, script->str, script->len, nullptr, nullptr, nullptr, nullptr, nullptr);
-    g_string_free(script, TRUE);
+    StringBuilder scriptBuilder;
+    scriptBuilder.append("document.getElementById('targetlist').innerHTML='"_s);
+    clientForWebView->appendTargetList(scriptBuilder, RemoteInspectorClient::InspectorType::UI, RemoteInspectorClient::ShouldEscapeSingleQuote::Yes);
+    scriptBuilder.append("';"_s);
+    auto script = scriptBuilder.toString().utf8();
+    webkit_web_view_evaluate_javascript(webView, script.data(), script.length(), nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 void RemoteInspectorProtocolHandler::webViewLoadChanged(WebKitWebView* webView, WebKitLoadEvent event, RemoteInspectorProtocolHandler* handler)

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -297,53 +297,49 @@ void RemoteInspectorClient::sendMessageToFrontend(uint64_t connectionID, uint64_
     proxy->sendMessageToFrontend(String::fromUTF8(message));
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-
-void RemoteInspectorClient::appendTargetList(GString* html, InspectorType inspectorType, ShouldEscapeSingleQuote escapeSingleQuote) const
+void RemoteInspectorClient::appendTargetList(StringBuilder& html, InspectorType inspectorType, ShouldEscapeSingleQuote escapeSingleQuote) const
 {
     if (m_targets.isEmpty())
-        g_string_append(html, "<p>No targets found</p>");
+        html.append("<p>No targets found</p>"_s);
     else {
-        g_string_append(html, "<table>");
+        html.append("<table>"_s);
         for (auto connectionID : m_targets.keys()) {
             for (auto& target : m_targets.get(connectionID)) {
-                g_string_append_printf(html,
-                    "<tbody><tr>"
-                    "<td class=\"data\"><div class=\"targetname\">%s</div><div class=\"targeturl\">%s</div></td>"
-                    "<td class=\"input\"><input type=\"button\" value=\"Inspect\" onclick=",
-                    target.name.data(), target.url.data());
+                html.append("<tbody><tr>"_s,
+                    "<td class=\"data\"><div class=\"targetname\">"_s, String::fromUTF8(target.name.span()), "</div><div class=\"targeturl\">"_s,
+                    target.url, "</div></td>"_s,
+                    "<td class=\"input\"><input type=\"button\" value=\"Inspect\" onclick="_s);
 
                 switch (inspectorType) {
                 case InspectorType::UI:
-                    g_string_append(html, "\"window.webkit.messageHandlers.inspector.postMessage(");
+                    html.append("\"window.webkit.messageHandlers.inspector.postMessage("_s);
                     if (escapeSingleQuote == ShouldEscapeSingleQuote::Yes)
-                        g_string_append(html, "\\'");
+                        html.append("\\'"_s);
                     else
-                        g_string_append_c(html, '\'');
-                    g_string_append_printf(html, "%" G_GUINT64_FORMAT ":%" G_GUINT64_FORMAT ":%s", connectionID, target.id, target.type.data());
+                        html.append('\'');
+                    html.append(connectionID, ':', target.id, ':', target.type);
                     if (escapeSingleQuote == ShouldEscapeSingleQuote::Yes)
-                        g_string_append(html, "\\')\"");
+                        html.append("\\')\""_s);
                     else
-                        g_string_append(html, "')\"");
+                        html.append("')\""_s);
                     break;
                 case InspectorType::HTTP:
-                    g_string_append_printf(html,
-                        "\"window.open('Main.html?ws=' + window.location.host + '/socket/%" G_GUINT64_FORMAT "/%" G_GUINT64_FORMAT "/%s', "
-                        "'_blank', 'location=no,menubar=no,status=no,toolbar=no');\"",
-                        connectionID, target.id, target.type.data());
+                    html.append("\"window.open('Main.html?ws=' + window.location.host + '/socket/"_s, connectionID, '/', target.id, '/',
+                        target.type, "', '_blank', 'location=no,menubar=no,status=no,toolbar=no');\""_s);
                     break;
                 }
 
-                g_string_append(html, "></td></tr></tbody>");
+                html.append("></td></tr></tbody>"_s);
             }
         }
-        g_string_append(html, "</table>");
+        html.append("</table>"_s);
     }
 }
 
-GString* RemoteInspectorClient::buildTargetListPage(InspectorType inspectorType) const
+StringBuilder RemoteInspectorClient::buildTargetListPage(InspectorType inspectorType) const
 {
-    GString* html = g_string_new(
+    StringBuilder html;
+    html.append(
         "<html><head><title>Remote inspector</title>"
         "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />"
         "<style>"
@@ -362,14 +358,12 @@ GString* RemoteInspectorClient::buildTargetListPage(InspectorType inspectorType)
         "  input { width: 100%; padding: 8px; }"
         "</style>"
         "</head><body><h1>Inspectable targets</h1>"
-        "<div id='targetlist'>");
+        "<div id='targetlist'>"_s);
     appendTargetList(html, inspectorType, ShouldEscapeSingleQuote::No);
-    g_string_append(html, "</div></body></html>");
+    html.append("</div></body></html>"_s);
 
     return html;
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
@@ -59,9 +59,9 @@ public:
     const String& backendCommandsURL() const LIFETIME_BOUND { return m_backendCommandsURL; }
 
     enum class InspectorType { UI, HTTP };
-    GString* buildTargetListPage(InspectorType) const;
+    StringBuilder buildTargetListPage(InspectorType) const;
     enum class ShouldEscapeSingleQuote : bool { No, Yes };
-    void appendTargetList(GString*, InspectorType, ShouldEscapeSingleQuote) const;
+    void appendTargetList(StringBuilder&, InspectorType, ShouldEscapeSingleQuote) const;
     void inspect(uint64_t connectionID, uint64_t targetID, const String& targetType, InspectorType = InspectorType::UI);
     void sendMessageToBackend(uint64_t connectionID, uint64_t targetID, const String&);
     void closeFromFrontend(uint64_t connectionID, uint64_t targetID);

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -33,6 +33,7 @@
 #include <wtf/URL.h>
 #include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/CStringView.h>
 
 namespace WebKit {
 
@@ -85,15 +86,12 @@ const String& RemoteInspectorHTTPServer::inspectorServerAddress() const
 
 unsigned RemoteInspectorHTTPServer::handleRequest(const char* path, SoupMessageHeaders* responseHeaders, SoupMessageBody* responseBody) const
 {
-    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
-    if (g_str_equal(path, "/")) {
-        auto* html = m_client->buildTargetListPage(RemoteInspectorClient::InspectorType::HTTP);
+    if (CStringView::unsafeFromUTF8(path) == "/"_s) {
+        auto html = m_client->buildTargetListPage(RemoteInspectorClient::InspectorType::HTTP).toString().utf8();
         soup_message_headers_append(responseHeaders, "Content-Type", "text/html");
-        gsize bodyLength = html->len;
-        soup_message_body_append(responseBody, SOUP_MEMORY_TAKE, g_string_free(html, FALSE), bodyLength);
+        soup_message_body_append(responseBody, SOUP_MEMORY_COPY, html.data(), html.length());
         return SOUP_STATUS_OK;
     }
-    IGNORE_CLANG_WARNINGS_END
 
     GUniquePtr<char> resourcePath(g_build_filename("/org/webkit/inspector/UserInterface", path, nullptr));
 


### PR DESCRIPTION
#### f55ac7e8ac6d979d05718f0e4a25337aff989751
<pre>
[GLIB] Reduce unsafe buffer usage in remote inspector code
<a href="https://bugs.webkit.org/show_bug.cgi?id=308886">https://bugs.webkit.org/show_bug.cgi?id=308886</a>

Reviewed by Adrian Perez de Castro.

Move from GString to StringBuilder and from strcmp() to CStringView==().

* Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::handleRequest):
(WebKit::RemoteInspectorProtocolHandler::updateTargetList):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp:
(WebKit::RemoteInspectorClient::appendTargetList const):
(WebKit::RemoteInspectorClient::buildTargetListPage const):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h:
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp:
(WebKit::RemoteInspectorHTTPServer::handleRequest const):

Canonical link: <a href="https://commits.webkit.org/308432@main">https://commits.webkit.org/308432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9047f3590044225175c3c8498302bd5065ef7268

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113726 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81106 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94485 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15130 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12918 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3668 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124725 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158560 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121751 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121951 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132220 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76103 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9000 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19374 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->