### PR TITLE
Invalid render pass usage leads to crashes in the WebGPU Swift backend

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1386,18 +1386,14 @@ extension WebGPU.CommandEncoder {
             }
 
             if zeroColorTargets {
-                // FIXME: rdar://170997914 (Invalid render pass usage leads to crashes in the WebGPU Swift backend (308471)).
-                // swift-format-ignore: NeverForceUnwrap
-                mtlDescriptor.defaultRasterSampleCount = metalDepthStencilTexture!.sampleCount
-                if mtlDescriptor.defaultRasterSampleCount == 0 {
+                // FIMXE: (rdar://170907318) This should be changed to `guard let` when possible.
+                guard var metalDepthStencilTexture, metalDepthStencilTexture.sampleCount > 0 else {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "no color targets and depth-stencil texture is nil")
                 }
-                // FIXME: rdar://170997914 (Invalid render pass usage leads to crashes in the WebGPU Swift backend (308471))
-                // swift-format-ignore: NeverForceUnwrap
-                mtlDescriptor.renderTargetWidth = metalDepthStencilTexture!.width
-                // FIXME: rdar://170997914 (Invalid render pass usage leads to crashes in the WebGPU Swift backend (308471))
-                // swift-format-ignore: NeverForceUnwrap
-                mtlDescriptor.renderTargetHeight = metalDepthStencilTexture!.height
+
+                mtlDescriptor.defaultRasterSampleCount = metalDepthStencilTexture.sampleCount
+                mtlDescriptor.renderTargetWidth = metalDepthStencilTexture.width
+                mtlDescriptor.renderTargetHeight = metalDepthStencilTexture.height
             }
         }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1089,7 +1089,6 @@ extension WKBridgeModelLoader {
     }
 }
 
-
 extension WKBridgeReceiver {
     internal func configureDeformation(
         identifier: _Proto_ResourceId,


### PR DESCRIPTION
#### ff519eabb8a0e7391c9b3d34ff4a40dd759c517a
<pre>
Invalid render pass usage leads to crashes in the WebGPU Swift backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=308471">https://bugs.webkit.org/show_bug.cgi?id=308471</a>
<a href="https://rdar.apple.com/170997914">rdar://170997914</a>

Reviewed by Mike Wyrzykowski, Lily Spiniolas, and Abrar Rahman Protyasha.

Check that metalDepthStencilTexture is non-nil and has a sampleCount greater than 0 instead of
assuming it is non-nil and force unwrapping it. This matches the non-Swift implementation logic.

Also fix a swift-format formatting error in `USDModel.swift`.

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/308434@main">https://commits.webkit.org/308434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744164d99ffd0e42acacd0cb7f85b57bf0da058f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156179 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100912 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0e08019-ef57-43dc-bc04-1e6bd44d3496) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113680 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81074 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c42b9d5b-8f92-4b4a-9553-80af7e6bc455) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94440 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/863cbeca-32cd-4d69-99db-b23e989fee29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15089 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12873 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3620 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124684 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158512 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121707 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121906 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31223 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132172 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76035 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8952 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83359 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->