### PR TITLE
[Scroll snap] YouTube shorts scroll to the next video and back

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
@@ -1,6 +1,6 @@
 Header 1Footer 1
 Header 2Footer 2
 
-FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: Verify snap on relayout expected 0 but got 40
+FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 39 but got 449
 FAIL Mouse-wheel scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 100 but got 101
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate-expected.txt
@@ -1,0 +1,3 @@
+
+PASS When re-snap happens on layout, the new scroll position should be set immediately
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.scroller {
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  border: 1px solid black;
+  width: 400px;
+  height: 400px;
+}
+
+.scroller .box {
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  width: 100%;
+  height: 100%;
+}
+
+.changer {
+  height: 100%;
+  width: 100%;
+  background-color: red;
+}    
+
+body.changed .changer {
+  height: 0;
+}
+</style>
+
+<div class="scroller" id="scroller">
+  <div class="changer"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+</div>
+
+<script>
+let scroller = document.getElementById('scroller');
+promise_test(async t => {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert_equals(scroller.scrollTop, 400);
+  document.body.classList.add('changed');
+  assert_equals(scroller.scrollTop, 0);
+}, "When re-snap happens on layout, the new scroll position should be set immediately");
+
+</script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -611,7 +611,6 @@ imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-scrollbar
 imported/w3c/web-platform-tests/css/css-masking/clip/clip-rect-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-position/position-fixed-scroll-nested-fixed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ui/outline-negative-offset-composited-scroll.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Failure ]
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -667,9 +667,10 @@ void ScrollableArea::resnapAfterLayout()
     if (correctedOffset != currentOffset) {
         LOG_WITH_STREAM(ScrollSnap, stream << "ScrollableArea::resnapAfterLayout - adjusting scroll position from " << currentOffset << " to " << correctedOffset << " for snap point at index " << currentVerticalSnapPointIndex());
         auto position = scrollPositionFromOffset(correctedOffset);
-        if (scrollAnimationStatus() == ScrollAnimationStatus::NotAnimating)
+        if (scrollAnimationStatus() == ScrollAnimationStatus::NotAnimating) {
+            auto scrollTypeScope = ScrollTypeScope(*this, ScrollType::Programmatic);
             scrollToOffsetWithoutAnimation(correctedOffset);
-        else
+        } else
             scrollAnimator->retargetRunningAnimation(position);
     }
 }


### PR DESCRIPTION
#### 7bdd6f4aabffd6a17c4c5663b6d4e26a90190c63
<pre>
[Scroll snap] YouTube shorts scroll to the next video and back
<a href="https://bugs.webkit.org/show_bug.cgi?id=308913">https://bugs.webkit.org/show_bug.cgi?id=308913</a>
<a href="https://rdar.apple.com/166596210">rdar://166596210</a>

Reviewed by Wenson Hsieh and Alan Baradlay.

The YouTube shorts page uses scroll snap. When the page first loads, there&apos;s a `&lt;div id=&apos;initial-player-container’&gt;`
item above the first short with non-zero height, pushing the first video (which has the first snap point) down. We
scroll down to snap to it, and then a layout changes the height of `&lt;div id=&apos;initial-player-container’&gt;` to zero,
triggering a scroll back to 0. However, a message comes back from the UI process for the first scroll, and resets
the scroll position closer to the second video, so we scroll back down (and then the page calls `scrollIntoView()`
and the scroll position animates back up).

The bug here was that the scroll-snap related scrolls were not marked as programmatic, so they did not cause
synchronous scroll position updates in the web process, and thus mis-handled the messages coming back from
the UI process (logic fixed in 308215@main).

The fix uses a `ScrollTypeScope` to mark resnapping scrolls as programmatic.

Test: imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt: Fails
in a different way now.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/resnap-on-layout-is-immediate.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations: One new pass.
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::resnapAfterLayout):

Canonical link: <a href="https://commits.webkit.org/308420@main">https://commits.webkit.org/308420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8723d36db2bda05cf6a7209d636069f1a9c075b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100896 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2e1f45f-e760-4180-b553-28dcea4b7036) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81065 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61e224bf-49a8-4309-9ccd-e6f333d66619) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f24a5f2b-6c3c-4840-8f65-183fd915e818) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15074 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12859 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3604 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158496 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121697 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121896 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31216 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Wenson Hsieh and Alan Baradlay; Compiled WebKit (warnings); Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76005 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8940 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83343 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->