### PR TITLE
Unable to select live text on paused video on youtube, khan academy, marketwatch and cnbc

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -514,7 +514,7 @@ public:
     bool taintsOrigin(const SecurityOrigin&) const;
     
     WEBCORE_EXPORT bool isFullscreen() const override;
-    bool isInFullscreenOrPictureInPicture() const;
+    WEBCORE_EXPORT bool isInFullscreenOrPictureInPicture() const;
     bool isStandardFullscreen() const;
     void toggleStandardFullscreenState();
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -740,6 +740,7 @@ WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
 WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
 WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
 WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+WebProcess/cocoa/TextRecognitionRequest.cpp
 WebProcess/cocoa/UserMediaCaptureManager.cpp
 WebProcess/cocoa/VideoPresentationManager.mm @nonARC
 WebProcess/cocoa/WebProcessCocoa.mm @nonARC

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16816,11 +16816,24 @@ void WebPageProxy::clearAppPrivacyReportTestingData(CompletionHandler<void()>&& 
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)
-void WebPageProxy::beginTextRecognitionForVideoInElementFullScreen(ShareableBitmap::Handle&& bitmapHandle, FloatRect bounds)
+void WebPageProxy::beginTextRecognitionForVideoInElementFullScreen(PlaybackSessionContextIdentifier identifier, ShareableBitmap::Handle&& bitmapHandle, FloatRect bounds)
 {
     RefPtr pageClient = this->pageClient();
     if (!pageClient || !pageClient->isTextRecognitionInFullscreenVideoEnabled())
         return;
+
+#if PLATFORM(IOS_FAMILY)
+    if (internals().currentFullscreenVideoSessionIdentifier == identifier && m_videoPresentationManager) {
+        RefPtr presentationManager = m_videoPresentationManager;
+        // Suppress forward declaration warning. see webkit.org/b/308991
+        SUPPRESS_FORWARD_DECL_ARG RetainPtr controller = presentationManager->playerViewController(identifier);
+        if (controller) {
+            if (RefPtr pageClient = this->pageClient())
+                SUPPRESS_FORWARD_DECL_ARG pageClient->beginTextRecognitionForFullscreenVideo(WTF::move(bitmapHandle), controller.get());
+            return;
+        }
+    }
+#endif
 
     pageClient->beginTextRecognitionForVideoInElementFullscreen(WTF::move(bitmapHandle), bounds);
 }
@@ -16830,6 +16843,16 @@ void WebPageProxy::cancelTextRecognitionForVideoInElementFullScreen()
     RefPtr pageClient = this->pageClient();
     if (!pageClient || !pageClient->isTextRecognitionInFullscreenVideoEnabled())
         return;
+
+#if PLATFORM(IOS_FAMILY)
+    if (internals().currentFullscreenVideoSessionIdentifier && m_videoPresentationManager) {
+        RefPtr presentationManager = m_videoPresentationManager;
+        // Suppress forward declaration warning. see webkit.org/b/308991
+        SUPPRESS_FORWARD_DECL_ARG RetainPtr controller = presentationManager->playerViewController(*internals().currentFullscreenVideoSessionIdentifier);
+        if (controller)
+            SUPPRESS_FORWARD_DECL_ARG pageClient->cancelTextRecognitionForFullscreenVideo(controller.get());
+    }
+#endif
 
     pageClient->cancelTextRecognitionForVideoInElementFullscreen();
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2659,7 +2659,7 @@ public:
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)
-    void beginTextRecognitionForVideoInElementFullScreen(WebCore::ShareableBitmapHandle&&, WebCore::FloatRect);
+    void beginTextRecognitionForVideoInElementFullScreen(PlaybackSessionContextIdentifier, WebCore::ShareableBitmapHandle&&, WebCore::FloatRect);
     void cancelTextRecognitionForVideoInElementFullScreen();
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -414,7 +414,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)
-    [EnabledBy=TextRecognitionInVideosEnabled] BeginTextRecognitionForVideoInElementFullScreen(WebCore::ShareableBitmapHandle bitmapHandle, WebCore::FloatRect videoBounds)
+    [EnabledBy=TextRecognitionInVideosEnabled] BeginTextRecognitionForVideoInElementFullScreen(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::ShareableBitmapHandle bitmapHandle, WebCore::FloatRect videoBounds)
     [EnabledBy=TextRecognitionInVideosEnabled] CancelTextRecognitionForVideoInElementFullScreen()
 #endif
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5912,6 +5912,8 @@
 		510CC7E016138E2900D03ED3 /* NetworkProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcess.h; sourceTree = "<group>"; };
 		510CC7EA16138E7200D03ED3 /* NetworkProcessProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcessProxy.cpp; sourceTree = "<group>"; };
 		510CC7EB16138E7200D03ED3 /* NetworkProcessProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcessProxy.h; sourceTree = "<group>"; };
+		510CDD082F53C70E006BB4E0 /* TextRecognitionRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextRecognitionRequest.h; sourceTree = "<group>"; };
+		510CDD092F53C70E006BB4E0 /* TextRecognitionRequest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextRecognitionRequest.cpp; sourceTree = "<group>"; };
 		510FBB981288C95E00AFFDF4 /* WebContextMenuItemData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebContextMenuItemData.cpp; sourceTree = "<group>"; };
 		510FBB991288C95E00AFFDF4 /* WebContextMenuItemData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebContextMenuItemData.h; sourceTree = "<group>"; };
 		511065F923EC956B005443D6 /* WKContentWorld.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKContentWorld.mm; sourceTree = "<group>"; };
@@ -14644,6 +14646,8 @@
 				416008B125DA86B900E892FE /* RemoteRealtimeMediaSourceProxy.h */,
 				418FCBE3271049DB00F96ECA /* RemoteRealtimeVideoSource.cpp */,
 				418FCBE4271049DC00F96ECA /* RemoteRealtimeVideoSource.h */,
+				510CDD092F53C70E006BB4E0 /* TextRecognitionRequest.cpp */,
+				510CDD082F53C70E006BB4E0 /* TextRecognitionRequest.h */,
 				E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */,
 				E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */,
 				CD491B051E70D05F00009066 /* UserMediaCaptureManager.cpp */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -69,6 +69,7 @@
 #include "NotificationPermissionRequestManager.h"
 #include "PageBanner.h"
 #include "PageInspectorTarget.h"
+#include "PlaybackSessionContextIdentifier.h"
 #include "PluginView.h"
 #include "PolicyDecision.h"
 #include "PrintInfo.h"
@@ -9562,22 +9563,22 @@ void WebPage::beginTextRecognitionForVideoInElementFullScreen(const HTMLVideoEle
     if (rectInRootView.isEmpty())
         return;
 
-    m_isPerformingTextRecognitionInElementFullScreen = true;
-    element.bitmapImageForCurrentTime()->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, rectInRootView](auto&& result) {
+    m_elementIsPerformingTextRecognitionInElementFullScreen = element.identifier();
+    element.bitmapImageForCurrentTime()->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, rectInRootView, identifier = element.identifier()](auto&& result) {
         if (!result)
             return;
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_isPerformingTextRecognitionInElementFullScreen)
+        if (!protectedThis || protectedThis->m_elementIsPerformingTextRecognitionInElementFullScreen != identifier)
             return;
         if (auto handle = (*result)->createHandle())
-            protectedThis->send(Messages::WebPageProxy::BeginTextRecognitionForVideoInElementFullScreen(WTF::move(*handle), rectInRootView));
-        protectedThis->m_isPerformingTextRecognitionInElementFullScreen = false;
+            protectedThis->send(Messages::WebPageProxy::BeginTextRecognitionForVideoInElementFullScreen(processQualify(identifier), WTF::move(*handle), rectInRootView));
+        protectedThis->m_elementIsPerformingTextRecognitionInElementFullScreen.reset();
     });
 }
 
 void WebPage::cancelTextRecognitionForVideoInElementFullScreen()
 {
-    m_isPerformingTextRecognitionInElementFullScreen = false;
+    m_elementIsPerformingTextRecognitionInElementFullScreen.reset();
     send(Messages::WebPageProxy::CancelTextRecognitionForVideoInElementFullScreen());
 }
 #endif // ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -3279,7 +3279,7 @@ private:
 
 #if ENABLE(IMAGE_ANALYSIS)
     Vector<std::pair<WeakPtr<WebCore::HTMLElement, WebCore::WeakPtrImplWithEventTargetData>, Vector<CompletionHandler<void(RefPtr<WebCore::Element>&&)>>>> m_elementsPendingTextRecognition;
-    bool m_isPerformingTextRecognitionInElementFullScreen { false };
+    std::optional<WebCore::HTMLMediaElementIdentifier> m_elementIsPerformingTextRecognitionInElementFullScreen;
 #endif
 
 #if ENABLE(WEBXR)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -44,6 +44,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 
 namespace IPC {
@@ -61,6 +62,7 @@ namespace WebKit {
 
 class WebPage;
 class PlaybackSessionManager;
+class TextRecognitionRequest;
 
 class PlaybackSessionInterfaceContext final
     : public RefCounted<PlaybackSessionInterfaceContext>
@@ -229,6 +231,10 @@ private:
 
     void forEachModel(Function<void(WebCore::PlaybackSessionModel&)>&&);
 
+#if ENABLE(IMAGE_ANALYSIS)
+    TextRecognitionRequest& textRecognitionRequest() { return m_textRecognitionRequest.get(); }
+#endif
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
@@ -249,6 +255,10 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
+#endif
+
+#if ENABLE(IMAGE_ANALYSIS)
+    const UniqueRef<TextRecognitionRequest> m_textRecognitionRequest;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -33,6 +33,7 @@
 #import "MessageSenderInlines.h"
 #import "PlaybackSessionManagerMessages.h"
 #import "PlaybackSessionManagerProxyMessages.h"
+#import "TextRecognitionRequest.h"
 #import "VideoPresentationManager.h"
 #import "WebPage.h"
 #import "WebProcess.h"
@@ -190,6 +191,9 @@ PlaybackSessionManager::PlaybackSessionManager(WebPage& page)
 #if !RELEASE_LOG_DISABLED
     , m_logger(page.logger())
     , m_logIdentifier(page.logIdentifier())
+#endif
+#if ENABLE(IMAGE_ANALYSIS)
+    , m_textRecognitionRequest(makeUniqueRef<TextRecognitionRequest>(page, *this))
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -393,6 +397,9 @@ void PlaybackSessionManager::durationChanged(WebCore::HTMLMediaElementIdentifier
 void PlaybackSessionManager::currentTimeChanged(WebCore::HTMLMediaElementIdentifier contextId, double currentTime, double anchorTime)
 {
     m_page->send(Messages::PlaybackSessionManagerProxy::CurrentTimeChanged(processQualify(contextId), currentTime, anchorTime));
+#if ENABLE(IMAGE_ANALYSIS)
+    m_textRecognitionRequest->requestTextRecognitionFor(contextId);
+#endif
 }
 
 void PlaybackSessionManager::bufferedTimeChanged(WebCore::HTMLMediaElementIdentifier contextId, double bufferedTime)
@@ -408,6 +415,9 @@ void PlaybackSessionManager::playbackStartedTimeChanged(WebCore::HTMLMediaElemen
 void PlaybackSessionManager::rateChanged(WebCore::HTMLMediaElementIdentifier contextId, OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
 {
     m_page->send(Messages::PlaybackSessionManagerProxy::RateChanged(processQualify(contextId), playbackState, playbackRate, defaultPlaybackRate));
+#if ENABLE(IMAGE_ANALYSIS)
+    m_textRecognitionRequest->requestTextRecognitionFor(contextId);
+#endif
 }
 
 void PlaybackSessionManager::seekableRangesChanged(WebCore::HTMLMediaElementIdentifier contextId, const WebCore::PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)

--- a/Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.cpp
+++ b/Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextRecognitionRequest.h"
+
+#include "PlaybackSessionManager.h"
+#include "WebPage.h"
+#include <WebCore/HTMLVideoElement.h>
+#include <wtf/RunLoop.h>
+
+#if ENABLE(IMAGE_ANALYSIS)
+
+namespace WebKit {
+using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextRecognitionRequest);
+
+TextRecognitionRequest::TextRecognitionRequest(WebPage& page, PlaybackSessionManager& manager)
+    : m_page(page)
+    , m_manager(manager)
+{
+}
+
+TextRecognitionRequest::~TextRecognitionRequest()
+{
+    cancel();
+}
+
+void TextRecognitionRequest::requestTextRecognitionFor(HTMLMediaElementIdentifier identifier)
+{
+    RefPtr element = dynamicDowncast<HTMLVideoElement>(m_manager->mediaElementWithContextId(identifier));
+    if (!element)
+        return;
+
+    if (!element->isInFullscreenOrPictureInPicture()) {
+        if (identifier == m_identifier)
+            cancel();
+        return;
+    }
+    if (!element->paused() || element->seeking()) {
+        cancel();
+        return;
+    }
+    if (m_timer)
+        m_timer->stop();
+    m_identifier = identifier;
+    m_timer = makeUnique<RunLoop::Timer>(RunLoop::mainSingleton(), "TextRecognitionRequest"_s, [page = m_page, manager = m_manager, identifier] {
+        if (!page)
+            return;
+        RefPtr element = dynamicDowncast<HTMLVideoElement>(manager->mediaElementWithContextId(identifier));
+        if (!element)
+            return;
+        page->beginTextRecognitionForVideoInElementFullScreen(*element);
+    });
+    m_timer->startOneShot(250_ms);
+}
+
+void TextRecognitionRequest::cancel()
+{
+    if (auto timer = std::exchange(m_timer, { }))
+        timer->stop();
+
+    m_identifier.reset();
+    if (RefPtr page = m_page.get())
+        page->cancelTextRecognitionForVideoInElementFullScreen();
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.h
+++ b/Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(IMAGE_ANALYSIS)
+
+#include <WebCore/HTMLMediaElementIdentifier.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/RunLoop.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class PlaybackSessionManager;
+class WebPage;
+
+class TextRecognitionRequest final {
+    WTF_MAKE_TZONE_ALLOCATED(TextRecognitionRequest);
+public:
+    TextRecognitionRequest(WebPage&, PlaybackSessionManager&);
+    ~TextRecognitionRequest();
+
+    void requestTextRecognitionFor(WebCore::HTMLMediaElementIdentifier);
+    void cancel();
+
+private:
+    const WeakPtr<WebPage> m_page;
+    const CheckedPtr<PlaybackSessionManager> m_manager;
+    std::unique_ptr<RunLoop::Timer> m_timer;
+    std::optional<WebCore::HTMLMediaElementIdentifier> m_identifier;
+};
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -33,6 +33,7 @@
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "PlaybackSessionManager.h"
+#import "TextRecognitionRequest.h"
 #import "TextTrackRepresentationCocoa.h"
 #import "VideoPresentationManagerMessages.h"
 #import "VideoPresentationManagerProxyMessages.h"
@@ -741,8 +742,12 @@ void VideoPresentationManager::didEnterFullscreen(WebCore::MediaPlayerClientIden
 
     videoElement->didEnterFullscreenOrPictureInPicture(valueOrDefault(size));
 
-    if (interface->targetIsFullscreen() || interface->fullscreenStandby())
+    if (interface->targetIsFullscreen() || interface->fullscreenStandby()) {
+#if ENABLE(IMAGE_ANALYSIS) && PLATFORM(IOS_FAMILY)
+        m_playbackSessionManager->textRecognitionRequest().requestTextRecognitionFor(contextId);
+#endif
         return;
+    }
 
     // exit fullscreen now if it was previously requested during an animation.
     RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, videoElement] {
@@ -797,6 +802,10 @@ void VideoPresentationManager::didExitFullscreen(WebCore::MediaPlayerClientIdent
     auto [model, interface] = ensureModelAndInterface(contextId);
 
 #if PLATFORM(IOS_FAMILY)
+#if ENABLE(IMAGE_ANALYSIS)
+    m_playbackSessionManager->textRecognitionRequest().requestTextRecognitionFor(contextId);
+#endif
+
     RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, contextId] {
         if (RefPtr page = protectedThis->m_page.get())
             page->send(Messages::VideoPresentationManagerProxy::CleanupFullscreen(processQualify(contextId)));


### PR DESCRIPTION
#### 5ddb3547ed33c90b6fc9d152aeabf20335323002
<pre>
Unable to select live text on paused video on youtube, khan academy, marketwatch and cnbc
<a href="https://bugs.webkit.org/show_bug.cgi?id=308914">https://bugs.webkit.org/show_bug.cgi?id=308914</a>
<a href="https://rdar.apple.com/170817667">rdar://170817667</a>

Reviewed by Wenson Hsieh.

In 305540@main; code thought to be redundant was incorrectly removed.
Some of the code removed handled the case where a video element was in native
fullscreen and handling of selected text in a paused video was handled
by the AVPlayerViewController.

We continue on the logic flow used in 305540@main (where the content process
instruct the UI process on when to start text recognition analysis) but
now when a video enters native fullscreen, the web process sends
the associated bitmap to a CocoaImageAnalyzerRequest in the UIP to be
ultimately delegated to the AVPlayerViewController.

We do this by having TextRecognitionRequest class instance, controlled by the
web process&apos; PlaybackSessionManager. Using the same heuristics as the logic
pre-305540@main for when to start the text recognition analysis:
1- The video is in native full screen
2- The video is paused and not seeking

A new analysis will be performed when we either:
- enter native fullscreen,
- the currentTime of the video has changed or the video has been paused for over 250ms.

Manually tested on iPad and iPhone.
On mac, covered by API tests.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::beginTextRecognitionForVideoInElementFullScreen):
(WebKit::WebPageProxy::cancelTextRecognitionForVideoInElementFullScreen):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::beginTextRecognitionForVideoInElementFullScreen):
(WebKit::WebPage::cancelTextRecognitionForVideoInElementFullScreen):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
(WebKit::PlaybackSessionManager::textRecognitionRequest):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::PlaybackSessionManager):
(WebKit::PlaybackSessionManager::currentTimeChanged):
(WebKit::PlaybackSessionManager::rateChanged):
* Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.cpp: Added.
(WebKit::TextRecognitionRequest::TextRecognitionRequest):
(WebKit::TextRecognitionRequest::~TextRecognitionRequest):
(WebKit::TextRecognitionRequest::textRecognitionFor):
(WebKit::TextRecognitionRequest::cancel):
* Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.h: Added.
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::didEnterFullscreen):
(WebKit::VideoPresentationManager::didExitFullscreen):

Canonical link: <a href="https://commits.webkit.org/308498@main">https://commits.webkit.org/308498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98c398422e796f3db62c4859eec859e1dc9b6a16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101134 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41ec0953-8702-4fdd-b390-80989fc5b759) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113875 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94635 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13061 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3842 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158736 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121902 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122103 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31275 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76329 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17624 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9149 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83581 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->