### PR TITLE
Update WeakPtr threading assertions to catch more bugs

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -136,7 +136,7 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT(canSafelyBeUsed());
+        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
     }
 
@@ -165,7 +165,7 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT(canSafelyBeUsed());
+        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         auto* result = get();
         RELEASE_ASSERT(result);
         return result;
@@ -180,7 +180,7 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT(canSafelyBeUsed());
+        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         auto* result = get();
         RELEASE_ASSERT(result);
         return *result;
@@ -211,14 +211,14 @@ private:
         UNUSED_PARAM(shouldEnableAssertions);
     }
 
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     inline bool canSafelyBeUsed() const
     {
         // FIXME: Our GC threads currently need to get opaque pointers from WeakPtrs and have to be special-cased.
         return !m_impl
             || !m_shouldEnableAssertions
-            || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
-            || m_impl->wasConstructedOnMainThread() == isMainThread();
+            || m_impl->threadAssertion().isCurrent()
+            || Thread::mayBeGCThread();
     }
 #endif
 

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Packed.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/WeakRef.h>
 
 namespace WTF {
@@ -50,24 +51,23 @@ public:
     using WeakPtrImplType = WeakPtrImpl;
 
     WeakPtrFactory()
-#if ASSERT_ENABLED
-        : m_wasConstructedOnMainThread(isMainThread())
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        : m_thread(currentThreadLike)
 #endif
     {
     }
 
     void prepareForUseOnlyOnMainThread()
     {
-#if ASSERT_ENABLED
-        m_wasConstructedOnMainThread = true;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = mainThreadLike;
 #endif
     }
 
     void prepareForUseOnlyOnNonMainThread()
     {
-#if ASSERT_ENABLED
-        ASSERT(m_wasConstructedOnMainThread);
-        m_wasConstructedOnMainThread = false;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
 #endif
     }
 
@@ -75,6 +75,9 @@ public:
     {
         if (m_impl)
             m_impl->clear();
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
     }
 
     WeakPtrImpl* impl() const LIFETIME_BOUND
@@ -87,7 +90,9 @@ public:
         if (m_impl)
             return;
 
-        ASSERT(m_wasConstructedOnMainThread == isMainThread());
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        assertIsCurrent(m_thread);
+#endif
 
         static_assert(std::is_final_v<WeakPtrImpl>);
         m_impl = adoptRef(*new WeakPtrImpl(const_cast<T*>(&object)));
@@ -121,8 +126,8 @@ private:
     template<typename, typename> friend class WeakRef;
 
     mutable RefPtr<WeakPtrImpl> m_impl;
-#if ASSERT_ENABLED
-    bool m_wasConstructedOnMainThread;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_thread;
 #endif
 };
 
@@ -136,8 +141,8 @@ public:
     using WeakPtrImplType = WeakPtrImpl;
 
     WeakPtrFactoryWithBitField()
-#if ASSERT_ENABLED
-        : m_wasConstructedOnMainThread(isMainThread())
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        : m_thread(currentThreadLike)
 #endif
     {
     }
@@ -146,6 +151,9 @@ public:
     {
         if (auto* pointer = m_impl.pointer())
             pointer->clear();
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
     }
 
     WeakPtrImpl* impl() const LIFETIME_BOUND
@@ -158,7 +166,9 @@ public:
         if (m_impl.pointer())
             return;
 
-        ASSERT(m_wasConstructedOnMainThread == isMainThread());
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        assertIsCurrent(m_thread);
+#endif
 
         static_assert(std::is_final_v<WeakPtrImpl>);
         m_impl.setPointer(adoptRef(*new WeakPtrImpl(const_cast<T*>(&object))));
@@ -199,8 +209,8 @@ private:
     template<typename, typename> friend class WeakRef;
 
     mutable CompactRefPtrTuple<WeakPtrImpl, uint16_t> m_impl;
-#if ASSERT_ENABLED
-    bool m_wasConstructedOnMainThread;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_thread;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakPtrImpl.h
+++ b/Source/WTF/wtf/WeakPtrImpl.h
@@ -28,6 +28,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/SingleThreadIntegralWrapper.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
@@ -47,25 +48,38 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
+    void clear()
+    {
+        m_ptr = nullptr;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
+    }
 
-#if ASSERT_ENABLED
-    bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    const ThreadLikeAssertion& threadAssertion() const { return m_thread; }
 #endif
 
     template<typename T>
     explicit WeakPtrImplBase(T* ptr)
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
-#if ASSERT_ENABLED
-        , m_wasConstructedOnMainThread(isMainThread())
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        , m_thread(currentThreadLike)
 #endif
     {
     }
 
+    ~WeakPtrImplBase()
+    {
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
+    }
+
 private:
     void* m_ptr;
-#if ASSERT_ENABLED
-    bool m_wasConstructedOnMainThread;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    NO_UNIQUE_ADDRESS mutable ThreadLikeAssertion m_thread;
 #endif
 };
 
@@ -91,19 +105,32 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
+    void clear()
+    {
+        m_ptr = nullptr;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
+    }
 
-#if ASSERT_ENABLED
-    bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    const ThreadLikeAssertion& threadAssertion() const { return m_thread; }
 #endif
 
     template<typename T>
     explicit WeakPtrImplBaseSingleThread(T* ptr)
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
-#if ASSERT_ENABLED
-        , m_wasConstructedOnMainThread(isMainThread())
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        , m_thread(currentThreadLike)
 #endif
     {
+    }
+
+    ~WeakPtrImplBaseSingleThread()
+    {
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
     }
 
     uint32_t refCount() const { return m_refCount; }
@@ -121,8 +148,8 @@ public:
 private:
     mutable SingleThreadIntegralWrapper<uint32_t> m_refCount { 1 };
     void* m_ptr;
-#if ASSERT_ENABLED
-    bool m_wasConstructedOnMainThread;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    NO_UNIQUE_ADDRESS mutable ThreadLikeAssertion m_thread;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -116,7 +116,7 @@ public:
 
     T* operator->() const
     {
-        ASSERT(canSafelyBeUsed());
+        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
         return ptr();
     }
 
@@ -130,14 +130,14 @@ public:
     }
 
 private:
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     inline bool canSafelyBeUsed() const
     {
         // FIXME: Our GC threads currently need to get opaque pointers from WeakPtrs and have to be special-cased.
         return !m_impl
             || !m_shouldEnableAssertions
-            || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
-            || m_impl->wasConstructedOnMainThread() == isMainThread();
+            || m_impl->threadAssertion().isCurrent()
+            || Thread::mayBeGCThread();
     }
 #endif
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -53,7 +53,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_audio_file_reader_debug);
 #define GST_CAT_DEFAULT webkit_audio_file_reader_debug
 
-class AudioFileReader : public CanMakeWeakPtr<AudioFileReader> {
+class AudioFileReader : public CanMakeWeakPtr<AudioFileReader, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioFileReader);
     WTF_MAKE_NONCOPYABLE(AudioFileReader);
 public:

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -44,7 +44,9 @@ class CDMProxyDecryptionClientImplementation final : public WebCore::CDMProxyDec
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMProxyDecryptionClientImplementation);
 public:
     CDMProxyDecryptionClientImplementation(WebKitMediaCommonEncryptionDecrypt* decryptor)
-        : m_decryptor(decryptor) { }
+        : m_decryptor(decryptor)
+    {
+    }
     virtual bool isAborting()
     {
         return webKitMediaCommonEncryptionDecryptIsAborting(m_decryptor);
@@ -501,7 +503,8 @@ bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDec
 WeakPtr<WebCore::CDMProxyDecryptionClient> webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient(WebKitMediaCommonEncryptionDecrypt* self)
 {
     WebKitMediaCommonEncryptionDecryptPrivate* priv = WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(self);
-    return *priv->cdmProxyDecryptionClientImplementation;
+    // FXIME: We should not need EnableWeakPtrThreadingAssertions::No here. This is likely indicative of a bug.
+    return WeakPtr { *priv->cdmProxyDecryptionClientImplementation, EnableWeakPtrThreadingAssertions::No };
 }
 
 static GstStateChangeReturn changeState(GstElement* element, GstStateChange transition)

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -3176,7 +3176,13 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
+    void clear()
+    {
+        m_ptr = nullptr;
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+        m_thread = anyThreadLike;
+#endif
+    }
 
     template<typename T>
     explicit DidUpdateRefCountWeakPtrImpl(T* ptr)
@@ -3184,8 +3190,10 @@ public:
     {
     }
 
-#if ASSERT_ENABLED
-    bool wasConstructedOnMainThread() const { return true; }
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    ~DidUpdateRefCountWeakPtrImpl() { m_thread = anyThreadLike; }
+
+    const ThreadLikeAssertion& threadAssertion() const { return m_thread; }
 #endif
 
     void resetDidUpdateRefCount() { m_didUpdateRefCount = false; }
@@ -3211,6 +3219,9 @@ private:
     mutable uint32_t m_refCount { 1 };
     void* m_ptr;
     mutable bool m_didUpdateRefCount { false };
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    NO_UNIQUE_ADDRESS mutable ThreadLikeAssertion m_thread { mainThreadLike };
+#endif
 };
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DidUpdateRefCountWeakPtrImpl);
 


### PR DESCRIPTION
#### 293a7d44cdd5185d6f668a83f8c561cb25998a6d
<pre>
Update WeakPtr threading assertions to catch more bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=308941">https://bugs.webkit.org/show_bug.cgi?id=308941</a>

Reviewed by Darin Adler.

Update WeakPtr threading assertions to catch more bugs:
- Leverage ThreadLikeAssertion instead of a simple `wasConstructedOnMainThread`
  boolean to distinguish different threads / work queues.
- Promote ASSERT to ASSERT_WITH_SECURITY_IMPLICATION

* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::get const):
(WTF::WeakPtr::operator-&gt; const):
(WTF::WeakPtr::operator* const):
(WTF::WeakPtr::canSafelyBeUsed const):
* Source/WTF/wtf/WeakPtrFactory.h:
(WTF::WeakPtrFactory::WeakPtrFactory):
(WTF::WeakPtrFactory::prepareForUseOnlyOnMainThread):
(WTF::WeakPtrFactory::prepareForUseOnlyOnNonMainThread):
(WTF::WeakPtrFactory::~WeakPtrFactory):
(WTF::WeakPtrFactory::initializeIfNeeded const):
(WTF::WeakPtrFactoryWithBitField::WeakPtrFactoryWithBitField):
(WTF::WeakPtrFactoryWithBitField::~WeakPtrFactoryWithBitField):
(WTF::WeakPtrFactoryWithBitField::initializeIfNeeded const):
* Source/WTF/wtf/WeakPtrImpl.h:
(WTF::WeakPtrImplBase::clear):
(WTF::WeakPtrImplBase::threadAssertion const):
(WTF::WeakPtrImplBase::WeakPtrImplBase):
(WTF::WeakPtrImplBase::~WeakPtrImplBase):
(WTF::WeakPtrImplBaseSingleThread::clear):
(WTF::WeakPtrImplBaseSingleThread::threadAssertion const):
(WTF::WeakPtrImplBaseSingleThread::WeakPtrImplBaseSingleThread):
(WTF::WeakPtrImplBaseSingleThread::~WeakPtrImplBaseSingleThread):
(WTF::WeakPtrImplBase::wasConstructedOnMainThread const): Deleted.
(WTF::WeakPtrImplBaseSingleThread::wasConstructedOnMainThread const): Deleted.
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::operator-&gt; const):
(WTF::WeakRef::canSafelyBeUsed const):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:

Canonical link: <a href="https://commits.webkit.org/308485@main">https://commits.webkit.org/308485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edb4429384fe2ec7609470a9bf241deb8f616040

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147597 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101012 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab22b965-e9ad-45ea-9138-17a311a19f9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113776 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81150 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f98ed358-d085-4c4f-a8c3-825d664f1da7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94537 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84928f45-449b-4a24-8eea-f722a89a2b43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15180 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12987 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3720 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139567 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158613 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8385 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121801 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31266 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132270 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76196 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9050 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179018 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83459 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->