### PR TITLE
[JSC] Use `WTF::find64` in `containsHole` for double array

### DIFF
--- a/JSTests/stress/array-contains-hole-double-simd.js
+++ b/JSTests/stress/array-contains-hole-double-simd.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function test(a) {
+    return a.includes(undefined);
+}
+noInline(test);
+
+const dense1 = [1.5];
+const dense3 = [1.5, 2.5, 3.5];
+const dense4 = [1.5, 2.5, 3.5, 4.5];
+const dense8 = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5];
+const dense16 = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5];
+
+const hole0 = [, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5];
+const hole3 = [1.5, 2.5, 3.5, , 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5];
+const hole4 = [1.5, 2.5, 3.5, 4.5, , 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5];
+const hole7 = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, , 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5];
+const hole8 = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, , 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5];
+const hole15 = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, ,];
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(test(dense1), false);
+    shouldBe(test(dense3), false);
+    shouldBe(test(dense4), false);
+    shouldBe(test(dense8), false);
+    shouldBe(test(dense16), false);
+
+    shouldBe(test(hole0), true);
+    shouldBe(test(hole3), true);
+    shouldBe(test(hole4), true);
+    shouldBe(test(hole7), true);
+    shouldBe(test(hole8), true);
+    shouldBe(test(hole15), true);
+}

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -342,13 +342,9 @@ ALWAYS_INLINE bool isHole(double value)
 template<typename T>
 ALWAYS_INLINE bool containsHole(const T* data, unsigned length)
 {
-    if constexpr (std::is_same_v<T, double>) {
-        for (unsigned i = 0; i < length; ++i) {
-            if (isHole(data[i]))
-                return true;
-        }
-        return false;
-    } else
+    if constexpr (std::is_same_v<T, double>)
+        return WTF::findNaN(data, length);
+    else
         return WTF::find64(std::bit_cast<const uint64_t*>(data), JSValue::encode(JSValue()), length);
 }
 

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -83,6 +83,11 @@ struct LaneToVector<uint64_t> {
     using Type = simde_uint64x2_t;
 };
 
+template<>
+struct LaneToVector<double> {
+    using Type = simde_float64x2_t;
+};
+
 template<typename LaneType>
 using VectorType = typename LaneToVector<LaneType>::Type;
 
@@ -143,6 +148,11 @@ ALWAYS_INLINE simde_uint32x4_t load(const uint32_t* ptr)
 ALWAYS_INLINE simde_uint64x2_t load(const uint64_t* ptr)
 {
     return simde_vld1q_u64(ptr);
+}
+
+ALWAYS_INLINE simde_float64x2_t load(const double* ptr)
+{
+    return simde_vld1q_f64(ptr);
 }
 
 ALWAYS_INLINE void store(simde_uint8x16_t value, uint8_t* ptr)
@@ -505,6 +515,11 @@ ALWAYS_INLINE simde_uint32x4_t equal(simde_uint32x4_t lhs, simde_uint32x4_t rhs)
 ALWAYS_INLINE simde_uint64x2_t equal(simde_uint64x2_t lhs, simde_uint64x2_t rhs)
 {
     return simde_vceqq_u64(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint64x2_t equal(simde_float64x2_t lhs, simde_float64x2_t rhs)
+{
+    return simde_vceqq_f64(lhs, rhs);
 }
 
 ALWAYS_INLINE simde_uint8x16_t lessThan(simde_uint8x16_t lhs, simde_uint8x16_t rhs)

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -684,6 +684,72 @@ SUPPRESS_NODELETE ALWAYS_INLINE const uint64_t* NODELETE find64(const uint64_t* 
     return nullptr;
 }
 
+SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findNaN(const double* pointer, size_t length)
+{
+    constexpr size_t scalarThreshold = 4;
+    size_t index = 0;
+    size_t runway = std::min(scalarThreshold, length);
+    for (; index < runway; ++index) {
+        double value = pointer[index];
+        if (value != value)
+            return pointer + index;
+    }
+    if (runway == length)
+        return nullptr;
+
+    constexpr size_t stride = SIMD::stride<double>;
+    constexpr size_t unrollFactor = 4;
+    constexpr size_t unrolledStride = stride * unrollFactor;
+
+    // NaN is the only IEEE 754 value for which self-compare yields false.
+    // fcmeq(v, v) produces all-zero lanes for NaN and all-one lanes otherwise.
+    auto vectorMatch = [](simde_float64x2_t value) ALWAYS_INLINE_LAMBDA {
+        return SIMD::findFirstNonZeroIndex(SIMD::bitNot(SIMD::equal(value, value)));
+    };
+
+    auto* cursor = pointer + index;
+    auto* end = pointer + length;
+
+    // Common case: all doubles are ordered (dense array). AND the fcmeq results
+    // together and take a single branch; if every lane stayed all-ones we skip
+    // the per-vector work entirely. This avoids per-vector bitNot and branch on
+    // the hot path.
+    for (; cursor + unrolledStride <= end; cursor += unrolledStride) {
+        auto v0 = SIMD::load(cursor);
+        auto v1 = SIMD::load(cursor + stride);
+        auto v2 = SIMD::load(cursor + stride * 2);
+        auto v3 = SIMD::load(cursor + stride * 3);
+
+        auto eq0 = SIMD::equal(v0, v0);
+        auto eq1 = SIMD::equal(v1, v1);
+        auto eq2 = SIMD::equal(v2, v2);
+        auto eq3 = SIMD::equal(v3, v3);
+
+        auto merged = SIMD::bitAnd(eq0, eq1, eq2, eq3);
+        if (SIMD::isNonZero(SIMD::bitNot(merged))) [[unlikely]] {
+            if (auto idx = SIMD::findFirstNonZeroIndex(SIMD::bitNot(eq0)))
+                return cursor + idx.value();
+            if (auto idx = SIMD::findFirstNonZeroIndex(SIMD::bitNot(eq1)))
+                return cursor + stride + idx.value();
+            if (auto idx = SIMD::findFirstNonZeroIndex(SIMD::bitNot(eq2)))
+                return cursor + stride * 2 + idx.value();
+            return cursor + stride * 3 + SIMD::findFirstNonZeroIndex(SIMD::bitNot(eq3)).value();
+        }
+    }
+
+    for (; cursor + stride <= end; cursor += stride) {
+        if (auto idx = vectorMatch(SIMD::load(cursor)))
+            return cursor + idx.value();
+    }
+
+    if (cursor < end) {
+        if (auto idx = vectorMatch(SIMD::load(end - stride)))
+            return end - stride + idx.value();
+    }
+
+    return nullptr;
+}
+
 ALWAYS_INLINE const Float16* NODELETE findFloat16(const Float16* pointer, Float16 target, size_t length)
 {
     for (size_t index = 0; index < length; ++index) {

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -100,6 +100,88 @@ TEST(WTF_StringCommon, Find16NonASCII)
 }
 #endif
 
+TEST(WTF_StringCommon, FindNaN)
+{
+    auto bitsToDouble = [](uint64_t bits) {
+        return std::bit_cast<double>(bits);
+    };
+
+    // IEEE 754 NaN: exponent all-ones, mantissa non-zero. Cover multiple
+    // bit patterns to exercise the self-compare SIMD path.
+    const double nanSamples[] = {
+        bitsToDouble(0x7ff8000000000000ULL), // PNaN (quiet_NaN on most platforms)
+        bitsToDouble(0xfff8000000000000ULL), // -PNaN (e.g. sin(-inf))
+        bitsToDouble(0x7ff0000000000001ULL), // Signaling NaN, min payload
+        bitsToDouble(0x7fffffffffffffffULL), // Max payload
+        bitsToDouble(0xffff000000000000ULL), // ImpureNaN in JSC terminology
+        bitsToDouble(0xfffffffffffffffeULL),
+    };
+
+    // Non-NaN values that share bit patterns close to NaN boundaries.
+    const double nonNaNSamples[] = {
+        0.0,
+        -0.0,
+        1.5,
+        -42.25,
+        bitsToDouble(0x7ff0000000000000ULL), // +Infinity
+        bitsToDouble(0xfff0000000000000ULL), // -Infinity
+        bitsToDouble(0x7fefffffffffffffULL), // DBL_MAX
+        bitsToDouble(0x0000000000000001ULL), // Smallest subnormal
+    };
+
+    // Empty and short inputs (scalar path).
+    {
+        EXPECT_FALSE(WTF::findNaN(nullptr, 0));
+
+        double a[] = { 1.5 };
+        EXPECT_FALSE(WTF::findNaN(a, 1));
+
+        double b[] = { 1.5, 2.5, 3.5 };
+        EXPECT_FALSE(WTF::findNaN(b, 3));
+
+        double c[] = { 1.5, 2.5, nanSamples[0], 4.5 };
+        EXPECT_EQ(WTF::findNaN(c, 4), c + 2);
+
+        double d[] = { nanSamples[1], 2.5, 3.5, 4.5 };
+        EXPECT_EQ(WTF::findNaN(d, 4), d);
+    }
+
+    // SIMD path: fill with non-NaN values (including Infinities) and verify no false positive.
+    {
+        Vector<double> v(64);
+        for (unsigned i = 0; i < v.size(); ++i)
+            v[i] = nonNaNSamples[i % std::size(nonNaNSamples)];
+        EXPECT_FALSE(WTF::findNaN(v.span().data(), v.size()));
+    }
+
+    // SIMD path: place each NaN bit pattern at every position in 0..31 and
+    // verify the returned pointer, covering scalar runway, unrolled body and
+    // overlapping tail load.
+    for (double nan : nanSamples) {
+        for (unsigned len : { 5u, 8u, 11u, 12u, 16u, 17u, 31u, 32u }) {
+            Vector<double> v(len);
+            for (unsigned i = 0; i < len; ++i)
+                v[i] = static_cast<double>(i) + 0.5;
+            for (unsigned pos = 0; pos < len; ++pos) {
+                v[pos] = nan;
+                EXPECT_EQ(WTF::findNaN(v.span().data(), len), v.span().data() + pos)
+                    << "len=" << len << " pos=" << pos;
+                v[pos] = static_cast<double>(pos) + 0.5;
+            }
+        }
+    }
+
+    // Returns the first NaN when multiple are present.
+    {
+        Vector<double> v(32);
+        for (unsigned i = 0; i < v.size(); ++i)
+            v[i] = static_cast<double>(i) + 0.5;
+        v[9] = nanSamples[2];
+        v[20] = nanSamples[0];
+        EXPECT_EQ(WTF::findNaN(v.span().data(), v.size()), v.span().data() + 9);
+    }
+}
+
 TEST(WTF_StringCommon, FindIgnoringASCIICaseWithoutLengthIdentical)
 {
     EXPECT_EQ(WTF::findIgnoringASCIICaseWithoutLength("needle", "needle"), 0UL);


### PR DESCRIPTION
#### 26af206baebb8ac5135d558d416c7a313e2c9afe
<pre>
[JSC] Use `WTF::find64` in `containsHole` for double array
<a href="https://bugs.webkit.org/show_bug.cgi?id=308947">https://bugs.webkit.org/show_bug.cgi?id=308947</a>

Reviewed by Yusuke Suzuki.

This patch changes to use `WTF::find64` in `containsHole` for double array.

                                                  TipOfTree                  Patched

array-prototype-copyWithin-double             317.7650+-3.3929     ^    142.9628+-1.7475        ^ definitely 2.2227x faster
array-prototype-toSpliced-double-double        60.8339+-7.0380     ^     42.0956+-0.7234        ^ definitely 1.4451x faster
array-prototype-toReversed-double               8.3990+-0.0933     ^      6.8441+-0.2938        ^ definitely 1.2272x faster
array-prototype-with-hole-double                6.0217+-0.2820     ^      4.9676+-0.1240        ^ definitely 1.2122x faster

Test: JSTests/stress/array-contains-hole-double-simd.js

* JSTests/stress/array-contains-hole-double-simd.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::containsHole):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::findNaN):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, FindNaN)):

Canonical link: <a href="https://commits.webkit.org/308834@main">https://commits.webkit.org/308834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcc3733e3eb7802ca5b4686f882601ba82c15758

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114483 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81537 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95253 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15806 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13635 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4620 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140467 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159519 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9287 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122532 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33399 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133024 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77145 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9793 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84426 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->