### PR TITLE
[WTF][GLib] Adopt LIFETIME_BOUND annotations in Source/WTF/wtf/glib

### DIFF
--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -143,7 +143,7 @@ public:
         return RefDerefTraits::refIfNotNull(m_ptr);
     }
 
-    T*& outPtr()
+    T*& outPtr() LIFETIME_BOUND
     {
         clear();
         return m_ptr;
@@ -163,7 +163,7 @@ public:
     // Only used for C API functions returning (transfer none) of objects where the above
     // can be established, e.g. objects stored in a global dictionary.
     T* /* (transfer none) */ getUncheckedLifetime() const { return m_ptr; }
-    ALWAYS_INLINE T* operator->() const { return m_ptr; }
+    ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return m_ptr; }
 
     bool operator!() const { return !m_ptr; }
     explicit operator bool() const { return !!m_ptr; }

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -80,54 +80,54 @@ WTF_EXPORT_PRIVATE Expected<GMallocSpan<char*, GMallocStrv>, GUniquePtr<GError>>
 WTF_EXPORT_PRIVATE GMallocSpan<GParamSpec*> gObjectClassGetProperties(GObjectClass*);
 WTF_EXPORT_PRIVATE GMallocSpan<const char*> gVariantGetStrv(const GRefPtr<GVariant>&);
 
-inline std::span<const uint8_t> span(GBytes* bytes)
+inline std::span<const uint8_t> span(GBytes* bytes LIFETIME_BOUND)
 {
     size_t size = 0;
     const auto* ptr = static_cast<const uint8_t*>(g_bytes_get_data(bytes, &size));
     return unsafeMakeSpan<const uint8_t>(ptr, size);
 }
 
-inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes)
+inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes LIFETIME_BOUND)
 {
     return span(bytes.get());
 }
 
-inline std::span<const uint8_t> span(GByteArray* array)
+inline std::span<const uint8_t> span(GByteArray* array LIFETIME_BOUND)
 {
     return unsafeMakeSpan<const uint8_t>(array->data, array->len);
 }
 
-inline std::span<const uint8_t> span(const GRefPtr<GByteArray>& array)
+inline std::span<const uint8_t> span(const GRefPtr<GByteArray>& array LIFETIME_BOUND)
 {
     return span(array.get());
 }
 
-inline std::span<const uint8_t> span(GVariant* variant)
+inline std::span<const uint8_t> span(GVariant* variant LIFETIME_BOUND)
 {
     const auto* ptr = static_cast<const uint8_t*>(g_variant_get_data(variant));
     size_t size = g_variant_get_size(variant);
     return unsafeMakeSpan<const uint8_t>(ptr, size);
 }
 
-inline std::span<const uint8_t> span(const GRefPtr<GVariant>& variant)
+inline std::span<const uint8_t> span(const GRefPtr<GVariant>& variant LIFETIME_BOUND)
 {
     return span(variant.get());
 }
 
-static inline std::span<char*> span(char** strv)
+static inline std::span<char*> span(char** strv LIFETIME_BOUND)
 {
     auto size = g_strv_length(strv);
     return unsafeMakeSpan(strv, size);
 }
 
-static inline std::span<const char* const> span(const char* const* strv)
+static inline std::span<const char* const> span(const char* const* strv LIFETIME_BOUND)
 {
     auto size = g_strv_length(const_cast<char**>(strv));
     return unsafeMakeSpan(strv, size);
 }
 
 template <typename T = void*, typename = std::enable_if_t<std::is_pointer_v<T>>>
-inline std::span<T> span(GPtrArray* array)
+inline std::span<T> span(GPtrArray* array LIFETIME_BOUND)
 {
     if (!array)
         return unsafeMakeSpan<T>(nullptr, 0);
@@ -136,7 +136,7 @@ inline std::span<T> span(GPtrArray* array)
 }
 
 template <typename T = void*, typename = std::enable_if_t<std::is_pointer_v<T>>>
-inline std::span<T> span(GRefPtr<GPtrArray>& array)
+inline std::span<T> span(GRefPtr<GPtrArray>& array LIFETIME_BOUND)
 {
     return span<T>(array.get());
 }

--- a/Source/WTF/wtf/glib/GUniquePtr.h
+++ b/Source/WTF/wtf/glib/GUniquePtr.h
@@ -92,30 +92,30 @@ public:
         reset();
     }
 
-    T*& outPtr()
+    T*& outPtr() LIFETIME_BOUND
     {
         reset();
         return m_ptr;
     }
 
-    T* release()
+    [[nodiscard]] T* release()
     {
         return std::exchange(m_ptr, nullptr);
     }
 
-    T& operator*() const
+    T& operator*() const LIFETIME_BOUND
     {
         ASSERT(m_ptr);
         return *m_ptr;
     }
 
-    T* operator->() const
+    T* operator->() const LIFETIME_BOUND
     {
         ASSERT(m_ptr);
         return m_ptr;
     }
 
-    T* get() const { return m_ptr; }
+    T* get() const LIFETIME_BOUND { return m_ptr; }
 
     bool operator!() const { return !m_ptr; }
 

--- a/Source/WTF/wtf/glib/GWeakPtr.h
+++ b/Source/WTF/wtf/glib/GWeakPtr.h
@@ -50,19 +50,19 @@ public:
         removeWeakPtr();
     }
 
-    T& operator*() const
+    T& operator*() const LIFETIME_BOUND
     {
         ASSERT(m_ptr);
         return *m_ptr;
     }
 
-    T* operator->() const
+    T* operator->() const LIFETIME_BOUND
     {
         ASSERT(m_ptr);
         return m_ptr;
     }
 
-    T* get() const
+    T* LIFETIME_BOUND get() const
     {
         return m_ptr;
     }


### PR DESCRIPTION
#### 684b329d05b499f00edff45f2f57b3d567e4c799
<pre>
[WTF][GLib] Adopt LIFETIME_BOUND annotations in Source/WTF/wtf/glib
<a href="https://bugs.webkit.org/show_bug.cgi?id=308936">https://bugs.webkit.org/show_bug.cgi?id=308936</a>

Reviewed by Chris Dumez.

Add LIFETIME_BOUND to functions that were missing the annotation in
GRefPtr, GUniquePtr, GWeakPtr, and the helper template functions that
create std::span object from GLib types.

 * Source/WTF/wtf/glib/GRefPtr.h:
 (WTF::GRefPtr::outPtr): Deleted.
 (WTF::GRefPtr::operator-&gt; const): Deleted.
 * Source/WTF/wtf/glib/GSpanExtras.h:
 (WTF::span):
 * Source/WTF/wtf/glib/GUniquePtr.h:
 (WTF::GUniqueOutPtr::release):
 (WTF::GUniqueOutPtr::outPtr): Deleted.
 (WTF::GUniqueOutPtr::operator* const): Deleted.
 (WTF::GUniqueOutPtr::operator-&gt; const): Deleted.
 (WTF::GUniqueOutPtr::get const): Deleted.
 * Source/WTF/wtf/glib/GWeakPtr.h:
 (WTF::GWeakPtr::get const):
 (WTF::GWeakPtr::operator* const): Deleted.
 (WTF::GWeakPtr::operator-&gt; const): Deleted.

Canonical link: <a href="https://commits.webkit.org/308446@main">https://commits.webkit.org/308446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/793ddc1e97f713fd647b755b41154c9ea049d62d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113744 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81120 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12932 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3686 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139533 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158578 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8351 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121768 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121969 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76141 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9014 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/178922 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83425 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45794 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->