### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in dom and editing

### DIFF
--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -63,7 +63,7 @@ public:
     void signalFollow(AbortSignal&);
 
     bool aborted() const { return m_aborted; }
-    const JSValueInWrappedObject& reason() const { return m_reason; }
+    const JSValueInWrappedObject& reason() const LIFETIME_BOUND { return m_reason; }
 
     bool hasActiveTimeoutTimer() const { return m_hasActiveTimeoutTimer; }
     bool hasAbortEventListener() const { return m_hasAbortEventListener; }
@@ -77,8 +77,8 @@ public:
     void throwIfAborted(JSC::JSGlobalObject&);
 
     using AbortSignalSet = WeakListHashSet<AbortSignal, WeakPtrImplWithEventTargetData>;
-    const AbortSignalSet& sourceSignals() const { return m_sourceSignals; }
-    AbortSignalSet& sourceSignals() { return m_sourceSignals; }
+    const AbortSignalSet& sourceSignals() const LIFETIME_BOUND { return m_sourceSignals; }
+    AbortSignalSet& sourceSignals() LIFETIME_BOUND { return m_sourceSignals; }
 
     bool isDependent() const { return m_isDependent; }
 

--- a/Source/WebCore/dom/Attribute.h
+++ b/Source/WebCore/dom/Attribute.h
@@ -50,14 +50,14 @@ public:
     // NOTE: The references returned by these functions are only valid for as long
     // as the Attribute stays in place. For example, calling a function that mutates
     // an Element's internal attribute storage may invalidate them.
-    const AtomString& value() const { return m_value; }
+    const AtomString& value() const LIFETIME_BOUND { return m_value; }
     static constexpr ptrdiff_t valueMemoryOffset() { return OBJECT_OFFSETOF(Attribute, m_value); }
-    const AtomString& prefix() const { return m_name.prefix(); }
-    const AtomString& localName() const { return m_name.localName(); }
-    const AtomString& localNameLowercase() const { return m_name.localNameLowercase(); }
-    const AtomString& namespaceURI() const { return m_name.namespaceURI(); }
+    const AtomString& prefix() const LIFETIME_BOUND { return m_name.prefix(); }
+    const AtomString& localName() const LIFETIME_BOUND { return m_name.localName(); }
+    const AtomString& localNameLowercase() const LIFETIME_BOUND { return m_name.localNameLowercase(); }
+    const AtomString& namespaceURI() const LIFETIME_BOUND { return m_name.namespaceURI(); }
 
-    const QualifiedName& name() const { return m_name; }
+    const QualifiedName& name() const LIFETIME_BOUND { return m_name; }
     static constexpr ptrdiff_t nameMemoryOffset() { return OBJECT_OFFSETOF(Attribute, m_name); }
 
     bool isEmpty() const { return m_value.isEmpty(); }

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -34,7 +34,7 @@ class CharacterData : public Node {
     WTF_MAKE_TZONE_ALLOCATED(CharacterData);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CharacterData);
 public:
-    const String& data() const { return m_data; }
+    const String& data() const LIFETIME_BOUND { return m_data; }
     static constexpr ptrdiff_t dataMemoryOffset() { return OBJECT_OFFSETOF(CharacterData, m_data); }
 
     WEBCORE_EXPORT void setData(const String&);

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -62,7 +62,7 @@ public:
     explicit ConstantPropertyMap(Document&);
 
     using Values = HashMap<AtomString, Ref<const Style::CustomProperty>>;
-    const Values& values() const;
+    const Values& values() const LIFETIME_BOUND;
 
     void didChangeSafeAreaInsets();
     void didChangeFullscreenInsets();

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -111,7 +111,7 @@ public:
     void upgrade(Node& root);
     ExceptionOr<void> initialize(Node& root);
 
-    MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() { return m_promiseMap; }
+    MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() LIFETIME_BOUND { return m_promiseMap; }
     bool isShadowDisabled(const AtomString& name) const { return m_disabledShadowSet.contains(name); }
 
     template<typename Visitor> void visitJSCustomElementInterfaces(Visitor&) const;

--- a/Source/WebCore/dom/CustomEvent.h
+++ b/Source/WebCore/dom/CustomEvent.h
@@ -47,8 +47,8 @@ public:
 
     void initCustomEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail = JSC::JSValue::JSUndefined);
 
-    const JSValueInWrappedObject& detail() const { return m_detail; }
-    JSValueInWrappedObject& cachedDetail() { return m_cachedDetail; }
+    const JSValueInWrappedObject& detail() const LIFETIME_BOUND { return m_detail; }
+    JSValueInWrappedObject& cachedDetail() LIFETIME_BOUND { return m_cachedDetail; }
 
 private:
     CustomEvent(IsTrusted);

--- a/Source/WebCore/dom/DOMStringList.h
+++ b/Source/WebCore/dom/DOMStringList.h
@@ -57,7 +57,7 @@ public:
     String NODELETE item(unsigned index) const;
     bool contains(const String& str) const;
 
-    operator const Vector<String>&() const { return m_strings; }
+    operator const Vector<String>&() const LIFETIME_BOUND { return m_strings; }
 
 private:
     DOMStringList() = default;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -561,7 +561,7 @@ public:
     WEBCORE_EXPORT DOMImplementation& implementation();
     
     Element* documentElement() const { return m_documentElement.get(); }
-    AsyncNodeDeletionQueue& asyncNodeDeletionQueue() { return m_asyncNodeDeletionQueue; };
+    AsyncNodeDeletionQueue& asyncNodeDeletionQueue() LIFETIME_BOUND { return m_asyncNodeDeletionQueue; };
     static constexpr ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
 
     WEBCORE_EXPORT Element* activeElement();
@@ -614,7 +614,7 @@ public:
     void overrideMIMEType(const String&);
     WEBCORE_EXPORT String contentType() const;
 
-    const AtomString& contentLanguage() const { return m_contentLanguage; }
+    const AtomString& contentLanguage() const LIFETIME_BOUND { return m_contentLanguage; }
     void setContentLanguage(const AtomString&);
 
     const AtomString& NODELETE effectiveDocumentElementLanguage() const;
@@ -729,7 +729,7 @@ public:
     const CSSCounterStyleRegistry& NODELETE counterStyleRegistry() const;
     CSSCounterStyleRegistry& counterStyleRegistry();
 
-    WEBCORE_EXPORT const CSSParserContext& cssParserContext() const;
+    WEBCORE_EXPORT const CSSParserContext& cssParserContext() const LIFETIME_BOUND;
     void invalidateCachedCSSParserContext();
 
     bool gotoAnchorNeededAfterStylesheetsLoad() { return m_gotoAnchorNeededAfterStylesheetsLoad; }
@@ -827,7 +827,7 @@ public:
     void suspendFontLoading();
 
     RenderView* renderView() const { return m_renderView.get(); }
-    const RenderStyle* initialContainingBlockStyle() const { return m_initialContainingBlockStyle.get(); } // This may end up differing from renderView()->style() due to adjustments.
+    const RenderStyle* initialContainingBlockStyle() const LIFETIME_BOUND { return m_initialContainingBlockStyle.get(); } // This may end up differing from renderView()->style() due to adjustments.
 
     bool renderTreeBeingDestroyed() const { return m_renderTreeBeingDestroyed; }
     bool hasLivingRenderTree() const { return renderView() && !renderTreeBeingDestroyed(); }
@@ -882,15 +882,15 @@ public:
 
     URL adjustedURL() const;
 
-    const URL& creationURL() const { return m_creationURL; }
+    const URL& creationURL() const LIFETIME_BOUND { return m_creationURL; }
 
     // To understand how these concepts relate to one another, please see the
     // comments surrounding their declaration.
-    const URL& baseURL() const { return m_baseURL; }
+    const URL& baseURL() const LIFETIME_BOUND { return m_baseURL; }
     void setBaseURLOverride(const URL&);
-    const URL& baseURLOverride() const { return m_baseURLOverride; }
-    const URL& baseElementURL() const { return m_baseElementURL; }
-    const AtomString& baseTarget() const { return m_baseTarget; }
+    const URL& baseURLOverride() const LIFETIME_BOUND { return m_baseURLOverride; }
+    const URL& baseElementURL() const LIFETIME_BOUND { return m_baseElementURL; }
+    const AtomString& baseTarget() const LIFETIME_BOUND { return m_baseTarget; }
     HTMLBaseElement* NODELETE firstBaseElement() const;
     void processBaseElement();
 
@@ -970,11 +970,11 @@ public:
     const Color& themeColor();
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
-    const std::optional<SpatialBackdropSource>& spatialBackdropSource() const { return m_cachedSpatialBackdropSource; }
+    const std::optional<SpatialBackdropSource>& spatialBackdropSource() const LIFETIME_BOUND { return m_cachedSpatialBackdropSource; }
 #endif
 
     void setTextColor(const Color& color) { m_textColor = color; }
-    const Color& textColor() const { return m_textColor; }
+    const Color& textColor() const LIFETIME_BOUND { return m_textColor; }
 
     Color linkColor(const Style::ComputedStyle&) const;
     Color visitedLinkColor(const Style::ComputedStyle&) const;
@@ -996,8 +996,8 @@ public:
     Element* focusedElement() const { return m_focusedElement.get(); }
     inline bool wasLastFocusByClick() const;
     void setLatestFocusTrigger(FocusTrigger trigger) { m_latestFocusTrigger = trigger; }
-    UserActionElementSet& userActionElements()  { return m_userActionElements; }
-    const UserActionElementSet& userActionElements() const { return m_userActionElements; }
+    UserActionElementSet& userActionElements() LIFETIME_BOUND  { return m_userActionElements; }
+    const UserActionElementSet& userActionElements() const LIFETIME_BOUND { return m_userActionElements; }
 
     void setFocusNavigationStartingNode(Node*);
     Element* focusNavigationStartingNode(FocusDirection) const;
@@ -1187,9 +1187,9 @@ public:
     WEBCORE_EXPORT std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const;
 
     // Used by DOM bindings; no direction known.
-    const String& title() const { return m_title.string; }
+    const String& title() const LIFETIME_BOUND { return m_title.string; }
     WEBCORE_EXPORT void setTitle(String&&);
-    const StringWithDirection& titleWithDirection() const { return m_title; }
+    const StringWithDirection& titleWithDirection() const LIFETIME_BOUND { return m_title; }
 
     WEBCORE_EXPORT const AtomString& dir() const;
     WEBCORE_EXPORT void setDir(const AtomString&);
@@ -1233,7 +1233,7 @@ public:
     //       firstPartyForCookies have a different registry-controlled
     //       domain.
     //
-    const URL& firstPartyForCookies() const { return m_firstPartyForCookies; }
+    const URL& firstPartyForCookies() const LIFETIME_BOUND { return m_firstPartyForCookies; }
     void setFirstPartyForCookies(const URL&);
     std::optional<bool> cachedCookiesEnabled() const { return m_cachedCookiesEnabled; }
     void setCachedCookiesEnabled(bool enabled) { m_cachedCookiesEnabled = enabled; }
@@ -1246,7 +1246,7 @@ public:
     // the URL of the top-level document or the null URL depending on whether the registrable
     // domain of this document's URL matches the registrable domain of its parent's/opener's
     // URL. For the top-level document, it is set to the document's URL.
-    const URL& siteForCookies() const { return m_siteForCookies; }
+    const URL& siteForCookies() const LIFETIME_BOUND { return m_siteForCookies; }
     void setSiteForCookies(const URL& url) { m_siteForCookies = url; }
     bool isSameSiteForCookies(const URL&) const;
 
@@ -1324,7 +1324,7 @@ public:
     void setTransformSourceDocument(Document* document) { m_transformSourceDocument = document; }
 
     void setTransformSource(std::unique_ptr<TransformSource>);
-    TransformSource* transformSource() const { return m_transformSource.get(); }
+    TransformSource* transformSource() const LIFETIME_BOUND { return m_transformSource.get(); }
 #endif
 
     void incDOMTreeVersion() { m_domTreeVersion = ++s_globalTreeVersion; }
@@ -1523,7 +1523,7 @@ public:
 #endif
 
     WEBCORE_EXPORT double monotonicTimestamp() const;
-    const DocumentEventTiming& eventTiming() const { return m_eventTiming; }
+    const DocumentEventTiming& eventTiming() const LIFETIME_BOUND { return m_eventTiming; }
 
     LargestContentfulPaintData& largestContentfulPaintData() const;
     void didLoadImage(Element&, CachedImage*) const;
@@ -1617,7 +1617,7 @@ public:
 
     bool hasActiveParserYieldToken() const { return m_parserYieldTokenCount; }
 
-    DocumentSharedObjectPool* sharedObjectPool() { return m_sharedObjectPool.get(); }
+    DocumentSharedObjectPool* sharedObjectPool() LIFETIME_BOUND { return m_sharedObjectPool.get(); }
 
     void invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 
@@ -1766,7 +1766,7 @@ public:
 
     void scheduleInitialIntersectionObservationUpdate();
     IntersectionObserverData& ensureIntersectionObserverData();
-    IntersectionObserverData* intersectionObserverDataIfExists() { return m_intersectionObserverData.get(); }
+    IntersectionObserverData* intersectionObserverDataIfExists() LIFETIME_BOUND { return m_intersectionObserverData.get(); }
 
     void addResizeObserver(ResizeObserver&);
     void removeResizeObserver(ResizeObserver&);
@@ -1829,7 +1829,7 @@ public:
 
     void didInsertInDocumentShadowRoot(ShadowRoot&);
     void didRemoveInDocumentShadowRoot(ShadowRoot&);
-    const WeakListHashSet<ShadowRoot, WeakPtrImplWithEventTargetData>& inDocumentShadowRoots() const { return m_inDocumentShadowRoots; }
+    const WeakListHashSet<ShadowRoot, WeakPtrImplWithEventTargetData>& inDocumentShadowRoots() const LIFETIME_BOUND { return m_inDocumentShadowRoots; }
 
     void attachToCachedFrame(CachedFrameBase&);
     void detachFromCachedFrame(CachedFrameBase&);
@@ -1882,10 +1882,10 @@ public:
 
     void addTopLayerElement(Element&);
     void removeTopLayerElement(Element&);
-    const ListHashSet<Ref<Element>>& topLayerElements() const { return m_topLayerElements; }
+    const ListHashSet<Ref<Element>>& topLayerElements() const LIFETIME_BOUND { return m_topLayerElements; }
     bool hasTopLayerElement() const { return !m_topLayerElements.isEmpty(); }
 
-    const ListHashSet<Ref<HTMLElement>>& autoPopoverList() const { return m_autoPopoverList; }
+    const ListHashSet<Ref<HTMLElement>>& autoPopoverList() const LIFETIME_BOUND { return m_autoPopoverList; }
 
     HTMLDialogElement* activeModalDialog() const;
     HTMLElement* NODELETE topmostAutoPopover() const;
@@ -1899,7 +1899,7 @@ public:
     void didInsertAttachmentElement(HTMLAttachmentElement&);
     void didRemoveAttachmentElement(HTMLAttachmentElement&);
     WEBCORE_EXPORT RefPtr<HTMLAttachmentElement> attachmentForIdentifier(const String&) const;
-    const HashMap<String, Ref<HTMLAttachmentElement>>& attachmentElementsByIdentifier() const { return m_attachmentIdentifierToElementMap; }
+    const HashMap<String, Ref<HTMLAttachmentElement>>& attachmentElementsByIdentifier() const LIFETIME_BOUND { return m_attachmentIdentifierToElementMap; }
 #endif
 
     void setServiceWorkerConnection(RefPtr<SWClientConnection>&&);
@@ -1974,7 +1974,7 @@ public:
     WEBCORE_EXPORT HighlightRegistry& appHighlightRegistry();
 
     WEBCORE_EXPORT AppHighlightStorage& appHighlightStorage();
-    AppHighlightStorage* appHighlightStorageIfExists() const { return m_appHighlightStorage.get(); };
+    AppHighlightStorage* appHighlightStorageIfExists() const LIFETIME_BOUND { return m_appHighlightStorage.get(); };
 
     void restoreUnrestoredAppHighlights(MonotonicTime renderingUpdateTime);
 #endif
@@ -2006,7 +2006,7 @@ public:
     const FrameSelection& selection() const { return m_selection; }
 
     void setFragmentDirective(const String& fragmentDirective) { m_fragmentDirective = fragmentDirective; }
-    const String& fragmentDirective() const { return m_fragmentDirective; }
+    const String& fragmentDirective() const LIFETIME_BOUND { return m_fragmentDirective; }
 
     FragmentDirective& NODELETE fragmentDirectiveForBindings();
 
@@ -2083,7 +2083,7 @@ public:
     WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, std::optional<ReferrerPolicy>, bool lowPriority = false);
 
     void processSpeculationRulesHeader(const String& headerValue, const URL& baseURL);
-    CachedSetInnerHTML& cachedSetInnerHTML() { return m_cachedSetInnerHTML; }
+    CachedSetInnerHTML& cachedSetInnerHTML() LIFETIME_BOUND { return m_cachedSetInnerHTML; }
     void updateCachedSetInnerHTML(const String& sourceString, ContainerNode&, Element& contextElement);
     void invalidateCachedSetInnerHTML();
 
@@ -2220,7 +2220,7 @@ private:
     bool shouldMaskURLForBindingsInternal(const URL&) const;
 
     // DOM Cookies caching.
-    const String& cachedDOMCookies() const { return m_cachedDOMCookies; }
+    const String& cachedDOMCookies() const LIFETIME_BOUND { return m_cachedDOMCookies; }
     void setCachedDOMCookies(const String&);
     bool isDOMCookieCacheValid() const { return m_cookieCacheExpiryTimer.isActive(); }
     void didLoadResourceSynchronously(const URL&) final;

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -167,7 +167,7 @@ public:
 
     String description() const;
 
-    const Data& data() const { return m_data; }
+    const Data& data() const LIFETIME_BOUND { return m_data; }
     void clearData() { m_data = String { }; }
 
     // Offset modifications are done by DocumentMarkerController.

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -375,7 +375,7 @@ public:
 
     const Vector<Ref<Attr>>& NODELETE attrNodeList();
 
-    const QualifiedName& tagQName() const { return m_tagName; }
+    const QualifiedName& tagQName() const LIFETIME_BOUND { return m_tagName; }
 #if ENABLE(JIT)
     static constexpr ptrdiff_t tagQNameMemoryOffset() { return OBJECT_OFFSETOF(Element, m_tagName); }
 #endif
@@ -686,26 +686,26 @@ public:
 
     virtual bool childShouldCreateRenderer(const Node&) const;
 
-    KeyframeEffectStack* keyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&) const;
-    KeyframeEffectStack& ensureKeyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&);
+    KeyframeEffectStack* keyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
+    KeyframeEffectStack& ensureKeyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
     bool hasKeyframeEffects(const std::optional<Style::PseudoElementIdentifier>&) const;
     bool NODELETE mayHaveKeyframeEffects() const;
 
-    const AnimationCollection* animations(const std::optional<Style::PseudoElementIdentifier>&) const;
+    const AnimationCollection* animations(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
     bool hasCompletedTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
     bool hasRunningTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
     bool hasRunningTransitions(const std::optional<Style::PseudoElementIdentifier>&) const;
-    AnimationCollection& ensureAnimations(const std::optional<Style::PseudoElementIdentifier>&);
+    AnimationCollection& ensureAnimations(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
 
-    const AnimatableCSSPropertyToTransitionMap* completedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) const;
-    const AnimatableCSSPropertyToTransitionMap* runningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) const;
+    const AnimatableCSSPropertyToTransitionMap* completedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
+    const AnimatableCSSPropertyToTransitionMap* runningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
 
-    AnimatableCSSPropertyToTransitionMap& ensureCompletedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&);
-    AnimatableCSSPropertyToTransitionMap& ensureRunningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&);
-    CSSAnimationCollection& animationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>&);
+    AnimatableCSSPropertyToTransitionMap& ensureCompletedTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
+    AnimatableCSSPropertyToTransitionMap& ensureRunningTransitionsByProperty(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
+    CSSAnimationCollection& animationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
     void setAnimationsCreatedByMarkup(const std::optional<Style::PseudoElementIdentifier>&, CSSAnimationCollection&&);
 
-    const RenderStyle* lastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
+    const RenderStyle* lastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
     void setLastStyleChangeEventStyle(const std::optional<Style::PseudoElementIdentifier>&, std::unique_ptr<const RenderStyle>&&);
     bool hasPropertiesOverridenAfterAnimation(const std::optional<Style::PseudoElementIdentifier>&) const;
     void setHasPropertiesOverridenAfterAnimation(const std::optional<Style::PseudoElementIdentifier>&, bool);
@@ -729,8 +729,8 @@ public:
     virtual void requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&&);
 #endif
 
-    PopoverData* NODELETE popoverData() const;
-    PopoverData& ensurePopoverData();
+    PopoverData* NODELETE popoverData() const LIFETIME_BOUND;
+    PopoverData& ensurePopoverData() LIFETIME_BOUND;
     void clearPopoverData();
     bool NODELETE isPopoverShowing() const;
     PopoverState NODELETE popoverState() const;
@@ -796,9 +796,9 @@ public:
 
     LayoutRect absoluteEventHandlerBounds(bool& includesFixedPositionElements) override;
 
-    const RenderStyle* existingComputedStyle() const;
-    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle() const;
-    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
+    const RenderStyle* existingComputedStyle() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
 
     void clearBeforePseudoElement();
     void clearAfterPseudoElement();
@@ -859,14 +859,14 @@ public:
     using ContainerNode::setAttributeEventListener;
     void setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& value);
 
-    virtual IntersectionObserverData& ensureIntersectionObserverData();
-    virtual IntersectionObserverData* NODELETE intersectionObserverDataIfExists() const;
+    virtual IntersectionObserverData& ensureIntersectionObserverData() LIFETIME_BOUND;
+    virtual IntersectionObserverData* NODELETE intersectionObserverDataIfExists() const LIFETIME_BOUND;
 
-    ResizeObserverData& ensureResizeObserverData();
-    ResizeObserverData* NODELETE resizeObserverDataIfExists() const;
+    ResizeObserverData& ensureResizeObserverData() LIFETIME_BOUND;
+    ResizeObserverData* NODELETE resizeObserverDataIfExists() const LIFETIME_BOUND;
 
-    ElementLargestContentfulPaintData& ensureLargestContentfulPaintData();
-    ElementLargestContentfulPaintData* NODELETE largestContentfulPaintDataIfExists() const;
+    ElementLargestContentfulPaintData& ensureLargestContentfulPaintData() LIFETIME_BOUND;
+    ElementLargestContentfulPaintData* NODELETE largestContentfulPaintDataIfExists() const LIFETIME_BOUND;
 
     std::optional<LayoutUnit> NODELETE lastRememberedLogicalWidth() const;
     std::optional<LayoutUnit> NODELETE lastRememberedLogicalHeight() const;
@@ -891,8 +891,8 @@ public:
 
     StylePropertyMapReadOnly& computedStyleMap();
 
-    ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
-    ExplicitlySetAttrElementsMap* NODELETE explicitlySetAttrElementsMapIfExists() const;
+    ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap() LIFETIME_BOUND;
+    ExplicitlySetAttrElementsMap* NODELETE explicitlySetAttrElementsMapIfExists() const LIFETIME_BOUND;
 
     bool NODELETE isRelevantToUser() const;
 
@@ -1024,11 +1024,11 @@ private:
 
     void createUniqueElementData();
 
-    inline ElementRareData* elementRareData() const;
-    ElementRareData& ensureElementRareData();
+    inline ElementRareData* elementRareData() const LIFETIME_BOUND;
+    ElementRareData& ensureElementRareData() LIFETIME_BOUND;
 
-    ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const;
-    ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&);
+    ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
+    ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
 
     virtual int defaultTabIndex() const;
 

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -85,13 +85,13 @@ public:
     String userInfo() const { return m_userInfo; }
     void setUserInfo(String&& userInfo) { m_userInfo = WTF::move(userInfo); }
 
-    RenderStyle* computedStyle() const { return m_computedStyle.get(); }
+    RenderStyle* computedStyle() const LIFETIME_BOUND { return m_computedStyle.get(); }
     void setComputedStyle(std::unique_ptr<RenderStyle>&& computedStyle) { m_computedStyle = WTF::move(computedStyle); }
 
-    RenderStyle* displayContentsOrNoneStyle() const { return m_displayContentsOrNoneStyle.get(); }
+    RenderStyle* displayContentsOrNoneStyle() const LIFETIME_BOUND { return m_displayContentsOrNoneStyle.get(); }
     void setDisplayContentsOrNoneStyle(std::unique_ptr<RenderStyle> style) { m_displayContentsOrNoneStyle = WTF::move(style); }
 
-    const AtomString& effectiveLang() const { return m_effectiveLang; }
+    const AtomString& effectiveLang() const LIFETIME_BOUND { return m_effectiveLang; }
     void setEffectiveLang(const AtomString& lang) { m_effectiveLang = lang; }
 
     DOMTokenList* classList() const { return m_classList.get(); }
@@ -104,8 +104,8 @@ public:
     void setSavedLayerScrollPosition(ScrollPosition position) { m_savedLayerScrollPosition = position; }
 
     bool hasAnimationRareData() const { return !m_animationRareData.isEmpty(); }
-    ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const;
-    ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&);
+    ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const LIFETIME_BOUND;
+    ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&) LIFETIME_BOUND;
 
     AtomString viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&) const;
     void setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&, AtomString);
@@ -113,16 +113,16 @@ public:
     DOMTokenList* partList() const { return m_partList.get(); }
     void setPartList(const std::unique_ptr<DOMTokenList>&& partList) { lazyInitialize(m_partList, std::move(partList)); }
 
-    const SpaceSplitString& partNames() const { return m_partNames; }
+    const SpaceSplitString& partNames() const LIFETIME_BOUND { return m_partNames; }
     void setPartNames(SpaceSplitString&& partNames) { m_partNames = WTF::move(partNames); }
 
-    IntersectionObserverData* intersectionObserverData() { return m_intersectionObserverData.get(); }
+    IntersectionObserverData* intersectionObserverData() const LIFETIME_BOUND { return m_intersectionObserverData.get(); }
     void setIntersectionObserverData(std::unique_ptr<IntersectionObserverData>&& data) { m_intersectionObserverData = WTF::move(data); }
 
-    ResizeObserverData* resizeObserverData() { return m_resizeObserverData.get(); }
+    ResizeObserverData* resizeObserverData() const LIFETIME_BOUND { return m_resizeObserverData.get(); }
     void setResizeObserverData(std::unique_ptr<ResizeObserverData>&& data) { m_resizeObserverData = WTF::move(data); }
 
-    ElementLargestContentfulPaintData* largestContentfulPaintData() { return m_largestContentfulPaintData.get(); }
+    ElementLargestContentfulPaintData* largestContentfulPaintData() const LIFETIME_BOUND { return m_largestContentfulPaintData.get(); }
     void setLargestContentfulPaintData(std::unique_ptr<ElementLargestContentfulPaintData>&& data) { m_largestContentfulPaintData = WTF::move(data); }
 
     std::optional<LayoutUnit> lastRememberedLogicalWidth() const { return m_lastRememberedLogicalWidth; }
@@ -132,7 +132,7 @@ public:
     void clearLastRememberedLogicalWidth() { m_lastRememberedLogicalWidth.reset(); }
     void clearLastRememberedLogicalHeight() { m_lastRememberedLogicalHeight.reset(); }
 
-    const AtomString& nonce() const { return m_nonce; }
+    const AtomString& nonce() const LIFETIME_BOUND { return m_nonce; }
     void setNonce(const AtomString& value) { m_nonce = value; }
 
     StylePropertyMap* attributeStyleMap() { return m_attributeStyleMap.get(); }
@@ -141,15 +141,15 @@ public:
     StylePropertyMapReadOnly* computedStyleMap() { return m_computedStyleMap.get(); }
     void setComputedStyleMap(Ref<StylePropertyMapReadOnly>&& map) { m_computedStyleMap = WTF::move(map); }
 
-    ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap() { return m_explicitlySetAttrElementsMap; }
+    ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap() LIFETIME_BOUND { return m_explicitlySetAttrElementsMap; }
 
-    PopoverData* popoverData() { return m_popoverData.get(); }
+    PopoverData* popoverData() const LIFETIME_BOUND { return m_popoverData.get(); }
     void setPopoverData(std::unique_ptr<PopoverData>&& popoverData) { m_popoverData = WTF::move(popoverData); }
 
     Element* invokedPopover() const { return m_invokedPopover.get(); }
     void setInvokedPopover(RefPtr<Element>&& element) { m_invokedPopover = WTF::move(element); }
 
-    const std::optional<OptionSet<ContentRelevancy>>& contentRelevancy() const { return m_contentRelevancy; }
+    const std::optional<OptionSet<ContentRelevancy>>& contentRelevancy() const LIFETIME_BOUND { return m_contentRelevancy; }
     void setContentRelevancy(OptionSet<ContentRelevancy>& contentRelevancy) { m_contentRelevancy = contentRelevancy; }
 
     CustomStateSet* customStateSet() { return m_customStateSet.get(); }

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -111,7 +111,7 @@ public:
     void copyEventListenersNotCreatedFromMarkupToTarget(EventTarget*);
     
     template<typename Visitor> void visitJSEventListeners(Visitor&);
-    Lock& lock() { return m_lock; }
+    Lock& lock() LIFETIME_BOUND { return m_lock; }
 
 private:
     void releaseAssertOrSetThreadUID()

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -76,8 +76,8 @@ public:
 // Do not make WeakPtrImplWithEventTargetData a derived class of DefaultWeakPtrImpl to catch the bug which uses incorrect impl class.
 class WeakPtrImplWithEventTargetData final : public WTF::WeakPtrImplBase<WeakPtrImplWithEventTargetData> {
 public:
-    EventTargetData& eventTargetData() { return m_eventTargetData; }
-    const EventTargetData& eventTargetData() const { return m_eventTargetData; }
+    EventTargetData& eventTargetData() LIFETIME_BOUND { return m_eventTargetData; }
+    const EventTargetData& eventTargetData() const LIFETIME_BOUND { return m_eventTargetData; }
 
     template<typename T> WeakPtrImplWithEventTargetData(T* ptr) : WTF::WeakPtrImplBase<WeakPtrImplWithEventTargetData>(ptr) { }
 
@@ -191,7 +191,7 @@ protected:
         HasPendingResources = 1 << 15,
     };
 
-    EventTargetData& ensureEventTargetData();
+    EventTargetData& ensureEventTargetData() LIFETIME_BOUND;
 
     virtual void eventListenersDidChange() { }
 

--- a/Source/WebCore/dom/Exception.h
+++ b/Source/WebCore/dom/Exception.h
@@ -39,7 +39,7 @@ public:
     explicit Exception(ExceptionCode, String = { });
 
     ExceptionCode code() const { return m_code; }
-    const String& message() const { return m_message; }
+    const String& message() const LIFETIME_BOUND { return m_message; }
     String&& releaseMessage() { return WTF::move(m_message); }
 
     Exception isolatedCopy() const & { return Exception { m_code, m_message.isolatedCopy() }; }

--- a/Source/WebCore/dom/ExceptionOr.h
+++ b/Source/WebCore/dom/ExceptionOr.h
@@ -47,9 +47,9 @@ public:
 
 
     bool hasException() const;
-    const Exception& exception() const;
+    const Exception& exception() const LIFETIME_BOUND;
     Exception releaseException();
-    const ReturnType& returnValue() const;
+    const ReturnType& returnValue() const LIFETIME_BOUND;
     ReturnType releaseReturnValue();
     
 private:
@@ -68,9 +68,9 @@ public:
     ExceptionOr(ReturnReferenceType&);
 
     bool hasException() const;
-    const Exception& exception() const;
+    const Exception& exception() const LIFETIME_BOUND;
     Exception releaseException();
-    const ReturnReferenceType& returnValue() const;
+    const ReturnReferenceType& returnValue() const LIFETIME_BOUND;
     ReturnReferenceType& releaseReturnValue();
     
 private:
@@ -85,7 +85,7 @@ public:
     ExceptionOr() = default;
 
     bool hasException() const;
-    const Exception& exception() const;
+    const Exception& exception() const LIFETIME_BOUND;
     Exception releaseException();
 
 private:

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -59,10 +59,10 @@ public:
     ~ExtensionStyleSheets();
 
     CSSStyleSheet* pageUserSheet();
-    const Vector<Ref<CSSStyleSheet>>& documentUserStyleSheets() const { return m_userStyleSheets; }
-    const Vector<Ref<CSSStyleSheet>>& injectedUserStyleSheets() const;
-    const Vector<Ref<CSSStyleSheet>>& injectedAuthorStyleSheets() const;
-    const Vector<Ref<CSSStyleSheet>>& authorStyleSheetsForTesting() const { return m_authorStyleSheetsForTesting; }
+    const Vector<Ref<CSSStyleSheet>>& documentUserStyleSheets() const LIFETIME_BOUND { return m_userStyleSheets; }
+    const Vector<Ref<CSSStyleSheet>>& injectedUserStyleSheets() const LIFETIME_BOUND;
+    const Vector<Ref<CSSStyleSheet>>& injectedAuthorStyleSheets() const LIFETIME_BOUND;
+    const Vector<Ref<CSSStyleSheet>>& authorStyleSheetsForTesting() const LIFETIME_BOUND { return m_authorStyleSheetsForTesting; }
 
     bool NODELETE hasCachedInjectedStyleSheets() const;
 

--- a/Source/WebCore/dom/FragmentDirectiveParser.h
+++ b/Source/WebCore/dom/FragmentDirectiveParser.h
@@ -37,7 +37,7 @@ public:
     WEBCORE_EXPORT explicit FragmentDirectiveParser(StringView);
     WEBCORE_EXPORT ~FragmentDirectiveParser();
     
-    const Vector<ParsedTextDirective>& parsedTextDirectives() const { return m_parsedTextDirectives; };
+    const Vector<ParsedTextDirective>& parsedTextDirectives() const LIFETIME_BOUND { return m_parsedTextDirectives; };
     StringView fragmentDirective() const { return m_fragmentDirective; };
     StringView remainingURLFragment() const { return m_remainingURLFragment; };
     bool isValid() const { return  m_isValid; };

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -54,10 +54,10 @@ public:
         return adoptRef(*new InputEvent(type, initializer));
     }
 
-    const String& inputType() const { return m_inputType; }
-    const String& data() const { return m_data; }
+    const String& inputType() const LIFETIME_BOUND { return m_inputType; }
+    const String& data() const LIFETIME_BOUND { return m_data; }
     DataTransfer* NODELETE dataTransfer() const;
-    const Vector<Ref<StaticRange>>& getTargetRanges() { return m_targetRanges; }
+    const Vector<Ref<StaticRange>>& getTargetRanges() LIFETIME_BOUND { return m_targetRanges; }
     bool isInputMethodComposing() const { return m_isInputMethodComposing; }
 
 private:

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -74,14 +74,14 @@ public:
         const AtomString& keyIdentifier, unsigned location,
         bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
     
-    const String& key() const { return m_key; }
-    const String& code() const { return m_code; }
-    const AtomString& keyIdentifier() const { return m_keyIdentifier; }
+    const String& key() const LIFETIME_BOUND { return m_key; }
+    const String& code() const LIFETIME_BOUND { return m_code; }
+    const AtomString& keyIdentifier() const LIFETIME_BOUND { return m_keyIdentifier; }
     unsigned location() const { return m_location; }
     bool repeat() const { return m_repeat; }
 
-    const PlatformKeyboardEvent* underlyingPlatformEvent() const { return m_underlyingPlatformEvent.get(); }
-    PlatformKeyboardEvent* underlyingPlatformEvent() { return m_underlyingPlatformEvent.get(); }
+    const PlatformKeyboardEvent* underlyingPlatformEvent() const LIFETIME_BOUND { return m_underlyingPlatformEvent.get(); }
+    PlatformKeyboardEvent* underlyingPlatformEvent() LIFETIME_BOUND { return m_underlyingPlatformEvent.get(); }
 
     WEBCORE_EXPORT int keyCode() const; // key code for keydown and keyup, character for keypress
     int NODELETE keyCodeForKeyDown() const; // key code for the keydown that matches the keypress
@@ -93,8 +93,8 @@ public:
 
 #if PLATFORM(COCOA)
     bool handledByInputMethod() const { return m_handledByInputMethod; }
-    const Vector<KeypressCommand>& keypressCommands() const { return m_keypressCommands; }
-    Vector<KeypressCommand>& keypressCommands() { return m_keypressCommands; }
+    const Vector<KeypressCommand>& keypressCommands() const LIFETIME_BOUND { return m_keypressCommands; }
+    Vector<KeypressCommand>& keypressCommands() LIFETIME_BOUND { return m_keypressCommands; }
 #endif
 
     FocusEventData NODELETE focusEventData() const;

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -57,7 +57,7 @@ public:
 
     UniquedStringImpl* moduleKey() const { return m_moduleKey.get(); }
 
-    ModuleFetchParameters& parameters() { return m_parameters.get(); }
+    ModuleFetchParameters& parameters() const LIFETIME_BOUND { return m_parameters.get(); }
 
 private:
     LoadableModuleScript(IsInline, const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -275,19 +275,19 @@ public:
     bool isElementRareData() const { return m_isElementRareData; }
 
     void clearNodeLists() { m_nodeLists = nullptr; }
-    NodeListsNodeData* nodeLists() const { return m_nodeLists.get(); }
-    NodeListsNodeData& ensureNodeLists()
+    NodeListsNodeData* nodeLists() const LIFETIME_BOUND { return m_nodeLists.get(); }
+    NodeListsNodeData& ensureNodeLists() LIFETIME_BOUND
     {
         if (!m_nodeLists)
             m_nodeLists = makeUnique<NodeListsNodeData>();
         return *m_nodeLists;
     }
 
-    NodeMutationObserverData* mutationObserverDataIfExists() { return m_mutationObserverData.get(); }
-    NodeMutationObserverData& mutationObserverData()
+    NodeMutationObserverData* mutationObserverDataIfExists() const LIFETIME_BOUND { return m_mutationObserverData.get(); }
+    NodeMutationObserverData& mutationObserverData() const LIFETIME_BOUND
     {
         if (!m_mutationObserverData)
-            m_mutationObserverData = makeUnique<NodeMutationObserverData>();
+            lazyInitialize(m_mutationObserverData, makeUnique<NodeMutationObserverData>());
         return *m_mutationObserverData;
     }
 
@@ -316,7 +316,7 @@ public:
 
 private:
     std::unique_ptr<NodeListsNodeData> m_nodeLists;
-    std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;
+    const std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;
     WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_manuallyAssignedSlot;
     bool m_isElementRareData;
     bool m_hasEverPaintedImages { false }; // Keep last for better bit packing with ElementRareData.

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -263,7 +263,7 @@ public:
     {
     }
 
-    const Position& position() const { return m_position; }
+    const Position& position() const LIFETIME_BOUND { return m_position; }
     Affinity affinity() const { return m_affinity; }
 
 private:

--- a/Source/WebCore/dom/QualifiedName.h
+++ b/Source/WebCore/dom/QualifiedName.h
@@ -94,11 +94,11 @@ public:
     bool hasPrefix() const { return !m_impl->m_prefix.isNull(); }
     void setPrefix(const AtomString& prefix) { *this = QualifiedName(prefix, localName(), namespaceURI()); }
 
-    const AtomString& prefix() const { return m_impl->m_prefix; }
-    const AtomString& localName() const { return m_impl->m_localName; }
-    const AtomString& namespaceURI() const { return m_impl->m_namespaceURI; }
-    const AtomString& localNameLowercase() const { return m_impl->m_localNameLower; }
-    const AtomString& localNameUppercase() const;
+    const AtomString& prefix() const LIFETIME_BOUND { return m_impl->m_prefix; }
+    const AtomString& localName() const LIFETIME_BOUND { return m_impl->m_localName; }
+    const AtomString& namespaceURI() const LIFETIME_BOUND { return m_impl->m_namespaceURI; }
+    const AtomString& localNameLowercase() const LIFETIME_BOUND { return m_impl->m_localNameLower; }
+    const AtomString& localNameUppercase() const LIFETIME_BOUND;
 
     NodeName nodeName() const { return m_impl->m_nodeName; }
     Namespace nodeNamespace() const { return m_impl->m_namespace; }

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -79,16 +79,16 @@ public:
 
     inline void setEmptySecurityOriginPolicyAndContentSecurityPolicy();
 
-    const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const { return m_crossOriginEmbedderPolicy; }
+    const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const LIFETIME_BOUND { return m_crossOriginEmbedderPolicy; }
     void setCrossOriginEmbedderPolicy(const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy) { m_crossOriginEmbedderPolicy = crossOriginEmbedderPolicy; }
 
     virtual CrossOriginOpenerPolicy crossOriginOpenerPolicy() const { return m_crossOriginOpenerPolicy; }
     void setCrossOriginOpenerPolicy(const CrossOriginOpenerPolicy& crossOriginOpenerPolicy) { m_crossOriginOpenerPolicy = crossOriginOpenerPolicy; }
 
-    const IntegrityPolicy* NODELETE integrityPolicy() const;
+    const IntegrityPolicy* NODELETE integrityPolicy() const LIFETIME_BOUND;
     void setIntegrityPolicy(std::unique_ptr<IntegrityPolicy>&&);
 
-    const IntegrityPolicy* NODELETE integrityPolicyReportOnly() const;
+    const IntegrityPolicy* NODELETE integrityPolicyReportOnly() const LIFETIME_BOUND;
     void setIntegrityPolicyReportOnly(std::unique_ptr<IntegrityPolicy>&&);
 
     virtual ReferrerPolicy referrerPolicy() const { return m_referrerPolicy; }

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -141,13 +141,13 @@ public:
     void moveShadowRootToNewDocument(Document& oldDocument, Document& newDocument);
 
     using PartMappings = HashMap<AtomString, Vector<AtomString, 1>>;
-    const PartMappings& partMappings() const;
+    const PartMappings& partMappings() const LIFETIME_BOUND;
     void invalidatePartMappings();
 
     Vector<Ref<WebAnimation>> getAnimations();
 
     bool hasReferenceTarget() const { return !m_referenceTarget.isNull(); }
-    const AtomString& referenceTarget() const { return m_referenceTarget; }
+    const AtomString& referenceTarget() const LIFETIME_BOUND { return m_referenceTarget; }
     void setReferenceTarget(const AtomString&);
     RefPtr<Element> referenceTargetElement() const
     {

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -53,9 +53,9 @@ public:
     virtual ~WindowEventLoop();
 
     void queueMutationObserverCompoundMicrotask();
-    Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() { return m_signalSlotList; }
-    HashSet<Ref<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
-    HashSet<Ref<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
+    Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() LIFETIME_BOUND { return m_signalSlotList; }
+    HashSet<Ref<MutationObserver>>& activeMutationObservers() LIFETIME_BOUND { return m_activeObservers; }
+    HashSet<Ref<MutationObserver>>& suspendedMutationObservers() LIFETIME_BOUND { return m_suspendedObservers; }
 
     CustomElementQueue& backupElementQueue();
 

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -45,8 +45,8 @@ public:
 
     WEBCORE_EXPORT ~MessagePortChannel();
 
-    const MessagePortIdentifier& port1() const { return m_ports[0]; }
-    const MessagePortIdentifier& port2() const { return m_ports[1]; }
+    const MessagePortIdentifier& port1() const LIFETIME_BOUND { return m_ports[0]; }
+    const MessagePortIdentifier& port2() const LIFETIME_BOUND { return m_ports[1]; }
 
     WEBCORE_EXPORT std::optional<ProcessIdentifier> NODELETE processForPort(const MessagePortIdentifier&);
     bool NODELETE includesPort(const MessagePortIdentifier&);

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -84,8 +84,8 @@ public:
     void append(SimpleEditCommand&);
     bool wasCreateLinkCommand() const { return m_editAction == EditAction::CreateLink; }
 
-    const VisibleSelection& startingSelection() const { return m_startingSelection; }
-    const VisibleSelection& endingSelection() const { return m_endingSelection; }
+    const VisibleSelection& startingSelection() const LIFETIME_BOUND { return m_startingSelection; }
+    const VisibleSelection& endingSelection() const LIFETIME_BOUND { return m_endingSelection; }
     void setStartingSelection(const VisibleSelection&);
     void setEndingSelection(const VisibleSelection&);
     Element* startingRootEditableElement() const { return m_startingRootEditableElement.get(); }

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -55,8 +55,8 @@ public:
 
     virtual EditAction editingAction() const;
 
-    const VisibleSelection& startingSelection() const { return m_startingSelection; }
-    const VisibleSelection& endingSelection() const { return m_endingSelection; }
+    const VisibleSelection& startingSelection() const LIFETIME_BOUND { return m_startingSelection; }
+    const VisibleSelection& endingSelection() const LIFETIME_BOUND { return m_endingSelection; }
 
     virtual bool isInsertTextCommand() const { return false; }    
     virtual bool isSimpleEditCommand() const { return false; }

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -222,9 +222,9 @@ public:
     bool applyFontFace() const { return m_applyFontFace.length() > 0; }
     bool applyFontSize() const { return m_applyFontSize.length() > 0; }
 
-    const AtomString& fontColor() { return m_applyFontColor; }
-    const AtomString& fontFace() { return m_applyFontFace; }
-    const AtomString& fontSize() { return m_applyFontSize; }
+    const AtomString& fontColor() const LIFETIME_BOUND { return m_applyFontColor; }
+    const AtomString& fontFace() const LIFETIME_BOUND { return m_applyFontFace; }
+    const AtomString& fontSize() const LIFETIME_BOUND { return m_applyFontSize; }
 
     bool operator==(const StyleChange&);
 

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -449,11 +449,11 @@ public:
     unsigned compositionStart() const { return m_compositionStart; }
     unsigned compositionEnd() const { return m_compositionEnd; }
     bool compositionUsesCustomUnderlines() const { return !m_customCompositionUnderlines.isEmpty(); }
-    const Vector<CompositionUnderline>& customCompositionUnderlines() const { return m_customCompositionUnderlines; }
+    const Vector<CompositionUnderline>& customCompositionUnderlines() const LIFETIME_BOUND { return m_customCompositionUnderlines; }
     bool compositionUsesCustomHighlights() const { return !m_customCompositionHighlights.isEmpty(); }
-    const Vector<CompositionHighlight>& customCompositionHighlights() const { return m_customCompositionHighlights; }
+    const Vector<CompositionHighlight>& customCompositionHighlights() const LIFETIME_BOUND { return m_customCompositionHighlights; }
     bool compositionUsesCustomAnnotations() const { return !m_customCompositionAnnotations.isEmpty(); }
-    const HashMap<String, Vector<CharacterRange>>& customCompositionAnnotations() const { return m_customCompositionAnnotations; }
+    const HashMap<String, Vector<CharacterRange>>& customCompositionAnnotations() const LIFETIME_BOUND { return m_customCompositionAnnotations; }
 
     // FIXME: This should be a page-level concept (i.e. on EditorClient) instead of on the Editor, which
     // is a frame-specific concept, because executing an editing command can run JavaScript that can do
@@ -469,7 +469,7 @@ public:
 
     VisibleSelection selectionForCommand(Event*);
 
-    PAL::KillRing& killRing() const { return m_killRing; }
+    PAL::KillRing& killRing() const LIFETIME_BOUND { return m_killRing; }
     SpellChecker& spellChecker() const { return m_spellChecker; }
 
     EditingBehavior behavior() const;
@@ -511,7 +511,7 @@ public:
 
     WEBCORE_EXPORT std::optional<SimpleRange> rangeOfString(const String&, const std::optional<SimpleRange>& searchRange, FindOptions);
 
-    const VisibleSelection& mark() const; // Mark, to be used as emacs uses it.
+    const VisibleSelection& mark() const LIFETIME_BOUND; // Mark, to be used as emacs uses it.
     void setMark(const VisibleSelection&);
 
     void computeAndSetTypingStyle(EditingStyle& , EditAction = EditAction::Unspecified);
@@ -624,7 +624,7 @@ public:
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(MAC)
     void scanSelectionForTelephoneNumbers();
-    const Vector<SimpleRange>& detectedTelephoneNumberRanges() const { return m_detectedTelephoneNumberRanges; }
+    const Vector<SimpleRange>& detectedTelephoneNumberRanges() const LIFETIME_BOUND { return m_detectedTelephoneNumberRanges; }
 #endif
 
     WEBCORE_EXPORT String stringForCandidateRequest() const;
@@ -660,7 +660,7 @@ public:
 
     WEBCORE_EXPORT Node* nodeBeforeWritingSuggestions() const;
     Element* writingSuggestionsContainerElement() const;
-    WritingSuggestionData* writingSuggestionData() const { return m_writingSuggestionData.get(); }
+    WritingSuggestionData* writingSuggestionData() const LIFETIME_BOUND { return m_writingSuggestionData.get(); }
     bool isInsertingTextForWritingSuggestion() const { return m_isInsertingTextForWritingSuggestion; }
 
     RenderInline* NODELETE writingSuggestionRenderer() const;

--- a/Source/WebCore/editing/FontAttributeChanges.h
+++ b/Source/WebCore/editing/FontAttributeChanges.h
@@ -63,7 +63,7 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<FontChanges>;
-    const String& platformFontFamilyNameForCSS() const;
+    const String& platformFontFamilyNameForCSS() const LIFETIME_BOUND;
 
     String m_fontName;
     String m_fontFamily;

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -78,7 +78,7 @@ protected:
     bool shouldRepaintCaret(const RenderView*, bool isContentEditable) const;
     void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, CaretAnimator*) const;
 
-    const LayoutRect& localCaretRectWithoutUpdate() const { return m_caretLocalRect; }
+    const LayoutRect& localCaretRectWithoutUpdate() const LIFETIME_BOUND { return m_caretLocalRect; }
 
     bool shouldUpdateCaretRect() const { return m_caretRectNeedsUpdate; }
     void setCaretRectNeedsUpdate() { m_caretRectNeedsUpdate = true; }
@@ -106,7 +106,7 @@ public:
     WEBCORE_EXPORT bool isContentRichlyEditable() const;
 
     bool hasCaret() const { return m_position.isNotNull(); }
-    const VisiblePosition& caretPosition() { return m_position; }
+    const VisiblePosition& caretPosition() const LIFETIME_BOUND { return m_position; }
     void setCaretPosition(const VisiblePosition&);
     void clear() { setCaretPosition(VisiblePosition()); }
     WEBCORE_EXPORT IntRect caretRectInRootViewCoordinates() const;
@@ -169,7 +169,7 @@ public:
     void moveTo(const Position&, const Position&, Affinity, UserTriggered = UserTriggered::No);
     void moveWithoutValidationTo(const Position&, const Position&, bool selectionHasDirection, OptionSet<SetSelectionOption> = defaultSetSelectionOptions(), const AXTextStateChangeIntent& = AXTextStateChangeIntent());
 
-    const VisibleSelection& selection() const { return m_selection; }
+    const VisibleSelection& selection() const LIFETIME_BOUND { return m_selection; }
     WEBCORE_EXPORT void setSelection(const VisibleSelection&, OptionSet<SetSelectionOption> = defaultSetSelectionOptions(), AXTextStateChangeIntent = AXTextStateChangeIntent(), CursorAlignOnScroll = CursorAlignOnScroll::IfNeeded, TextGranularity = TextGranularity::CharacterGranularity);
 
     enum class ShouldCloseTyping : bool { No, Yes };

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.h
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new InsertIntoTextNodeCommand(WTF::move(node), offset, text, allowPasswordEcho, editingAction));
     }
 
-    const String& insertedText();
+    const String& insertedText() LIFETIME_BOUND;
 
 protected:
     InsertIntoTextNodeCommand(Ref<Text>&& node, unsigned offset, const String& text, AllowPasswordEcho, EditAction editingAction);

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -46,16 +46,16 @@ public:
     static RefPtr<SpellCheckRequest> create(OptionSet<TextCheckingType>, TextCheckingProcessType, const SimpleRange& checkingRange, const SimpleRange& automaticReplacementRange, const SimpleRange& paragraphRange);
     virtual ~SpellCheckRequest();
 
-    const SimpleRange& checkingRange() const { return m_checkingRange; }
-    const SimpleRange& paragraphRange() const { return m_paragraphRange; }
-    const SimpleRange& automaticReplacementRange() const { return m_automaticReplacementRange; }
+    const SimpleRange& checkingRange() const LIFETIME_BOUND { return m_checkingRange; }
+    const SimpleRange& paragraphRange() const LIFETIME_BOUND { return m_paragraphRange; }
+    const SimpleRange& automaticReplacementRange() const LIFETIME_BOUND { return m_automaticReplacementRange; }
     Element* rootEditableElement() const { return m_rootEditableElement.get(); }
 
     void setCheckerAndIdentifier(SpellChecker*, TextCheckingRequestIdentifier);
     void setExistingResults(const Vector<TextCheckingResult>&);
     void requesterDestroyed();
 
-    const TextCheckingRequestData& data() const final;
+    const TextCheckingRequestData& data() const LIFETIME_BOUND final;
 
 private:
     void didSucceed(const Vector<TextCheckingResult>&) final;

--- a/Source/WebCore/editing/TextCheckingHelper.h
+++ b/Source/WebCore/editing/TextCheckingHelper.h
@@ -62,11 +62,11 @@ public:
     bool isCheckingRangeCoveredBy(CharacterRange range) const { return range.location <= checkingStart() && range.location + range.length >= checkingStart() + checkingLength(); }
     bool checkingRangeCovers(CharacterRange range) const { return range.location < checkingEnd() && range.location + range.length > checkingStart(); }
 
-    const SimpleRange& paragraphRange() const;
+    const SimpleRange& paragraphRange() const LIFETIME_BOUND;
 
 private:
     void invalidateParagraphRangeValues();
-    const SimpleRange& offsetAsRange() const;
+    const SimpleRange& offsetAsRange() const LIFETIME_BOUND;
 
     SimpleRange m_checkingRange;
     SimpleRange m_automaticReplacementRange;

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -112,7 +112,7 @@ public:
     WEBCORE_EXPORT SimpleRange range() const;
     WEBCORE_EXPORT Node* node() const;
 
-    const TextIteratorCopyableText& copyableText() const { ASSERT(!atEnd()); return m_copyableText; }
+    const TextIteratorCopyableText& copyableText() const LIFETIME_BOUND { ASSERT(!atEnd()); return m_copyableText; }
     void appendTextToStringBuilder(StringBuilder& builder) const { copyableText().appendToStringBuilder(builder); }
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -70,17 +70,17 @@ public:
     // These functions return the values that were passed in, without the canonicalization done by VisiblePosition.
     // FIXME: When we expand granularity, we canonicalize as a side effect, so expanded values have been made canonical.
     // FIXME: Replace start/range/base/end/firstRange with these, renaming these to the shorter names.
-    const Position& uncanonicalizedStart() const;
-    const Position& uncanonicalizedEnd() const;
-    const Position& anchor() const { return m_anchor; }
-    const Position& focus() const { return m_focus; }
+    const Position& uncanonicalizedStart() const LIFETIME_BOUND;
+    const Position& uncanonicalizedEnd() const LIFETIME_BOUND;
+    const Position& anchor() const LIFETIME_BOUND { return m_anchor; }
+    const Position& focus() const LIFETIME_BOUND { return m_focus; }
     WEBCORE_EXPORT std::optional<SimpleRange> range() const;
 
     // FIXME: Rename these to include the word "canonical" or remove.
-    const Position& base() const { return m_base; }
-    const Position& extent() const { return m_extent; }
-    const Position& start() const { return m_start; }
-    const Position& end() const { return m_end; }
+    const Position& base() const LIFETIME_BOUND { return m_base; }
+    const Position& extent() const LIFETIME_BOUND { return m_extent; }
+    const Position& start() const LIFETIME_BOUND { return m_start; }
+    const Position& end() const LIFETIME_BOUND { return m_end; }
 
     VisiblePosition visibleStart() const { return VisiblePosition(m_start, isRange() ? Affinity::Downstream : affinity()); }
     VisiblePosition visibleEnd() const { return VisiblePosition(m_end, isRange() ? Affinity::Upstream : affinity()); }

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -146,12 +146,13 @@ static bool isCachedPrefixMatch(const CachedSetInnerHTML& cache, std::span<const
 template<typename CharacterType>
 static FragmentReuseResult tryAvoidParsingByCloningExistingSubtree(std::span<const CharacterType> source, ContainerNode& destinationParent, Element& contextElement)
 {
-    auto& cache = protect(destinationParent.document())->cachedSetInnerHTML();
+    Ref destinationParentDocument = destinationParent.document();
+    auto& cache = destinationParentDocument->cachedSetInnerHTML();
     RefPtr cachedContainer = cache.cachedContainer.get();
     if (!cachedContainer)
         return FragmentReuseResult::CannotReuse;
     if (!isCachedSubtreeValid(*cachedContainer)) {
-        protect(destinationParent.document())->invalidateCachedSetInnerHTML();
+        destinationParentDocument->invalidateCachedSetInnerHTML();
         return FragmentReuseResult::CannotReuse;
     }
 

--- a/Source/WebCore/page/PerformanceTiming.cpp
+++ b/Source/WebCore/page/PerformanceTiming.cpp
@@ -364,11 +364,10 @@ const DocumentEventTiming* PerformanceTiming::documentEventTiming() const
     if (!frame)
         return nullptr;
 
-    RefPtr document = frame->document();
-    if (!document)
-        return nullptr;
+    if (auto* document = frame->document())
+        return &document->eventTiming();
 
-    return &document->eventTiming();
+    return nullptr;
 }
 
 const DocumentLoadTiming* PerformanceTiming::documentLoadTiming() const


### PR DESCRIPTION
#### 273f5ae59f83e05dc24a94acfaa9d857ca485907
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in dom and editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=308951">https://bugs.webkit.org/show_bug.cgi?id=308951</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/Attribute.h:
(WebCore::Attribute::value const): Deleted.
(WebCore::Attribute::prefix const): Deleted.
(WebCore::Attribute::localName const): Deleted.
(WebCore::Attribute::localNameLowercase const): Deleted.
(WebCore::Attribute::namespaceURI const): Deleted.
(WebCore::Attribute::name const): Deleted.
* Source/WebCore/dom/CharacterData.h:
(WebCore::CharacterData::data const): Deleted.
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/CustomElementRegistry.h:
(WebCore::CustomElementRegistry::promiseMap): Deleted.
* Source/WebCore/dom/CustomEvent.h:
* Source/WebCore/dom/DOMStringList.h:
(WebCore::DOMStringList::operator const Vector&lt;String&gt;&amp; const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::asyncNodeDeletionQueue): Deleted.
(WebCore::Document::contentLanguage const): Deleted.
(WebCore::Document::initialContainingBlockStyle const): Deleted.
(WebCore::Document::creationURL const): Deleted.
(WebCore::Document::baseURL const): Deleted.
(WebCore::Document::baseURLOverride const): Deleted.
(WebCore::Document::baseElementURL const): Deleted.
(WebCore::Document::baseTarget const): Deleted.
(WebCore::Document::spatialBackdropSource const): Deleted.
(WebCore::Document::textColor const): Deleted.
(WebCore::Document::userActionElements): Deleted.
(WebCore::Document::userActionElements const): Deleted.
(WebCore::Document::title const): Deleted.
(WebCore::Document::titleWithDirection const): Deleted.
(WebCore::Document::firstPartyForCookies const): Deleted.
(WebCore::Document::siteForCookies const): Deleted.
(WebCore::Document::transformSource const): Deleted.
(WebCore::Document::eventTiming const): Deleted.
(WebCore::Document::sharedObjectPool): Deleted.
(WebCore::Document::intersectionObserverDataIfExists): Deleted.
(WebCore::Document::inDocumentShadowRoots const): Deleted.
(WebCore::Document::topLayerElements const): Deleted.
(WebCore::Document::autoPopoverList const): Deleted.
(WebCore::Document::attachmentElementsByIdentifier const): Deleted.
(WebCore::Document::appHighlightStorageIfExists const): Deleted.
(WebCore::Document::fragmentDirective const): Deleted.
(WebCore::Document::cachedSetInnerHTML): Deleted.
(WebCore::Document::cachedDOMCookies const): Deleted.
* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::data const): Deleted.
* Source/WebCore/dom/Element.h:
(WebCore::Element::tagQName const): Deleted.
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::computedStyle const): Deleted.
(WebCore::ElementRareData::displayContentsOrNoneStyle const): Deleted.
(WebCore::ElementRareData::effectiveLang const): Deleted.
(WebCore::ElementRareData::partNames const): Deleted.
(WebCore::ElementRareData::intersectionObserverData): Deleted.
(WebCore::ElementRareData::resizeObserverData): Deleted.
(WebCore::ElementRareData::largestContentfulPaintData): Deleted.
(WebCore::ElementRareData::nonce const): Deleted.
(WebCore::ElementRareData::explicitlySetAttrElementsMap): Deleted.
(WebCore::ElementRareData::popoverData): Deleted.
(WebCore::ElementRareData::contentRelevancy const): Deleted.
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::lock): Deleted.
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/Exception.h:
(WebCore::Exception::message const): Deleted.
* Source/WebCore/dom/ExceptionOr.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/FragmentDirectiveParser.h:
(WebCore::FragmentDirectiveParser::parsedTextDirectives const): Deleted.
* Source/WebCore/dom/InputEvent.h:
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeRareData::nodeLists const): Deleted.
(WebCore::NodeRareData::ensureNodeLists): Deleted.
(WebCore::NodeRareData::mutationObserverDataIfExists): Deleted.
(WebCore::NodeRareData::mutationObserverData): Deleted.
* Source/WebCore/dom/Position.h:
(WebCore::PositionWithAffinity::position const): Deleted.
* Source/WebCore/dom/QualifiedName.h:
(WebCore::QualifiedName::prefix const): Deleted.
(WebCore::QualifiedName::localName const): Deleted.
(WebCore::QualifiedName::namespaceURI const): Deleted.
(WebCore::QualifiedName::localNameLowercase const): Deleted.
* Source/WebCore/dom/SecurityContext.h:
(WebCore::SecurityContext::crossOriginEmbedderPolicy const): Deleted.
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/dom/messageports/MessagePortChannel.h:
(WebCore::MessagePortChannel::port1 const): Deleted.
(WebCore::MessagePortChannel::port2 const): Deleted.
* Source/WebCore/editing/CompositeEditCommand.h:
(WebCore::EditCommandComposition::startingSelection const): Deleted.
(WebCore::EditCommandComposition::endingSelection const): Deleted.
* Source/WebCore/editing/EditCommand.h:
(WebCore::EditCommand::startingSelection const): Deleted.
(WebCore::EditCommand::endingSelection const): Deleted.
* Source/WebCore/editing/EditingStyle.h:
(WebCore::StyleChange::fontColor): Deleted.
(WebCore::StyleChange::fontFace): Deleted.
(WebCore::StyleChange::fontSize): Deleted.
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FontAttributeChanges.h:
* Source/WebCore/editing/FrameSelection.h:
(WebCore::CaretBase::localCaretRectWithoutUpdate const): Deleted.
(WebCore::DragCaretController::caretPosition): Deleted.
* Source/WebCore/editing/InsertIntoTextNodeCommand.h:
* Source/WebCore/editing/SpellChecker.h:
* Source/WebCore/editing/TextCheckingHelper.h:
* Source/WebCore/editing/TextIterator.h:
(WebCore::TextIterator::copyableText const): Deleted.
* Source/WebCore/editing/VisibleSelection.h:
(WebCore::VisibleSelection::anchor const): Deleted.
(WebCore::VisibleSelection::focus const): Deleted.
(WebCore::VisibleSelection::base const): Deleted.
(WebCore::VisibleSelection::extent const): Deleted.
(WebCore::VisibleSelection::start const): Deleted.
(WebCore::VisibleSelection::end const): Deleted.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::tryAvoidParsingByCloningExistingSubtree):
* Source/WebCore/page/PerformanceTiming.cpp:
(WebCore::PerformanceTiming::documentEventTiming const):

Canonical link: <a href="https://commits.webkit.org/308448@main">https://commits.webkit.org/308448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/091aac33e747271a2967cbe722f91d6be8098fa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101015 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96723bfc-0914-4958-b6a7-e41bce0e086f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81151 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/865c00a1-a78d-4257-84b0-123bb071090b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94540 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e72b75f4-84f6-4ff0-959b-38477afa4240) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12969 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3723 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124781 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158616 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121805 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31234 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76199 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9052 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19429 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->