### PR TITLE
Dispatch load events to detached SVG image and script elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/image-load-error-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/image-load-error-events-expected.txt
@@ -1,0 +1,7 @@
+
+PASS 'load' and 'error' events for SVG <image>, external reference, existing
+PASS 'load' and 'error' events for SVG <image>, external data: URL reference, existing
+PASS 'load' and 'error' events for SVG <image>, external reference, non-existing
+PASS 'load' and 'error' events for SVG <image>, external reference, existing, detached
+PASS 'load' and 'error' events for SVG <image>, external reference, non-existing, detached
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/image-load-error-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/image-load-error-events.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<title>'load' and 'error' events for SVG &lt;image></title>
+<link rel="help" href="https://www.w3.org/TR/SVG2/embedded.html#ImageElement">
+<link rel="help" href="https://www.w3.org/TR/SVG2/interact.html#LoadEvent">
+<link rel="help" href="https://www.w3.org/TR/SVG2/interact.html#ErrorEvent">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<svg>
+</svg>
+<script>
+  function newImageElement() {
+    return document.createElementNS('http://www.w3.org/2000/svg', 'image');
+  }
+  function expectEvents(t, element, event) {
+    return new EventWatcher(t, element, ['load', 'error']).wait_for(event);
+  }
+  const DATA_URL_PAYLOAD =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect id="green" fill="lime" width="100" height="50"/></svg>';
+  const cookie = Date.now();
+  let counter = 0;
+  function makeCookie(index) {
+    return `${cookie}-${index}`;
+  }
+  function getUrl(type) {
+    const cookie = makeCookie(counter++);
+    switch (type) {
+    case 'existing':
+      return `/images/colors.svg?${cookie}`;
+    case 'existing-data':
+      return `data:image/svg+xml,${DATA_URL_PAYLOAD}`;
+    case 'non-existing':
+      return `/images/this-file-should-not-exist.svg?${cookie}`;
+    case 'existing-slow':
+      return `./resources/load-error-events.py?test=test_svg_load&delay=1&${cookie}`;
+    case 'non-existing-slow':
+      return `./resources/load-error-events.py?test=test_error&delay=1&${cookie}`;
+    }
+  }
+
+  promise_test(t => {
+    const svg = document.querySelector('svg');
+    const image = newImageElement();
+    const watcher = expectEvents(t, image, ['load']);
+    const url = getUrl('existing');
+    svg.appendChild(image).setAttribute('href', url);
+    return watcher;
+  }, document.title + ', external reference, existing');
+
+  promise_test(t => {
+    const svg = document.querySelector('svg');
+    const image = newImageElement();
+    const watcher = expectEvents(t, image, ['load']);
+    const url = getUrl('existing-data');
+    svg.appendChild(image).setAttribute('href', url);
+    return watcher;
+  }, document.title + ', external data: URL reference, existing');
+
+  promise_test(t => {
+    const svg = document.querySelector('svg');
+    const image = newImageElement();
+    const watcher = expectEvents(t, image, ['error']);
+    const url = getUrl('non-existing');
+    svg.appendChild(image).setAttribute('href', url);
+    return watcher;
+  }, document.title + ', external reference, non-existing');
+
+  promise_test(async t => {
+    const svg = document.querySelector('svg');
+    const image = newImageElement();
+    const watcher = expectEvents(t, image, ['load']);
+    const url = getUrl('existing-slow');
+    svg.appendChild(image).setAttribute('href', url);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    image.remove();
+    await watcher;
+  }, document.title + ', external reference, existing, detached');
+
+  promise_test(async t => {
+    const svg = document.querySelector('svg');
+    const image = newImageElement();
+    const watcher = expectEvents(t, image, ['error']);
+    const url = getUrl('non-existing-slow');
+    svg.appendChild(image).setAttribute('href', url);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    image.remove();
+    await watcher;
+  }, document.title + ', external reference, non-existing, detached');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/resources/load-error-events.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/resources/load-error-events.py
@@ -1,0 +1,28 @@
+import re
+import time
+
+def main(request, response):
+    test = request.GET.first(b'test')
+    assert(re.match(b'^[a-zA-Z0-9_]+$', test))
+
+    delay = int(request.GET.first(b'delay', 0))
+    time.sleep(delay);
+
+    if test.find(b'_svg') >= 0:
+        mime_type = b'image/svg+xml'
+        content = b'<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    elif test.find(b'_script') >= 0:
+        mime_type = b'text/javascript'
+        content = b'// comment'
+    else:
+        mime_type = b'text/plain'
+        content = b'text'
+
+    headers = [(b'Content-Type', mime_type)]
+
+    if test.find(b'_load') >= 0:
+      status = 200
+    else:
+      status = 404
+
+    return status, headers, content

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/script-load-error-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/script-load-error-events-expected.txt
@@ -1,0 +1,7 @@
+
+PASS 'load' and 'error' events for SVG <script>, external reference, existing
+PASS 'load' and 'error' events for SVG <script>, external data: URL reference, existing
+PASS 'load' and 'error' events for SVG <script>, external reference, non-existing
+PASS 'load' and 'error' events for SVG <script>, external reference, existing, detached
+PASS 'load' and 'error' events for SVG <script>, external reference, non-existing, detached
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/script-load-error-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/script-load-error-events.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<title>'load' and 'error' events for SVG &lt;script></title>
+<link rel="help" href="https://www.w3.org/TR/SVG2/embedded.html#ScriptElement">
+<link rel="help" href="https://www.w3.org/TR/SVG2/interact.html#LoadEvent">
+<link rel="help" href="https://www.w3.org/TR/SVG2/interact.html#ErrorEvent">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<svg>
+</svg>
+<script>
+  function newScriptElement() {
+    return document.createElementNS('http://www.w3.org/2000/svg', 'script');
+  }
+  function expectEvents(t, element, event) {
+    return new EventWatcher(t, element, ['load', 'error']).wait_for(event);
+  }
+  const DATA_URL_PAYLOAD =
+      '# comment';
+  const cookie = Date.now();
+  let counter = 0;
+  function makeCookie(index) {
+    return `${cookie}-${index}`;
+  }
+  function getUrl(type) {
+    const cookie = makeCookie(counter++);
+    switch (type) {
+    case 'existing':
+      return `./resources/load-error-events.py?test=test_script_load&${cookie}`;
+    case 'existing-data':
+      return `data:text/javascript,${DATA_URL_PAYLOAD}`;
+    case 'non-existing':
+      return `./resources/load-error-events.py?test=test_script_error&${cookie}`;
+    case 'existing-slow':
+      return `./resources/load-error-events.py?test=test_script_load&delay=1&${cookie}`;
+    case 'non-existing-slow':
+      return `./resources/load-error-events.py?test=test_error&delay=1&${cookie}`;
+    }
+  }
+
+  promise_test(t => {
+    const svg = document.querySelector('svg');
+    const script = newScriptElement();
+    const watcher = expectEvents(t, script, ['load']);
+    const url = getUrl('existing');
+    svg.appendChild(script).setAttribute('href', url);
+    return watcher;
+  }, document.title + ', external reference, existing');
+
+  promise_test(t => {
+    const svg = document.querySelector('svg');
+    const script = newScriptElement();
+    const watcher = expectEvents(t, script, ['load']);
+    const url = getUrl('existing-data');
+    svg.appendChild(script).setAttribute('href', url);
+    return watcher;
+  }, document.title + ', external data: URL reference, existing');
+
+  promise_test(t => {
+    const svg = document.querySelector('svg');
+    const script = newScriptElement();
+    const watcher = expectEvents(t, script, ['error']);
+    const url = getUrl('non-existing');
+    svg.appendChild(script).setAttribute('href', url);
+    return watcher;
+  }, document.title + ', external reference, non-existing');
+
+  promise_test(async t => {
+    const svg = document.querySelector('svg');
+    const script = newScriptElement();
+    const watcher = expectEvents(t, script, ['load']);
+    const url = getUrl('existing-slow');
+    svg.appendChild(script).setAttribute('href', url);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    script.remove();
+    await watcher;
+  }, document.title + ', external reference, existing, detached');
+
+  promise_test(async t => {
+    const svg = document.querySelector('svg');
+    const script = newScriptElement();
+    const watcher = expectEvents(t, script, ['error']);
+    const url = getUrl('non-existing-slow');
+    svg.appendChild(script).setAttribute('href', url);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    script.remove();
+    await watcher;
+  }, document.title + ', external reference, non-existing, detached');
+
+</script>

--- a/Source/WebCore/svg/SVGImageLoader.cpp
+++ b/Source/WebCore/svg/SVGImageLoader.cpp
@@ -43,7 +43,7 @@ void SVGImageLoader::dispatchLoadEvent()
     if (image()->errorOccurred())
         protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
     else
-        downcast<SVGImageElement>(protect(ImageLoader::element()))->sendLoadEventIfPossible();
+        protect(element())->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 }

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -24,6 +24,8 @@
 
 #include "Document.h"
 #include "Element.h"
+#include "Event.h"
+#include "EventNames.h"
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGUseElement.h"
@@ -160,7 +162,7 @@ void SVGURIReference::dispatchLoadEvent()
     setHaveFiredLoadEvent(true);
     ASSERT(contextElement().haveLoadedRequiredResources());
 
-    contextElement().sendLoadEventIfPossible();
+    protect(contextElement())->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 }


### PR DESCRIPTION
#### 38271b8fa0c2d200d4a48a65a9d49fe32821894f
<pre>
Dispatch load events to detached SVG image and script elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=308801">https://bugs.webkit.org/show_bug.cgi?id=308801</a>

Reviewed by Ryosuke Niwa.

WebKit dispatches error event to detached SVG image and script elements as well
as Chrome and Firefox. However, it didn&apos;t dispatch load event to them. Aligned
WebKit&apos;s behavior to other browsers.

Test: imported/w3c/web-platform-tests/svg/interact/image-load-error-events.html
      imported/w3c/web-platform-tests/svg/interact/script-load-error-events.html

* LayoutTests/imported/w3c/web-platform-tests/svg/interact/image-load-error-events-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/image-load-error-events.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/resources/load-error-events.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/script-load-error-events-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/script-load-error-events.html: Added.
* Source/WebCore/svg/SVGImageLoader.cpp:
(WebCore::SVGImageLoader::dispatchLoadEvent):
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::dispatchLoadEvent):

Canonical link: <a href="https://commits.webkit.org/308532@main">https://commits.webkit.org/308532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c1a207cada9da3bfe12f429d4ddd1c59ae7d38b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156481 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94700 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158816 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1950 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121968 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76408 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22772 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9218 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19898 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83660 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->