### PR TITLE
Fix CSS gradients with large color-stop-length rendering bug

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-expected.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, minimum-scale=1.0">
+<title>Reference for gradients with huge color-stop-length</title>
+<style>
+    div {
+        display: inline-block;
+        vertical-align: top;
+        font-family: sans-serif;
+        width: 100px;
+        height: 100px;
+        background: linear-gradient(green 100px, red 0px);
+    }
+</style>
+
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-ref.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, minimum-scale=1.0">
+<title>Reference for gradients with huge color-stop-length</title>
+<style>
+    div {
+        display: inline-block;
+        vertical-align: top;
+        font-family: sans-serif;
+        width: 100px;
+        height: 100px;
+        background: linear-gradient(green 100px, red 0px);
+    }
+</style>
+
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>
+<div>This should be a green background.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, minimum-scale=1.0">
+<title>Gradients with huge color-stop-length should work</title>
+<link rel="author" title="CGQAQ" href="mailto:cgqaq@chromium.org">
+<link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
+<meta name="assert" content="Tests that gradients with huge color-stop-length works.">
+<link rel="match" href="gradient-with-huge-color-stop-length-ref.html">
+<style>
+    div {
+        display: inline-block;
+        vertical-align: top;
+        font-family: sans-serif;
+        width: 100px;
+        height: 100px;
+    }
+    .expected {
+        background: linear-gradient(green 100px, red 0px);
+    }
+    .test1 {
+        background: linear-gradient(green 100px, red 100px 30000000000px);
+    }
+    .test2 {
+        background: linear-gradient(green 100px, red 100px 3000000px);
+    }
+    .test3 {
+        background: linear-gradient(green 100px, red 0px 30000000000%);
+    }
+    .test4 {
+        background: linear-gradient(green 100px, red 100px calc(Infinity * 1px));
+    }
+    .test5 {
+        background: linear-gradient(green 100px, red 100px calc(Infinity * 1%));
+    }
+</style>
+
+<div class="expected">This should be a green background.</div>
+<div class="test1">This should be a green background.</div>
+<div class="test2">This should be a green background.</div>
+<div class="test3">This should be a green background.</div>
+<div class="test4">This should be a green background.</div>
+<div class="test5">This should be a green background.</div>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -106,6 +106,8 @@ webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-a
 # Event timing: timing out for unclear reasons - perhaps scheduling. Events handlers are called but event timing entries aren't produced
 webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html [ Skip ]
 webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Skip ]
+# Only gtk-wk2 had this test failing, skip it for now.
+webkit.org/b/308922 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length.html [ Skip ]
 
 # Media controls
 accessibility/gtk/media-controls-panel-title.html [ Failure ]

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -190,20 +190,99 @@ public:
 
     static constexpr float maxExtent(float) { return 1; }
 
-    void normalizeStopsAndEndpointsOutsideRange(Vector<ResolvedGradientStop>& stops, ColorInterpolationMethod)
+    void normalizeStopsAndEndpointsOutsideRange(Vector<ResolvedGradientStop>& stops, ColorInterpolationMethod colorInterpolationMethod)
     {
+        auto clampStopsOutsideUnitInterval = [&] {
+            size_t numberOfStops = stops.size();
+            size_t lastStopIndex = numberOfStops - 1;
+
+            std::optional<size_t> firstZeroOrGreaterIndex;
+            for (size_t i = 0; i < numberOfStops; ++i) {
+                if (*stops[i].offset >= 0) {
+                    firstZeroOrGreaterIndex = i;
+                    break;
+                }
+            }
+
+            if (firstZeroOrGreaterIndex) {
+                size_t index = *firstZeroOrGreaterIndex;
+                if (index > 0) {
+                    float previousOffset = *stops[index - 1].offset;
+                    float nextOffset = *stops[index].offset;
+
+                    float interStopProportion = -previousOffset / (nextOffset - previousOffset);
+                    auto blendedColor = interpolateColors(colorInterpolationMethod, stops[index - 1].color, 1.0f - interStopProportion, stops[index].color, interStopProportion);
+
+                    // Clamp the positions to 0 and set the color.
+                    for (size_t i = 0; i < index; ++i) {
+                        stops[i].offset = 0;
+                        stops[i].color = blendedColor;
+                    }
+                }
+            } else {
+                // All stop offsets below 0, clamp them.
+                for (auto& stop : stops)
+                    stop.offset = 0;
+            }
+
+            std::optional<size_t> lastOneOrLessIndex;
+            for (int i = lastStopIndex; i >= 0; --i) {
+                if (*stops[i].offset <= 1) {
+                    lastOneOrLessIndex = i;
+                    break;
+                }
+            }
+
+            if (lastOneOrLessIndex) {
+                size_t index = *lastOneOrLessIndex;
+                if (index < lastStopIndex) {
+                    float previousOffset = *stops[index].offset;
+                    float nextOffset = *stops[index + 1].offset;
+
+                    float interStopProportion = (1 - previousOffset) / (nextOffset - previousOffset);
+                    auto blendedColor = interpolateColors(colorInterpolationMethod, stops[index].color, 1.0f - interStopProportion, stops[index + 1].color, interStopProportion);
+
+                    // Clamp the positions to 1 and set the color.
+                    for (size_t i = index + 1; i < numberOfStops; ++i) {
+                        stops[i].offset = 1;
+                        stops[i].color = blendedColor;
+                    }
+                }
+            } else {
+                // All stop offsets above 1, clamp them.
+                for (auto& stop : stops)
+                    stop.offset = 1;
+            }
+        };
+
         float firstOffset = *stops.first().offset;
         float lastOffset = *stops.last().offset;
         if (firstOffset != lastOffset) {
             float scale = lastOffset - firstOffset;
+            auto p0 = m_data.point0;
+            auto p1 = m_data.point1;
+
+            FloatPoint newPoint0 { p0.x() + firstOffset * (p1.x() - p0.x()), p0.y() + firstOffset * (p1.y() - p0.y()) };
+            FloatPoint newPoint1 { p1.x() + (lastOffset - 1) * (p1.x() - p0.x()), p1.y() + (lastOffset - 1) * (p1.y() - p0.y()) };
+
+            // Keep coordinates in a range where float still has about pixel-level precision.
+            // This is basically 1.0f * 2^30, which is approximately 1e9, so it should be large
+            // enough for any reasonable gradient size while still keeping good precision.
+            const float maxEndpointMagnitude = std::scalbn(1.0f, 30);
+            auto isReasonable = [maxEndpointMagnitude](const FloatPoint& point) {
+                return std::isfinite(point.x()) && std::isfinite(point.y()) && std::abs(point.x()) <= maxEndpointMagnitude && std::abs(point.y()) <= maxEndpointMagnitude;
+            };
+            if (!isReasonable(newPoint0) || !isReasonable(newPoint1)) {
+                // Keep endpoints stable if the normalized geometry grows too large for platform gradients.
+                clampStopsOutsideUnitInterval();
+                return;
+            }
 
             for (auto& stop : stops)
                 stop.offset = (*stop.offset - firstOffset) / scale;
 
-            auto p0 = m_data.point0;
-            auto p1 = m_data.point1;
-            m_data.point0 = { p0.x() + firstOffset * (p1.x() - p0.x()), p0.y() + firstOffset * (p1.y() - p0.y()) };
-            m_data.point1 = { p1.x() + (lastOffset - 1) * (p1.x() - p0.x()), p1.y() + (lastOffset - 1) * (p1.y() - p0.y()) };
+            m_data.point0 = newPoint0;
+            m_data.point1 = newPoint1;
         } else {
             // All stops at same position - clamp offsets but keep all colors.
             // This creates a hard color stop at the clamped position.


### PR DESCRIPTION
#### df972d1d504e7198b998a5cba32471cb457da3c6
<pre>
Fix CSS gradients with large color-stop-length rendering bug
<a href="https://bugs.webkit.org/show_bug.cgi?id=308922">https://bugs.webkit.org/show_bug.cgi?id=308922</a>

Reviewed by NOBODY (OOPS!).

If the &lt;color-stop-length&gt; is so large in percentage,
when we fit it into [0,1], the LinearData&apos;s points got
expanded to a value that is so large and the graphics
backend just can&apos;t handle it.
This PR fixes it by clamp values into reasonable range.

Tests: imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-ref.html
       imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/gradient-with-huge-color-stop-length.html: Added.
* Source/WebCore/style/values/images/StyleGradient.cpp:
(WebCore::Style::LinearGradientAdapter::normalizeStopsAndEndpointsOutsideRange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df972d1d504e7198b998a5cba32471cb457da3c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81139 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12952 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158599 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121786 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132254 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76174 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9034 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83445 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19412 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19563 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->