### PR TITLE
border-spacing should not include collapsed columns in auto table layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-004-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-004-dynamic-expected.txt
@@ -8,5 +8,5 @@ row 2
 row 3	
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 122 but got 124
+PASS col visibility:collapse changes table width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt
@@ -4,6 +4,6 @@ Spec
 Setting row and column to visibility:collapse changes both height and width. The collapsed result should have whitespace in the bottom right corner.
 
 
-FAIL spanning col visibility:collapse changes table width assert_equals: spanning col visibility:collapse changes table width expected 112 but got 114
+PASS spanning col visibility:collapse changes table width
 PASS spanning row visibility:collapse changes height
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -542,17 +542,17 @@ layer at (0,0) size 785x2448
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,112) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-        RenderTable {TABLE} at (0,130) size 107x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 107x18
-            RenderInline {B} at (37,0) size 33x18
-              RenderText {#text} at (37,0) size 33x18
-                text run at (37,0) width 33: "after"
+        RenderTable {TABLE} at (0,130) size 105x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 105x18
+            RenderInline {B} at (36,0) size 33x18
+              RenderText {#text} at (36,0) size 33x18
+                text run at (36,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 105x50
-            RenderTableRow {TR} at (0,2) size 105x22
+          RenderTableSection {TBODY} at (1,19) size 103x50
+            RenderTableRow {TR} at (0,2) size 103x22
               RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C11"
@@ -562,7 +562,7 @@ layer at (0,0) size 785x2448
               RenderTableCell {TD} at (35,2) size 66x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 62x18
                   text run at (2,2) width 62: "C13 large"
-            RenderTableRow {TR} at (0,26) size 105x0
+            RenderTableRow {TR} at (0,26) size 103x0
               RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,3) width 27: "C21"
@@ -572,7 +572,7 @@ layer at (0,0) size 785x2448
               RenderTableCell {TD} at (35,14) size 66x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,3) width 27: "C23"
-            RenderTableRow {TR} at (0,26) size 105x22
+            RenderTableRow {TR} at (0,26) size 103x22
               RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C31"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -542,17 +542,17 @@ layer at (0,0) size 800x2665
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,122) size 784x20
           RenderBR {BR} at (0,0) size 0x20
-        RenderTable {TABLE} at (0,142) size 108x76 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 108x20
-            RenderInline {B} at (37,0) size 33x20
-              RenderText {#text} at (37,0) size 33x20
-                text run at (37,0) width 33: "after"
+        RenderTable {TABLE} at (0,142) size 106x76 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 106x20
+            RenderInline {B} at (36,0) size 33x20
+              RenderText {#text} at (36,0) size 33x20
+                text run at (36,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 106x54
-            RenderTableRow {TR} at (0,2) size 106x24
+          RenderTableSection {TBODY} at (1,21) size 104x54
+            RenderTableRow {TR} at (0,2) size 104x24
               RenderTableCell {TD} at (2,2) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x20
                   text run at (2,2) width 27: "C11"
@@ -562,7 +562,7 @@ layer at (0,0) size 800x2665
               RenderTableCell {TD} at (34,2) size 68x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x20
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,28) size 106x0
+            RenderTableRow {TR} at (0,28) size 104x0
               RenderTableCell {TD} at (2,15) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-11) size 27x20
                   text run at (2,3) width 27: "C21"
@@ -572,7 +572,7 @@ layer at (0,0) size 800x2665
               RenderTableCell {TD} at (34,15) size 68x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,-11) size 27x20
                   text run at (2,3) width 27: "C23"
-            RenderTableRow {TR} at (0,28) size 106x24
+            RenderTableRow {TR} at (0,28) size 104x24
               RenderTableCell {TD} at (2,28) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x20
                   text run at (2,2) width 27: "C31"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -542,17 +542,17 @@ layer at (0,0) size 785x2450
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,112) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-        RenderTable {TABLE} at (0,130) size 108x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 108x18
-            RenderInline {B} at (37,0) size 33x18
-              RenderText {#text} at (37,0) size 33x18
-                text run at (37,0) width 33: "after"
+        RenderTable {TABLE} at (0,130) size 106x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 106x18
+            RenderInline {B} at (36,0) size 33x18
+              RenderText {#text} at (36,0) size 33x18
+                text run at (36,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 106x50
-            RenderTableRow {TR} at (0,2) size 106x22
+          RenderTableSection {TBODY} at (1,19) size 104x50
+            RenderTableRow {TR} at (0,2) size 104x22
               RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C11"
@@ -562,7 +562,7 @@ layer at (0,0) size 785x2450
               RenderTableCell {TD} at (34,2) size 68x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x18
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,26) size 106x0
+            RenderTableRow {TR} at (0,26) size 104x0
               RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C21"
@@ -572,7 +572,7 @@ layer at (0,0) size 785x2450
               RenderTableCell {TD} at (34,14) size 68x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,26) size 106x22
+            RenderTableRow {TR} at (0,26) size 104x22
               RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C31"

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1104,6 +1104,22 @@ void RenderTable::appendColumn(unsigned span)
     m_columnPos.grow(numEffCols() + 1);
 }
 
+LayoutUnit RenderTable::borderSpacingInRowDirection() const
+{
+    unsigned effectiveColumnCount = numEffCols();
+    if (!effectiveColumnCount)
+        return { };
+
+    unsigned collapsedColumnCount = 0;
+    for (unsigned i = 0; i < effectiveColumnCount; ++i) {
+        if (auto* col = colElement(i); col && col->style().visibility() == Visibility::Collapse)
+            ++collapsedColumnCount;
+    }
+
+    unsigned visibleColumnCount = effectiveColumnCount - collapsedColumnCount;
+    return (visibleColumnCount + 1) * hBorderSpacing();
+}
+
 RenderTableCol* RenderTable::firstColumn() const
 {
     for (auto& child : childrenOfType<RenderObject>(*this)) {

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -146,13 +146,7 @@ public:
         return c;
     }
 
-    LayoutUnit borderSpacingInRowDirection() const
-    {
-        if (unsigned effectiveColumnCount = numEffCols())
-            return (effectiveColumnCount + 1) * hBorderSpacing();
-
-        return 0;
-    }
+    LayoutUnit borderSpacingInRowDirection() const;
 
     // The collapsing border model dissallows paddings on table, which is why we
     // override those functions.


### PR DESCRIPTION
#### 8538f6ca6c3ead157ca33da297567d65de3e73c0
<pre>
border-spacing should not include collapsed columns in auto table layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=308927">https://bugs.webkit.org/show_bug.cgi?id=308927</a>
<a href="https://rdar.apple.com/171468102">rdar://171468102</a>

Reviewed by Alan Baradlay.

borderSpacingInRowDirection() used (numEffCols + 1) * hBorderSpacing,
counting all columns including those with visibility:collapse. This
inflated the table&apos;s preferred width and available width calculations,
making the table 2px too wide per collapsed column (one extra
border-spacing slot).

Move borderSpacingInRowDirection() out of the header into RenderTable.cpp
so it can access RenderTableCol, and subtract collapsed columns from the
count before computing total spacing.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::borderSpacingInRowDirection const):
* Source/WebCore/rendering/RenderTable.h:
(WebCore::RenderTable::borderSpacingInRowDirection const): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-004-dynamic-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt: Ditto

&gt; Rebaselines:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt:

Canonical link: <a href="https://commits.webkit.org/308549@main">https://commits.webkit.org/308549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26c6625da015594f9935d03a43ff64dba86775b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101268 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f589e05-9fb3-4028-b45f-253b6e6768f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113987 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0bc4bd0-62bd-4ba1-8eaa-5a5ea14cf1c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0777a72-b786-4200-b08c-7071ae2a2eea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15381 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3976 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12194 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122217 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31305 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76487 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9265 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83715 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19682 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19833 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->