### PR TITLE
Allow JSBuffer to take virtual copy of read-only memory

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.mm
@@ -33,6 +33,34 @@
 #import <WebCore/SharedMemory.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/FileSystem.h>
+#import <wtf/Scope.h>
+#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/spi/cocoa/MachVMSPI.h>
+
+static bool isInReadOnlyRegion(std::span<const uint8_t> span)
+{
+    if (span.empty())
+        return false;
+
+    auto addr = reinterpret_cast<mach_vm_address_t>(const_cast<uint8_t*>(span.data()));
+    auto end = addr + span.size();
+    auto regionAddr = addr;
+    mach_vm_size_t regionSize = 0;
+    vm_region_basic_info_data_64_t info { };
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t vmObject = MACH_PORT_NULL;
+    auto scopeExit = makeScopeExit([&] {
+        if (vmObject != MACH_PORT_NULL)
+            mach_port_deallocate(mach_task_self(), vmObject);
+    });
+
+    auto kr = mach_vm_region(mach_task_self(), &regionAddr, &regionSize, VM_REGION_BASIC_INFO_64, (vm_region_info_t)&info, &count, &vmObject);
+    if (kr != KERN_SUCCESS)
+        return false;
+
+    auto regionEnd = regionAddr + regionSize;
+    return (info.protection & VM_PROT_READ) && !(info.protection & VM_PROT_WRITE) && addr >= regionAddr && end <= regionEnd;
+}
 
 @implementation WKJSScriptingBuffer
 
@@ -41,10 +69,22 @@
     if (!(self = [super init]))
         return nil;
 
-    Ref sharedBuffer = WebCore::SharedBuffer::create(data);
-    RefPtr sharedMemory = WebCore::SharedMemory::copyBuffer(sharedBuffer);
-    if (!sharedMemory)
+    RefPtr<WebCore::SharedMemory> sharedMemory;
+    auto dataSpan = span(data);
+
+    if (isInReadOnlyRegion(dataSpan))
+        sharedMemory = WebCore::SharedMemory::wrapMap(dataSpan, WebCore::SharedMemoryProtection::ReadOnly);
+
+    if (!sharedMemory) {
+        Ref sharedBuffer = WebCore::SharedBuffer::create(data);
+        sharedMemory = WebCore::SharedMemory::copyBuffer(sharedBuffer);
+    }
+
+    if (!sharedMemory) {
+        [self release];
         return nil;
+    }
+
     API::Object::constructInWrapper<API::JSBuffer>(self, sharedMemory.releaseNonNull());
 
     return self;


### PR DESCRIPTION
#### 193c672c58d91efbf9c9f894208ea93407a62aa8
<pre>
Allow JSBuffer to take virtual copy of read-only memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=308889">https://bugs.webkit.org/show_bug.cgi?id=308889</a>
<a href="https://rdar.apple.com/171312066">rdar://171312066</a>

Reviewed by Ryosuke Niwa.

To reduce the memory overhead of JSBuffer, allow it to take a virtual copy rather than a physical
copy of memory within a read-only region.

Test: JSBuffer.Data
* Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.mm:
(isInReadOnlyRegion):
(-[WKJSScriptingBuffer initWithData:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm:
(TEST(JSBuffer, Data)):

Canonical link: <a href="https://commits.webkit.org/308439@main">https://commits.webkit.org/308439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad14948a25ba9a4eb58bf24aadb5a37d36e92a47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7cdd5058-f647-4a20-aa51-6ee21ecfde46) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113756 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81134 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a00c62f-86a6-4582-88f7-cc77b58593a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94516 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1c30f8c-2371-446a-b5f1-fef11de35888) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3700 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158592 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1729 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121780 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121981 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31227 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132249 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76166 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9029 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19676 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19557 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->