### PR TITLE
Annotate Element's member functions to get an attribute with NODELETE

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -217,7 +217,6 @@ dom/DataTransfer.cpp
 dom/Document.cpp
 dom/Element.cpp
 dom/ElementData.cpp
-dom/ElementInlines.h
 dom/ElementInternals.cpp
 dom/ElementIteratorInlines.h
 dom/ElementTraversal.h

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -294,12 +294,12 @@ public:
 
     // Internal methods that assume the existence of attribute storage, one should use hasAttributes()
     // before calling them.
-    inline std::span<const Attribute> attributes() const;
-    inline unsigned attributeCount() const;
-    inline const Attribute& attributeAt(unsigned index) const;
-    inline const Attribute* findAttributeByName(const QualifiedName&) const;
-    inline unsigned findAttributeIndexByName(const QualifiedName&) const;
-    inline unsigned findAttributeIndexByName(const AtomString&, bool shouldIgnoreAttributeCase) const;
+    inline std::span<const Attribute> NODELETE attributes() const;
+    inline unsigned NODELETE attributeCount() const;
+    inline const Attribute& NODELETE attributeAt(unsigned index) const;
+    inline const Attribute* NODELETE findAttributeByName(const QualifiedName&) const;
+    inline unsigned NODELETE findAttributeIndexByName(const QualifiedName&) const;
+    inline unsigned NODELETE findAttributeIndexByName(const AtomString&, bool shouldIgnoreAttributeCase) const;
 
     bool checkVisibility(const CheckVisibilityOptions&);
 

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -179,7 +179,7 @@ bool ElementData::isEquivalent(const ElementData* other) const
     return true;
 }
 
-Attribute* UniqueElementData::findAttributeByName(const QualifiedName& name)
+Attribute* NODELETE UniqueElementData::findAttributeByName(const QualifiedName& name)
 {
     for (auto& attribute : m_attributeVector) {
         if (attribute.name().matches(name))

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -64,11 +64,11 @@ public:
     unsigned length() const;
     bool isEmpty() const { return !length(); }
 
-    std::span<const Attribute> attributes() const LIFETIME_BOUND;
-    const Attribute& attributeAt(unsigned index) const;
-    const Attribute* findAttributeByName(const QualifiedName&) const;
-    unsigned findAttributeIndexByName(const QualifiedName&) const;
-    unsigned findAttributeIndexByName(const AtomString& name, bool shouldIgnoreAttributeCase) const;
+    std::span<const Attribute> NODELETE attributes() const LIFETIME_BOUND;
+    const Attribute& NODELETE attributeAt(unsigned index) const;
+    const Attribute* NODELETE findAttributeByName(const QualifiedName&) const;
+    unsigned NODELETE findAttributeIndexByName(const QualifiedName&) const;
+    unsigned NODELETE findAttributeIndexByName(const AtomString& name, bool shouldIgnoreAttributeCase) const;
 
     bool hasID() const { return !m_idForStyleResolution.isNull(); }
     bool hasClass() const { return !m_classNames.isEmpty(); }
@@ -158,8 +158,8 @@ public:
 
     static constexpr ptrdiff_t attributeArrayMemoryOffset() { return OBJECT_OFFSETOF(ShareableElementData, m_attributeArray); }
 
-    std::span<Attribute> attributes() { return unsafeMakeSpan(m_attributeArray, arraySize()); }
-    std::span<const Attribute> attributes() const { return unsafeMakeSpan(m_attributeArray, arraySize()); }
+    std::span<Attribute> NODELETE attributes() { return unsafeMakeSpan(m_attributeArray, arraySize()); }
+    std::span<const Attribute> NODELETE attributes() const { return unsafeMakeSpan(m_attributeArray, arraySize()); }
 
     Attribute m_attributeArray[0];
 };
@@ -173,10 +173,10 @@ public:
     void addAttribute(const QualifiedName&, const AtomString&);
     void removeAttributeAt(unsigned index);
 
-    Attribute& attributeAt(unsigned index);
+    Attribute& NODELETE attributeAt(unsigned index);
     Attribute* NODELETE findAttributeByName(const QualifiedName&);
 
-    std::span<const Attribute> attributes() const LIFETIME_BOUND { return m_attributeVector.span(); }
+    std::span<const Attribute> NODELETE attributes() const LIFETIME_BOUND { return m_attributeVector.span(); }
 
     UniqueElementData();
     explicit UniqueElementData(const ShareableElementData&);
@@ -224,7 +224,7 @@ inline std::span<const Attribute> ElementData::attributes() const LIFETIME_BOUND
     return uncheckedDowncast<ShareableElementData>(*this).attributes();
 }
 
-ALWAYS_INLINE const Attribute* ElementData::findAttributeByName(const AtomString& name, bool shouldIgnoreAttributeCase) const
+ALWAYS_INLINE const Attribute* NODELETE ElementData::findAttributeByName(const AtomString& name, bool shouldIgnoreAttributeCase) const
 {
     unsigned index = findAttributeIndexByName(name, shouldIgnoreAttributeCase);
     if (index != attributeNotFound)
@@ -232,7 +232,7 @@ ALWAYS_INLINE const Attribute* ElementData::findAttributeByName(const AtomString
     return nullptr;
 }
 
-ALWAYS_INLINE unsigned ElementData::findAttributeIndexByName(const QualifiedName& name) const
+SUPPRESS_NODELETE ALWAYS_INLINE unsigned NODELETE ElementData::findAttributeIndexByName(const QualifiedName& name) const
 {
     auto attributes = attributeSpan();
     for (auto [i, attribute] : indexedRange(attributes)) {
@@ -244,7 +244,7 @@ ALWAYS_INLINE unsigned ElementData::findAttributeIndexByName(const QualifiedName
 
 // We use a boolean parameter instead of calling shouldIgnoreAttributeCase so that the caller
 // can tune the behavior (hasAttribute is case sensitive whereas getAttribute is not).
-ALWAYS_INLINE unsigned ElementData::findAttributeIndexByName(const AtomString& name, bool shouldIgnoreAttributeCase) const
+SUPPRESS_NODELETE ALWAYS_INLINE unsigned NODELETE ElementData::findAttributeIndexByName(const AtomString& name, bool shouldIgnoreAttributeCase) const
 {
     auto attributes = attributeSpan();
     if (attributes.empty())
@@ -265,7 +265,7 @@ ALWAYS_INLINE unsigned ElementData::findAttributeIndexByName(const AtomString& n
     return attributeNotFound;
 }
 
-ALWAYS_INLINE const Attribute* ElementData::findAttributeByName(const QualifiedName& name) const
+SUPPRESS_NODELETE ALWAYS_INLINE const Attribute* NODELETE ElementData::findAttributeByName(const QualifiedName& name) const
 {
     for (auto& attribute : attributeSpan()) {
         if (attribute.name().matches(name))
@@ -274,7 +274,7 @@ ALWAYS_INLINE const Attribute* ElementData::findAttributeByName(const QualifiedN
     return nullptr;
 }
 
-inline const Attribute& ElementData::attributeAt(unsigned index) const
+inline const Attribute& NODELETE ElementData::attributeAt(unsigned index) const
 {
     return attributeSpan()[index];
 }
@@ -289,7 +289,7 @@ inline void UniqueElementData::removeAttributeAt(unsigned index)
     m_attributeVector.removeAt(index);
 }
 
-inline Attribute& UniqueElementData::attributeAt(unsigned index)
+inline Attribute& NODELETE UniqueElementData::attributeAt(unsigned index)
 {
     return m_attributeVector.at(index);
 }


### PR DESCRIPTION
#### 7014e9cf32af78289b561efe5a893796060a515b
<pre>
Annotate Element&apos;s member functions to get an attribute with NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=308888">https://bugs.webkit.org/show_bug.cgi?id=308888</a>

Reviewed by Chris Dumez.

Added NODELETE annotations on the member functions of Element which queries an attribute.

No new tests since there should be no behavioral changes.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementData.cpp:
(WebCore::UniqueElementData::findAttributeByName):
* Source/WebCore/dom/ElementData.h:
(WebCore::ShareableElementData::attributes):
(WebCore::ShareableElementData::attributes const):
(WebCore::ElementData::findAttributeByName const):
(WebCore::ElementData::findAttributeIndexByName const):
(WebCore::ElementData::attributeAt const):
(WebCore::UniqueElementData::attributeAt):

Canonical link: <a href="https://commits.webkit.org/308422@main">https://commits.webkit.org/308422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/732b5039250fff382fcc946b9843d73a1f6cbdf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100902 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2eb82c8d-57f5-4b75-91de-af6b84199fc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113674 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81069 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94434 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6242f16-39e3-46e2-984b-3e30f41c8bf4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15077 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12863 "Found 2 new API test failures: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3610 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158502 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121701 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121900 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76023 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8946 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83349 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->