### PR TITLE
auto table layout doesn't honor "max-width" on table cells, when distributing width between them

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout-expected.txt
@@ -1,0 +1,10 @@
+ 	 
+ 	 
+ 	 
+ 	 
+
+PASS Cell with max-width smaller than width is clamped
+PASS Cell with max-width larger than width is not affected
+PASS Cell with max-width equal to width is not affected
+PASS Cell without max-width is not affected
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<title>Auto table layout should honor max-width on table cells</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#computing-column-measures" />
+<style>
+table { border-collapse: collapse; }
+td { padding: 0; }
+</style>
+
+<table style="width:100px; height:20px" id="basic">
+  <tr>
+    <td id="basic-auto">&nbsp;</td>
+    <td id="basic-clamped" style="width:50px; max-width:1px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<table style="width:100px; height:20px" id="larger-max">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="larger-max-cell" style="width:50px; max-width:100px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<table style="width:100px; height:20px" id="equal-max">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="equal-max-cell" style="width:50px; max-width:50px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<table style="width:100px; height:20px" id="no-max">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="no-max-cell" style="width:50px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<script>
+test(() => {
+  assert_equals(document.getElementById('basic-clamped').offsetWidth, 1,
+    'max-width:1px should clamp width:50px to 1px');
+}, 'Cell with max-width smaller than width is clamped');
+
+test(() => {
+  assert_equals(document.getElementById('larger-max-cell').offsetWidth, 50,
+    'max-width:100px should not reduce width:50px');
+}, 'Cell with max-width larger than width is not affected');
+
+test(() => {
+  assert_equals(document.getElementById('equal-max-cell').offsetWidth, 50,
+    'max-width:50px equal to width:50px should not change width');
+}, 'Cell with max-width equal to width is not affected');
+
+test(() => {
+  assert_equals(document.getElementById('no-max-cell').offsetWidth, 50,
+    'Cell with width:50px and no max-width should remain 50px');
+}, 'Cell without max-width is not affected');
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout-expected.txt
@@ -1,0 +1,10 @@
+ 	 
+ 	 
+ 	 
+ 	 
+
+PASS Cell with min-width larger than width is expanded
+PASS Cell with min-width smaller than width is not affected
+PASS Cell with min-width equal to width is not affected
+PASS Cell with min-width larger than max-width uses min-width
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<title>Auto table layout should honor min-width on table cells</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#computing-column-measures" />
+<style>
+table { border-collapse: collapse; }
+td { padding: 0; }
+</style>
+
+<table style="width:400px; height:20px" id="basic">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="basic-clamped" style="width:50px; min-width:150px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<table style="width:400px; height:20px" id="smaller-min">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="smaller-min-cell" style="width:150px; min-width:50px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<table style="width:400px; height:20px" id="equal-min">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="equal-min-cell" style="width:100px; min-width:100px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<table style="width:400px; height:20px" id="min-wins">
+  <tr>
+    <td>&nbsp;</td>
+    <td id="min-wins-cell" style="width:200px; min-width:150px; max-width:100px; background:blue;">&nbsp;</td>
+  </tr>
+</table>
+
+<script>
+test(() => {
+  assert_equals(document.getElementById('basic-clamped').offsetWidth, 150,
+    'min-width:150px should override width:50px');
+}, 'Cell with min-width larger than width is expanded');
+
+test(() => {
+  assert_equals(document.getElementById('smaller-min-cell').offsetWidth, 150,
+    'min-width:50px should not increase width:150px');
+}, 'Cell with min-width smaller than width is not affected');
+
+test(() => {
+  assert_equals(document.getElementById('equal-min-cell').offsetWidth, 100,
+    'min-width:100px equal to width:100px should not change width');
+}, 'Cell with min-width equal to width is not affected');
+
+test(() => {
+  assert_equals(document.getElementById('min-wins-cell').offsetWidth, 150,
+    'min-width:150px should win over max-width:100px');
+}, 'Cell with min-width larger than max-width uses min-width');
+</script>
+</html>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -115,6 +115,9 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                             // ignore width=0
                             if (fixedCellLogicalWidth.isPositive() && !columnLayout.logicalWidth.isPercentOrCalculated()) {
                                 float logicalWidth = cell->adjustBorderBoxLogicalWidthForBoxSizing(fixedCellLogicalWidth);
+                                // Honor the cell's CSS max-width constraint.
+                                if (auto fixedMaxWidth = cell->style().logicalMaxWidth().tryFixed())
+                                    logicalWidth = std::min(logicalWidth, cell->adjustBorderBoxLogicalWidthForBoxSizing(*fixedMaxWidth).toFloat());
                                 if (auto fixedColumnLayoutLogicalWidth = columnLayout.logicalWidth.tryFixed()) {
                                     // Nav/IE weirdness
                                     if ((logicalWidth > fixedColumnLayoutLogicalWidth->resolveZoom(cellUsedZoom))


### PR DESCRIPTION
#### 34394ef2a45b9ea5b1a721ae9f6e9defe7abb342
<pre>
auto table layout doesn&apos;t honor &quot;max-width&quot; on table cells, when distributing width between them
<a href="https://bugs.webkit.org/show_bug.cgi?id=144338">https://bugs.webkit.org/show_bug.cgi?id=144338</a>
<a href="https://rdar.apple.com/171459245">rdar://171459245</a>

Reviewed by Alan Baradlay.

In AutoTableLayout::recalcColumn(), when a cell has an explicit CSS width,
the value is stored into columnLayout.logicalWidth without consulting the
cell&apos;s max-width. This causes max-width to be ignored during fixed-width
column distribution in layout().

Clamp the resolved logicalWidth by the cell&apos;s CSS max-width right after
it is computed, so the clamped value flows into columnLayout.logicalWidth
and is respected during width distribution.

Test: imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout.html
      imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-max-width-auto-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/td-min-width-auto-layout.html: Added.
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):

Canonical link: <a href="https://commits.webkit.org/308934@main">https://commits.webkit.org/308934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58a3c9191d8d47887b235dc4059ec814ac95e46d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102161 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/303ced5f-e93a-4489-a3b6-fae358f331ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114658 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81647 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d9c5747-84b6-4a23-b1dc-63c6f1db622f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95428 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35b47b04-23e4-4993-9155-0826647e1c72) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13816 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4851 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2891 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122723 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122947 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33459 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77411 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18247 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9988 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84658 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20644 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->