### PR TITLE
[Site Isolation] Fix datetime picker positioning in cross-origin iframes

### DIFF
--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -683,6 +683,7 @@ bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserPar
         parameters.anchorRectInRootView = protect(document->view())->contentsToRootView(renderer->absoluteBoundingBoxRect());
     else
         parameters.anchorRectInRootView = IntRect();
+    parameters.rootFrameID = protect(document->view())->rootFrameID();
     parameters.currentValue = element->value();
 
     CheckedRef computedStyle = *element->computedStyle();

--- a/Source/WebCore/platform/DateTimeChooserParameters.h
+++ b/Source/WebCore/platform/DateTimeChooserParameters.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -51,6 +52,7 @@ struct DateTimeChooserParameters {
     bool hasSecondField { false };
     bool hasMillisecondField { false };
     bool wasActivatedByKeyboard { false };
+    std::optional<FrameIdentifier> rootFrameID;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2372,6 +2372,7 @@ struct WebCore::DateTimeChooserParameters {
     bool hasSecondField;
     bool hasMillisecondField;
     bool wasActivatedByKeyboard;
+    std::optional<WebCore::FrameIdentifier> rootFrameID;
 }
 
 header: <WebCore/ScreenProperties.h>

--- a/Source/WebKit/UIProcess/WebDateTimePicker.cpp
+++ b/Source/WebKit/UIProcess/WebDateTimePicker.cpp
@@ -27,6 +27,7 @@
 #include "WebDateTimePicker.h"
 
 #include "WebPageProxy.h"
+#include <WebCore/DateTimeChooserParameters.h>
 
 namespace WebKit {
 
@@ -37,6 +38,12 @@ WebDateTimePicker::WebDateTimePicker(WebPageProxy& page)
 
 WebDateTimePicker::~WebDateTimePicker()
 {
+}
+
+void WebDateTimePicker::showDateTimePicker(WebCore::DateTimeChooserParameters&& params)
+{
+    m_frameID = params.rootFrameID;
+    platformShowDateTimePicker(WTF::move(params));
 }
 
 void WebDateTimePicker::endPicker()

--- a/Source/WebKit/UIProcess/WebDateTimePicker.h
+++ b/Source/WebKit/UIProcess/WebDateTimePicker.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -41,12 +42,17 @@ public:
     virtual ~WebDateTimePicker();
 
     virtual void endPicker();
-    virtual void showDateTimePicker(WebCore::DateTimeChooserParameters&&) = 0;
+    void showDateTimePicker(WebCore::DateTimeChooserParameters&&);
+
+    std::optional<WebCore::FrameIdentifier> frameID() const { return m_frameID; }
 
 protected:
     explicit WebDateTimePicker(WebPageProxy&);
 
+    virtual void platformShowDateTimePicker(WebCore::DateTimeChooserParameters&&) = 0;
+
     WeakPtr<WebPageProxy> m_page;
+    std::optional<WebCore::FrameIdentifier> m_frameID;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -223,6 +223,7 @@
 #include <WebCore/CrossSiteNavigationDataTransfer.h>
 #include <WebCore/CryptoKey.h>
 #include <WebCore/DOMPasteAccess.h>
+#include <WebCore/DateTimeChooserParameters.h>
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
@@ -10609,7 +10610,17 @@ void WebPageProxy::showDateTimePicker(WebCore::DateTimeChooserParameters&& param
     if (!m_dateTimePicker)
         return;
 
-    protect(*m_dateTimePicker)->showDateTimePicker(WTF::move(params));
+    convertRectToMainFrameCoordinates(params.anchorRectInRootView, params.rootFrameID, [weakThis = WeakPtr { *this }, params = WTF::move(params)](std::optional<FloatRect> convertedRect) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !convertedRect)
+            return;
+
+        if (!protectedThis->m_dateTimePicker)
+            return;
+
+        params.anchorRectInRootView = IntRect(*convertedRect);
+        protect(*protectedThis->m_dateTimePicker)->showDateTimePicker(WTF::move(params));
+    });
 }
 
 void WebPageProxy::endDateTimePicker()
@@ -10625,18 +10636,18 @@ void WebPageProxy::didChooseDate(StringView date)
     if (!hasRunningProcess())
         return;
 
-    auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
-    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidChooseDate(date.toString()));
+    auto frameID = m_dateTimePicker ? m_dateTimePicker->frameID() : std::nullopt;
+    sendToProcessContainingFrame(frameID, Messages::WebPage::DidChooseDate(date.toString()));
 }
 
 void WebPageProxy::didEndDateTimePicker()
 {
+    auto frameID = m_dateTimePicker ? m_dateTimePicker->frameID() : std::nullopt;
     m_dateTimePicker = nullptr;
     if (!hasRunningProcess())
         return;
 
-    auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
-    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidEndDateTimePicker());
+    sendToProcessContainingFrame(frameID, Messages::WebPage::DidEndDateTimePicker());
 }
 
 WebInspectorUIProxy* WebPageProxy::inspector() const

--- a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp
@@ -122,7 +122,7 @@ void WebDateTimePickerGtk::didChooseDate()
     m_page->didChooseDate(calendarDateToString(year, month, day, m_currentDate, m_secondFormat));
 }
 
-void WebDateTimePickerGtk::showDateTimePicker(WebCore::DateTimeChooserParameters&& params)
+void WebDateTimePickerGtk::platformShowDateTimePicker(WebCore::DateTimeChooserParameters&& params)
 {
     if (m_popover) {
         update(WTF::move(params));

--- a/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.h
@@ -41,7 +41,7 @@ private:
     WebDateTimePickerGtk(WebPageProxy&);
 
     void endPicker() final;
-    void showDateTimePicker(WebCore::DateTimeChooserParameters&&) final;
+    void platformShowDateTimePicker(WebCore::DateTimeChooserParameters&&) final;
 
     void update(WebCore::DateTimeChooserParameters&&);
     void didChooseDate();

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h
@@ -48,7 +48,7 @@ public:
 private:
     WebDateTimePickerMac(WebPageProxy&, NSView *);
 
-    void showDateTimePicker(WebCore::DateTimeChooserParameters&&) final;
+    void platformShowDateTimePicker(WebCore::DateTimeChooserParameters&&) final;
 
     WeakObjCPtr<NSView> m_view;
     RetainPtr<WKDateTimePicker> m_picker;

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -88,7 +88,7 @@ void WebDateTimePickerMac::endPicker()
     WebDateTimePicker::endPicker();
 }
 
-void WebDateTimePickerMac::showDateTimePicker(WebCore::DateTimeChooserParameters&& params)
+void WebDateTimePickerMac::platformShowDateTimePicker(WebCore::DateTimeChooserParameters&& params)
 {
     if (m_picker) {
         [m_picker updatePicker:WTF::move(params)];


### PR DESCRIPTION
#### 826329072b7dc2eae74aa481a382224373ceee9e
<pre>
[Site Isolation] Fix datetime picker positioning in cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308921">https://bugs.webkit.org/show_bug.cgi?id=308921</a>
<a href="https://rdar.apple.com/171461287">rdar://171461287</a>

Reviewed by Aditya Keerthi.

The anchorRectInRootView in DateTimeChooserParameters is
relative to the iframe&apos;s root view, but the UI process interprets it
as main-frame coordinates. Add rootFrameID to
DateTimeChooserParameters and use convertRectToMainFrameCoordinates()
 in showDateTimePicker, matching the existing color picker fix. Also
store the frameID on WebDateTimePicker so
didChooseDate/didEndDateTimePicker route responses reliably instead
of using focusedOrMainFrame().

* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::setupDateTimeChooserParameters):
* Source/WebCore/platform/DateTimeChooserParameters.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebDateTimePicker.cpp:
(WebKit::WebDateTimePicker::showDateTimePicker):
* Source/WebKit/UIProcess/WebDateTimePicker.h:
(WebKit::WebDateTimePicker::frameID const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showDateTimePicker):
(WebKit::WebPageProxy::didChooseDate):
(WebKit::WebPageProxy::didEndDateTimePicker):
* Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.cpp:
(WebKit::WebDateTimePickerGtk::platformShowDateTimePicker):
(WebKit::WebDateTimePickerGtk::showDateTimePicker):
* Source/WebKit/UIProcess/gtk/WebDateTimePickerGtk.h:
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h:
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(WebKit::WebDateTimePickerMac::platformShowDateTimePicker):
(WebKit::WebDateTimePickerMac::showDateTimePicker):

Canonical link: <a href="https://commits.webkit.org/309104@main">https://commits.webkit.org/309104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/781c669dc11f740903bb25245a23a81636857d78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158133 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16f71122-9d8c-48f9-bc22-68e083d3fcd5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b622c46e-55de-456f-a91c-24227165eccb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95993 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92c145fa-a8ff-4e71-a3ad-6a61e8c6c3f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16495 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5976 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160610 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123289 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33564 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78173 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10575 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85381 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21291 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->