### PR TITLE
Align LocalFrameView::documentBackgroundColor() with CSS

### DIFF
--- a/LayoutTests/compositing/contents-opaque/body-background-painted.html
+++ b/LayoutTests/compositing/contents-opaque/body-background-painted.html
@@ -28,7 +28,7 @@
     </head>
     <!-- Composited body over the child div. -->
     <!-- Root <html> element has a background-color. -->
-    <!-- Background for the body element is painted in this case. -->
+    <!-- Background for the html element is painted in this case. -->
     <!-- GraphicsLayer::contentsOpaque for the body layer should be false. -->
     <body>
         <!-- Box under the body. -->

--- a/LayoutTests/fast/scrolling/mac/wheel-event-listener-region-window-scrollable-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/wheel-event-listener-region-window-scrollable-expected.txt
@@ -6,7 +6,7 @@
       (bounds 785.00 2000.00)
       (contentsOpaque 1)
       (drawsContent 1)
-      (backgroundColor #C0C0C0)
+      (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=785 height=2000)
       (wheel event listener region

--- a/LayoutTests/platform/glib/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/glib/compositing/contents-opaque/body-background-painted-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (backgroundColor #0000FF)
+      (backgroundColor #D3D3D3)
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)

--- a/LayoutTests/platform/ios/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/ios/compositing/contents-opaque/body-background-painted-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (backgroundColor #0000FF)
+      (backgroundColor #D3D3D3)
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)

--- a/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (backgroundColor #0000FF)
+      (backgroundColor #D3D3D3)
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -137,6 +137,8 @@ enum class SDKAlignedBehavior {
     NoHTMLEnhancedSelectParsingQuirk,
     DataURLForPastedImages,
     SuppressKeypressForModifierShortcuts,
+    DocumentBackgroundColorFromCanvas,
+
     NumberOfBehaviors
 };
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -150,6 +150,10 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 #include "DocumentLoader.h"
 #include "LegacyTileCache.h"
@@ -5427,10 +5431,6 @@ void LocalFrameView::paintScrollbar(GraphicsContext& context, Scrollbar& bar, co
 
 Color LocalFrameView::documentBackgroundColor() const
 {
-    // <https://bugs.webkit.org/show_bug.cgi?id=59540> We blend the background color of
-    // the document and the body against the base background color of the frame view.
-    // Background images are unfortunately impractical to include.
-
     // Return invalid Color objects whenever there is insufficient information.
     RefPtr backgroundDocument = [&] {
 #if ENABLE(FULLSCREEN_API)
@@ -5445,19 +5445,8 @@ Color LocalFrameView::documentBackgroundColor() const
     if (!backgroundDocument)
         return Color();
 
-    RefPtr htmlElement = backgroundDocument->documentElement();
-    RefPtr bodyElement = backgroundDocument->bodyOrFrameset();
-
-    // Start with invalid colors.
-    Color htmlBackgroundColor;
-    Color bodyBackgroundColor;
-    if (htmlElement && htmlElement->renderer())
-        htmlBackgroundColor = htmlElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
-    if (bodyElement && bodyElement->renderer())
-        bodyBackgroundColor = bodyElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
-
 #if ENABLE(FULLSCREEN_API)
-    Color fullscreenBackgroundColor = [&] () -> Color {
+    auto fullscreenBackgroundColor = [&] -> Color {
         RefPtr documentFullscreen = backgroundDocument->fullscreenIfExists();
         if (!documentFullscreen)
             return { };
@@ -5480,33 +5469,74 @@ Color LocalFrameView::documentBackgroundColor() const
         // intentionally be visible underneath (and around) the fullscreen element.
         return backdropRenderer->style().visitedDependentBackgroundColorApplyingColorFilter();
     }();
+#endif
 
-    // Replace or blend the fullscreen background color with the body background color, if present.
-    if (fullscreenBackgroundColor.isValid()) {
-        if (!bodyBackgroundColor.isValid())
-            bodyBackgroundColor = fullscreenBackgroundColor;
-        else
-            bodyBackgroundColor = blendSourceOver(bodyBackgroundColor, fullscreenBackgroundColor);
+#if PLATFORM(COCOA)
+    // <https://bugs.webkit.org/show_bug.cgi?id=59540> We blend the background color of
+    // the document and the body against the base background color of the frame view.
+    // Background images are unfortunately impractical to include.
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DocumentBackgroundColorFromCanvas)) {
+        RefPtr htmlElement = backgroundDocument->documentElement();
+        RefPtr bodyElement = backgroundDocument->bodyOrFrameset();
+
+        // Start with invalid colors.
+        Color htmlBackgroundColor;
+        Color bodyBackgroundColor;
+        if (htmlElement && htmlElement->renderer())
+            htmlBackgroundColor = htmlElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
+        if (bodyElement && bodyElement->renderer())
+            bodyBackgroundColor = bodyElement->renderer()->style().visitedDependentBackgroundColorApplyingColorFilter();
+
+#if ENABLE(FULLSCREEN_API)
+        // Replace or blend the fullscreen background color with the body background color, if present.
+        if (fullscreenBackgroundColor.isValid()) {
+            if (!bodyBackgroundColor.isValid())
+                bodyBackgroundColor = fullscreenBackgroundColor;
+            else
+                bodyBackgroundColor = blendSourceOver(bodyBackgroundColor, fullscreenBackgroundColor);
+        }
+#endif
+
+        if (!bodyBackgroundColor.isValid()) {
+            if (!htmlBackgroundColor.isValid())
+                return Color();
+            return blendSourceOver(baseBackgroundColor(), htmlBackgroundColor);
+        }
+
+        if (!htmlBackgroundColor.isValid())
+            return blendSourceOver(baseBackgroundColor(), bodyBackgroundColor);
+
+        // We take the aggregate of the base background color
+        // the <html> background color, and the <body>
+        // background color to find the document color. The
+        // addition of the base background color is not
+        // technically part of the document background, but it
+        // otherwise poses problems when the aggregate is not
+        // fully opaque.
+        return blendSourceOver(blendSourceOver(baseBackgroundColor(), htmlBackgroundColor), bodyBackgroundColor);
     }
 #endif
 
-    if (!bodyBackgroundColor.isValid()) {
-        if (!htmlBackgroundColor.isValid())
-            return Color();
-        return blendSourceOver(baseBackgroundColor(), htmlBackgroundColor);
+    CheckedPtr renderView = backgroundDocument->renderView();
+    Color result;
+    if (renderView) {
+        if (CheckedPtr canvasRenderer = renderView->rendererForRootBackground()) {
+            auto canvasColor = canvasRenderer->style().visitedDependentBackgroundColorApplyingColorFilter();
+            if (canvasColor.isValid())
+                result = blendSourceOver(baseBackgroundColor(), canvasColor);
+        }
     }
 
-    if (!htmlBackgroundColor.isValid())
-        return blendSourceOver(baseBackgroundColor(), bodyBackgroundColor);
+#if ENABLE(FULLSCREEN_API)
+    if (fullscreenBackgroundColor.isValid()) {
+        if (result.isValid())
+            result = blendSourceOver(result, fullscreenBackgroundColor);
+        else
+            result = blendSourceOver(baseBackgroundColor(), fullscreenBackgroundColor);
+    }
+#endif
 
-    // We take the aggregate of the base background color
-    // the <html> background color, and the <body>
-    // background color to find the document color. The
-    // addition of the base background color is not
-    // technically part of the document background, but it
-    // otherwise poses problems when the aggregate is not
-    // fully opaque.
-    return blendSourceOver(blendSourceOver(baseBackgroundColor(), htmlBackgroundColor), bodyBackgroundColor);
+    return result;
 }
 
 bool LocalFrameView::hasCustomScrollbars() const

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
@@ -90,13 +90,13 @@ TEST(WKWebViewUnderPageBackgroundColor, SingleBlendedColor)
 TEST(WKWebViewUnderPageBackgroundColor, MultipleSolidColors)
 {
     auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> html { background-color: blue; } body { background-color: red; } </style>"];
-    EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, redColor.get()));
+    EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, blueColor.get()));
 }
 
 TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
@@ -106,9 +106,9 @@ TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> html { background-color: rgba(255, 0, 0, 0.5); } body { background-color: rgba(0, 0, 255, 0.5); } </style>"];
     auto components = CGColorGetComponents([webView underPageBackgroundColor].CGColor);
-    EXPECT_IN_RANGE(components[0], 0.45, 0.55);
-    EXPECT_IN_RANGE(components[1], 0.2, 0.25);
-    EXPECT_IN_RANGE(components[2], 0.7, 0.75);
+    EXPECT_EQ(components[0], 1);
+    EXPECT_IN_RANGE(components[1], 0.45, 0.55);
+    EXPECT_IN_RANGE(components[2], 0.45, 0.55);
     EXPECT_EQ(components[3], 1);
 }
 


### PR DESCRIPTION
#### e7414e1a8b1901805c2724ff94fb5add7fb81214
<pre>
Align LocalFrameView::documentBackgroundColor() with CSS
<a href="https://bugs.webkit.org/show_bug.cgi?id=308931">https://bugs.webkit.org/show_bug.cgi?id=308931</a>
<a href="https://rdar.apple.com/23607800">rdar://23607800</a>

Reviewed by Wenson Hsieh.

Instead of always drawing the HTML body element background on top, we
should follow how CSS picks the canvas background color.

To be extra cautious, place this behind a linked-on-or-after check.

Canonical link: <a href="https://commits.webkit.org/309332@main">https://commits.webkit.org/309332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3eb6ba5bdf1bb1721134b5607d096b6e4d3b1b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23107 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159065 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1c94637-55f3-464c-ab17-a57fc7f9e744) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da56f51e-4f73-4e42-8337-b7478cb8767b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18113 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/96737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ebfc2b0-3206-433b-91c6-81fdac1bc419) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142332 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11147 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22909 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23107 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181781 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22510 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46509 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22223 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->