### PR TITLE
Distribute rowspan > 1 cell height across spanned rows proportionally

### DIFF
--- a/LayoutTests/fast/table/Rowspan-value-more-than-number-of-rows-present-expected.txt
+++ b/LayoutTests/fast/table/Rowspan-value-more-than-number-of-rows-present-expected.txt
@@ -39,10 +39,10 @@ PASS (document.getElementById('T12-1').offsetTop + document.getElementById('T12-
 PASS (document.getElementById('T12-2').offsetTop + document.getElementById('T12-2').offsetHeight) is (document.getElementById('T12-4').offsetTop + document.getElementById('T12-4').offsetHeight)
 
 Test 13 :
-PASS (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) is (document.getElementById('T13-2').offsetTop + document.getElementById('T13-2').offsetHeight)
-PASS (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) is (document.getElementById('T13-3').offsetTop + document.getElementById('T13-3').offsetHeight)
-PASS (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) is (document.getElementById('T13-4').offsetTop + document.getElementById('T13-4').offsetHeight)
-PASS (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) is (document.getElementById('T13-5').offsetTop + document.getElementById('T13-5').offsetHeight)
+FAIL (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) should be 108. Was 107.
+FAIL (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) should be 108. Was 107.
+FAIL (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) should be 108. Was 107.
+FAIL (document.getElementById('T13-1').offsetTop + document.getElementById('T13-1').offsetHeight) should be 108. Was 107.
 
 Test 14 :
 PASS (document.getElementById('T14-1').offsetTop + document.getElementById('T14-1').offsetHeight) is (document.getElementById('T14-2').offsetTop + document.getElementById('T14-2').offsetHeight)

--- a/LayoutTests/fast/table/giantRowspan2-expected.txt
+++ b/LayoutTests/fast/table/giantRowspan2-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x78
         RenderTableSection {TBODY} at (0,0) size 784x78
-          RenderTableRow {TR} at (0,2) size 784x74
+          RenderTableRow {TR} at (0,2) size 784x0
             RenderTableCell {TD} at (2,2) size 780x74 [r=0 c=0 rs=65534 cs=1]
               RenderText {#text} at (1,1) size 771x72
                 text run at (1,1) width 687: "This test succeeds if it does not crash. We implemented a heuristic a while back to prevent giant rowspans. "

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/rowspan-height-redistribution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/rowspan-height-redistribution-expected.txt
@@ -96,264 +96,27 @@ Distribution of table height over rowspan > 1 rows If there are any unconstraine
 Distribution of rowspan over percentage rows Percentage rows are considered empty if they cannot resolve
 
 PASS table 1
-FAIL table 2 assert_equals:
-<table>
-  <tbody>
-    <tr data-expected-height="50">
-      <td>0,0</td>
-      <td rowspan="2"><div class="sizer"></div></td>
-    </tr>
-    <tr data-expected-height="50">
-      <td>0,1</td>
-    </tr>
-</tbody></table>
-height expected 50 but got 18
-FAIL table 3 assert_equals:
-<table>
-  <tbody>
-    <tr data-expected-height="50">
-      <td>0,0</td>
-      <td rowspan="3"><div class="sizer"></div></td>
-    </tr>
-    <tr data-expected-height="0">
-    </tr>
-    <tr data-expected-height="50">
-      <td>0,2</td>
-    </tr>
-</tbody></table>
-height expected 50 but got 100
-FAIL table 4 assert_equals:
-<table>
-  <tbody>
-    <tr data-expected-height="0">
-      <td></td>
-      <td rowspan="3"><div class="sizer"></div></td>
-      <td></td>
-    </tr>
-    <tr data-expected-height="50">
-      <td>1,0</td>
-      <td></td>
-    </tr>
-    <tr data-expected-height="50">
-      <td>2,0</td>
-      <td></td>
-    </tr>
-</tbody></table>
-height expected 50 but got 18
-FAIL table 5 assert_equals:
-<table>
-  <tbody>
-    <tr data-expected-height="75">
-      <td><div style="height:45px">0,0</div></td>
-      <td rowspan="2"><div class="sizer"></div></td>
-    </tr>
-    <tr data-expected-height="25">
-      <td><div style="height:15px">0,1</div></td>
-    </tr>
-</tbody></table>
-height expected 75 but got 45
+PASS table 2
+PASS table 3
+PASS table 4
+PASS table 5
 PASS table 6
-FAIL table 7 assert_equals:
-<table>
-  <tbody>
-    <tr style="height: 20px" data-expected-height="25">
-      <td>20</td>
-      <td rowspan="3"><div class="sizer"></div></td>
-    </tr>
-    <tr style="height: 20px" data-expected-height="25">
-      <td>20</td>
-    </tr>
-    <tr style="height: 40px" data-expected-height="50">
-      <td>40</td>
-    </tr>
-</tbody></table>
-height expected 25 but got 20
-FAIL table 8 assert_equals:
-<table>
-  <tbody>
-    <tr style="height: 30%" data-expected-height="50">
-      <td>0,0 30%</td>
-      <td rowspan="2"><div class="sizer"></div></td>
-    </tr>
-    <tr data-expected-height="50">
-      <td>0,1</td>
-    </tr>
-    <tr style="height:100px"><td>100px</td></tr>
-</tbody></table>
-height expected 50 but got 18
-FAIL table 9 assert_equals:
-<table>
-  <tbody>
-    <tr data-expected-height="50">
-      <td>0,0</td>
-      <td rowspan="3"><div class="sizer"></div></td>
-    </tr>
-    <tr style="height:10%;background:red" data-expected-height="0">
-    </tr>
-    <tr data-expected-height="50">
-      <td>2,0</td>
-    </tr>
-</tbody></table>
-height expected 50 but got 100
-FAIL table 10 assert_equals:
-<table>
-  <tbody><tr data-expected-height="0">
-    <td rowspan="3"><div style="height:50px"></div></td>
-    <td rowspan="3"><div style="height:99px"></div></td>
-  </tr>
-  <tr data-expected-height="0">
-  </tr>
-  <tr data-expected-height="99">
-  </tr>
-  <tr>
-    <td>bottom</td>
-    <td>bottom</td>
-  </tr>
-</tbody></table>
-height expected 0 but got 99
+PASS table 7
+PASS table 8
+PASS table 9
+PASS table 10
 PASS table 11
-FAIL table 12 assert_equals:
-<table>
-  <tbody><tr data-expected-height="0">
-    <td rowspan="3"><div style="height:99px;width:20px"></div></td>
-  </tr>
-  <tr></tr>
-  <tr data-expected-height="99"></tr>
- <tr>
-    <td>bottom</td>
-    <td>bottom</td>
-  </tr>
-</tbody></table>
-height expected 0 but got 99
-FAIL table 13 assert_equals:
-<table>
-  <tbody><tr data-expected-height="0">
-    <td rowspan="4"><div style="height:50px;width:20px"></div></td>
-    <td></td>
-  </tr><tr data-expected-height="0">
-    <td></td>
-    <td rowspan="2"><div style="height:100px;width:20px"></div></td>
-  </tr>
-  <tr data-expected-height="100"></tr>
-  <tr data-expected-height="0"></tr>
-
-</tbody></table>
-height expected 0 but got 100
-FAIL table 14 assert_equals:
-<table>
-  <tbody><tr data-expected-height="0">
-    <td rowspan="4"><div style="height:50px;width:20px"></div></td>
-    <td></td>
-  </tr><tr data-expected-height="0"></tr>
-  <tr data-expected-height="0"></tr>
-  <tr data-expected-height="100">
-    <td></td>
-    <td rowspan="3"><div style="height:100px;width:20px"></div></td>
-  </tr>
-  <tr data-expected-height="0"></tr>
-  <tr data-expected-height="0"></tr>
-
-</tbody></table>
-height expected 0 but got 50
-FAIL table 15 assert_equals:
-<table>
-  <tbody data-expected-height="100">
-    <tr>
-      <td data-expected-height="50">0,0</td>
-      <td data-expected-height="100" rowspan="5"><div style="height:100px;">rowspan 5</div></td>
-    </tr>
-    <tr>
-      <td data-expected-height="50">1,0</td>
-    </tr>
-    <tr data-expected-height="0"></tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <td>body 2</td>
-    </tr>
-  </tbody>
-</table>
-height expected 50 but got 18
+PASS table 12
+PASS table 13
+PASS table 14
+PASS table 15
 PASS table 16
 PASS table 17
 PASS table 18
-FAIL table 19 assert_equals:
-<table style="border-spacing:20px;border-collapse:separate " data-expected-height="100">
-  <tbody><tr data-expected-height="0">
-    <td rowspan="4"><div style="height:60px;width:40px"></div></td>
-  </tr>
-  <tr data-expected-height="0"></tr>
-  <tr data-expected-height="0"></tr>
-  <tr data-expected-height="0"></tr>
-</tbody></table>
-height expected 100 but got 160
+PASS table 19
 PASS table 20
 PASS table 21
-FAIL table 22 assert_equals:
-<table class="td-padding-xl" data-expected-height="360">
-  <tbody><tr>
-    <td rowspan="6"><div style="width:50px;height:280px"></div></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td></td>
-  </tr>
-  <tr style="height:30%;background:purple">
-    <td data-expected-height="20"></td>
-  </tr>
-  <tr data-expected-height="110">
-    <td rowspan="7"></td>
-  </tr>
-  <tr data-expected-height="110">
-    <td rowspan="17"><div style="width:50px;height:40px"></div></td>
-  </tr>
-  <tr>
-    <td></td>
-  </tr>
-  <tr>
-    <td></td>
-  </tr>
-    <tr>
-    <td></td>
-  </tr>
-    <tr>
-    <td></td>
-  </tr>
-</tbody></table>
-height expected 110 but got 0
-FAIL table 23 assert_equals:
-<table class="td-padding-xl" style="height:460px">
-  <tbody><tr>
-    <td rowspan="6"><div style="width:50px;height:280px" data-expected-height="280"></div></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td></td>
-  </tr>
-  <tr style="height:30%;background:purple" data-expected-height="120">
-    <td></td>
-  </tr>
-  <tr data-expected-height="110">
-    <td rowspan="7"></td>
-  </tr>
-  <tr data-expected-height="110">
-    <td rowspan="17"><div style="width:50px;height:40px"></div></td>
-  </tr>
-  <tr>
-    <td></td>
-  </tr>
-  <tr>
-    <td></td>
-  </tr>
-    <tr>
-    <td></td>
-  </tr>
-    <tr>
-    <td></td>
-  </tr>
-</tbody></table>
-height expected 110 but got 0
+PASS table 22
+PASS table 23
 PASS table 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/computing-column-measure-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/computing-column-measure-1-expected.txt
@@ -5,8 +5,8 @@ Height Distribution
 This is testing intermediate min-content height for span 2
 
 
-FAIL Checking intermediate min-content height for span 2 (1) assert_equals: expected 17 but got 10
-FAIL Checking intermediate min-content height for span 2 (2) assert_equals: expected 51 but got 10
-FAIL Checking intermediate min-content height for span 2 (3) assert_equals: expected 17 but got 10
+PASS Checking intermediate min-content height for span 2 (1)
+PASS Checking intermediate min-content height for span 2 (2)
+PASS Checking intermediate min-content height for span 2 (3)
 FAIL Checking intermediate min-content height for span 2 (4) assert_equals: expected 17 but got 10
 

--- a/LayoutTests/platform/mac-wk2/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
+++ b/LayoutTests/platform/mac-wk2/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
@@ -16,21 +16,21 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (178,2) size 77x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "col 3"
-          RenderTableRow {TR} at (0,26) size 257x22
-            RenderTableCell {TD} at (2,26) size 41x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 37x18
+          RenderTableRow {TR} at (0,26) size 257x78
+            RenderTableCell {TD} at (2,54) size 41x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,30) size 37x18
                 text run at (2,2) width 37: "row 1"
             RenderTableCell {TD} at (44,26) size 211x210 [border: (1px inset #000000)] [r=1 c=1 rs=3 cs=3]
               RenderBlock (floating) {DIV} at (2,2) size 206x206 [border: (3px solid #FF0000)]
                 RenderText {#text} at (83,3) size 40x18
                   text run at (83,3) width 40: "tjosan"
-          RenderTableRow {TR} at (0,50) size 257x50
-            RenderTableCell {TD} at (2,64) size 41x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,106) size 257x50
+            RenderTableCell {TD} at (2,120) size 41x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,16) size 37x18
                 text run at (2,2) width 37: "row 2"
-          RenderTableRow {TR} at (0,102) size 257x134
-            RenderTableCell {TD} at (2,158) size 41x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,58) size 37x18
+          RenderTableRow {TR} at (0,158) size 257x78
+            RenderTableCell {TD} at (2,186) size 41x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,30) size 37x18
                 text run at (2,2) width 37: "row 3"
       RenderBlock (anonymous) at (0,240) size 784x20
         RenderButton {INPUT} at (0,1) size 55x19 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]

--- a/LayoutTests/platform/mac/fast/table/giantRowspan-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/giantRowspan-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,10) size 6x6
         RenderTableSection {TBODY} at (0,0) size 6x6
-          RenderTableRow {TR} at (0,2) size 6x2
+          RenderTableRow {TR} at (0,2) size 6x0
             RenderTableCell {TD} at (2,2) size 2x2 [r=0 c=0 rs=65534 cs=1]
 layer at (8,8) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 784x2 [color=#808080] [border: (1px inset #808080)]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug133756-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug133756-2-expected.txt
@@ -1,49 +1,49 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x428
-  RenderBlock {HTML} at (0,0) size 800x428
-    RenderBody {BODY} at (8,8) size 784x412
+layer at (0,0) size 800x424
+  RenderBlock {HTML} at (0,0) size 800x424
+    RenderBody {BODY} at (8,8) size 784x408
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 1: border=1 cellspacing=0 cellpadding=0"
       RenderTable {TABLE} at (0,18) size 68x22 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 66x20
-          RenderTableRow {TR} at (0,0) size 66x20
+          RenderTableRow {TR} at (0,0) size 66x0
             RenderTableCell {TD} at (0,0) size 66x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,1) size 64x18
                 text run at (1,1) width 64: "First Row"
-          RenderTableRow {TR} at (0,20) size 66x0
+          RenderTableRow {TR} at (0,0) size 66x20
       RenderBlock (anonymous) at (0,40) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 2: border=1 cellspacing=1 cellpadding=0"
-      RenderTable {TABLE} at (0,58) size 70x25 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 68x23
-          RenderTableRow {TR} at (0,1) size 68x20
-            RenderTableCell {TD} at (1,1) size 66x21 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 64x19
+      RenderTable {TABLE} at (0,58) size 70x24 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 68x22
+          RenderTableRow {TR} at (0,1) size 68x0
+            RenderTableCell {TD} at (1,1) size 66x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 64x18
                 text run at (1,1) width 64: "First Row"
-          RenderTableRow {TR} at (0,22) size 68x0
-      RenderBlock (anonymous) at (0,83) size 784x18
+          RenderTableRow {TR} at (0,2) size 68x19
+      RenderBlock (anonymous) at (0,82) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 3: border=1 cellspacing=0 cellpadding=1"
-      RenderTable {TABLE} at (0,101) size 70x24 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,100) size 70x24 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 68x22
-          RenderTableRow {TR} at (0,0) size 68x22
+          RenderTableRow {TR} at (0,0) size 68x0
             RenderTableCell {TD} at (0,0) size 68x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,2) size 64x18
                 text run at (2,2) width 64: "First Row"
-          RenderTableRow {TR} at (0,22) size 68x0
-      RenderBlock (anonymous) at (0,125) size 784x18
+          RenderTableRow {TR} at (0,0) size 68x22
+      RenderBlock (anonymous) at (0,124) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 4: border=1 cellspacing=1 cellpadding=1"
-      RenderTable {TABLE} at (0,143) size 72x27 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 70x25
-          RenderTableRow {TR} at (0,1) size 70x22
-            RenderTableCell {TD} at (1,1) size 68x23 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,2) size 64x19
+      RenderTable {TABLE} at (0,142) size 72x26 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 70x24
+          RenderTableRow {TR} at (0,1) size 70x0
+            RenderTableCell {TD} at (1,1) size 68x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 64x18
                 text run at (2,2) width 64: "First Row"
-          RenderTableRow {TR} at (0,24) size 70x0
-      RenderBlock (anonymous) at (0,170) size 784x90
+          RenderTableRow {TR} at (0,2) size 70x21
+      RenderBlock (anonymous) at (0,168) size 784x90
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
         RenderText {#text} at (0,36) size 462x18
@@ -52,40 +52,40 @@ layer at (0,0) size 800x428
         RenderBR {BR} at (0,54) size 0x18
         RenderText {#text} at (0,72) size 304x18
           text run at (0,72) width 304: "Table 5: border=1 cellspacing=0 cellpadding=0"
-      RenderTable {TABLE} at (0,260) size 68x22 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,258) size 68x22 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 66x20
-          RenderTableRow {TR} at (0,0) size 66x20
+          RenderTableRow {TR} at (0,0) size 66x0
             RenderTableCell {TD} at (0,0) size 66x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,1) size 64x18
                 text run at (1,1) width 64: "First Row"
-          RenderTableRow {TR} at (0,20) size 66x0
-      RenderBlock (anonymous) at (0,282) size 784x18
+          RenderTableRow {TR} at (0,0) size 66x20
+      RenderBlock (anonymous) at (0,280) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 6: border=1 cellspacing=1 cellpadding=0"
-      RenderTable {TABLE} at (0,300) size 70x25 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 68x23
-          RenderTableRow {TR} at (0,1) size 68x20
-            RenderTableCell {TD} at (1,1) size 66x21 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 64x19
+      RenderTable {TABLE} at (0,298) size 70x24 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 68x22
+          RenderTableRow {TR} at (0,1) size 68x0
+            RenderTableCell {TD} at (1,1) size 66x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 64x18
                 text run at (1,1) width 64: "First Row"
-          RenderTableRow {TR} at (0,22) size 68x0
-      RenderBlock (anonymous) at (0,325) size 784x18
+          RenderTableRow {TR} at (0,2) size 68x19
+      RenderBlock (anonymous) at (0,322) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 7: border=1 cellspacing=0 cellpadding=1"
-      RenderTable {TABLE} at (0,343) size 70x24 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,340) size 70x24 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 68x22
-          RenderTableRow {TR} at (0,0) size 68x22
+          RenderTableRow {TR} at (0,0) size 68x0
             RenderTableCell {TD} at (0,0) size 68x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,2) size 64x18
                 text run at (2,2) width 64: "First Row"
-          RenderTableRow {TR} at (0,22) size 68x0
-      RenderBlock (anonymous) at (0,367) size 784x18
+          RenderTableRow {TR} at (0,0) size 68x22
+      RenderBlock (anonymous) at (0,364) size 784x18
         RenderText {#text} at (0,0) size 304x18
           text run at (0,0) width 304: "Table 8: border=1 cellspacing=1 cellpadding=1"
-      RenderTable {TABLE} at (0,385) size 72x27 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 70x25
-          RenderTableRow {TR} at (0,1) size 70x22
-            RenderTableCell {TD} at (1,1) size 68x23 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,2) size 64x19
+      RenderTable {TABLE} at (0,382) size 72x26 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 70x24
+          RenderTableRow {TR} at (0,1) size 70x0
+            RenderTableCell {TD} at (1,1) size 68x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 64x18
                 text run at (2,2) width 64: "First Row"
-          RenderTableRow {TR} at (0,24) size 70x0
+          RenderTableRow {TR} at (0,2) size 70x21

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug17138-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug17138-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
             text run at (156,0) width 167: "http://www.weather.com"
       RenderTable {TABLE} at (0,39) size 450x197
         RenderTableSection {TBODY} at (0,0) size 450x196
-          RenderTableRow {TR} at (0,0) size 450x17
+          RenderTableRow {TR} at (0,0) size 450x28
             RenderTableCell {TD} at (0,0) size 325x17 [r=0 c=0 rs=1 cs=3]
               RenderImage {IMG} at (0,0) size 318x17
             RenderTableCell {TD} at (325,0) size 125x196 [r=0 c=3 rs=2 cs=1]
@@ -32,14 +32,14 @@ layer at (0,0) size 800x600
                       RenderBR {BR} at (0,142) size 0x18
                       RenderBR {BR} at (0,160) size 0x18
                       RenderBR {BR} at (0,178) size 0x18
-          RenderTableRow {TR} at (0,17) size 450x179
-            RenderTableCell {TD} at (0,17) size 167x105 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,27) size 450x169
+            RenderTableCell {TD} at (0,27) size 167x106 [r=1 c=0 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 167x105
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (167,97) size 4x19 [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (0,80) size 4x19
+            RenderTableCell {TD} at (167,102) size 4x19 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (0,75) size 4x19
                 text run at (0,0) width 4: " "
-            RenderTableCell {TD} at (171,17) size 154x75 [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (171,27) size 154x76 [r=1 c=2 rs=1 cs=1]
               RenderInline {FONT} at (0,0) size 144x75
                 RenderInline {B} at (0,0) size 66x15
                   RenderText {#text} at (0,0) size 66x15

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug17548-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug17548-expected.txt
@@ -5,16 +5,16 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584 [bgcolor=#FFFFFF]
       RenderTable {TABLE} at (0,0) size 784x78 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x76
-          RenderTableRow {TR} at (0,2) size 782x4
+          RenderTableRow {TR} at (0,2) size 782x8
             RenderTableCell {TD} at (2,2) size 198x49 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderImage {IMG} at (2,2) size 194x45
-            RenderTableCell {TD} at (202,2) size 578x4 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-          RenderTableRow {TR} at (0,8) size 782x43
-            RenderTableCell {TD} at (202,18) size 578x23 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,12) size 81x19
+            RenderTableCell {TD} at (202,3) size 578x5 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,11) size 782x40
+            RenderTableCell {TD} at (202,20) size 578x23 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (2,10) size 81x19
                 text run at (2,2) width 81: "Information "
-              RenderImage {IMG} at (82,19) size 5x8
-              RenderText {#text} at (86,12) size 84x19
+              RenderImage {IMG} at (82,17) size 5x8
+              RenderText {#text} at (86,10) size 84x19
                 text run at (86,2) width 5: " "
                 text run at (90,2) width 80: "Student Life"
           RenderTableRow {TR} at (0,53) size 782x21

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug220536-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug220536-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 126x54 [border: (1px outset #000000)]
-        RenderTableSection {THEAD} at (1,1) size 124x28
-          RenderTableRow {TR} at (0,2) size 124x22
-            RenderTableCell {TH} at (2,3) size 36x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,3) size 32x18
+      RenderTable {TABLE} at (0,0) size 126x52 [border: (1px outset #000000)]
+        RenderTableSection {THEAD} at (1,1) size 124x26
+          RenderTableRow {TR} at (0,2) size 124x0
+            RenderTableCell {TH} at (2,2) size 36x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "aaaa"
-            RenderTableCell {TH} at (40,3) size 40x22 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
-              RenderText {#text} at (2,3) size 36x18
+            RenderTableCell {TH} at (40,2) size 40x22 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 36x18
                 text run at (2,2) width 36: "bbbb"
-            RenderTableCell {TH} at (81,3) size 41x22 [border: (1px inset #000000)] [r=0 c=2 rs=2 cs=1]
-              RenderText {#text} at (2,3) size 36x18
+            RenderTableCell {TH} at (81,2) size 41x22 [border: (1px inset #000000)] [r=0 c=2 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 36x18
                 text run at (2,2) width 36: "dddd"
-          RenderTableRow {TR} at (0,26) size 124x0
-        RenderTableSection {TBODY} at (1,29) size 124x24
+          RenderTableRow {TR} at (0,4) size 124x20
+        RenderTableSection {TBODY} at (1,27) size 124x24
           RenderTableRow {TR} at (0,0) size 124x22
             RenderTableCell {TD} at (2,0) size 36x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 31x18

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug73321-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug73321-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 785x1325
           text run at (412,32) width 235: " Table Testcase"
       RenderTable {TABLE} at (16,159) size 737x1134
         RenderTableSection {TBODY} at (0,0) size 737x1134
-          RenderTableRow {TR} at (0,2) size 737x382
+          RenderTableRow {TR} at (0,2) size 737x794
             RenderTableCell {TD} at (2,2) size 135x687 [bgcolor=#FFFFFF] [r=0 c=0 rs=2 cs=1]
               RenderBlock {H2} at (5,18) size 125x19
                 RenderText {#text} at (0,0) size 118x18
@@ -188,13 +188,13 @@ layer at (0,0) size 785x1325
                   text run at (0,30) width 110: "blah blah blah blah"
                   text run at (0,45) width 110: "blah blah blah blah"
                   text run at (0,60) width 53: "blah blah"
-          RenderTableRow {TR} at (0,385) size 737x747
+          RenderTableRow {TR} at (0,797) size 737x335
             RenderTableCell {TD} at (600,970) size 135x162 [bgcolor=#FFFFFF] [r=1 c=2 rs=1 cs=1]
-              RenderBlock {H2} at (5,603) size 125x37
+              RenderBlock {H2} at (5,191) size 125x37
                 RenderText {#text} at (0,0) size 88x36
                   text run at (0,0) width 88: "Community"
                   text run at (0,18) width 56: "Banner"
-              RenderBlock {P} at (5,652) size 125x76
+              RenderBlock {P} at (5,240) size 125x76
                 RenderText {#text} at (0,0) size 110x75
                   text run at (0,0) width 110: "blah blah blah blah"
                   text run at (0,15) width 110: "blah blah blah blah"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug8858-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug8858-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
           text run at (0,18) width 419: "of content beginning 'Pacific Shore Properties ...'. Can you see it?"
       RenderTable {TABLE} at (0,52) size 777x529 [border: (2px outset #000000)]
         RenderTableSection {TBODY} at (2,2) size 773x525
-          RenderTableRow {TR} at (0,1) size 773x284
+          RenderTableRow {TR} at (0,1) size 773x80
             RenderTableCell {TD} at (1,1) size 771x205 [bgcolor=#FFFFFF] [border: (1px inset #000000)] [r=0 c=0 rs=4 cs=2]
               RenderBlock {P} at (5,5) size 761x43
                 RenderInline {FONT} at (0,0) size 23x28 [color=#E91C05]
@@ -45,6 +45,6 @@ layer at (0,0) size 800x600
                     text run at (0,45) width 714: "In business for over 35 years, and the oldest real estate company on Mayne Island, Pacific Shore Properties knowledge and"
                     text run at (0,60) width 250: "expertise on the Gulf Islands is unmatched."
               RenderBlock {P} at (5,216) size 761x0
-          RenderTableRow {TR} at (0,285) size 773x80
-          RenderTableRow {TR} at (0,365) size 773x80
-          RenderTableRow {TR} at (0,445) size 773x79
+          RenderTableRow {TR} at (0,81) size 773x80
+          RenderTableRow {TR} at (0,162) size 773x80
+          RenderTableRow {TR} at (0,242) size 773x282

--- a/LayoutTests/platform/mac/tables/mozilla/core/bloomberg-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/bloomberg-expected.txt
@@ -209,7 +209,7 @@ layer at (0,0) size 785x669
               RenderBR {BR} at (4,593) size 0x18
             RenderTableCell {TD} at (148,0) size 486x24 [bgcolor=#660000] [border: (1px inset #333333)] [r=0 c=1 rs=1 cs=3]
               RenderImage {IMG} at (10,4) size 466x16
-          RenderTableRow {TR} at (0,24) size 634x69
+          RenderTableRow {TR} at (0,24) size 634x162
             RenderTableCell {TD} at (148,24) size 128x69 [border: (1px inset #333333)] [r=1 c=1 rs=1 cs=1]
               RenderInline {A} at (4,50) size 120x18
                 RenderText {#text} at (0,0) size 0x0
@@ -275,8 +275,8 @@ layer at (0,0) size 785x669
                   RenderImage {IMG} at (25,362) size 125x125
                 RenderText {#text} at (0,0) size 0x0
                 RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,93) size 634x116
-            RenderTableCell {TD} at (148,93) size 303x116 [bgcolor=#FFFFFF] [border: (1px inset #333333)] [r=2 c=1 rs=1 cs=2]
+          RenderTableRow {TR} at (0,186) size 634x116
+            RenderTableCell {TD} at (148,186) size 303x116 [bgcolor=#FFFFFF] [border: (1px inset #333333)] [r=2 c=1 rs=1 cs=2]
               RenderInline {A} at (295,4) size 0x18
                 RenderImage {IMG} at (4,4) size 288x26
               RenderBR {BR} at (295,4) size 0x18
@@ -293,8 +293,8 @@ layer at (0,0) size 785x669
                   RenderText {#text} at (4,94) size 47x18
                     text run at (4,94) width 47: "More..."
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,209) size 634x406
-            RenderTableCell {TD} at (148,209) size 303x313 [bgcolor=#C0C0C0] [border: (1px inset #333333)] [r=3 c=1 rs=1 cs=2]
+          RenderTableRow {TR} at (0,302) size 634x313
+            RenderTableCell {TD} at (148,302) size 303x313 [bgcolor=#C0C0C0] [border: (1px inset #333333)] [r=3 c=1 rs=1 cs=2]
               RenderImage {IMG} at (4,4) size 290x35
               RenderBR {BR} at (294,25) size 0x18
               RenderInline {A} at (4,37) size 248x18

--- a/LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt
@@ -136,19 +136,19 @@ layer at (0,0) size 785x4336
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,3312) size 105x585 [bgcolor=#FF0000] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 103x582
-          RenderTableRow {TR} at (0,2) size 103x40
+          RenderTableRow {TR} at (0,2) size 103x267
             RenderTableCell {TD} at (2,259) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,259) size 24x18
                 text run at (2,2) width 24: "500"
-            RenderTableCell {TD} at (35,11) size 33x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,11) size 28x18
+            RenderTableCell {TD} at (35,124) size 33x23 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (2,124) size 28x19
                 text run at (2,2) width 28: "auto"
-          RenderTableRow {TR} at (0,44) size 103x494
-            RenderTableCell {TD} at (35,280) size 33x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,238) size 28x18
+          RenderTableRow {TR} at (0,271) size 103x267
+            RenderTableCell {TD} at (35,393) size 33x23 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (2,124) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (69,280) size 32x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (2,238) size 28x18
+            RenderTableCell {TD} at (69,393) size 32x23 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (2,124) size 28x19
                 text run at (2,2) width 28: "auto"
           RenderTableRow {TR} at (0,540) size 103x40
             RenderTableCell {TD} at (2,549) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/other/test6-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/other/test6-expected.txt
@@ -16,51 +16,51 @@ layer at (0,0) size 785x1376
           text run at (0,0) width 504: "Auto-width tables with spans nested 8 levels deep"
       RenderTable {TABLE} at (0,172) size 769x387 [bgcolor=#FF0000] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x384
-          RenderTableRow {TR} at (0,2) size 767x22
-            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 27x18
+          RenderTableRow {TR} at (0,2) size 767x177
+            RenderTableCell {TD} at (2,79) size 31x23 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,79) size 27x19
                 text run at (2,2) width 27: "Cell"
             RenderTableCell {TD} at (34,2) size 732x356 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
               RenderTable {TABLE} at (2,2) size 727x352 [bgcolor=#ADD8E6] [border: (1px outset #000000)]
                 RenderTableSection {TBODY} at (1,1) size 725x350
-                  RenderTableRow {TR} at (0,2) size 725x22
-                    RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                      RenderText {#text} at (2,2) size 27x18
+                  RenderTableRow {TR} at (0,2) size 725x160
+                    RenderTableCell {TD} at (2,71) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                      RenderText {#text} at (2,71) size 27x18
                         text run at (2,2) width 27: "Cell"
                     RenderTableCell {TD} at (34,2) size 689x322 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
                       RenderTable {TABLE} at (2,2) size 684x318 [bgcolor=#90EE90] [border: (1px outset #000000)]
                         RenderTableSection {TBODY} at (1,1) size 682x316
-                          RenderTableRow {TR} at (0,2) size 682x22
-                            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                              RenderText {#text} at (2,2) size 27x18
+                          RenderTableRow {TR} at (0,2) size 682x143
+                            RenderTableCell {TD} at (2,62) size 31x23 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                              RenderText {#text} at (2,62) size 27x19
                                 text run at (2,2) width 27: "Cell"
                             RenderTableCell {TD} at (34,2) size 646x288 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
                               RenderTable {TABLE} at (2,2) size 642x284 [border: (1px outset #000000)]
                                 RenderTableSection {TBODY} at (1,1) size 640x282
-                                  RenderTableRow {TR} at (0,2) size 640x22
-                                    RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                                      RenderText {#text} at (2,2) size 27x18
+                                  RenderTableRow {TR} at (0,2) size 640x126
+                                    RenderTableCell {TD} at (2,54) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                                      RenderText {#text} at (2,54) size 27x18
                                         text run at (2,2) width 27: "Cell"
                                     RenderTableCell {TD} at (34,2) size 604x254 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
                                       RenderTable {TABLE} at (2,2) size 599x250 [bgcolor=#FFA500] [border: (1px outset #000000)]
                                         RenderTableSection {TBODY} at (1,1) size 597x248
-                                          RenderTableRow {TR} at (0,2) size 597x22
-                                            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                                              RenderText {#text} at (2,2) size 27x18
+                                          RenderTableRow {TR} at (0,2) size 597x100
+                                            RenderTableCell {TD} at (2,41) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                                              RenderText {#text} at (2,41) size 27x18
                                                 text run at (2,2) width 27: "Cell"
                                             RenderTableCell {TD} at (34,2) size 561x202 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
                                               RenderTable {TABLE} at (2,2) size 556x198 [bgcolor=#FF0000] [border: (1px outset #000000)]
                                                 RenderTableSection {TBODY} at (1,1) size 554x196
-                                                  RenderTableRow {TR} at (0,2) size 554x22
-                                                    RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                                                      RenderText {#text} at (2,2) size 27x18
+                                                  RenderTableRow {TR} at (0,2) size 554x74
+                                                    RenderTableCell {TD} at (2,28) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                                                      RenderText {#text} at (2,28) size 27x18
                                                         text run at (2,2) width 27: "Cell"
                                                     RenderTableCell {TD} at (34,2) size 518x150 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
                                                       RenderTable {TABLE} at (2,2) size 514x146 [bgcolor=#ADD8E6] [border: (1px outset #000000)]
                                                         RenderTableSection {TBODY} at (1,1) size 512x144
-                                                          RenderTableRow {TR} at (0,2) size 512x22
-                                                            RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                                                              RenderText {#text} at (2,2) size 27x18
+                                                          RenderTableRow {TR} at (0,2) size 512x48
+                                                            RenderTableCell {TD} at (2,15) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                                                              RenderText {#text} at (2,15) size 27x18
                                                                 text run at (2,2) width 27: "Cell"
                                                             RenderTableCell {TD} at (34,2) size 476x98 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=2]
                                                               RenderTable {TABLE} at (2,2) size 471x94 [bgcolor=#90EE90] [border: (1px outset #000000)]
@@ -89,9 +89,9 @@ layer at (0,0) size 785x1376
                                                                     RenderTableCell {TD} at (435,59) size 32x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                                                                       RenderText {#text} at (2,11) size 27x18
                                                                         text run at (2,2) width 27: "Cell"
-                                                          RenderTableRow {TR} at (0,26) size 512x74
-                                                            RenderTableCell {TD} at (2,52) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                                                              RenderText {#text} at (2,28) size 27x18
+                                                          RenderTableRow {TR} at (0,52) size 512x48
+                                                            RenderTableCell {TD} at (2,65) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                                                              RenderText {#text} at (2,15) size 27x18
                                                                 text run at (2,2) width 27: "Cell"
                                                           RenderTableRow {TR} at (0,102) size 512x40
                                                             RenderTableCell {TD} at (2,111) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
@@ -104,9 +104,9 @@ layer at (0,0) size 785x1376
                                                             RenderTableCell {TD} at (478,111) size 32x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                                                               RenderText {#text} at (2,11) size 27x18
                                                                 text run at (2,2) width 27: "Cell"
-                                                  RenderTableRow {TR} at (0,26) size 554x126
-                                                    RenderTableCell {TD} at (2,78) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                                                      RenderText {#text} at (2,54) size 27x18
+                                                  RenderTableRow {TR} at (0,78) size 554x74
+                                                    RenderTableCell {TD} at (2,104) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                                                      RenderText {#text} at (2,28) size 27x18
                                                         text run at (2,2) width 27: "Cell"
                                                   RenderTableRow {TR} at (0,154) size 554x40
                                                     RenderTableCell {TD} at (2,163) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
@@ -120,9 +120,9 @@ layer at (0,0) size 785x1376
                                                     RenderTableCell {TD} at (521,163) size 31x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                                                       RenderText {#text} at (2,11) size 27x18
                                                         text run at (2,2) width 27: "Cell"
-                                          RenderTableRow {TR} at (0,26) size 597x178
-                                            RenderTableCell {TD} at (2,104) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                                              RenderText {#text} at (2,80) size 27x18
+                                          RenderTableRow {TR} at (0,104) size 597x100
+                                            RenderTableCell {TD} at (2,143) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                                              RenderText {#text} at (2,41) size 27x18
                                                 text run at (2,2) width 27: "Cell"
                                           RenderTableRow {TR} at (0,206) size 597x40
                                             RenderTableCell {TD} at (2,215) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
@@ -136,9 +136,9 @@ layer at (0,0) size 785x1376
                                             RenderTableCell {TD} at (563,215) size 32x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                                               RenderText {#text} at (2,11) size 27x18
                                                 text run at (2,2) width 27: "Cell"
-                                  RenderTableRow {TR} at (0,26) size 640x230
-                                    RenderTableCell {TD} at (2,130) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                                      RenderText {#text} at (2,106) size 27x18
+                                  RenderTableRow {TR} at (0,130) size 640x126
+                                    RenderTableCell {TD} at (2,182) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                                      RenderText {#text} at (2,54) size 27x18
                                         text run at (2,2) width 27: "Cell"
                                   RenderTableRow {TR} at (0,258) size 640x22
                                     RenderTableCell {TD} at (2,258) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
@@ -151,9 +151,9 @@ layer at (0,0) size 785x1376
                                     RenderTableCell {TD} at (604,258) size 34x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                                       RenderText {#text} at (2,2) size 27x18
                                         text run at (2,2) width 27: "Cell"
-                          RenderTableRow {TR} at (0,26) size 682x264
-                            RenderTableCell {TD} at (2,147) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                              RenderText {#text} at (2,123) size 27x18
+                          RenderTableRow {TR} at (0,147) size 682x143
+                            RenderTableCell {TD} at (2,207) size 31x23 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                              RenderText {#text} at (2,62) size 27x19
                                 text run at (2,2) width 27: "Cell"
                           RenderTableRow {TR} at (0,292) size 682x22
                             RenderTableCell {TD} at (2,292) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
@@ -166,9 +166,9 @@ layer at (0,0) size 785x1376
                             RenderTableCell {TD} at (644,292) size 36x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                               RenderText {#text} at (2,2) size 27x18
                                 text run at (2,2) width 27: "Cell"
-                  RenderTableRow {TR} at (0,26) size 725x298
-                    RenderTableCell {TD} at (2,164) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                      RenderText {#text} at (2,140) size 27x18
+                  RenderTableRow {TR} at (0,164) size 725x160
+                    RenderTableCell {TD} at (2,233) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                      RenderText {#text} at (2,71) size 27x18
                         text run at (2,2) width 27: "Cell"
                   RenderTableRow {TR} at (0,326) size 725x22
                     RenderTableCell {TD} at (2,326) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
@@ -181,9 +181,9 @@ layer at (0,0) size 785x1376
                     RenderTableCell {TD} at (684,326) size 39x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 27x18
                         text run at (2,2) width 27: "Cell"
-          RenderTableRow {TR} at (0,26) size 767x332
-            RenderTableCell {TD} at (2,181) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,157) size 27x18
+          RenderTableRow {TR} at (0,181) size 767x177
+            RenderTableCell {TD} at (2,258) size 31x23 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,79) size 27x19
                 text run at (2,2) width 27: "Cell"
           RenderTableRow {TR} at (0,360) size 767x22
             RenderTableCell {TD} at (2,360) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1010-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1010-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 784x260 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x258
-          RenderTableRow {TR} at (0,2) size 782x22
+          RenderTableRow {TR} at (0,2) size 782x126
             RenderTableCell {TD} at (2,2) size 669x254 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderBlock {UL} at (2,2) size 665x234
                 RenderListItem {LI} at (40,0) size 625x18
@@ -78,16 +78,16 @@ layer at (0,0) size 800x600
                     RenderText {#text} at (0,0) size 477x18
                       text run at (0,0) width 334: "A relatively large (150k) document with an average "
                       text run at (333,0) width 144: "mix of HTML content"
-            RenderTableCell {TD} at (672,2) size 54x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 34x18
+            RenderTableCell {TD} at (672,54) size 54x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (2,54) size 34x18
                 text run at (2,2) width 34: "foo 1"
-            RenderTableCell {TD} at (727,2) size 54x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 34x18
+            RenderTableCell {TD} at (727,54) size 54x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (2,54) size 34x18
                 text run at (2,2) width 34: "foo 2"
-          RenderTableRow {TR} at (0,26) size 782x230
-            RenderTableCell {TD} at (672,130) size 54x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,106) size 37x18
+          RenderTableRow {TR} at (0,130) size 782x126
+            RenderTableCell {TD} at (672,182) size 54x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (2,54) size 37x18
                 text run at (2,2) width 37: "Foo 3"
-            RenderTableCell {TD} at (727,130) size 54x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (2,106) size 37x18
+            RenderTableCell {TD} at (727,182) size 54x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (2,54) size 37x18
                 text run at (2,2) width 37: "Foo 4"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
@@ -142,11 +142,11 @@ layer at (0,0) size 785x2276
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,1431) size 64x23 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 62x20
-          RenderTableRow {TR} at (0,0) size 62x20
+          RenderTableRow {TR} at (0,0) size 62x0
             RenderTableCell {TD} at (0,0) size 62x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,1) size 60x18
                 text run at (1,1) width 60: "blah blah"
-          RenderTableRow {TR} at (0,20) size 62x0
+          RenderTableRow {TR} at (0,0) size 62x20
       RenderBlock (anonymous) at (0,1453) size 769x19
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,1471) size 602x365 [border: (1px outset #000000)]

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug23847-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug23847-expected.txt
@@ -5,15 +5,15 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 345x123 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 343x121
-          RenderTableRow {TR} at (0,2) size 343x9
+          RenderTableRow {TR} at (0,2) size 343x25
             RenderTableCell {TD} at (2,41) size 126x39 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=2]
               RenderImage {IMG} at (2,41) size 122x35
-            RenderTableCell {TD} at (130,2) size 199x9 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (2,2) size 195x5
+            RenderTableCell {TD} at (130,9) size 199x10 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (2,9) size 195x6
             RenderTableCell {TD} at (331,2) size 10x117 [border: (1px inset #000000)] [r=0 c=3 rs=4 cs=1]
               RenderImage {IMG} at (2,2) size 6x113
-          RenderTableRow {TR} at (0,13) size 343x106
-            RenderTableCell {TD} at (130,49) size 199x34 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-              RenderInline {A} at (2,54) size 195x18 [color=#0000EE]
+          RenderTableRow {TR} at (0,28) size 343x91
+            RenderTableCell {TD} at (130,56) size 199x35 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderInline {A} at (2,46) size 195x19 [color=#0000EE]
                 RenderText {#text} at (0,0) size 0x0
-                RenderImage {IMG} at (2,38) size 195x30
+                RenderImage {IMG} at (2,30) size 195x31

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug6933-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug6933-expected.txt
@@ -5,14 +5,14 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTable {TABLE} at (0,0) size 197x246 [bgcolor=#FF0000] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 195x244
-          RenderTableRow {TR} at (0,20) size 195x22
-            RenderTableCell {TD} at (20,20) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 27x18
+          RenderTableRow {TR} at (0,20) size 195x92
+            RenderTableCell {TD} at (20,55) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,37) size 27x18
                 text run at (2,2) width 27: "Cell"
             RenderTableCell {TD} at (70,20) size 105x204 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderImage {IMG} at (2,2) size 100x200
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,62) size 195x162
-            RenderTableCell {TD} at (20,132) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,72) size 27x18
+          RenderTableRow {TR} at (0,132) size 195x92
+            RenderTableCell {TD} at (20,167) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,37) size 27x18
                 text run at (2,2) width 27: "Cell"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2418
+layer at (0,0) size 785x2386
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2418
-  RenderBlock {HTML} at (0,0) size 785x2419
-    RenderBody {BODY} at (8,8) size 769x2395
+layer at (0,0) size 785x2386
+  RenderBlock {HTML} at (0,0) size 785x2387
+    RenderBody {BODY} at (8,8) size 769x2363
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x37
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -582,7 +582,7 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (34,26) size 68x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1630) size 769x245
+      RenderBlock {P} at (0,1630) size 769x229
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 756x18
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,7 +641,7 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (153,66) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,126) size 95x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,126) size 95x102 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 95x18
             RenderInline {B} at (30,0) size 34x18
               RenderText {#text} at (30,0) size 34x18
@@ -651,7 +651,7 @@ layer at (0,0) size 785x2418
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 93x98
+          RenderTableSection {TBODY} at (1,19) size 93x82
             RenderTableRow {TR} at (0,0) size 93x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
@@ -669,8 +669,8 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,11) size 32x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,-9) size 27x72
+              RenderTableCell {TD} at (30,3) size 32x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-17) size 27x72
                   text run at (2,2) width 27: "C12"
                   text run at (2,20) width 27: "C13"
                   text run at (2,38) width 27: "C22"
@@ -678,27 +678,27 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (61,11) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 93x54
-              RenderTableCell {TD} at (0,38) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,18) size 27x18
+            RenderTableRow {TR} at (0,22) size 93x38
+              RenderTableCell {TD} at (0,30) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,10) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (61,38) size 32x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,18) size 27x18
+              RenderTableCell {TD} at (61,30) size 32x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,10) size 27x18
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,76) size 93x22
-              RenderTableCell {TD} at (0,76) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,60) size 93x22
+              RenderTableCell {TD} at (0,60) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (30,76) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,60) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (30,76) size 32x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,60) size 32x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (61,76) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,60) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1890) size 769x227
+      RenderBlock {P} at (0,1874) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 463x18
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -825,7 +825,7 @@ layer at (0,0) size 785x2418
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,2132) size 769x263
+      RenderBlock {P} at (0,2116) size 769x247
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 747x36
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -886,7 +886,7 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,144) size 95x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,144) size 95x102 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 95x18
             RenderInline {B} at (30,0) size 34x18
               RenderText {#text} at (30,0) size 34x18
@@ -896,7 +896,7 @@ layer at (0,0) size 785x2418
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 93x98
+          RenderTableSection {TBODY} at (1,19) size 93x82
             RenderTableRow {TR} at (0,0) size 93x22
               RenderTableCell {TD} at (61,0) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
@@ -914,8 +914,8 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (61,11) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,11) size 32x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,-9) size 27x72
+              RenderTableCell {TD} at (30,3) size 32x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-17) size 27x72
                   text run at (2,2) width 27: "C12"
                   text run at (2,20) width 27: "C13"
                   text run at (2,38) width 27: "C22"
@@ -923,23 +923,23 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 93x54
-              RenderTableCell {TD} at (61,38) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,18) size 27x18
+            RenderTableRow {TR} at (0,22) size 93x38
+              RenderTableCell {TD} at (61,30) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,10) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,38) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,18) size 27x18
+              RenderTableCell {TD} at (0,30) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,10) size 27x18
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,76) size 93x22
-              RenderTableCell {TD} at (61,76) size 32x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,60) size 93x22
+              RenderTableCell {TD} at (61,60) size 32x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (61,76) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (61,60) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (-25,2) size 27x18
                   text run at (-24,2) width 26: "C42"
-              RenderTableCell {TD} at (30,76) size 32x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,60) size 32x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (0,76) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,60) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"

--- a/LayoutTests/tables/mozilla/bugs/bug133756-1-expected.txt
+++ b/LayoutTests/tables/mozilla/bugs/bug133756-1-expected.txt
@@ -5,14 +5,14 @@ layer at (0,0) size 800x108
     RenderBody {BODY} at (8,8) size 784x84
       RenderTable {TABLE} at (0,0) size 60x50
         RenderTableSection {TBODY} at (0,0) size 60x50
-          RenderTableRow {TR} at (0,0) size 60x50
+          RenderTableRow {TR} at (0,0) size 60x0
             RenderTableCell {TD} at (0,0) size 60x50 [r=0 c=0 rs=4 cs=1]
               RenderBlock {P} at (0,16) size 60x18
                 RenderText {#text} at (0,0) size 60x18
                   text run at (0,0) width 60: "blah blah"
-          RenderTableRow {TR} at (0,50) size 60x0
-          RenderTableRow {TR} at (0,50) size 60x0
-          RenderTableRow {TR} at (0,50) size 60x0
+          RenderTableRow {TR} at (0,0) size 60x0
+          RenderTableRow {TR} at (0,0) size 60x0
+          RenderTableRow {TR} at (0,0) size 60x50
       RenderBlock {P} at (0,66) size 784x18
         RenderText {#text} at (0,0) size 113x18
           text run at (0,0) width 113: "text at the bottom"

--- a/LayoutTests/tables/mozilla_expected_failures/bugs/bug65372-expected.txt
+++ b/LayoutTests/tables/mozilla_expected_failures/bugs/bug65372-expected.txt
@@ -6,60 +6,60 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 4x18
           text run at (0,0) width 4: " "
-      RenderTable {TABLE} at (0,18) size 69x54 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 67x52
-          RenderTableRow {TR} at (0,2) size 67x22
-            RenderTableCell {TD} at (2,3) size 63x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,3) size 59x18
+      RenderTable {TABLE} at (0,18) size 69x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 67x50
+          RenderTableRow {TR} at (0,2) size 67x0
+            RenderTableCell {TD} at (2,2) size 63x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 59x18
                 text run at (2,2) width 59: "First row"
-          RenderTableRow {TR} at (0,26) size 67x0
-          RenderTableRow {TR} at (0,28) size 67x22
-            RenderTableCell {TD} at (2,28) size 63x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,4) size 67x20
+          RenderTableRow {TR} at (0,26) size 67x22
+            RenderTableCell {TD} at (2,26) size 63x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "Last row"
-      RenderBlock (anonymous) at (0,72) size 784x18
+      RenderBlock (anonymous) at (0,70) size 784x18
         RenderText {#text} at (0,0) size 8x18
           text run at (0,0) width 8: "  "
-      RenderTable {TABLE} at (0,90) size 69x56 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 67x54
-          RenderTableRow {TR} at (0,2) size 67x22
-            RenderTableCell {TD} at (2,4) size 63x22 [border: (1px inset #000000)] [r=0 c=0 rs=3 cs=1]
-              RenderText {#text} at (2,4) size 59x18
+      RenderTable {TABLE} at (0,88) size 69x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 67x50
+          RenderTableRow {TR} at (0,2) size 67x0
+            RenderTableCell {TD} at (2,2) size 63x22 [border: (1px inset #000000)] [r=0 c=0 rs=3 cs=1]
+              RenderText {#text} at (2,2) size 59x18
                 text run at (2,2) width 59: "First row"
-          RenderTableRow {TR} at (0,26) size 67x0
-          RenderTableRow {TR} at (0,28) size 67x0
-          RenderTableRow {TR} at (0,30) size 67x22
-            RenderTableCell {TD} at (2,30) size 63x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,4) size 67x0
+          RenderTableRow {TR} at (0,6) size 67x18
+          RenderTableRow {TR} at (0,26) size 67x22
+            RenderTableCell {TD} at (2,26) size 63x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "Last row"
-      RenderBlock (anonymous) at (0,146) size 784x18
+      RenderBlock (anonymous) at (0,140) size 784x18
         RenderText {#text} at (0,0) size 12x18
           text run at (0,0) width 12: "   "
-      RenderTable {TABLE} at (0,164) size 69x58 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 67x56
-          RenderTableRow {TR} at (0,2) size 67x22
-            RenderTableCell {TD} at (2,5) size 63x22 [border: (1px inset #000000)] [r=0 c=0 rs=4 cs=1]
-              RenderText {#text} at (2,5) size 59x18
+      RenderTable {TABLE} at (0,158) size 69x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 67x50
+          RenderTableRow {TR} at (0,2) size 67x0
+            RenderTableCell {TD} at (2,2) size 63x22 [border: (1px inset #000000)] [r=0 c=0 rs=4 cs=1]
+              RenderText {#text} at (2,2) size 59x18
                 text run at (2,2) width 59: "First row"
-          RenderTableRow {TR} at (0,26) size 67x0
-          RenderTableRow {TR} at (0,28) size 67x0
-          RenderTableRow {TR} at (0,30) size 67x0
-          RenderTableRow {TR} at (0,32) size 67x22
-            RenderTableCell {TD} at (2,32) size 63x22 [border: (1px inset #000000)] [r=4 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,4) size 67x0
+          RenderTableRow {TR} at (0,6) size 67x0
+          RenderTableRow {TR} at (0,8) size 67x16
+          RenderTableRow {TR} at (0,26) size 67x22
+            RenderTableCell {TD} at (2,26) size 63x22 [border: (1px inset #000000)] [r=4 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "Last row"
-      RenderBlock (anonymous) at (0,222) size 784x36
+      RenderBlock (anonymous) at (0,210) size 784x36
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 110x18
           text run at (0,18) width 110: "an additional test"
-      RenderTable {TABLE} at (0,258) size 33x54 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 31x52
-          RenderTableRow {TR} at (0,2) size 31x22
-            RenderTableCell {TD} at (2,3) size 27x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,3) size 8x18
+      RenderTable {TABLE} at (0,246) size 33x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 31x50
+          RenderTableRow {TR} at (0,2) size 31x0
+            RenderTableCell {TD} at (2,2) size 27x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "1"
-          RenderTableRow {TR} at (0,26) size 31x0
-          RenderTableRow {TR} at (0,28) size 31x22
-            RenderTableCell {TD} at (2,28) size 27x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,4) size 31x20
+          RenderTableRow {TR} at (0,26) size 31x22
+            RenderTableCell {TD} at (2,26) size 27x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 23x18
                 text run at (2,2) width 23: "abc"

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -264,34 +264,10 @@ LayoutUnit RenderTableSection::calcRowLogicalHeight()
             CellStruct& current = cellAt(r, c);
             for (unsigned i = 0; i < current.cells.size(); i++) {
                 cell = current.cells[i];
-                if (current.inColSpan && cell->rowSpan() == 1)
+                // Phase 1: Only process rowspan=1 cells for base row heights.
+                // Rowspan>1 cells are handled in Phase 2 below.
+                if (current.inColSpan || cell->rowSpan() != 1)
                     continue;
-
-                // FIXME: We are always adding the height of a rowspan to the last rows which doesn't match
-                // other browsers. See webkit.org/b/52185 for example.
-                if ((cell->rowIndex() + cell->rowSpan() - 1) != r) {
-                    // We will apply the height of the rowspan to the current row if next row is not valid.
-                    if ((r + 1) < totalRows) {
-                        unsigned col = 0;
-                        CellStruct nextRowCell = cellAt(r + 1, col);
-
-                        // We are trying to find that next row is valid or not.
-                        while (nextRowCell.cells.size() && nextRowCell.cells[0]->rowSpan() > 1 && nextRowCell.cells[0]->rowIndex() < (r + 1)) {
-                            col++;
-                            if (col < totalCols)
-                                nextRowCell = cellAt(r + 1, col);
-                            else
-                                break;
-                        }
-
-                        // We are adding the height of the rowspan to the current row if next row is not valid.
-                        if (col < totalCols && nextRowCell.cells.size())
-                            continue;
-                    }
-                }
-
-                // For row spanning cells, |r| is the last row in the span.
-                unsigned cellStartRow = cell->rowIndex();
 
                 if (cell->overridingBorderBoxLogicalHeight() && !cell->isOrthogonal()) {
                     cell->clearIntrinsicPadding();
@@ -301,23 +277,16 @@ LayoutUnit RenderTableSection::calcRowLogicalHeight()
                 }
 
                 LayoutUnit cellLogicalHeight = cell->logicalHeightForRowSizing();
-                m_rowPos[r + 1] = std::max(m_rowPos[r + 1], m_rowPos[cellStartRow] + cellLogicalHeight);
+                m_rowPos[r + 1] = std::max(m_rowPos[r + 1], m_rowPos[r] + cellLogicalHeight);
 
-                // Find out the baseline. The baseline is set on the first row in a rowspan.
+                // Find out the baseline.
                 if (cell->isBaselineAligned()) {
                     LayoutUnit baselinePosition = cell->cellBaselinePosition() - cell->intrinsicPaddingBefore();
                     LayoutUnit borderAndComputedPaddingBefore = cell->borderAndPaddingBefore() - cell->intrinsicPaddingBefore();
                     if (baselinePosition > borderAndComputedPaddingBefore) {
-                        m_grid[cellStartRow].baseline = std::max(m_grid[cellStartRow].baseline, baselinePosition);
-                        // The descent of a cell that spans multiple rows does not affect the height of the first row it spans, so don't let it
-                        // become the baseline descent applied to the rest of the row. Also we don't account for the baseline descent of
-                        // non-spanning cells when computing a spanning cell's extent.
-                        LayoutUnit cellStartRowBaselineDescent;
-                        if (cell->rowSpan() == 1) {
-                            baselineDescent = std::max(baselineDescent, cellLogicalHeight - baselinePosition);
-                            cellStartRowBaselineDescent = baselineDescent;
-                        }
-                        m_rowPos[cellStartRow + 1] = std::max(m_rowPos[cellStartRow + 1], m_rowPos[cellStartRow] + m_grid[cellStartRow].baseline + cellStartRowBaselineDescent);
+                        m_grid[r].baseline = std::max(m_grid[r].baseline, baselinePosition);
+                        baselineDescent = std::max(baselineDescent, cellLogicalHeight - baselinePosition);
+                        m_rowPos[r + 1] = std::max(m_rowPos[r + 1], m_rowPos[r] + m_grid[r].baseline + baselineDescent);
                     }
                 }
             }
@@ -328,6 +297,201 @@ LayoutUnit RenderTableSection::calcRowLogicalHeight()
         spacing = table()->vBorderSpacing();
         m_rowPos[r + 1] += m_grid[r].rowRenderer ? spacing : 0_lu;
         m_rowPos[r + 1] = std::max(m_rowPos[r + 1], m_rowPos[r]);
+    }
+
+    // Phase 2: Distribute rowspan>1 cell heights across spanned rows.
+    {
+        LayoutUnit vspacing = table()->vBorderSpacing();
+
+        // 2a. Collect unique rowspan>1 cells from their originating rows.
+        struct RowspanCellInfo {
+            RenderTableCell* cell;
+            unsigned startRow;
+            unsigned endRow; // exclusive
+        };
+        Vector<RowspanCellInfo> rowspanCells;
+        HashSet<RenderTableCell*> seen;
+
+        for (unsigned r = 0; r < totalRows; r++) {
+            Row& row = m_grid[r].row;
+            unsigned totalCols = row.size();
+            for (unsigned c = 0; c < totalCols; c++) {
+                CellStruct& current = cellAt(r, c);
+                for (unsigned i = 0; i < current.cells.size(); i++) {
+                    RenderTableCell* cell = current.cells[i];
+                    if (cell->rowSpan() <= 1)
+                        continue;
+                    if (cell->rowIndex() != r)
+                        continue;
+                    if (!seen.add(cell).isNewEntry)
+                        continue;
+                    unsigned endRow = std::min(r + cell->rowSpan(), totalRows);
+                    if (endRow <= r + 1)
+                        continue;
+                    rowspanCells.append({ cell, r, endRow });
+                }
+            }
+        }
+
+        // 2b. Sort: enclosed cells process first, then earlier start row, then shorter span.
+        std::sort(rowspanCells.begin(), rowspanCells.end(), [](const RowspanCellInfo& a, const RowspanCellInfo& b) {
+            // If A is fully enclosed by B (not identical), A goes first.
+            bool aEnclosedByB = a.startRow >= b.startRow && a.endRow <= b.endRow && !(a.startRow == b.startRow && a.endRow == b.endRow);
+            bool bEnclosedByA = b.startRow >= a.startRow && b.endRow <= a.endRow && !(a.startRow == b.startRow && a.endRow == b.endRow);
+            if (aEnclosedByB != bEnclosedByA)
+                return aEnclosedByB;
+            if (a.startRow != b.startRow)
+                return a.startRow < b.startRow;
+            return (a.endRow - a.startRow) < (b.endRow - b.startRow);
+        });
+
+        // Returns true if the given row originates a rowspan>1 cell other than |excludeCell|.
+        auto rowOriginatesOtherRowspan = [&](unsigned r, RenderTableCell* excludeCell) -> bool {
+            Row& row = m_grid[r].row;
+            for (unsigned c = 0; c < row.size(); c++) {
+                CellStruct& cs = cellAt(r, c);
+                for (auto* otherCell : cs.cells) {
+                    if (otherCell != excludeCell && otherCell->rowSpan() > 1 && otherCell->rowIndex() == r)
+                        return true;
+                }
+            }
+            return false;
+        };
+
+        // Reusable buffers for per-cell distribution, avoiding repeated heap allocation.
+        Vector<LayoutUnit, 8> rowHeights;
+        Vector<LayoutUnit, 8> rowGrowth;
+
+        // Distributes |amount| proportionally to rows where |eligible| returns a non-zero weight.
+        // Rounding remainder goes to the last eligible row.
+        auto distributeProportionally = [&](LayoutUnit amount, unsigned startRow, unsigned endRow, auto&& eligible) -> LayoutUnit {
+            LayoutUnit totalWeight;
+            unsigned lastEligible = UINT_MAX;
+            for (unsigned r = startRow; r < endRow; r++) {
+                LayoutUnit weight = eligible(r);
+                if (weight > 0) {
+                    totalWeight += weight;
+                    lastEligible = r;
+                }
+            }
+            if (totalWeight <= 0)
+                return 0_lu;
+            LayoutUnit distributed;
+            for (unsigned r = startRow; r < endRow; r++) {
+                LayoutUnit weight = eligible(r);
+                if (weight > 0) {
+                    LayoutUnit share = (r == lastEligible) ? (amount - distributed) : (amount * weight / totalWeight);
+                    rowGrowth[r - startRow] += share;
+                    distributed += share;
+                }
+            }
+            return distributed;
+        };
+
+        // 2c-2d. Distribute each cell's extra height.
+        for (auto& info : rowspanCells) {
+            unsigned startRow = info.startRow;
+            unsigned endRow = info.endRow;
+            RenderTableCell* cell = info.cell;
+
+            // Re-layout cell if needed to get accurate height.
+            if (cell->overridingBorderBoxLogicalHeight() && !cell->isOrthogonal()) {
+                cell->clearIntrinsicPadding();
+                cell->clearOverridingSize();
+                cell->setChildNeedsLayout(MarkOnlyThis);
+                cell->layoutIfNeeded();
+            }
+
+            LayoutUnit cellLogicalHeight = cell->logicalHeightForRowSizing();
+
+            // Available space already allocated to the spanned rows.
+            // Match layoutRows() formula: m_rowPos[endRow] - m_rowPos[startRow] - vspacing
+            LayoutUnit availableSpace = m_rowPos[endRow] - m_rowPos[startRow] - vspacing;
+            LayoutUnit extra = cellLogicalHeight - availableSpace;
+            if (extra <= 0)
+                continue;
+
+            unsigned spanLength = endRow - startRow;
+
+            // Compute per-row heights (excluding border-spacing contribution).
+            rowHeights.resize(spanLength);
+            for (unsigned r = startRow; r < endRow; r++) {
+                LayoutUnit rh = m_rowPos[r + 1] - m_rowPos[r];
+                if (m_grid[r].rowRenderer)
+                    rh -= vspacing;
+                rowHeights[r - startRow] = std::max(rh, 0_lu);
+            }
+
+            rowGrowth.fill(0_lu, spanLength);
+
+            // Distribute extra height via priority cascade, then apply growth.
+            auto distributeAndApply = [&] {
+                LayoutUnit remaining = extra;
+
+                // Step 1: Rows originating other rowspan>1 cells (after startRow) get all extra, evenly.
+                unsigned originCount = 0;
+                for (unsigned r = startRow + 1; r < endRow; r++) {
+                    if (rowOriginatesOtherRowspan(r, cell))
+                        originCount++;
+                }
+                if (originCount > 0) {
+                    LayoutUnit perRow = remaining / originCount;
+                    LayoutUnit distributed;
+                    unsigned count = 0;
+                    for (unsigned r = startRow + 1; r < endRow; r++) {
+                        if (rowOriginatesOtherRowspan(r, cell)) {
+                            count++;
+                            LayoutUnit share = (count == originCount) ? (remaining - distributed) : perRow;
+                            rowGrowth[r - startRow] += share;
+                            distributed += share;
+                        }
+                    }
+                    remaining -= distributed;
+                    if (remaining <= 0)
+                        return;
+                }
+
+                // Step 2: Unconstrained non-zero rows grow proportionally.
+                remaining -= distributeProportionally(remaining, startRow, endRow, [&](unsigned r) -> LayoutUnit {
+                    return (!m_grid[r].logicalHeight.isFixed() && rowHeights[r - startRow] > 0) ? rowHeights[r - startRow] : 0_lu;
+                });
+                if (remaining <= 0)
+                    return;
+
+                // Step 3: All zero-height rows — last row gets all.
+                bool allEmpty = true;
+                for (unsigned r = startRow; r < endRow; r++) {
+                    if (rowHeights[r - startRow] + rowGrowth[r - startRow] > 0) {
+                        allEmpty = false;
+                        break;
+                    }
+                }
+                if (allEmpty) {
+                    rowGrowth[spanLength - 1] += remaining;
+                    return;
+                }
+
+                // Step 4: Constrained non-zero rows grow proportionally (fallback).
+                LayoutUnit distributed = distributeProportionally(remaining, startRow, endRow, [&](unsigned r) -> LayoutUnit {
+                    LayoutUnit effectiveHeight = rowHeights[r - startRow] + rowGrowth[r - startRow];
+                    return effectiveHeight > 0 ? effectiveHeight : 0_lu;
+                });
+                remaining -= distributed;
+
+                if (remaining > 0)
+                    rowGrowth[spanLength - 1] += remaining;
+            };
+
+            distributeAndApply();
+
+            // Apply cumulative growth to m_rowPos.
+            LayoutUnit cumGrowth;
+            for (unsigned r = startRow; r < totalRows; r++) {
+                if (r < endRow)
+                    cumGrowth += rowGrowth[r - startRow];
+                m_rowPos[r + 1] += cumGrowth;
+            }
+        }
     }
 
     for (size_t rowIndex = 0; rowIndex < totalRows; ++rowIndex) {


### PR DESCRIPTION
#### 98522776cf13cb88c91c4d363d9d14fa8c463bbc
<pre>
Distribute rowspan &gt; 1 cell height across spanned rows proportionally
<a href="https://bugs.webkit.org/show_bug.cgi?id=308940">https://bugs.webkit.org/show_bug.cgi?id=308940</a>
<a href="https://rdar.apple.com/171489759">rdar://171489759</a>

Reviewed by NOBODY (OOPS!).

Previously, calcRowLogicalHeight() dumped all extra height from a
rowspan&gt;1 cell into a single row (usually the last &quot;valid&quot; row in the
span). This didn&apos;t match other browsers which distribute the height
using a priority cascade across the spanned rows.

 Split calcRowLogicalHeight() into two phases:

Phase 1 computes base row heights from rowspan=1 cells only.

Phase 2 collects rowspan&gt;1 cells, sorts them so enclosed spans
process first, then distributes each cell&apos;s extra height using a
priority cascade:
  1. Rows originating other rowspan&gt;1 cells (evenly)
  2. Unconstrained non-empty rows (proportionally)
  3. All-empty spans give height to the last row
  4. Constrained rows as a fallback (proportionally)

* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::calcRowLogicalHeight):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/rowspan-height-redistribution-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/width-distribution/computing-column-measure-1-expected.txt:

&gt; Rebaselines:
* LayoutTests/fast/table/Rowspan-value-more-than-number-of-rows-present-expected.txt:
* LayoutTests/fast/table/giantRowspan2-expected.txt:
* LayoutTests/platform/mac-wk2/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt:
* LayoutTests/platform/mac/fast/table/giantRowspan-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug133756-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug17138-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug17548-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug220536-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug73321-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug8858-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/bloomberg-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/cell_heights-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/other/test6-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1010-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug23847-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug6933-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/tables/mozilla/bugs/bug133756-1-expected.txt:
* LayoutTests/tables/mozilla_expected_failures/bugs/bug65372-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98522776cf13cb88c91c4d363d9d14fa8c463bbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100985 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f1536b7-8067-4a9b-8642-63230bc435b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20155 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113749 "Found 28 new test failures: accessibility/table-attributes.html accessibility/table-cells.html css2.1/20110323/table-height-algorithm-012.htm fast/css/vertical-align-baseline-rowspan-001.htm fast/css/vertical-align-baseline-rowspan-005.htm fast/css/vertical-align-baseline-rowspan-006.htm fast/css/vertical-align-baseline-rowspan-007.htm fast/css/vertical-align-baseline-rowspan-008.htm fast/css/vertical-align-baseline-rowspan-011.html fast/table/giantRowspan.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81127 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77913c3b-b673-4927-bc78-b571078b30f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150532 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15989 "Found 27 new test failures: css2.1/20110323/table-height-algorithm-012.htm fast/css/vertical-align-baseline-rowspan-001.htm fast/css/vertical-align-baseline-rowspan-002.htm fast/css/vertical-align-baseline-rowspan-005.htm fast/css/vertical-align-baseline-rowspan-006.htm fast/css/vertical-align-baseline-rowspan-007.htm fast/css/vertical-align-baseline-rowspan-008.htm fast/css/vertical-align-baseline-rowspan-011.html fast/table/giantRowspan.html fast/table/giantRowspan2.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94509 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d7e1c34-7c01-4739-8e75-aeeafed4e0bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12940 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158585 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1722 "Found 2 new failures in rendering/RenderTableSection.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11932 "Found 12 new test failures: accessibility/mac/table-relative-frame.html accessibility/table-attributes.html accessibility/table-cells.html css2.1/20110323/table-height-algorithm-012.htm fast/css/vertical-align-baseline-rowspan-001.htm fast/css/vertical-align-baseline-rowspan-002.htm fast/css/vertical-align-baseline-rowspan-005.htm fast/css/vertical-align-baseline-rowspan-006.htm fast/css/vertical-align-baseline-rowspan-007.htm fast/css/vertical-align-baseline-rowspan-008.htm ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121773 "Found 29 new test failures: accessibility/table-attributes.html accessibility/table-cells.html css2.1/20110323/table-height-algorithm-012.htm fast/css/vertical-align-baseline-rowspan-001.htm fast/css/vertical-align-baseline-rowspan-002.htm fast/css/vertical-align-baseline-rowspan-005.htm fast/css/vertical-align-baseline-rowspan-006.htm fast/css/vertical-align-baseline-rowspan-007.htm fast/css/vertical-align-baseline-rowspan-008.htm fast/css/vertical-align-baseline-rowspan-011.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20054 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16841 "Found 11 new test failures: accessibility/mac/table-relative-frame.html accessibility/table-attributes.html accessibility/table-cells.html css2.1/20110323/table-height-algorithm-012.htm fast/css/vertical-align-baseline-rowspan-001.htm fast/css/vertical-align-baseline-rowspan-002.htm fast/css/vertical-align-baseline-rowspan-005.htm fast/css/vertical-align-baseline-rowspan-006.htm fast/css/vertical-align-baseline-rowspan-007.htm fast/css/vertical-align-baseline-rowspan-008.htm ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121974 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76153 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17514 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9021 "Found 12 new test failures: accessibility/mac/table-relative-frame.html accessibility/table-attributes.html accessibility/table-cells.html css2.1/20110323/table-height-algorithm-012.htm fast/css/vertical-align-baseline-rowspan-001.htm fast/css/vertical-align-baseline-rowspan-002.htm fast/css/vertical-align-baseline-rowspan-005.htm fast/css/vertical-align-baseline-rowspan-006.htm fast/css/vertical-align-baseline-rowspan-007.htm fast/css/vertical-align-baseline-rowspan-008.htm ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19669 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83432 "Found 2 new failures in rendering/RenderTableSection.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->