### PR TITLE
Make ShadowRoot::findAssignedSlot NODELETE

### DIFF
--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -28,6 +28,7 @@
 #include "HTMLSlotElement.h"
 #include "PseudoElement.h"
 #include "ShadowRoot.h"
+#include "SlotAssignment.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/ComposedTreeIterator.h
+++ b/Source/WebCore/dom/ComposedTreeIterator.h
@@ -28,6 +28,7 @@
 #include "ElementAndTextDescendantIterator.h"
 #include "HTMLSlotElement.h"
 #include "ShadowRoot.h"
+#include "SlotAssignment.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -34,6 +34,7 @@
 #include "NodeInlines.h"
 #include "PseudoElement.h"
 #include "ShadowRoot.h"
+#include "SlotAssignment.h"
 #include "TouchEvent.h"
 #include "TreeScopeInlines.h"
 #include <wtf/CheckedPtr.h>

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -320,13 +320,6 @@ void ShadowRoot::removeAllEventListeners()
         node->removeAllEventListeners();
 }
 
-
-HTMLSlotElement* ShadowRoot::findAssignedSlot(const Node& node)
-{
-    ASSERT(node.parentNode() == host());
-    return m_slotAssignment ? m_slotAssignment->findAssignedSlot(node) : nullptr;
-}
-
 void ShadowRoot::renameSlotElement(HTMLSlotElement& slot, const AtomString& oldName, const AtomString& newName)
 {
     ASSERT(m_slotAssignment);

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -118,7 +118,7 @@ public:
     void removeAllEventListeners() override;
 
     SlotAssignmentMode slotAssignmentMode() const { return m_slotAssignmentMode; }
-    HTMLSlotElement* findAssignedSlot(const Node&);
+    inline HTMLSlotElement* NODELETE findAssignedSlot(const Node&); // Defined in SlotAssignment.h
 
     void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName);
     void addSlotElementByName(const AtomString&, HTMLSlotElement&);
@@ -126,14 +126,14 @@ public:
     void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current);
     void didRemoveManuallyAssignedNode(HTMLSlotElement&, const Node&);
     void slotFallbackDidChange(HTMLSlotElement&);
-    void resolveSlotsBeforeNodeInsertionOrRemoval();
-    void willRemoveAllChildren(ContainerNode&);
-    void willRemoveAssignedNode(Node&);
+    inline void NODELETE resolveSlotsBeforeNodeInsertionOrRemoval(); // Defined in SlotAssignment.h
+    inline void NODELETE willRemoveAllChildren(ContainerNode&); // Defined in SlotAssignment.h
+    inline void willRemoveAssignedNode(Node&); // Defined in SlotAssignment.h
 
-    void didRemoveAllChildrenOfShadowHost();
-    void didMutateTextNodesOfShadowHost();
-    void hostChildElementDidChange(const Element&);
-    void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue);
+    inline void didRemoveAllChildrenOfShadowHost(); // Defined in SlotAssignment.h
+    inline void didMutateTextNodesOfShadowHost(); // Defined in SlotAssignment.h
+    inline void hostChildElementDidChange(const Element&); // Defined in SlotAssignment.h
+    inline void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue); // Defined in SlotAssignment.h
 
     const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&);
 

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -59,7 +59,7 @@ static const AtomString& NODELETE slotNameFromAttributeValue(const AtomString& v
     return value == nullAtom() ? NamedSlotAssignment::defaultSlotName() : value;
 }
 
-static const AtomString& slotNameFromSlotAttribute(const Node& child)
+static const AtomString& NODELETE slotNameFromSlotAttribute(const Node& child)
 {
     if (is<Text>(child))
         return NamedSlotAssignment::defaultSlotName();
@@ -398,7 +398,7 @@ void NamedSlotAssignment::willRemoveAssignedNode(Node& node, ShadowRoot&)
     InspectorInstrumentation::didChangeAssignedSlot(node);
 }
 
-const AtomString& NamedSlotAssignment::slotNameForHostChild(const Node& child) const
+const AtomString& NODELETE NamedSlotAssignment::slotNameForHostChild(const Node& child) const
 {
     return slotNameFromSlotAttribute(child);
 }
@@ -458,11 +458,11 @@ void NamedSlotAssignment::assignToSlot(Node& child, const AtomString& slotName)
 
 HTMLSlotElement* ManualSlotAssignment::findAssignedSlot(const Node& node)
 {
-    RefPtr slot = node.manuallyAssignedSlot();
+    auto* slot = node.manuallyAssignedSlot();
     if (!slot)
         return nullptr;
-    RefPtr containingShadowRoot = slot->containingShadowRoot();
-    return containingShadowRoot && containingShadowRoot->host() == node.parentNode() ? slot.unsafeGet() : nullptr;
+    auto* containingShadowRoot = slot->containingShadowRoot();
+    return containingShadowRoot && containingShadowRoot->host() == node.parentNode() ? slot : nullptr;
 }
 
 static Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> effectiveAssignedNodes(ShadowRoot& shadowRoot, const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& manuallyAssingedNodes)

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -50,10 +50,10 @@ public:
     virtual ~SlotAssignment() = default;
 
     // These functions are only useful for NamedSlotAssignment but it's here to avoid virtual function calls in perf critical code paths.
-    void resolveSlotsBeforeNodeInsertionOrRemoval();
-    void willRemoveAllChildren();
+    inline void resolveSlotsBeforeNodeInsertionOrRemoval();
+    inline void willRemoveAllChildren();
 
-    virtual HTMLSlotElement* findAssignedSlot(const Node&) = 0;
+    virtual HTMLSlotElement* NODELETE findAssignedSlot(const Node&) = 0;
     virtual const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) = 0;
 
     virtual void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName, ShadowRoot&) = 0;
@@ -90,7 +90,7 @@ protected:
     void didChangeSlot(const AtomString&, ShadowRoot&);
 
 private:
-    HTMLSlotElement* findAssignedSlot(const Node&) final;
+    HTMLSlotElement* NODELETE findAssignedSlot(const Node&) final;
 
     void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName, ShadowRoot&) final;
     void addSlotElementByName(const AtomString&, HTMLSlotElement&, ShadowRoot&) final;
@@ -125,7 +125,7 @@ private:
     enum class SlotMutationType { Insertion, Removal };
     void resolveSlotsAfterSlotMutation(ShadowRoot&, SlotMutationType, ContainerNode* oldParentOfRemovedTree = nullptr);
 
-    virtual const AtomString& slotNameForHostChild(const Node&) const;
+    virtual const AtomString& NODELETE slotNameForHostChild(const Node&) const;
 
     HTMLSlotElement* NODELETE findFirstSlotElement(Slot&);
 
@@ -146,7 +146,7 @@ class ManualSlotAssignment : public SlotAssignment {
 public:
     ManualSlotAssignment() = default;
 
-    HTMLSlotElement* findAssignedSlot(const Node&) final;
+    HTMLSlotElement* NODELETE findAssignedSlot(const Node&) final;
 
     const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) final;
     void renameSlotElement(HTMLSlotElement&, const AtomString&, const AtomString&, ShadowRoot&) final;
@@ -172,6 +172,14 @@ private:
     uint64_t m_slottableVersion { 0 };
     unsigned m_slotElementCount { 0 };
 };
+
+inline HTMLSlotElement* ShadowRoot::findAssignedSlot(const Node& node)
+{
+    ASSERT(node.parentNode() == host());
+    if (m_slotAssignment) [[unlikely]]
+        return m_slotAssignment->findAssignedSlot(node);
+    return nullptr;
+}
 
 inline void SlotAssignment::resolveSlotsBeforeNodeInsertionOrRemoval()
 {

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -64,7 +64,7 @@ static const AtomString& summarySlotName()
 class DetailsSlotAssignment final : public NamedSlotAssignment {
 private:
     void hostChildElementDidChange(const Element&, ShadowRoot&) override;
-    const AtomString& slotNameForHostChild(const Node&) const override;
+    const AtomString& NODELETE slotNameForHostChild(const Node&) const override;
 };
 
 void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElement, ShadowRoot& shadowRoot)
@@ -82,7 +82,7 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
         didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
 }
 
-const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child) const
+SUPPRESS_NODELETE const AtomString& NODELETE DetailsSlotAssignment::slotNameForHostChild(const Node& child) const
 {
     Ref details = downcast<HTMLDetailsElement>(*child.parentNode());
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -103,7 +103,7 @@ static bool NODELETE isFirstElementChildButton(const Node& child)
 class SelectSlotAssignment final : public NamedSlotAssignment {
 private:
     void hostChildElementDidChange(const Element&, ShadowRoot&) final;
-    const AtomString& slotNameForHostChild(const Node&) const final;
+    const AtomString& NODELETE slotNameForHostChild(const Node&) const final;
 };
 
 void SelectSlotAssignment::hostChildElementDidChange(const Element& childElement, ShadowRoot& shadowRoot)
@@ -116,7 +116,7 @@ void SelectSlotAssignment::hostChildElementDidChange(const Element& childElement
         didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
 }
 
-const AtomString& SelectSlotAssignment::slotNameForHostChild(const Node& child) const
+SUPPRESS_NODELETE const AtomString& SelectSlotAssignment::slotNameForHostChild(const Node& child) const
 {
     return isFirstElementChildButton(child) ? buttonSlotName() : NamedSlotAssignment::defaultSlotName();
 }

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -33,6 +33,7 @@
 #include "NodeRenderStyle.h"
 #include "RenderElement.h"
 #include "SVGElement.h"
+#include "SlotAssignment.h"
 #include "Text.h"
 #include <wtf/TZoneMallocInlines.h>
 


### PR DESCRIPTION
#### ac35ddc56d00cacdddaa6b412677cd645f5ca7af
<pre>
Make ShadowRoot::findAssignedSlot NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=308923">https://bugs.webkit.org/show_bug.cgi?id=308923</a>

Reviewed by Anne van Kesteren.

Annotate a bunch of functions called by ShadowRoot::findAssignedSlot as NODELETE.

Also moved the implementation of ShadowRoot::findAssignedSlot from ShadowRoot.cpp
to SlotAssignment.h since it just forwards to SlotAssignment::findAssignedSlot.

No new tests since there should be no behavioral changes.

* Source/WebCore/dom/ComposedTreeAncestorIterator.h:
* Source/WebCore/dom/ComposedTreeIterator.h:
* Source/WebCore/dom/EventPath.cpp:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::findAssignedSlot): Deleted.
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::slotNameFromSlotAttribute):
(WebCore::NamedSlotAssignment::slotNameForHostChild const):
(WebCore::ManualSlotAssignment::findAssignedSlot):
* Source/WebCore/dom/SlotAssignment.h:
(WebCore::ShadowRoot::findAssignedSlot):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::slotNameForHostChild const):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::SelectSlotAssignment::slotNameForHostChild const):
* Source/WebCore/style/StyleUpdate.cpp:

Canonical link: <a href="https://commits.webkit.org/308440@main">https://commits.webkit.org/308440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/664099b2669212c9152313563b39d8d3554e1621

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100929 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e66f093e-c5cd-4798-8267-cc803345c83c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113696 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81079 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6e17a07-c3e2-497f-8dbe-f073dfdc1197) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94455 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/faed2bfc-e46a-4dc8-90f0-a44e2ad70d50) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15105 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12888 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3637 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158529 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121722 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121921 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76052 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8970 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83376 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->