### PR TITLE
Mark functions for composed tree ancestor traversal as NODELETE

### DIFF
--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -55,7 +55,7 @@ public:
 
 private:
     void traverseParentInShadowTree();
-    static CheckedPtr<Element> traverseParent(Node*);
+    static Element* NODELETE traverseParent(Node*);
 
     CheckedPtr<Element> m_current;
 };
@@ -75,19 +75,19 @@ inline ComposedTreeAncestorIterator::ComposedTreeAncestorIterator(Element& curre
 {
 }
 
-inline CheckedPtr<Element> ComposedTreeAncestorIterator::traverseParent(Node* current)
+inline Element* ComposedTreeAncestorIterator::traverseParent(Node* current)
 {
-    RefPtr parent = current->parentNode();
+    auto* parent = current->parentNode();
     if (!parent)
         return nullptr;
     if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*parent))
         return shadowRoot->host();
-    RefPtr parentElement = dynamicDowncast<Element>(*parent);
+    auto* parentElement = dynamicDowncast<Element>(*parent);
     if (!parentElement)
         return nullptr;
-    if (RefPtr shadowRoot = parentElement->shadowRoot())
+    if (auto* shadowRoot = parentElement->shadowRoot())
         return shadowRoot->findAssignedSlot(*current);
-    return parentElement.get();
+    return parentElement;
 }
 
 class ComposedTreeAncestorAdapter {
@@ -100,9 +100,9 @@ public:
 
     iterator begin()
     {
-        if (auto shadowRoot = dynamicDowncast<ShadowRoot>(m_node.get()))
+        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(m_node.get()))
             return iterator(*shadowRoot->host());
-        if (auto pseudoElement = dynamicDowncast<PseudoElement>(m_node.get()))
+        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(m_node.get()))
             return iterator(*pseudoElement->hostElement());
         return iterator(m_node);
     }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1332,16 +1332,16 @@ static inline ShadowRoot* NODELETE parentShadowRoot(const Node& node)
     return nullptr;
 }
 
-HTMLSlotElement* Node::assignedSlot() const
+HTMLSlotElement* NODELETE Node::assignedSlot() const
 {
-    if (RefPtr shadowRoot = parentShadowRoot(*this))
+    if (auto* shadowRoot = parentShadowRoot(*this))
         return shadowRoot->findAssignedSlot(*this);
     return nullptr;
 }
 
-HTMLSlotElement* Node::assignedSlotForBindings() const
+HTMLSlotElement* NODELETE Node::assignedSlotForBindings() const
 {
-    RefPtr shadowRoot = parentShadowRoot(*this);
+    auto* shadowRoot = parentShadowRoot(*this);
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::Open)
         return shadowRoot->findAssignedSlot(*this);
     return nullptr;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -272,8 +272,8 @@ public:
     inline ShadowRoot* shadowRoot() const; // Defined in Element.h.
     bool isClosedShadowHidden(const Node&) const;
 
-    HTMLSlotElement* assignedSlot() const;
-    HTMLSlotElement* assignedSlotForBindings() const;
+    HTMLSlotElement* NODELETE assignedSlot() const;
+    HTMLSlotElement* NODELETE assignedSlotForBindings() const;
     HTMLSlotElement* NODELETE manuallyAssignedSlot() const;
     void setManuallyAssignedSlot(HTMLSlotElement*);
 
@@ -304,9 +304,9 @@ public:
     Node* NODELETE nonBoundaryShadowTreeRootNode();
 
     // Node's parent or shadow tree host.
-    inline ContainerNode* parentOrShadowHostNode() const; // Defined in NodeInlines.h
-    ContainerNode* parentInComposedTree() const;
-    WEBCORE_EXPORT Element* parentElementInComposedTree() const;
+    inline ContainerNode* NODELETE parentOrShadowHostNode() const; // Defined in NodeInlines.h
+    ContainerNode* NODELETE parentInComposedTree() const;
+    WEBCORE_EXPORT Element* NODELETE parentElementInComposedTree() const;
     Element* NODELETE parentOrShadowHostElement() const;
     inline void setParentNode(ContainerNode*);
     inline Node& NODELETE rootNode() const;


### PR DESCRIPTION
#### 8af162c62e03384c11d74f8a4301b66790e90e0c
<pre>
Mark functions for composed tree ancestor traversal as NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=308950">https://bugs.webkit.org/show_bug.cgi?id=308950</a>

Reviewed by Anne van Kesteren.

Now that ShadowRoot::findAssignedSlot is NODELETE as of 308440@main,
this PR annotates functions to traverse ancestors in the composed tree
as also NODELETE. In some cases, this resulted in the removal of smart
pointers because the code block is entirely &quot;trivial&quot;.

No new tests since there should be no behavioral change.

* Source/WebCore/dom/ComposedTreeAncestorIterator.h:
(WebCore::ComposedTreeAncestorIterator::traverseParent):
(WebCore::ComposedTreeAncestorAdapter::begin):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::assignedSlot const):
(WebCore::Node::assignedSlotForBindings const):
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/308506@main">https://commits.webkit.org/308506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dff3a51eb593dcad29e1b2e6b5ca16c2a7f4b894

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101138 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a064d65-9b45-4f4d-880d-ef2f42023b61) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81216 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2887f6b0-0e42-4858-9a00-6fe1db5bc376) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94639 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04508740-eb58-4dc1-b07b-fb2cdb673be5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15280 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13064 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158740 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121905 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122106 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76333 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17628 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9153 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83585 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->