### PR TITLE
[Test coverage] Dropdown options on https://codepen.io/mobalti/full/myPPmwL don't appear after re-opening select

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS <optgroup> animations should restart when the picker is reopened.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<title>Test that animations for the select optgroups restart when re-opening select</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+optgroup {
+  animation: fade-in 1ms forwards;
+  opacity: 0;
+}
+
+@keyframes fade-in {
+  to {
+    opacity: 1;
+  }
+}
+</style>
+
+<select>
+  <optgroup>
+    <option>one</option>
+    <option>two</option>
+  </optgroup>
+</select>
+
+<script>
+const select = document.querySelector("select");
+const optgroup = document.querySelector("optgroup");
+
+function waitForAnimationEnd(element) {
+  return new Promise(resolve => element.addEventListener("animationend", resolve, { once: true }));
+}
+
+promise_test(async t => {
+  // Open picker and wait for the animation to complete.
+  await test_driver.bless();
+  assert_equals(getComputedStyle(optgroup).opacity, "0",
+    "optgroup opacity should be 0 before opening the picker.");
+  select.showPicker();
+  assert_true(select.matches(":open"));
+
+  await waitForAnimationEnd(optgroup);
+  assert_equals(getComputedStyle(optgroup).opacity, "1",
+    "optgroup opacity should be 1 after animation completes on first open.");
+
+  // Close the picker.
+  await test_driver.click(select);
+  assert_false(select.matches(":open"));
+
+  // Reopen the picker and verify the animation restarts and completes again.
+  await test_driver.bless();
+  assert_equals(getComputedStyle(optgroup).opacity, "0",
+    "optgroup opacity should be 0 before opening the picker a second time.");
+  select.showPicker();
+  assert_true(select.matches(":open"));
+
+  await waitForAnimationEnd(optgroup);
+  assert_equals(getComputedStyle(optgroup).opacity, "1",
+    "optgroup opacity should be 1 after animation completes on second open.");
+
+  // Close the picker.
+  await test_driver.click(select);
+}, "<optgroup> animations should restart when the picker is reopened.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS <option> animations should restart when the picker is reopened.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>Test that animations for the select options restart when re-opening select</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+option {
+  animation: fade-in 1ms forwards;
+  opacity: 0;
+}
+
+@keyframes fade-in {
+  to {
+    opacity: 1;
+  }
+}
+</style>
+
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+const select = document.querySelector("select");
+const firstOption = document.querySelector("option");
+
+function waitForAnimationEnd(element) {
+  return new Promise(resolve => element.addEventListener("animationend", resolve, { once: true }));
+}
+
+promise_test(async t => {
+  // Open picker and wait for the animation to complete.
+  await test_driver.bless();
+  assert_equals(getComputedStyle(firstOption).opacity, "0",
+    "option opacity should be 0 before opening the picker.");
+  select.showPicker();
+  assert_true(select.matches(":open"));
+
+  await waitForAnimationEnd(firstOption);
+  assert_equals(getComputedStyle(firstOption).opacity, "1",
+    "option opacity should be 1 after animation completes on first open.");
+
+  // Close the picker.
+  await test_driver.click(select);
+  assert_false(select.matches(":open"));
+
+  // Reopen the picker and verify the animation restarts and completes again.
+  await test_driver.bless();
+  assert_equals(getComputedStyle(firstOption).opacity, "0",
+    "option opacity should be 0 before opening the picker a second time.");
+  select.showPicker();
+  assert_true(select.matches(":open"));
+
+  await waitForAnimationEnd(firstOption);
+  assert_equals(getComputedStyle(firstOption).opacity, "1",
+    "option opacity should be 1 after animation completes on second open.");
+
+  // Close the picker.
+  await test_driver.click(select);
+}, "<option> animations should restart when the picker is reopened.");
+</script>


### PR DESCRIPTION
#### 11c24e59966306461056dfc2fdb6b629c25847ce
<pre>
[Test coverage] Dropdown options on <a href="https://codepen.io/mobalti/full/myPPmwL">https://codepen.io/mobalti/full/myPPmwL</a> don&apos;t appear after re-opening select
<a href="https://bugs.webkit.org/show_bug.cgi?id=308954">https://bugs.webkit.org/show_bug.cgi?id=308954</a>
<a href="https://rdar.apple.com/171478911">rdar://171478911</a>

Reviewed by NOBODY (OOPS!).

The demo has a fade-in animation on every option element with `animation-fill-mode: forwards` with a non-animated style of `opacity: 0`.

The first time opening the picker, the animation runs fine, and ends with `opacity: 1`.
However, the second time, the animation is not being re-ran and the non-animated style of `opacity: 0` is used, effectively hiding the options.

We need to cancel animations to allow them to restart next time we re-open the picker.
This bug occurs specifically with base appearance select pickers because of the special HTMLOptionElement::rendererIsNeeded() and HTMLOptGroupElement::rendererIsNeeded().

This issue was fixed as part of <a href="https://commits.webkit.org/308464@main">308464@main</a> by removing those methods, this PR adds tests.

Tests: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11c24e59966306461056dfc2fdb6b629c25847ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101112 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e46d18f2-1d9a-4ad8-b6c6-1ae53e9e4191) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113857 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81204 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06197915-3a02-4603-b00c-52e447c96450) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150659 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16102 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94617 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5ff4252-24d6-40e5-9f63-dd1db2df5d7c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15266 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13043 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3820 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158714 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12052 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121882 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20181 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16952 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122082 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20192 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132361 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76307 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17619 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9135 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-animation-restart.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-animation-restart.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19797 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->