### PR TITLE
Preserve navigatedFrameID in session state for correct child frame back/forward navigation .

### DIFF
--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -204,13 +204,22 @@ bool BackForwardListState::isEqualForTesting(const BackForwardListState& other) 
         return false;
 
     for (size_t i = 0; i < items.size(); ++i) {
-        Ref item = items[i];
-        Ref otherItem = other.items[i];
-        if (!item->isEqualForTesting(otherItem.get()))
+        if (!items[i].isEqualForTesting(other.items[i]))
             return false;
     }
 
     if (currentIndex != other.currentIndex)
+        return false;
+
+    return true;
+}
+
+bool BackForwardListItemState::isEqualForTesting(const BackForwardListItemState& other) const
+{
+    if (!protect(frameState)->isEqualForTesting(protect(other.frameState).get()))
+        return false;
+
+    if (navigatedFrameID != other.navigatedFrameID)
         return false;
 
     return true;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -147,8 +147,15 @@ private:
     Vector<AtomString> m_documentState;
 } SWIFT_SHARED_REFERENCE(refFrameState, derefFrameState);
 
+struct BackForwardListItemState {
+    Ref<FrameState> frameState;
+    std::optional<WebCore::FrameIdentifier> navigatedFrameID;
+
+    bool isEqualForTesting(const BackForwardListItemState&) const;
+};
+
 struct BackForwardListState {
-    Vector<Ref<FrameState>> items;
+    Vector<BackForwardListItemState> items;
     std::optional<uint32_t> currentIndex;
 
     bool isEqualForTesting(const BackForwardListState&) const;

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -78,7 +78,12 @@ header: "SessionState.h"
     [Validator='WebKit::FrameState::validateDocumentState(*documentState)'] Vector<AtomString> documentState();
 };
 
+[CustomHeader] struct WebKit::BackForwardListItemState {
+    Ref<WebKit::FrameState> frameState;
+    std::optional<WebCore::FrameIdentifier> navigatedFrameID;
+};
+
 [CustomHeader] struct WebKit::BackForwardListState {
-    Vector<Ref<WebKit::FrameState>> items;
+    Vector<WebKit::BackForwardListItemState> items;
     std::optional<uint32_t> currentIndex;
 };

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -228,9 +228,10 @@ static inline void encodeBackForwardListItemState(GVariantBuilder* sessionBuilde
 
 static inline void encodeBackForwardListState(GVariantBuilder* sessionBuilder, const BackForwardListState& backForwardListState)
 {
+    // FIXME: Encode navigatedFrameID for each item to support site isolation back/forward navigation after session restore.
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("a" BACK_FORWARD_LIST_ITEM_TYPE_STRING_V2));
     for (const auto& item : backForwardListState.items)
-        encodeBackForwardListItemState(sessionBuilder, item);
+        encodeBackForwardListItemState(sessionBuilder, item.frameState);
     g_variant_builder_close(sessionBuilder);
 
     if (backForwardListState.currentIndex)
@@ -375,7 +376,7 @@ static inline void decodeBackForwardListItemStateV1(GVariantIter* backForwardLis
         mainFrameState->title = String::fromUTF8(title);
         decodeFrameState(frameStateVariant, mainFrameState);
         mainFrameState->shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
-        backForwardListState.items.append(WTF::move(mainFrameState));
+        backForwardListState.items.append({ WTF::move(mainFrameState), std::nullopt });
     }
 }
 
@@ -399,7 +400,7 @@ static inline void decodeBackForwardListItemState(GVariantIter* backForwardListS
         mainFrameState->title = String::fromUTF8(title);
         decodeFrameState(frameStateVariant, mainFrameState);
         mainFrameState->shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
-        backForwardListState.items.append(WTF::move(mainFrameState));
+        backForwardListState.items.append({ WTF::move(mainFrameState), std::nullopt });
     }
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -441,7 +441,7 @@ BackForwardListState WebBackForwardList::backForwardListState(WTF::Function<bool
             continue;
         }
 
-        backForwardListState.items.append(entry->mainFrameState());
+        backForwardListState.items.append({ entry->mainFrameState(), entry->navigatedFrameID() });
     }
 
     if (backForwardListState.items.isEmpty())
@@ -466,13 +466,11 @@ void WebBackForwardList::restoreFromState(BackForwardListState backForwardListSt
         return;
 
     // FIXME: Enable restoring resourceDirectoryURL.
-    m_entries = WTF::map(WTF::move(backForwardListState.items), [this](auto&& state) {
-        Ref stateCopy = state->copy();
+    m_entries = WTF::map(WTF::move(backForwardListState.items), [this](auto&& itemState) {
+        Ref stateCopy = itemState.frameState->copy();
         setBackForwardItemIdentifiers(stateCopy, BackForwardItemIdentifier::generate());
         m_currentIndex = m_entries.isEmpty() ? std::nullopt : std::optional(m_entries.size() - 1);
-        // FIXME: navigatedFrameID will always be the main frame ID, causing the restored session state to be sent to an incorrect process when going back or forward with site isolation enabled.
-        auto navigatedFrameID = stateCopy->frameID;
-        return WebBackForwardListItem::create(WTF::move(stateCopy), m_page->identifier(), navigatedFrameID);
+        return WebBackForwardListItem::create(WTF::move(stateCopy), m_page->identifier(), itemState.navigatedFrameID);
     });
     m_currentIndex = backForwardListState.currentIndex ? std::optional<size_t>(*backForwardListState.currentIndex) : std::nullopt;
 

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -60,6 +60,7 @@ static const CFStringRef sessionHistoryEntryTitleKey = CFSTR("SessionHistoryEntr
 static const CFStringRef sessionHistoryEntryOriginalURLKey = CFSTR("SessionHistoryEntryOriginalURL");
 static const CFStringRef sessionHistoryEntryDataKey = CFSTR("SessionHistoryEntryData");
 static const CFStringRef sessionHistoryEntryShouldOpenExternalURLsPolicyKey = CFSTR("SessionHistoryEntryShouldOpenExternalURLsPolicyKey");
+static const CFStringRef sessionHistoryEntryNavigatedFrameIDKey = CFSTR("SessionHistoryEntryNavigatedFrameID");
 
 // Session history entry data.
 const uint32_t sessionHistoryEntryDataVersion = 2;
@@ -432,38 +433,32 @@ static RetainPtr<CFDictionaryRef> encodeSessionHistory(const BackForwardListStat
     size_t totalDataSize = 0;
 
     for (auto& item : backForwardListState.items) {
-        auto url = item->urlString.createCFString();
-        auto title = item->title.createCFString();
-        auto originalURL = item->originalURLString.createCFString();
+        auto& frameState = item.frameState;
+        auto url = frameState->urlString.createCFString();
+        auto title = frameState->title.createCFString();
+        auto originalURL = frameState->originalURLString.createCFString();
 
-        // We allow the first item to be unlimited in size. We refrain from serializing the data for subsequent items if they would cause us to trip over the maximumSessionStateDataSize limit.
-        auto data = totalDataSize <= maximumSessionStateDataSize ? encodeSessionHistoryEntryData(item) : nullptr;
-        if (data) {
-            totalDataSize += CFDataGetLength(data.get());
-            if (totalDataSize > maximumSessionStateDataSize && CFArrayGetCount(entries.get()) > 0)
-                data = nullptr;
-        }
-
-        auto shouldOpenExternalURLsPolicyValue = static_cast<uint64_t>(item->shouldOpenExternalURLsPolicy);
+        auto shouldOpenExternalURLsPolicyValue = static_cast<uint64_t>(frameState->shouldOpenExternalURLsPolicy);
         auto shouldOpenExternalURLsPolicy = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &shouldOpenExternalURLsPolicyValue));
 
-        RetainPtr<CFDictionaryRef> entryDictionary;
+        RetainPtr<CFMutableDictionaryRef> entryDictionary = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, createDictionary({
+            { sessionHistoryEntryURLKey, url.get() },
+            { sessionHistoryEntryTitleKey, title.get() },
+            { sessionHistoryEntryOriginalURLKey, originalURL.get() },
+            { sessionHistoryEntryShouldOpenExternalURLsPolicyKey, shouldOpenExternalURLsPolicy.get() },
+        }).get()));
 
-        if (data) {
-            entryDictionary = createDictionary({
-                { sessionHistoryEntryURLKey, url.get() },
-                { sessionHistoryEntryTitleKey, title.get() },
-                { sessionHistoryEntryOriginalURLKey, originalURL.get() },
-                { sessionHistoryEntryDataKey, data.get() },
-                { sessionHistoryEntryShouldOpenExternalURLsPolicyKey, shouldOpenExternalURLsPolicy.get() },
-            });
-        } else {
-            entryDictionary = createDictionary({
-                { sessionHistoryEntryURLKey, url.get() },
-                { sessionHistoryEntryTitleKey, title.get() },
-                { sessionHistoryEntryOriginalURLKey, originalURL.get() },
-                { sessionHistoryEntryShouldOpenExternalURLsPolicyKey, shouldOpenExternalURLsPolicy.get() },
-            });
+        // We allow the first item to be unlimited in size. We refrain from serializing the data for subsequent items if they would cause us to trip over the maximumSessionStateDataSize limit.
+        if (auto data = totalDataSize <= maximumSessionStateDataSize ? encodeSessionHistoryEntryData(frameState) : nullptr) {
+            totalDataSize += CFDataGetLength(data.get());
+            if (totalDataSize <= maximumSessionStateDataSize || !CFArrayGetCount(entries.get()))
+                CFDictionarySetValue(entryDictionary.get(), sessionHistoryEntryDataKey, data.get());
+        }
+
+        if (item.navigatedFrameID) {
+            auto navigatedFrameIDValue = static_cast<uint64_t>(item.navigatedFrameID->toUInt64());
+            auto navigatedFrameIDNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &navigatedFrameIDValue));
+            CFDictionarySetValue(entryDictionary.get(), sessionHistoryEntryNavigatedFrameIDKey, navigatedFrameIDNumber.get());
         }
 
         CFArrayAppendValue(entries.get(), entryDictionary.get());
@@ -1032,18 +1027,26 @@ static void decodeBackForwardTreeNode(HistoryEntryDataDecoder& decoder, FrameSta
     return true;
 }
 
-[[nodiscard]] static bool decodeSessionHistoryEntries(CFArrayRef entriesArray, Vector<Ref<FrameState>>& entries)
+[[nodiscard]] static bool decodeSessionHistoryEntries(CFArrayRef entriesArray, Vector<BackForwardListItemState>& entries)
 {
     for (CFIndex i = 0, size = CFArrayGetCount(entriesArray); i < size; ++i) {
         RetainPtr entryDictionary = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(entriesArray, i));
         if (!entryDictionary)
             return false;
 
-        Ref entry = FrameState::create();
-        if (!decodeSessionHistoryEntry(entryDictionary.get(), entry))
+        Ref frameState = FrameState::create();
+        if (!decodeSessionHistoryEntry(entryDictionary.get(), frameState))
             return false;
 
-        entries.append(WTF::move(entry));
+        std::optional<WebCore::FrameIdentifier> navigatedFrameID;
+        RetainPtr navigatedFrameIDNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(entryDictionary.get(), sessionHistoryEntryNavigatedFrameIDKey));
+        if (navigatedFrameIDNumber) {
+            uint64_t value;
+            CFNumberGetValue(navigatedFrameIDNumber.get(), kCFNumberSInt64Type, &value);
+            navigatedFrameID = WebCore::FrameIdentifier(value);
+        }
+
+        entries.append({ WTF::move(frameState), navigatedFrameID });
     }
 
     return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3863,7 +3863,9 @@ TEST(SiteIsolation, RestoreSessionFromAnotherWebView)
     EXPECT_WK_STREQ([webView2 _test_waitForAlert], "done");
 }
 
-static void testNavigateIframeBackForward(NSString *navigationURL, bool restoreSessionState)
+enum class SessionRestoreMethod : uint8_t { None, InPlace, NewWebView };
+
+static void testNavigateIframeBackForward(NSString *navigationURL, SessionRestoreMethod restoreMethod)
 {
     HTTPServer server({
         { "/example"_s, { "<iframe src='https://webkit.org/source'></iframe>"_s } },
@@ -3878,8 +3880,24 @@ static void testNavigateIframeBackForward(NSString *navigationURL, bool restoreS
     [webView evaluateJavaScript:[NSString stringWithFormat:@"location.href = '%@'", navigationURL] inFrame:childFrame.get() completionHandler:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "destination");
 
-    if (restoreSessionState)
+    switch (restoreMethod) {
+    case SessionRestoreMethod::None:
+        break;
+    case SessionRestoreMethod::InPlace:
         [webView _restoreSessionState:[webView _sessionState] andNavigate:NO];
+        break;
+    case SessionRestoreMethod::NewWebView: {
+        RetainPtr sessionState = [webView _sessionState];
+        auto [newWebView, newNavigationDelegate] = siteIsolatedViewAndDelegate(server);
+        [newWebView _restoreSessionState:sessionState.get() andNavigate:YES];
+        EXPECT_WK_STREQ([newWebView _test_waitForAlert], "destination");
+        webView = WTF::move(newWebView);
+        navigationDelegate = WTF::move(newNavigationDelegate);
+        break;
+    }
+    }
+
+    childFrame = [webView firstChildFrame];
 
     [webView goBack];
     EXPECT_WK_STREQ("source", [webView _test_waitForAlert]);
@@ -3896,22 +3914,32 @@ static void testNavigateIframeBackForward(NSString *navigationURL, bool restoreS
 
 TEST(SiteIsolation, NavigateIframeSameOriginBackForward)
 {
-    testNavigateIframeBackForward(@"https://webkit.org/destination", false);
+    testNavigateIframeBackForward(@"https://webkit.org/destination", SessionRestoreMethod::None);
 }
 
-TEST(SiteIsolation, DISABLED_NavigateIframeSameOriginBackForwardAfterSessionRestore)
+TEST(SiteIsolation, NavigateIframeSameOriginBackForwardAfterSessionRestore)
 {
-    testNavigateIframeBackForward(@"https://webkit.org/destination", true);
+    testNavigateIframeBackForward(@"https://webkit.org/destination", SessionRestoreMethod::InPlace);
+}
+
+TEST(SiteIsolation, NavigateIframeSameOriginBackForwardAfterSessionRestoreToNewWebView)
+{
+    testNavigateIframeBackForward(@"https://webkit.org/destination", SessionRestoreMethod::NewWebView);
 }
 
 TEST(SiteIsolation, NavigateIframeCrossOriginBackForward)
 {
-    testNavigateIframeBackForward(@"https://apple.com/destination", false);
+    testNavigateIframeBackForward(@"https://apple.com/destination", SessionRestoreMethod::None);
 }
 
-TEST(SiteIsolation, DISABLED_NavigateIframeCrossOriginBackForwardAfterSessionRestore)
+TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestore)
 {
-    testNavigateIframeBackForward(@"https://apple.com/destination", true);
+    testNavigateIframeBackForward(@"https://apple.com/destination", SessionRestoreMethod::InPlace);
+}
+
+TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestoreToNewWebView)
+{
+    testNavigateIframeBackForward(@"https://apple.com/destination", SessionRestoreMethod::NewWebView);
 }
 
 TEST(SiteIsolation, ValidateSessionRestoreWithoutNavigating)


### PR DESCRIPTION
#### a58aaf679b9152e0fefe7090bd78eec266acb105
<pre>
Preserve navigatedFrameID in session state for correct child frame back/forward navigation .
<a href="https://bugs.webkit.org/show_bug.cgi?id=308939">https://bugs.webkit.org/show_bug.cgi?id=308939</a>
<a href="https://rdar.apple.com/149987127">rdar://149987127</a>

Reviewed by Sihui Liu.

When session state is restored via _restoreSessionState:andNavigate:NO, the BackForwardList is
rebuilt from serialized FrameState data. However, the navigatedFrameID — which tracks which
frame was navigated to create each back/forward entry — was not preserved. restoreFromState()
always set it to the main frame&apos;s FrameIdentifier, causing goBack()/goForward() to reload the
entire page instead of navigating only the child frame.

This patch introduces BackForwardListItemState, which pairs a FrameState with its navigatedFrameID,
and uses it as the element type of BackForwardListState::items. The navigatedFrameID is now
serialized in the legacy session state format under the &quot;SessionHistoryEntryNavigatedFrameID&quot;
key, with backward compatibility: older data lacking this key decodes as nullopt, falling back
to the existing main-frame behavior.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* Source/WebKit/Shared/SessionState.cpp:
(WebKit::BackForwardListState::isEqualForTesting const):
(WebKit::BackForwardListItemState::isEqualForTesting const):
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp:
(encodeBackForwardListState):
(decodeBackForwardListItemStateV1):
(decodeBackForwardListItemState):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardListState const):
(WebKit::WebBackForwardList::restoreFromState):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeSessionHistory):
(WebKit::decodeSessionHistoryEntries):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::testNavigateIframeBackForward):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeSameOriginBackForward)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeSameOriginBackForwardAfterSessionRestore)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeSameOriginBackForwardAfterSessionRestoreToNewWebView)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeCrossOriginBackForward)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestore)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestoreToNewWebView)):
(TestWebKitAPI::TEST(SiteIsolation, DISABLED_NavigateIframeSameOriginBackForwardAfterSessionRestore)): Deleted.
(TestWebKitAPI::TEST(SiteIsolation, DISABLED_NavigateIframeCrossOriginBackForwardAfterSessionRestore)): Deleted.

Canonical link: <a href="https://commits.webkit.org/308501@main">https://commits.webkit.org/308501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b80b0cc60a392b3ee8289064ee180fe96e80faa4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101131 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b7adfca-fdaa-439a-ab0a-841aa20bb244) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81211 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e150b0c-7a64-476e-a245-74ec346dc13e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94634 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13059 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3839 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158733 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121900 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76326 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9144 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83578 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19545 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->