### PR TITLE
Make <option> and <optgroup> render outside <select> elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -659,9 +659,12 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 # Top layer exit animations (remove from implicit anchor/top layer after picker transition finishes).
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html [ ImageOnlyFailure ]
 
+# Need option & optgroup shadow tree fix
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html [ ImageOnlyFailure ]
+
 # Untriaged.
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.html [ Skip ]
 

--- a/LayoutTests/fast/forms/select/menulist-focusable-items-expected.txt
+++ b/LayoutTests/fast/forms/select/menulist-focusable-items-expected.txt
@@ -10,4 +10,4 @@ PASS isFocusable("optionD") is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+ D

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_delete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_delete-expected.txt
@@ -1,4 +1,5 @@
 
+
 PASS Test execCommand with selection around select element
 FAIL execCommand(delete, false, "") in <div contenteditable><p>ab[c</p><select><option>d]ef</option></select></div>: shouldn't modify in <option> assert_in_array: value "<div contenteditable><p>ac</p><select><option>def</option></select></div>" not in array ["<div contenteditable><p>abc</p><select><option>def</option></select></div>", "<div contenteditable><p>ab</p><select><option>def</option></select></div>"]
 PASS execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>d[]ef</option></select></div>: shouldn't modify in <option>
@@ -34,6 +35,6 @@ PASS execCommand(delete, false, "") in <select multiple contenteditable>{<option
 PASS execCommand(delete, false, "") in <select multiple><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>
 PASS execCommand(delete, false, "") in <select multiple><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s
 PASS execCommand(delete, false, "") in <select multiple><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup
-PASS execCommand(delete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup
-PASS execCommand(delete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option>
+FAIL execCommand(delete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option>def</option></optgroup>"
+FAIL execCommand(delete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option> assert_equals: expected "<option contenteditable>abc</option>" but got "<option contenteditable></option>"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_forwardDelete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_forwardDelete-expected.txt
@@ -1,4 +1,5 @@
 
+
 PASS Test execCommand with selection around select element
 PASS execCommand(forwardDelete, false, "") in <div contenteditable><p>ab[c</p><select><option>d]ef</option></select></div>: shouldn't modify in <option>
 PASS execCommand(forwardDelete, false, "") in <div contenteditable><p>abc</p><select><option>d[]ef</option></select></div>: shouldn't modify in <option>
@@ -34,6 +35,6 @@ PASS execCommand(forwardDelete, false, "") in <select multiple contenteditable>{
 PASS execCommand(forwardDelete, false, "") in <select multiple><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>
 PASS execCommand(forwardDelete, false, "") in <select multiple><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s
 PASS execCommand(forwardDelete, false, "") in <select multiple><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup
-PASS execCommand(forwardDelete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup
-PASS execCommand(forwardDelete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option>
+FAIL execCommand(forwardDelete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option>def</option></optgroup>"
+FAIL execCommand(forwardDelete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option> assert_equals: expected "<option contenteditable>abc</option>" but got "<option contenteditable></option>"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_insertText-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_insertText-expected.txt
@@ -1,3 +1,4 @@
+XYZ
 
 PASS Test execCommand with selection around select element
 FAIL execCommand(insertText, false, "XYZ") in <div contenteditable><p>ab[c</p><select><option>d]ef</option></select></div>: shouldn't modify in <option> assert_in_array: value "<div contenteditable><p>abXYZc</p><select><option>def</option></select></div>" not in array ["<div contenteditable><p>abc</p><select><option>def</option></select></div>", "<div contenteditable><p>abXYZ</p><select><option>def</option></select></div>"]
@@ -34,6 +35,6 @@ PASS execCommand(insertText, false, "XYZ") in <select multiple contenteditable>{
 PASS execCommand(insertText, false, "XYZ") in <select multiple><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>
 PASS execCommand(insertText, false, "XYZ") in <select multiple><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s
 PASS execCommand(insertText, false, "XYZ") in <select multiple><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup
-PASS execCommand(insertText, false, "XYZ") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup
-PASS execCommand(insertText, false, "XYZ") in <option contenteditable>{abc}</option>: shouldn't modify <option>
+FAIL execCommand(insertText, false, "XYZ") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option>XYZ</option><option>def</option></optgroup>"
+FAIL execCommand(insertText, false, "XYZ") in <option contenteditable>{abc}</option>: shouldn't modify <option> assert_equals: expected "<option contenteditable>abc</option>" but got "<option contenteditable>XYZ</option>"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt
@@ -37,7 +37,7 @@ Light DOM text
 Light DOM text
 
 Misspelling
-
+ Second option First option
 
 PASS aria-activedescendant element reflection
 PASS If the content attribute is set directly, the IDL attribute getter always returns the first element whose ID matches the content attribute.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -136,9 +136,9 @@ PASS <optgroup> containing <optgroup> ("<select><optgroup class='poke-optgroup'>
 FAIL <optgroup> containing <option> ("<select><optgroup><option>abc</select>") assert_equals: innerText expected "abc" but got ""
 FAIL <div> in <option> ("<select><option class='poke-div'>123</select>") assert_equals: innerText expected "123\nabc" but got ""
 FAIL empty <optgroup> in <div> ("<div>a<optgroup></optgroup>bc") assert_equals: innerText expected "a\nbc" but got "abc"
-FAIL <optgroup> in <div> ("<div>a<optgroup>123</optgroup>bc") assert_equals: innerText expected "a\nbc" but got "abc"
+FAIL <optgroup> in <div> ("<div>a<optgroup>123</optgroup>bc") assert_equals: innerText expected "a\nbc" but got "a123bc"
 FAIL empty <option> in <div> ("<div>a<option></option>bc") assert_equals: innerText expected "a\nbc" but got "abc"
-FAIL <option> in <div> ("<div>a<option>123</option>bc") assert_equals: innerText expected "a\n123\nbc" but got "abc"
+FAIL <option> in <div> ("<div>a<option>123</option>bc") assert_equals: innerText expected "a\n123\nbc" but got "a123bc"
 PASS <button> contents preserved ("<div><button>abc")
 FAIL <fieldset> contents preserved ("<div><fieldset>abc") assert_equals: innerText expected "abc" but got "abc\n"
 FAIL <fieldset> <legend> contents preserved ("<div><fieldset><legend>abc") assert_equals: innerText expected "abc" but got "abc\n"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-index-expected.txt
@@ -1,4 +1,4 @@
-
+ hello hello
 
 PASS option index should work inside the document
 PASS option index should always be 0 for options in datalists

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
+
+<div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
+
+<div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
+<link rel=match href="standalone-optgroup-no-shadow-tree-ref.html">
+<meta name=assert content="A standalone optgroup element with a label attribute should not get a UA shadow tree and should render its child text content.">
+
+<optgroup label="label attribute">child text</optgroup>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
+
+<div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
+
+<div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
+<link rel=match href="standalone-option-no-shadow-tree-ref.html">
+<meta name=assert content="A standalone option element with a label attribute should not get a UA shadow tree and should render its child text content.">
+
+<option label="label attribute">child text</option>

--- a/LayoutTests/platform/glib/fast/frames/iframe-option-crash-expected.txt
+++ b/LayoutTests/platform/glib/fast/frames/iframe-option-crash-expected.txt
@@ -9,7 +9,16 @@ layer at (0,0) size 800x192
       RenderBlock (anonymous) at (0,18) size 784x158
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+        RenderInline {option} at (0,140) size 304x17
+          RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+            layer at (0,0) size 300x150
+              RenderView at (0,0) size 300x150
+            layer at (0,0) size 300x150
+              RenderBlock {HTML} at (0,0) size 300x150
+                RenderBody {BODY} at (8,8) size 284x134
+                  RenderText {#text} at (0,0) size 16x18
+                    text run at (0,0) width 16: "11"
+        RenderIFrame {iframe} at (304,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
           layer at (0,0) size 300x150

--- a/LayoutTests/platform/ios/fast/frames/iframe-option-crash-expected.txt
+++ b/LayoutTests/platform/ios/fast/frames/iframe-option-crash-expected.txt
@@ -9,7 +9,16 @@ layer at (0,0) size 800x195
       RenderBlock (anonymous) at (0,20) size 784x159
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+        RenderInline {option} at (0,139) size 304x19
+          RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+            layer at (0,0) size 300x150
+              RenderView at (0,0) size 300x150
+            layer at (0,0) size 300x150
+              RenderBlock {HTML} at (0,0) size 300x150
+                RenderBody {BODY} at (8,8) size 284x134
+                  RenderText {#text} at (0,0) size 16x20
+                    text run at (0,0) width 16: "11"
+        RenderIFrame {iframe} at (304,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
           layer at (0,0) size 300x150

--- a/LayoutTests/platform/mac/fast/frames/iframe-option-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/frames/iframe-option-crash-expected.txt
@@ -9,7 +9,16 @@ layer at (0,0) size 800x192
       RenderBlock (anonymous) at (0,18) size 784x158
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+        RenderInline {option} at (0,140) size 304x18
+          RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+            layer at (0,0) size 300x150
+              RenderView at (0,0) size 300x150
+            layer at (0,0) size 300x150
+              RenderBlock {HTML} at (0,0) size 300x150
+                RenderBody {BODY} at (8,8) size 284x134
+                  RenderText {#text} at (0,0) size 16x18
+                    text run at (0,0) width 16: "11"
+        RenderIFrame {iframe} at (304,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
           layer at (0,0) size 300x150

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -55,15 +55,6 @@ Ref<HTMLOptGroupElement> HTMLOptGroupElement::create(const QualifiedName& tagNam
     return adoptRef(*new HTMLOptGroupElement(tagName, document));
 }
 
-bool HTMLOptGroupElement::rendererIsNeeded(const RenderStyle&)
-{
-    RefPtr select = ownerSelectElement();
-    if (!select)
-        return false;
-
-    return document().settings().htmlEnhancedSelectEnabled() && select->usesBaseAppearancePicker();
-}
-
 auto HTMLOptGroupElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
 {
     auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -49,7 +49,6 @@ private:
     const AtomString& formControlType() const;
     bool isFocusable() const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    bool rendererIsNeeded(const RenderStyle&) final;
 
     void childrenChanged(const ChildChange&) final;
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -180,15 +180,6 @@ bool HTMLOptionElement::isFocusable() const
     return HTMLElement::isFocusable();
 }
 
-bool HTMLOptionElement::rendererIsNeeded(const RenderStyle&)
-{
-    RefPtr select = ownerSelectElement();
-    if (!select)
-        return false;
-
-    return document().settings().htmlEnhancedSelectEnabled() && select->usesBaseAppearancePicker();
-}
-
 String HTMLOptionElement::text() const
 {
     String text = collectOptionInnerText();

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -81,7 +81,6 @@ private:
 
     bool supportsFocus() const final;
     bool isFocusable() const final;
-    bool rendererIsNeeded(const RenderStyle&) final;
     bool matchesDefaultPseudoClass() const final { return m_isDefault; }
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;


### PR DESCRIPTION
#### e7f328b0393a0c5f293b3acfb3b8ad8445552c93
<pre>
Make &lt;option&gt; and &lt;optgroup&gt; render outside &lt;select&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=308924">https://bugs.webkit.org/show_bug.cgi?id=308924</a>

Reviewed by Tim Nguyen.

Align with other browsers and the standard in treating &lt;option&gt; and
&lt;optgroup&gt; as ordinary elements outside of &lt;select&gt;.

(Chromium and WebKit currently do render a shadow root; that&apos;ll be
addressed in a follow-up.)

Tests:

    <a href="https://github.com/web-platform-tests/wpt/pull/58172">https://github.com/web-platform-tests/wpt/pull/58172</a>

Canonical link: <a href="https://commits.webkit.org/308464@main">https://commits.webkit.org/308464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0168974c27c810df14d180d1e6b88b24dd75f01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101058 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28c6da4a-2961-4257-91cc-8c50bdc3f59c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113811 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81173 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/247c4f5f-83c8-462f-a07f-6f420b3ea52d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d1c5604-3978-4b9b-9044-37ef04060e40) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15215 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3766 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158659 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132306 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76247 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9086 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83505 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19472 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->