### PR TITLE
Make a scope type to set/restore currentScrollType

### DIFF
--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -580,15 +580,15 @@ void LocalFrame::overflowScrollPositionChangedForNode(const IntPoint& position, 
     if (!renderer || !renderer->hasLayer())
         return;
 
-    auto* layer = downcast<RenderBoxModelObject>(*renderer).layer();
+    CheckedPtr layer = downcast<RenderBoxModelObject>(*renderer).layer();
     if (!layer)
         return;
-    auto* scrollableArea = layer->ensureLayerScrollableArea();
 
-    auto oldScrollType = scrollableArea->currentScrollType();
-    scrollableArea->setCurrentScrollType(isUserScroll ? ScrollType::User : ScrollType::Programmatic);
-    scrollableArea->scrollToOffsetWithoutAnimation(position);
-    scrollableArea->setCurrentScrollType(oldScrollType);
+    CheckedPtr scrollableArea = layer->ensureLayerScrollableArea();
+    {
+        auto scope = ScrollTypeScope(*scrollableArea, isUserScroll ? ScrollType::User : ScrollType::Programmatic);
+        scrollableArea->scrollToOffsetWithoutAnimation(position);
+    }
 
     scrollableArea->didEndScroll(); // FIXME: Should we always call this?
 }

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -612,15 +612,11 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     options.interruptsAnimation = ScrollInterruptsAnimation::No;
 
     auto revealScope = ScrollbarRevealBehaviorScope(m_owningScrollableArea.get(), ScrollbarRevealBehavior::DontReveal);
-
-    auto oldScrollType = m_owningScrollableArea->currentScrollType();
-    m_owningScrollableArea->setCurrentScrollType(ScrollType::Programmatic);
+    auto scrollTypeScope = ScrollTypeScope(m_owningScrollableArea.get(), ScrollType::Programmatic);
 
     // FIXME: This has to explicitly not stop animated scrolls (use ImplicitDeltaUpdate).
     if (!m_owningScrollableArea->requestScrollToPosition(newScrollPosition, options))
         m_owningScrollableArea->scrollToPositionWithoutAnimation(newScrollPosition);
-
-    m_owningScrollableArea->setCurrentScrollType(oldScrollType);
 }
 
 void ScrollAnchoringController::willDispatchScrollEvent()

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -562,6 +562,18 @@ private:
     WeakPtr<ScrollableArea> m_scrollableArea;
 };
 
+class ScrollTypeScope {
+public:
+    WEBCORE_EXPORT ScrollTypeScope(ScrollableArea&, ScrollType);
+    WEBCORE_EXPORT ~ScrollTypeScope();
+
+    void restore();
+
+private:
+    WeakRef<ScrollableArea> m_scrollableArea;
+    std::optional<ScrollType> m_oldScrollType;
+};
+
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableArea&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -316,8 +316,7 @@ ScrollOffset RenderLayerScrollableArea::scrollToOffset(const ScrollOffset& scrol
     if (clampedScrollOffset == this->scrollOffset())
         return clampedScrollOffset;
 
-    auto previousScrollType = currentScrollType();
-    setCurrentScrollType(options.type);
+    auto scrollTypeScope = ScrollTypeScope(*this, options.type);
 
     ScrollOffset snappedOffset = ceiledIntPoint(scrollAnimator().scrollOffsetAdjustedForSnapping(clampedScrollOffset, options.snapPointSelectionMethod));
     auto snappedPosition = scrollPositionFromOffset(snappedOffset);
@@ -327,7 +326,6 @@ ScrollOffset RenderLayerScrollableArea::scrollToOffset(const ScrollOffset& scrol
     } else if (!requestScrollToPosition(snappedPosition, options))
         scrollToPositionWithoutAnimation(snappedPosition, options.clamping);
 
-    setCurrentScrollType(previousScrollType);
     return snappedOffset;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1722,10 +1722,8 @@ void UnifiedPDFPlugin::updateScrollingExtents()
     auto scrollPosition = this->scrollPosition();
     auto constrainedPosition = constrainedScrollPosition(scrollPosition);
     if (scrollPosition != constrainedPosition) {
-        auto oldScrollType = currentScrollType();
-        setCurrentScrollType(ScrollType::Programmatic); // It's silly that we have to do this to avoid an AsyncScrollingCoordinator assertion.
+        auto scrollTypeScope = ScrollTypeScope(*this, ScrollType::Programmatic); // It's silly that we have to do this to avoid an AsyncScrollingCoordinator assertion.
         requestScrollToPosition(constrainedPosition);
-        setCurrentScrollType(oldScrollType);
     }
 
     RefPtr scrollingCoordinator = page->scrollingCoordinator();
@@ -2323,10 +2321,9 @@ bool UnifiedPDFPlugin::scrollToPointInContentsSpace(FloatPoint pointInContentsSp
         return true;
     }
 
-    auto oldScrollType = currentScrollType();
-    setCurrentScrollType(ScrollType::Programmatic);
+    auto scrollTypeScope = ScrollTypeScope(*this, ScrollType::Programmatic);
     bool success = scrollToPositionWithoutAnimation(roundedIntPoint(pointInContentsSpace));
-    setCurrentScrollType(oldScrollType);
+
     // We assume that callers have ensured the correct page is visible,
     // so this should always return true for discrete display modes.
     return isInDiscreteDisplayMode() || success;


### PR DESCRIPTION
#### 17edd052c8db011267aa352f46a1378683ffa2b8
<pre>
Make a scope type to set/restore currentScrollType
<a href="https://bugs.webkit.org/show_bug.cgi?id=308904">https://bugs.webkit.org/show_bug.cgi?id=308904</a>
<a href="https://rdar.apple.com/171438918">rdar://171438918</a>

Reviewed by Tim Nguyen.

It&apos;s a common pattern to do:
  previousScrollType = currentScrollType();
  setCurrentScrollType(...);
  // Do some kind of scroll
  setCurrentScrollType(previousScrollType);

So add ScrollTypeScope that does this set/restore. It supports
an early restore for one class site that would be ugly with
a braces scope.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setFrameRect):
(WebCore::LocalFrameView::obscuredContentInsetsDidChange):
(WebCore::LocalFrameView::setScrollOffsetWithOptions):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::overflowScrollPositionChangedForNode):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll):
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollToPositionWithAnimation):
(WebCore::ScrollTypeScope::ScrollTypeScope):
(WebCore::ScrollTypeScope::~ScrollTypeScope):
(WebCore::ScrollTypeScope::restore):
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollToOffset):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
(WebKit::UnifiedPDFPlugin::scrollToPointInContentsSpace):

Canonical link: <a href="https://commits.webkit.org/308414@main">https://commits.webkit.org/308414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7d90468fd26ef28f125c22ad36a066f1a854c01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100874 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba7aa303-6e06-4bd6-bf2f-03bc76da750b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113654 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81050 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab269c09-3d5a-4405-aa77-ee9491bcf277) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94414 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70708349-7873-4653-8980-646367bda62e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12836 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158474 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1611 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121682 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31212 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75976 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8921 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83321 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19288 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19439 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19346 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->