### PR TITLE
[css-values-5] Introduce custom-ident foundations for `ident()`

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1189,6 +1189,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     css/values/motion/CSSRayFunction.h
 
+    css/values/primitives/CSSCustomIdent.h
     css/values/primitives/CSSPosition.h
     css/values/primitives/CSSPrimitiveData.h
     css/values/primitives/CSSPrimitiveKeywordList.h
@@ -3345,6 +3346,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/position/StyleInset.h
 
+    style/values/primitives/StyleCustomIdent.h
     style/values/primitives/StyleCoordinatedValueList.h
     style/values/primitives/StyleCoordinatedValueListValue.h
     style/values/primitives/StyleLengthWrapper.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1174,6 +1174,7 @@ css/values/color/CSSResolvedColor.cpp
 css/values/grid/CSSGridNamedAreaMap.cpp
 css/values/images/CSSGradient.cpp
 css/values/motion/CSSRayFunction.cpp
+css/values/primitives/CSSCustomIdent.cpp
 css/values/primitives/CSSPosition.cpp
 css/values/primitives/CSSPrimitiveNumericCategory.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
@@ -3370,6 +3371,7 @@ style/values/overflow/StyleScrollbarGutter.cpp
 style/values/overflow/StyleOverflowClipMargin.cpp
 style/values/page/StylePageSize.cpp
 style/values/pointerevents/StyleTouchAction.cpp
+style/values/primitives/StyleCustomIdent.cpp
 style/values/primitives/StyleLengthResolution.cpp
 style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.cpp
 style/values/primitives/StyleLengthWrapperData.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1170,6 +1170,8 @@
 		2EF1BFEB121C9F4200C27627 /* FileStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF1BFE9121C9F4200C27627 /* FileStream.h */; };
 		2EF1BFF9121CB0CE00C27627 /* FileStreamClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF1BFF8121CB0CE00C27627 /* FileStreamClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2F98A2C62AA1407300B98574 /* PointerLockOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F98A2C52AA1407300B98574 /* PointerLockOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3084F8492F643F2600EC9C6E /* CSSCustomIdent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3084F8462F643F2600EC9C6E /* CSSCustomIdent.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3084F8532F64404900EC9C6E /* StyleCustomIdent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3084F84E2F64403D00EC9C6E /* StyleCustomIdent.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3103B7DF1DB01567008BB890 /* ColorHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 3103B7DE1DB01556008BB890 /* ColorHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		31078CC81880AABB008099DC /* OESTextureHalfFloatLinear.h in Headers */ = {isa = PBXBuildFile; fileRef = 31078CC31880A6A6008099DC /* OESTextureHalfFloatLinear.h */; };
 		31078CCA1880AACE008099DC /* JSOESTextureHalfFloatLinear.h in Headers */ = {isa = PBXBuildFile; fileRef = 31078CC61880AAAA008099DC /* JSOESTextureHalfFloatLinear.h */; };
@@ -10226,6 +10228,10 @@
 		2EF1BFF8121CB0CE00C27627 /* FileStreamClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileStreamClient.h; sourceTree = "<group>"; };
 		2F98A2C42AA13B3F00B98574 /* PointerLockOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = PointerLockOptions.idl; sourceTree = "<group>"; };
 		2F98A2C52AA1407300B98574 /* PointerLockOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PointerLockOptions.h; sourceTree = "<group>"; };
+		3084F8462F643F2600EC9C6E /* CSSCustomIdent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCustomIdent.h; sourceTree = "<group>"; };
+		3084F8472F643F2600EC9C6E /* CSSCustomIdent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCustomIdent.cpp; sourceTree = "<group>"; };
+		3084F84E2F64403D00EC9C6E /* StyleCustomIdent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleCustomIdent.h; sourceTree = "<group>"; };
+		3084F84F2F64403D00EC9C6E /* StyleCustomIdent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleCustomIdent.cpp; sourceTree = "<group>"; };
 		3103B7DE1DB01556008BB890 /* ColorHash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorHash.h; sourceTree = "<group>"; };
 		31055BB81E4FE18900EB604E /* WebKitFontFamilyNames.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebKitFontFamilyNames.in; sourceTree = "<group>"; };
 		31078CC21880A6A6008099DC /* OESTextureHalfFloatLinear.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OESTextureHalfFloatLinear.cpp; sourceTree = "<group>"; };
@@ -37992,6 +37998,8 @@
 		BCB271D72CC013E900265123 /* primitives */ = {
 			isa = PBXGroup;
 			children = (
+				3084F8472F643F2600EC9C6E /* CSSCustomIdent.cpp */,
+				3084F8462F643F2600EC9C6E /* CSSCustomIdent.h */,
 				BCB271D92CC0142C00265123 /* CSSPosition.cpp */,
 				BCB271D82CC0142C00265123 /* CSSPosition.h */,
 				BC2C0C8E2D32EBCB00FCFBA0 /* CSSPrimitiveData.h */,
@@ -38048,6 +38056,8 @@
 			children = (
 				BC7320162E7343D900A6584F /* StyleCoordinatedValueList.h */,
 				BCD278122EAEA47F0047A4DE /* StyleCoordinatedValueListValue.h */,
+				3084F84F2F64403D00EC9C6E /* StyleCustomIdent.cpp */,
+				3084F84E2F64403D00EC9C6E /* StyleCustomIdent.h */,
 				BCD67C652D2477D80079EB9C /* StyleLengthResolution.cpp */,
 				BCD67C642D2477CA0079EB9C /* StyleLengthResolution.h */,
 				BC34D37D2E428981001EAD95 /* StyleLengthWrapper+Blending.h */,
@@ -43706,6 +43716,7 @@
 				93B248932990CAFE00B769E4 /* CSSCounterValue.h in Headers */,
 				2D8FEBDD143E3EF70072502B /* CSSCrossfadeValue.h in Headers */,
 				AA21ECCD0ABF0FC6002B834C /* CSSCursorImageValue.h in Headers */,
+				3084F8492F643F2600EC9C6E /* CSSCustomIdent.h in Headers */,
 				46531BB52D616D7A008D8EFC /* CSSCustomPropertySyntax.h in Headers */,
 				BC779E141BB215BB00CAA8BF /* CSSCustomPropertyValue.h in Headers */,
 				BC5C89BB2D567D06000F45B7 /* CSSDynamicRangeLimitValue.h in Headers */,
@@ -47754,6 +47765,7 @@
 				BC966B422E280AAB0028A7AF /* StyleCounterStyle.h in Headers */,
 				BCF0BCEC2BEE8ED000F42CCD /* StyleCurrentColor.h in Headers */,
 				BC2272AD0E82E8F300E7F975 /* StyleCursor.h in Headers */,
+				3084F8532F64404900EC9C6E /* StyleCustomIdent.h in Headers */,
 				BC6AFC432DFC9BF30065FA1D /* StyleCustomProperty.h in Headers */,
 				BC63AD2B2F084C2F007B62C4 /* StyleCustomPropertyData.h in Headers */,
 				A8C4A7FD09D563270003AC8D /* StyledElement.h in Headers */,

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -209,7 +209,7 @@ CSSCounterStyleDescriptors::SystemData extractSystemDataFromCSSValue(const CSSVa
         Ref secondValue = systemValue->second();
         if (system == CSSCounterStyleDescriptors::System::Extends) {
             ASSERT(secondValue->isCustomIdent());
-            result.first = AtomString { secondValue->isCustomIdent() ? secondValue->customIdent() : "decimal"_s };
+            result.first = AtomString { secondValue->isCustomIdent() ? secondValue->customIdent().value : "decimal"_s };
         } else if (system == CSSCounterStyleDescriptors::System::Fixed) {
             ASSERT(secondValue->isInteger());
             result.second = secondValue->isInteger() ? secondValue->integerDeprecated() : 1;

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -54,7 +54,7 @@ bool CSSCounterValue::equals(const CSSCounterValue& other) const
 
 String CSSCounterValue::customCSSText(const CSS::SerializationContext&) const
 {
-    bool isDecimal = m_counterStyle->valueID() == CSSValueDecimal || (m_counterStyle->isCustomIdent() && m_counterStyle->customIdent() == "decimal"_s);
+    bool isDecimal = m_counterStyle->valueID() == CSSValueDecimal || (m_counterStyle->isCustomIdent() && m_counterStyle->customIdent().value == "decimal"_s);
     auto styleSeparator = isDecimal ? ""_s : ", "_s;
     auto styleLiteral = isDecimal ? ""_s : counterStyleCSSText();
     if (m_separator.isEmpty())
@@ -71,7 +71,7 @@ String CSSCounterValue::counterStyleCSSText() const
     if (m_counterStyle->isValueID())
         return nameString(m_counterStyle->valueID()).string();
     if (m_counterStyle->isCustomIdent())
-        return m_counterStyle->customIdent();
+        return m_counterStyle->customIdent().value;
 
     ASSERT_NOT_REACHED();
     return emptyString();

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -482,6 +482,11 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::createCustomIdent(String value)
     return adoptRef(*new CSSPrimitiveValue(WTF::move(value), CSSUnitType::CustomIdent));
 }
 
+Ref<CSSPrimitiveValue> CSSPrimitiveValue::createCustomIdent(const CSS::CustomIdent& value)
+{
+    return createCustomIdent(value.value);
+}
+
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::createFontFamily(String value)
 {
     return adoptRef(*new CSSPrimitiveValue(WTF::move(value), CSSUnitType::CSS_FONT_FAMILY));
@@ -1252,7 +1257,6 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
         break;
     case CSSUnitType::CSS_CALC:
         add(hasher, m_value.calc);
-        break;
         break;
     case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -23,6 +23,7 @@
 
 #include <WebCore/CSSAttrValue.h>
 #include <WebCore/CSSCalcValue.h>
+#include <WebCore/CSSCustomIdent.h>
 #include <WebCore/CSSPrimitiveNumericUnits.h>
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CSSValue.h>
@@ -101,9 +102,14 @@ public:
     bool isString() const { return primitiveUnitType() == CSSUnitType::CSS_STRING; }
     static Ref<CSSPrimitiveValue> create(String);
 
+    static Ref<CSSPrimitiveValue> createCustomIdent(const CSS::CustomIdent&);
     static Ref<CSSPrimitiveValue> createCustomIdent(String);
     bool isCustomIdent() const { return primitiveUnitType() == CSSUnitType::CustomIdent; }
-    String customIdent() const { ASSERT(isCustomIdent()); return stringValue(); }
+    CSS::CustomIdent customIdent() const
+    {
+        ASSERT(isCustomIdent());
+        return { m_value.string };
+    }
 
     static Ref<CSSPrimitiveValue> createFontFamily(String);
     bool isFontFamily() const { return primitiveUnitType() == CSSUnitType::CSS_FONT_FAMILY; }
@@ -220,7 +226,11 @@ private:
 
     // MARK: Non-converting
     double doubleValue(const CSSToLengthConversionData&) const;
-    double doubleValueNoConversionDataRequired() const { ASSERT(!isCalculated()); return m_value.number; }
+    double doubleValueNoConversionDataRequired() const
+    {
+        ASSERT(!isCalculated());
+        return m_value.number;
+    }
     double doubleValueDeprecated() const;
     double doubleValueDividingBy100IfPercentage(const CSSToLengthConversionData&) const;
     double NODELETE doubleValueDividingBy100IfPercentageNoConversionDataRequired() const;
@@ -747,10 +757,10 @@ inline bool CSSValue::isCustomIdent() const
     return value && value->isCustomIdent();
 }
 
-inline String CSSValue::customIdent() const
+inline CSS::CustomIdent CSSValue::customIdent() const
 {
     ASSERT(isCustomIdent());
-    return downcast<CSSPrimitiveValue>(*this).stringValue();
+    return downcast<CSSPrimitiveValue>(*this).customIdent();
 }
 
 inline bool CSSValue::isString() const

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -48,6 +48,7 @@ enum CSSPropertyID : uint16_t;
 enum CSSValueID : uint16_t;
 
 namespace CSS {
+struct CustomIdent;
 struct SerializationContext;
 }
 
@@ -172,7 +173,7 @@ public:
     enum ValueSeparator : uint8_t { SpaceSeparator, CommaSeparator, SlashSeparator };
 
     inline bool isCustomIdent() const;
-    inline String customIdent() const;
+    inline CSS::CustomIdent customIdent() const;
 
     inline bool isString() const;
     inline String string() const;

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -59,7 +59,7 @@ StyleRuleViewTransition::StyleRuleViewTransition(Ref<StyleProperties>&& properti
     if (auto value = properties->getPropertyCSSValue(CSSPropertyTypes)) {
         auto processSingleValue = [&](const CSSValue& currentValue) {
             if (currentValue.isCustomIdent())
-                m_types.append(currentValue.customIdent());
+                m_types.append(currentValue.customIdent().value);
         };
         if (auto* list = dynamicDowncast<CSSValueList>(*value)) {
             for (Ref currentValue : *list)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp
@@ -27,7 +27,6 @@
 #include "CSSPropertyParserConsumer+Content.h"
 
 #include "CSSCounterValue.h"
-#include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+Attr.h"
@@ -74,9 +73,10 @@ static RefPtr<CSSValue> consumeCounterContent(CSSParserTokenRange args, CSS::Pro
     // counter()  =  counter( <counter-name>, <counter-style>? )
     // https://www.w3.org/TR/css-lists-3/#funcdef-counter
 
-    AtomString identifier { consumeCustomIdentRaw(args) };
-    if (identifier.isNull())
+    auto identifierValue = consumeCustomIdent(args);
+    if (!identifierValue)
         return nullptr;
+    AtomString identifier { identifierValue->customIdent().value };
 
     RefPtr<CSSValue> counterStyle;
     if (consumeCommaIncludingWhitespace(args)) {
@@ -98,9 +98,10 @@ static RefPtr<CSSValue> consumeCountersContent(CSSParserTokenRange args, CSS::Pr
     // counters() = counters( <counter-name>, <string>, <counter-style>? )
     // https://www.w3.org/TR/css-lists-3/#funcdef-counters
 
-    AtomString identifier { consumeCustomIdentRaw(args) };
-    if (identifier.isNull())
+    auto identifierValue = consumeCustomIdent(args);
+    if (!identifierValue)
         return nullptr;
+    AtomString identifier { identifierValue->customIdent().value };
 
     if (!consumeCommaIncludingWhitespace(args) || args.peek().type() != StringToken)
         return nullptr;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -37,14 +37,11 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+Ident.h"
-#include "CSSPropertyParserConsumer+IntegerDefinitions.h"
-#include "CSSPropertyParserConsumer+LengthPercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
 #include "CSSSubgridValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
-#include "GridArea.h"
 #include "StyleGridPosition.h"
 #include <wtf/Vector.h>
 #include <wtf/text/StringView.h>
@@ -253,7 +250,7 @@ RefPtr<CSSGridLineNamesValue> consumeGridLineNames(CSSParserTokenRange& range, C
 
     Vector<String, 4> lineNames;
     while (auto lineName = consumeCustomIdentForGridLine(rangeCopy))
-        lineNames.append(lineName->customIdent());
+        lineNames.append(lineName->customIdent().value);
     if (rangeCopy.consumeIncludingWhitespace().type() != RightBracketToken)
         return nullptr;
     range = rangeCopy;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
@@ -51,7 +51,7 @@ RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range, CSS::Pro
         auto type = consumeCustomIdent(range);
         if (!type)
             return nullptr;
-        if (type->customIdent().startsWith("-ua-"_s))
+        if (type->customIdent().value.startsWith("-ua-"_s))
             return nullptr;
         list.append(type.releaseNonNull());
     } while (!range.atEnd());

--- a/Source/WebCore/css/values/CSSValueAggregates.cpp
+++ b/Source/WebCore/css/values/CSSValueAggregates.cpp
@@ -29,18 +29,6 @@
 
 namespace WebCore {
 
-// MARK: - CustomIdentifier
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const CustomIdentifier& value)
-{
-    return ts << value.value;
-}
-
-void add(Hasher& hasher, const CustomIdentifier& value)
-{
-    add(hasher, value.value);
-}
-
 // MARK: - PropertyIdentifier
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PropertyIdentifier& value)

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSCustomIdent.h"
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CSSValueConcepts.h>
 #include <WebCore/CSSValueKeywords.h>
@@ -194,17 +195,6 @@ template<typename... Ts> inline constexpr auto TreatAsTupleLike<std::tuple<Ts...
 template<typename... Ts> inline constexpr auto TreatAsVariantLike<Variant<Ts...>> = true;
 
 // MARK: - Standard Leaf Types
-
-// Helper type used to represent an arbitrary constant identifier.
-struct CustomIdentifier {
-    AtomString value;
-
-    bool operator==(const CustomIdentifier&) const = default;
-    bool operator==(const AtomString& other) const { return value == other; }
-};
-TextStream& operator<<(TextStream&, const CustomIdentifier&);
-
-void NODELETE add(Hasher&, const CustomIdentifier&);
 
 // Helper type used to represent an arbitrary property identifier.
 struct PropertyIdentifier {
@@ -2098,11 +2088,5 @@ struct supports_text_stream_insertion<WebCore::MinimallySerializingSpaceSeparate
 
 template<typename T>
 struct supports_text_stream_insertion<WebCore::MinimallySerializingSpaceSeparatedRectCorners<T>> : supports_text_stream_insertion<T> { };
-
-template<>
-struct MarkableTraits<WebCore::CustomIdentifier> {
-    static bool isEmptyValue(const WebCore::CustomIdentifier& value) { return value.value.isNull(); }
-    static WebCore::CustomIdentifier emptyValue() { return WebCore::CustomIdentifier { nullAtom() }; }
-};
 
 } // namespace WTF

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -36,11 +36,6 @@
 namespace WebCore {
 namespace CSS {
 
-void serializationForCSSCustomIdentifier(StringBuilder& builder, const SerializationContext&, const CustomIdentifier& value)
-{
-    WebCore::serializeIdentifier(value.value, builder);
-}
-
 void serializationForCSSPropertyIdentifier(StringBuilder& builder, const SerializationContext&, const PropertyIdentifier& value)
 {
     builder.append(nameLiteral(value.value));
@@ -59,11 +54,6 @@ void serializationForCSSString(StringBuilder& builder, const SerializationContex
 Ref<CSSValue> makePrimitiveCSSValue(CSSValueID value)
 {
     return CSSPrimitiveValue::create(value);
-}
-
-Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier& value)
-{
-    return CSSPrimitiveValue::createCustomIdent(value.value);
 }
 
 Ref<CSSValue> makePrimitiveCSSValue(const PropertyIdentifier& value)

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -63,7 +63,6 @@ struct SerializeInvoker {
 };
 inline constexpr SerializeInvoker serializationForCSS{};
 
-void serializationForCSSCustomIdentifier(StringBuilder&, const SerializationContext&, const CustomIdentifier&);
 void serializationForCSSPropertyIdentifier(StringBuilder&, const SerializationContext&, const PropertyIdentifier&);
 void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::AtomString&);
 void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::String&);
@@ -180,14 +179,6 @@ template<CSSValueID C> struct Serialize<Constant<C>> {
     template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext&, const Constant<C>& value, Rest&&...)
     {
         builder.append(nameLiteralForSerialization(value.value));
-    }
-};
-
-// Specialization for `CustomIdentifier`.
-template<> struct Serialize<CustomIdentifier> {
-    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CustomIdentifier& value, Rest&&...)
-    {
-        serializationForCSSCustomIdentifier(builder, context, value);
     }
 };
 
@@ -318,14 +309,6 @@ template<VariantLike CSSType> struct ComputedStyleDependenciesCollector<CSSType>
 // Specialization for `Constant`.
 template<CSSValueID C> struct ComputedStyleDependenciesCollector<Constant<C>> {
     constexpr void operator()(ComputedStyleDependencies&, const Constant<C>&)
-    {
-        // Nothing to do.
-    }
-};
-
-// Specialization for `CustomIdentifier`.
-template<> struct ComputedStyleDependenciesCollector<CustomIdentifier> {
-    constexpr void operator()(ComputedStyleDependencies&, const CustomIdentifier&)
     {
         // Nothing to do.
     }
@@ -464,14 +447,6 @@ template<CSSValueID C> struct CSSValueChildrenVisitor<Constant<C>> {
     }
 };
 
-// Specialization for `CustomIdentifier`.
-template<> struct CSSValueChildrenVisitor<CustomIdentifier> {
-    constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const CustomIdentifier&)
-    {
-        return IterationStatus::Continue;
-    }
-};
-
 // Specialization for `PropertyIdentifier`.
 template<> struct CSSValueChildrenVisitor<PropertyIdentifier> {
     constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const PropertyIdentifier&)
@@ -517,7 +492,6 @@ struct CSSValueCreationInvoker {
 inline constexpr CSSValueCreationInvoker createCSSValue{};
 
 Ref<CSSValue> NODELETE makePrimitiveCSSValue(CSSValueID);
-Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier&);
 Ref<CSSValue> makePrimitiveCSSValue(const PropertyIdentifier&);
 Ref<CSSValue> makePrimitiveCSSValue(const WTF::AtomString&);
 Ref<CSSValue> makePrimitiveCSSValue(const WTF::String&);
@@ -589,14 +563,6 @@ template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
     template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const Constant<Id>&, Rest&&...)
     {
         return makePrimitiveCSSValue(Id);
-    }
-};
-
-// Specialization for `CustomIdentifier`.
-template<> struct CSSValueCreation<CustomIdentifier> {
-    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const CustomIdentifier& customIdentifier, Rest&&...)
-    {
-        return makePrimitiveCSSValue(customIdentifier);
     }
 };
 

--- a/Source/WebCore/css/values/primitives/CSSCustomIdent.cpp
+++ b/Source/WebCore/css/values/primitives/CSSCustomIdent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 saku <saku@email.sakupi01.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,52 +25,40 @@
  */
 
 #include "config.h"
-#include "ScopedName.h"
+#include "CSSCustomIdent.h"
 
+#include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
-#include "StyleBuilderChecking.h"
-#include "StyleValueTypes+CSSValueConversion.h"
+#include <wtf/Hasher.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
-namespace Style {
 
-// MARK: - Conversion
-
-auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSPrimitiveValue& primitiveValue) -> ScopedName
+WTF::TextStream& operator<<(WTF::TextStream& ts, const CSS::CustomIdent& value)
 {
-    auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, primitiveValue);
-    if (customIdentifier.value.isNull())
-        return { };
-
-    return {
-        .name = customIdentifier.value,
-        .scopeOrdinal = state.styleScopeOrdinal()
-    };
+    return ts << value.value;
 }
 
-auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSValue& value) -> ScopedName
+void add(Hasher& hasher, const CSS::CustomIdent& value)
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return { };
-
-    auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, *primitiveValue);
-    if (customIdentifier.value.isNull())
-        return { };
-
-    return ScopedName {
-        .name = customIdentifier.value,
-        .scopeOrdinal = state.styleScopeOrdinal()
-    };
+    add(hasher, value.value);
 }
 
-// MARK: - Logging
+namespace CSS {
 
-WTF::TextStream& operator<<(WTF::TextStream& ts, const ScopedName& scopedName)
+// MARK: - Serialization
+
+void serializationForCSSCustomIdentifier(StringBuilder& builder, const SerializationContext&, const CustomIdent& value)
 {
-    return ts << scopedName.name;
+    WebCore::serializeIdentifier(value.value, builder);
 }
 
-} // namespace Style
+// MARK: - CSSValue Creation
+
+Ref<CSSValue> makePrimitiveCSSValue(const CustomIdent& value)
+{
+    return CSSPrimitiveValue::createCustomIdent(value);
+}
+
+} // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSCustomIdent.h
+++ b/Source/WebCore/css/values/primitives/CSSCustomIdent.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 saku <saku@email.sakupi01.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Compiler.h>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/IterationStatus.h>
+#include <wtf/Markable.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class CSSValue;
+struct ComputedStyleDependencies;
+
+namespace CSS {
+
+struct SerializationContext;
+
+// Helper type used to represent an arbitrary constant identifier.
+struct CustomIdent {
+    AtomString value;
+
+    bool operator==(const CustomIdent&) const = default;
+    bool operator==(const AtomString& other) const { return value == other; }
+};
+
+// MARK: - Serialization
+
+void serializationForCSSCustomIdentifier(StringBuilder&, const SerializationContext&, const CustomIdent&);
+
+template<typename CSSType> struct Serialize;
+
+// Specialization for `CustomIdent`.
+template<> struct Serialize<CustomIdent> {
+    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const CustomIdent& value, Rest&&...)
+    {
+        serializationForCSSCustomIdentifier(builder, context, value);
+    }
+};
+
+// MARK: - Computed Style Dependencies
+
+template<typename CSSType> struct ComputedStyleDependenciesCollector;
+
+// Specialization for `CustomIdent`.
+template<> struct ComputedStyleDependenciesCollector<CustomIdent> {
+    constexpr void operator()(ComputedStyleDependencies&, const CustomIdent&)
+    {
+        // Nothing to do.
+    }
+};
+
+// MARK: - CSSValue Visitation
+
+template<typename CSSType> struct CSSValueChildrenVisitor;
+
+// Specialization for `CustomIdent`.
+template<> struct CSSValueChildrenVisitor<CustomIdent> {
+    constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const CustomIdent&)
+    {
+        return IterationStatus::Continue;
+    }
+};
+
+// MARK: - CSSValue Creation
+
+Ref<CSSValue> makePrimitiveCSSValue(const CustomIdent&);
+
+template<typename CSSType> struct CSSValueCreation;
+
+// Specialization for `CustomIdent`.
+template<> struct CSSValueCreation<CustomIdent> {
+    template<typename CSSValuePool, typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const CustomIdent& customIdentifier, Rest&&...)
+    {
+        return makePrimitiveCSSValue(customIdentifier);
+    }
+};
+
+} // namespace CSS
+
+// TODO: Transitional alias while CSS/Style custom-ident representation is being split.
+using CustomIdentifier = CSS::CustomIdent;
+
+WTF::TextStream& operator<<(WTF::TextStream&, const CSS::CustomIdent&);
+void NODELETE add(Hasher&, const CSS::CustomIdent&);
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<>
+struct MarkableTraits<WebCore::CSS::CustomIdent> {
+    static bool isEmptyValue(const WebCore::CSS::CustomIdent& value) { return value.value.isNull(); }
+    static WebCore::CSS::CustomIdent emptyValue() { return WebCore::CSS::CustomIdent { nullAtom() }; }
+};
+
+} // namespace WTF

--- a/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
@@ -70,21 +70,21 @@ template<> struct CSSValueConversion<AtomString> {
     }
 };
 
-// Specialization for `CustomIdentifier`.
-template<> struct CSSValueConversion<CustomIdentifier> {
-    CustomIdentifier operator()(BuilderState& state, const CSSPrimitiveValue& value)
+// Specialization for `CustomIdent`.
+template<> struct CSSValueConversion<CustomIdent> {
+    CustomIdent operator()(BuilderState& state, const CSSPrimitiveValue& value)
     {
         if (!value.isCustomIdent()) [[unlikely]] {
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return { .value = emptyAtom() };
+            return CustomIdent { nullAtom() };
         }
-        return { .value = AtomString { value.customIdent() } };
+        return CustomIdent { value.customIdent().value };
     }
-    CustomIdentifier operator()(BuilderState& state, const CSSValue& value)
+    CustomIdent operator()(BuilderState& state, const CSSValue& value)
     {
         RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
         if (!primitiveValue) [[unlikely]]
-            return { .value = emptyAtom() };
+            return CustomIdent { nullAtom() };
         return this->operator()(state, *primitiveValue);
     }
 };
@@ -109,7 +109,9 @@ template<> struct CSSValueConversion<PropertyIdentifier> {
 };
 
 // Specialization for `TupleLike` (wrapper).
-template<TupleLike StyleType> requires (std::tuple_size_v<StyleType> == 1) struct CSSValueConversion<StyleType> {
+template<TupleLike StyleType>
+    requires(std::tuple_size_v<StyleType> == 1)
+struct CSSValueConversion<StyleType> {
     template<typename... Rest> StyleType operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         return { toStyleFromCSSValue<std::remove_cvref_t<std::tuple_element_t<0, StyleType>>>(state, value, std::forward<Rest>(rest)...) };

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -27,6 +27,7 @@
 #include <WebCore/CSSCalcSymbolTable.h>
 #include <WebCore/CSSNoConversionDataRequiredToken.h>
 #include <WebCore/CSSValueTypes.h>
+#include <WebCore/StyleCustomIdent.h>
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -105,9 +106,6 @@ template<typename> struct ToStyle;
 
 // Specialize `TreatAsNonConverting` for `Constant<C>`, to indicate that its type does not change from the CSS representation.
 template<CSSValueID C> inline constexpr bool TreatAsNonConverting<Constant<C>> = true;
-
-// Specialize `TreatAsNonConverting` for `CustomIdentifier`, to indicate that its type does not change from the CSS representation.
-template<> inline constexpr bool TreatAsNonConverting<CustomIdentifier> = true;
 
 // Specialize `TreatAsNonConverting` for `PropertyIdentifier`, to indicate that its type does not change from the CSS representation.
 template<> inline constexpr bool TreatAsNonConverting<PropertyIdentifier> = true;

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -33,6 +33,7 @@
 #include "StylePrimitiveKeyword+Logging.h"
 #include "StylePrimitiveKeyword+Serialization.h"
 #include "StylePropertiesInlines.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -101,9 +102,12 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
                 tactics.value.append(PositionTryFallbackTactic::FlipY);
                 break;
             case CSSValueInvalid:
-                if (item->isCustomIdent() && !rule) {
-                    rule = ScopedName { AtomString { item->customIdent() }, state.styleScopeOrdinal() };
-                    break;
+                if (!rule) {
+                    auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, item.get());
+                    if (!customIdentifier.value.isNull()) {
+                        rule = ScopedName { customIdentifier.value, state.styleScopeOrdinal() };
+                        break;
+                    }
                 }
                 [[fallthrough]];
             default:

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -43,7 +44,14 @@ auto CSSValueConversion<SingleAnimationName>::operator()(BuilderState& state, co
     if (primitiveValue->valueID() == CSSValueNone)
         return SingleAnimationName { CSS::Keyword::None { } };
 
-    return SingleAnimationName { ScopedName { AtomString { primitiveValue->stringValue() }, state.styleScopeOrdinal(), primitiveValue->isCustomIdent() } };
+    if (primitiveValue->isCustomIdent()) {
+        auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, *primitiveValue);
+        if (customIdentifier.value.isNull())
+            return SingleAnimationName { CSS::Keyword::None { } };
+        return SingleAnimationName { ScopedName { customIdentifier.value, state.styleScopeOrdinal(), true } };
+    }
+
+    return SingleAnimationName { ScopedName { AtomString { primitiveValue->stringValue() }, state.styleScopeOrdinal(), false } };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
@@ -30,6 +30,7 @@
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSValueList.h"
 #include "StyleBuilderChecking.h"
+#include "StyleValueTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
@@ -48,7 +49,10 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return false;
         }
-        parameterToSet = primitiveArgument->customIdent();
+        auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, *primitiveArgument);
+        if (customIdentifier.value.isNull())
+            return false;
+        parameterToSet = customIdentifier.value;
         return true;
     };
 
@@ -63,7 +67,10 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
                 state.setCurrentPropertyInvalidAtComputedValueTime();
                 return false;
             }
-            parameterToSet.append(primitiveArgument->customIdent());
+            auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, *primitiveArgument);
+            if (customIdentifier.value.isNull())
+                return false;
+            parameterToSet.append(customIdentifier.value);
         }
         return true;
     };

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 saku
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,51 +24,30 @@
  */
 
 #include "config.h"
-#include "ScopedName.h"
+#include "StyleCustomIdent.h"
 
 #include "CSSPrimitiveValue.h"
-#include "StyleBuilderChecking.h"
-#include "StyleValueTypes+CSSValueConversion.h"
+#include "StyleValueTypes.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
+void add(Hasher& hasher, const CustomIdent& value)
+{
+    add(hasher, value.value);
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const CustomIdent& value)
+{
+    return ts << value.value;
+}
+
 // MARK: - Conversion
 
-auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSPrimitiveValue& primitiveValue) -> ScopedName
+auto CSSValueCreation<CustomIdent>::operator()(CSSValuePool&, const RenderStyle&, const CustomIdent& value) -> Ref<CSSValue>
 {
-    auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, primitiveValue);
-    if (customIdentifier.value.isNull())
-        return { };
-
-    return {
-        .name = customIdentifier.value,
-        .scopeOrdinal = state.styleScopeOrdinal()
-    };
-}
-
-auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSValue& value) -> ScopedName
-{
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return { };
-
-    auto customIdentifier = toStyleFromCSSValue<CustomIdentifier>(state, *primitiveValue);
-    if (customIdentifier.value.isNull())
-        return { };
-
-    return ScopedName {
-        .name = customIdentifier.value,
-        .scopeOrdinal = state.styleScopeOrdinal()
-    };
-}
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const ScopedName& scopedName)
-{
-    return ts << scopedName.name;
+    return CSSPrimitiveValue::createCustomIdent(CSS::CustomIdent { value.value });
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.h
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 saku <saku@email.sakupi01.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCustomIdent.h"
+#include <wtf/Forward.h>
+#include <wtf/Markable.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class CSSValue;
+class CSSValuePool;
+class RenderStyle;
+
+namespace Style {
+
+// Custom-ident values have dedicated CSS and Style representations.
+struct CustomIdent {
+    AtomString value;
+
+    CustomIdent() = default;
+    CustomIdent(AtomString&& value)
+        : value(WTF::move(value))
+    {
+    }
+    CustomIdent(const AtomString& value)
+        : value(value)
+    {
+    }
+    CustomIdent(const CSS::CustomIdent& value)
+        : value(value.value)
+    {
+    }
+
+    operator CSS::CustomIdent() const { return { value }; }
+
+    bool operator==(const CustomIdent&) const = default;
+    bool operator==(const AtomString& other) const { return value == other; }
+};
+
+// Transitional alias while style code is moved to `CustomIdent`.
+using CustomIdentifier = CustomIdent;
+
+void NODELETE add(Hasher&, const CustomIdent&);
+WTF::TextStream& operator<<(WTF::TextStream&, const CustomIdent&);
+
+// MARK: Common Types.
+
+template<typename StyleType> struct ToCSS;
+template<typename CSSType> struct ToStyle;
+
+template<> struct ToCSS<CustomIdent> {
+    template<typename... Rest> CSS::CustomIdent operator()(const CustomIdent& value, Rest&&...) const
+    {
+        return { value.value };
+    }
+};
+
+template<> struct ToStyle<CSS::CustomIdent> {
+    template<typename... Rest> CustomIdent operator()(const CSS::CustomIdent& value, Rest&&...) const
+    {
+        return { value.value };
+    }
+};
+
+// Types that are treated as "tuple-like" can have their conversion operations defined
+// automatically by just defining their type mapping.
+template<typename> struct ToStyleMapping;
+template<typename> struct ToCSSMapping;
+
+// Two-way mapping between `CSS::CustomIdent` and `CustomIdent`. This is only needed
+// for "tuple-like" types, in lieu of explicit ToCSS/ToStyle specializations.
+template<> struct ToStyleMapping<CSS::CustomIdent> {
+    using type = CustomIdent;
+};
+template<> struct ToCSSMapping<CustomIdent> {
+    using type = CSS::CustomIdent;
+};
+
+// MARK: - Conversion directly from "Style to "Ref<CSSValue>"
+
+template<typename StyleType> struct CSSValueCreation;
+
+// Specialization for `CustomIdent`.
+template<> struct CSSValueCreation<CustomIdent> {
+    Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const CustomIdent&);
+};
+
+// MARK: - Serialization
+
+template<typename StyleType> struct Serialize;
+
+// Specialization for `CustomIdent`.
+template<> struct Serialize<CustomIdent> {
+    template<typename... Rest> void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle&, const CustomIdent& value, Rest&&...)
+    {
+        CSS::serializationForCSSCustomIdentifier(builder, context, CSS::CustomIdent { value.value });
+    }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+namespace WTF {
+
+template<>
+struct MarkableTraits<WebCore::Style::CustomIdent> {
+    static bool isEmptyValue(const WebCore::Style::CustomIdent& value) { return value.value.isNull(); }
+    static WebCore::Style::CustomIdent emptyValue() { return WebCore::Style::CustomIdent { nullAtom() }; }
+};
+
+} // namespace WTF


### PR DESCRIPTION
#### 0224b5d2a64bc18737b8a176709eab0122c19719
<pre>
[css-values-5] Introduce custom-ident foundations for `ident()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=284895.">https://bugs.webkit.org/show_bug.cgi?id=284895.</a>

Reviewed by NOBODY (OOPS!).

Introduce shared custom-ident foundations in both CSS and Style layers used by `ident()` and other custom-ident consumers.

No new tests. This commit only introduces shared infrastructure; parsing behavior and dedicated test coverage are added in follow-up patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::extractSystemDataFromCSSValue):
* Source/WebCore/css/CSSCounterValue.cpp:
(WebCore::CSSCounterValue::customCSSText const):
(WebCore::CSSCounterValue::counterStyleCSSText const):
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::createCustomIdent):
(WebCore::CSSPrimitiveValue::addDerivedHash const):
* Source/WebCore/css/CSSPrimitiveValue.h:
(WebCore::CSSValue::customIdent const):
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
(WebCore::StyleRuleViewTransition::StyleRuleViewTransition):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCounterContent):
(WebCore::CSSPropertyParserHelpers::consumeCountersContent):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
(WebCore::CSSPropertyParserHelpers::consumeGridLineNames):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp:
(WebCore::CSSPropertyParserHelpers::consumeViewTransitionTypes):
* Source/WebCore/css/values/CSSValueAggregates.cpp:
* Source/WebCore/css/values/CSSValueAggregates.h:
(WebCore::CustomIdentifier::operator== const): Deleted.
(WTF::MarkableTraits&lt;WebCore::CustomIdentifier&gt;::isEmptyValue): Deleted.
(WTF::MarkableTraits&lt;WebCore::CustomIdentifier&gt;::emptyValue): Deleted.
* Source/WebCore/css/values/CSSValueTypes.cpp:
(WebCore::CSS::serializationForCSSCustomIdentifier):
* Source/WebCore/css/values/CSSValueTypes.h:
(WebCore::CSS::Serialize&lt;CustomIdentifier&gt;::operator()): Deleted.
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;CustomIdentifier&gt;::operator()): Deleted.
(WebCore::CSS::CSSValueChildrenVisitor&lt;CustomIdentifier&gt;::operator()): Deleted.
(WebCore::CSS::CSSValueCreation&lt;CustomIdentifier&gt;::operator()): Deleted.
* Source/WebCore/css/values/primitives/CSSCustomIdent.cpp: Copied from Source/WebCore/css/values/CSSValueAggregates.cpp.
(WebCore::operator&lt;&lt;):
(WebCore::add):
(WebCore::CSS::serializationForCSSCustomIdentifier):
(WebCore::CSS::makePrimitiveCSSValue):
* Source/WebCore/css/values/primitives/CSSCustomIdent.h: Copied from Source/WebCore/css/values/CSSValueAggregates.cpp.
(WebCore::CSS::CustomIdent::operator== const):
(WebCore::CSS::Serialize&lt;CustomIdent&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;CustomIdent&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;CustomIdent&gt;::operator()):
(WebCore::CSS::CSSValueCreation&lt;CustomIdent&gt;::operator()):
(WTF::MarkableTraits&lt;WebCore::CSS::CustomIdent&gt;::isEmptyValue):
(WTF::MarkableTraits&lt;WebCore::CSS::CustomIdent&gt;::emptyValue):
* Source/WebCore/style/ScopedName.cpp:
(WebCore::Style::CSSValueConversion&lt;ScopedName&gt;::operator):
* Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h:
(WebCore::Style::CSSValueConversion&lt;CustomIdent&gt;::operator()):
(WebCore::Style::CSSValueConversion&lt;CustomIdentifier&gt;::operator()): Deleted.
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
(WebCore::Style::CSSValueConversion&lt;PositionTryFallback&gt;::operator):
* Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp:
(WebCore::Style::CSSValueConversion&lt;SingleAnimationName&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp:
(WebCore::Style::CSSValueConversion&lt;FontVariantAlternates&gt;::operator):
* Source/WebCore/style/values/primitives/StyleCustomIdent.cpp: Copied from Source/WebCore/css/values/CSSValueAggregates.cpp.
(WebCore::Style::add):
(WebCore::Style::operator&lt;&lt;):
(WebCore::Style::CSSValueCreation&lt;CustomIdent&gt;::operator):
* Source/WebCore/style/values/primitives/StyleCustomIdent.h: Copied from Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp.
(WebCore::Style::CustomIdent::CustomIdent):
(WebCore::Style::CustomIdent::operator CSS::CustomIdent const):
(WebCore::Style::CustomIdent::operator== const):
(WebCore::Style::ToCSS&lt;CustomIdent&gt;::operator() const):
(WebCore::Style::ToStyle&lt;CSS::CustomIdent&gt;::operator() const):
(WebCore::Style::Serialize&lt;CustomIdent&gt;::operator()):
(WTF::MarkableTraits&lt;WebCore::Style::CustomIdent&gt;::isEmptyValue):
(WTF::MarkableTraits&lt;WebCore::Style::CustomIdent&gt;::emptyValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0224b5d2a64bc18737b8a176709eab0122c19719

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162330 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107030 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118732 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107030 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18004 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164793 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7927 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126803 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126968 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137532 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82823 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14313 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90059 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25623 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->