### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/platform

### DIFF
--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -187,7 +187,7 @@ RetainPtr<NSAttributedString> AccessibilityObject::attributedStringForRange(cons
 
 RetainPtr<CTFontRef> fontFrom(const RenderStyle& style)
 {
-    return style.fontCascade().primaryFont()->ctFont();
+    return style.fontCascade().primaryFont().ctFont();
 }
 
 Color textColorFrom(const RenderStyle& style)

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -251,7 +251,7 @@ static void attributeStringSetStyle(NSMutableAttributedString *attrString, Rende
     auto& style = renderer->style();
 
     // Set basic font info.
-    attributedStringSetFont(attrString, style.fontCascade().primaryFont()->ctFont(), range);
+    attributedStringSetFont(attrString, style.fontCascade().primaryFont().ctFont(), range);
 
     if (style.textDecorationLineInEffect().hasUnderline())
         attributedStringSetNumber(attrString, AccessibilityTokenUnderline, @YES, range);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4999,7 +4999,7 @@ RefPtr<Font> Editor::fontForSelection(bool& hasMultipleFonts)
             if (!style)
                 return nullptr;
             ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-            font = const_cast<Font*>(style->fontCascade().primaryFont().ptr());
+            font = const_cast<Font*>(&style->fontCascade().primaryFont());
         }
 
         if (nodeToRemove)

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -358,10 +358,10 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
         [attributes removeObjectForKey:NSStrikethroughStyleAttributeName];
 
     CheckedRef fontCascade = style.fontCascade();
-    if (auto ctFont = fontCascade->primaryFont()->ctFont())
+    if (auto ctFont = fontCascade->primaryFont().ctFont())
         [attributes setObject:(__bridge PlatformFont *)ctFont forKey:NSFontAttributeName];
     else {
-        auto size = fontCascade->primaryFont()->platformData().size();
+        auto size = fontCascade->primaryFont().platformData().size();
 #if PLATFORM(IOS_FAMILY)
         PlatformFont *platformFont = [PlatformFontClass systemFontOfSize:size];
 #else

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -215,7 +215,7 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         CheckedRef boundaryOwnerStyle = inlineItemList[boundaryIndex].layoutBox().parent().style();
         auto boundaryTextAutospace = boundaryOwnerStyle->textAutospace();
         if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox->content().characterAt(start), lastCharacterFromPreviousRun))
-            spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(boundaryOwnerStyle->fontCascade().primaryFont()));
+            spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(protect(boundaryOwnerStyle->fontCascade().primaryFont())));
 
         lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(content);
         lastCharacterDepth = currentCharacterDepth;
@@ -781,7 +781,7 @@ static void handleTextSpacing(TextSpacing::SpacingState& spacingState, Trimmable
         // We need to store information about spacing added between inline text items since it needs to be trimmed during line breaking if the consecutive items are placed on different lines
         auto characterClass = TextSpacing::characterClass(inlineTextItem.content().characterAt(0));
         if (autospace.shouldApplySpacing(spacingState.lastCharacterClassFromPreviousRun, characterClass))
-            trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(inlineTextItem.style().fontCascade().primaryFont()));
+            trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(protect(inlineTextItem.style().fontCascade().primaryFont())));
 
         auto lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(inlineTextItem.content());
         spacingState.lastCharacterClassFromPreviousRun = TextSpacing::characterClass(lastCharacterFromPreviousRun);
@@ -820,7 +820,7 @@ void InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing(InlineItemLis
                 auto width = InlineLayoutUnit { };
                 auto mayHaveGlyphOverflow = [&] {
                     if (currentInlineTextBox != &inlineTextItem->inlineTextBox()) {
-                        currentInlineTextBoxMayHaveGlyphOverflow = !inlineTextItem->inlineTextBox().canUseSimpleFontCodePath() || fontCascade->primaryFont()->origin() == FontOrigin::Remote;
+                        currentInlineTextBoxMayHaveGlyphOverflow = !inlineTextItem->inlineTextBox().canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
                         currentInlineTextBox = &inlineTextItem->inlineTextBox();
                     }
                     return currentInlineTextBoxMayHaveGlyphOverflow;
@@ -861,7 +861,7 @@ bool InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache(co
     CheckedRef fontCascade = style->fontCascade();
     auto [ deferNonWhitespaceMeasurement, deferWhitespaceMeasurement ] = shouldDeferTextMeasurement(inlineTextBox);
     auto singleSpaceWidth = !deferWhitespaceMeasurement ? std::optional(std::max(0.f, TextUtil::singleSpaceWidth(fontCascade.get(), inlineTextBox.canUseSimplifiedContentMeasuring()))) : std::nullopt;
-    auto mayHaveGlyphOverflow = !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont()->origin() == FontOrigin::Remote;
+    auto mayHaveGlyphOverflow = !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
 
     inlineItemList.reserveCapacity(inlineItemList.size() + breakingPositions->size());
     size_t previousPosition = 0;
@@ -931,7 +931,7 @@ void InlineItemsBuilder::handleTextContent(const InlineTextBox& inlineTextBox, I
     CheckedRef style = inlineTextBox.style();
     CheckedRef fontCascade = style->fontCascade();
     auto [ deferNonWhitespaceMeasurement, deferWhitespaceMeasurement ] = shouldDeferTextMeasurement(inlineTextBox);
-    auto mayHaveGlyphOverflow = !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont()->origin() == FontOrigin::Remote;
+    auto mayHaveGlyphOverflow = !inlineTextBox.canUseSimpleFontCodePath() || fontCascade->primaryFont().origin() == FontOrigin::Remote;
     auto singleSpaceWidth = !deferWhitespaceMeasurement ? std::optional(std::max(0.f, TextUtil::singleSpaceWidth(fontCascade.get(), inlineTextBox.canUseSimplifiedContentMeasuring()))) : std::nullopt;
     auto shouldPreserveSpacesAndTabs = TextUtil::shouldPreserveSpacesAndTabs(inlineTextBox);
     auto shouldPreserveNewline = TextUtil::shouldPreserveNewline(inlineTextBox);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -686,7 +686,7 @@ void LineBoxBuilder::adjustIdeographicBaselineIfApplicable(LineBox& lineBox)
             return false;
 
         auto primaryFontRequiresIdeographicBaseline = [&] (auto& style) {
-            return style.fontDescription().orientation() == FontOrientation::Vertical || style.fontCascade().primaryFont()->hasVerticalGlyphs();
+            return style.fontDescription().orientation() == FontOrientation::Vertical || style.fontCascade().primaryFont().hasVerticalGlyphs();
         };
 
         if (m_fallbackFontRequiresIdeographicBaseline || primaryFontRequiresIdeographicBaseline(rootInlineBoxStyle))

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -51,7 +51,7 @@ namespace Layout {
 
 InlineLayoutUnit TextUtil::singleSpaceWidth(const FontCascade& fontCascade, bool canUseSimplifiedContentMeasuring)
 {
-    auto width = canUseSimplifiedContentMeasuring ? fontCascade.primaryFont()->spaceWidth() : fontCascade.widthOfSpaceString();
+    auto width = canUseSimplifiedContentMeasuring ? fontCascade.primaryFont().spaceWidth() : fontCascade.widthOfSpaceString();
     if (std::isnan(width) || std::isinf(width)) [[unlikely]]
         return std::isnan(width) ? 0.0f : maxInlineLayoutUnit();
     return width;

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -433,7 +433,7 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
     if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderBox)) {
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
         if (renderImage->isMultiRepresentationHEIC())
-            return snapToInt(marginBoxBottom, *renderImage) - LayoutUnit::fromFloatRound(renderImage->style().fontCascade().primaryFont()->metricsForMultiRepresentationHEIC().descent);
+            return snapToInt(marginBoxBottom, *renderImage) - LayoutUnit::fromFloatRound(renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC().descent);
 #endif
         return { };
     }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -67,7 +67,7 @@ static std::tuple<float, float> glyphOverflowInInlineDirection(size_t firstTextB
         auto character = isLeading ? textContent[0] : textContent[textContent.length() - 1];
         auto& fontCascade = textBox.style().fontCascade();
         auto glyphData = fontCascade.glyphDataForCharacter(character, !isLeftToRightDirection);
-        return (glyphData.font ? *glyphData.font : fontCascade.primaryFont().get()).boundsForGlyph(glyphData.glyph);
+        return (glyphData.font ? *glyphData.font : fontCascade.primaryFont()).boundsForGlyph(glyphData.glyph);
     };
 
     auto leadingOverflow = [&] {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -434,7 +434,7 @@ static inline std::optional<Layout::BlockLayoutState::LineGrid> lineGrid(const R
             lineGridOffset = lineGridOffset.transposedSize();
         }
 
-        auto columnWidth = lineGrid->style().fontCascade().primaryFont()->maxCharWidth();
+        auto columnWidth = lineGrid->style().fontCascade().primaryFont().maxCharWidth();
         auto rowHeight = LayoutUnit::fromFloatCeil(lineGrid->style().computedLineHeight());
         auto topRowOffset = lineGrid->borderAndPaddingBefore();
 

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -315,10 +315,8 @@ FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeT
         return { };
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
-    if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && renderImage->isMultiRepresentationHEIC()) {
-        auto metrics = renderImage->style().fontCascade().primaryFont()->metricsForMultiRepresentationHEIC();
-        return metrics.size();
-    }
+    if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && renderImage->isMultiRepresentationHEIC())
+        return renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC().size();
 #endif
 
     if (image->drawsSVGImage() && sizeType == UsedSize)

--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -79,14 +79,14 @@ public:
     WEBCORE_EXPORT bool needsNetworkProcess() const;
 #endif
 
-    const String& unblockURLHost() const { return m_unblockURLHost; }
-    const URL& unreachableURL() const { return m_unreachableURL; }
+    const String& unblockURLHost() const LIFETIME_BOUND { return m_unblockURLHost; }
+    const URL& unreachableURL() const LIFETIME_BOUND { return m_unreachableURL; }
     void setUnreachableURL(const URL& url) { m_unreachableURL = url; }
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     std::optional<URL> evaluatedURL() const { return m_evaluatedURL; }
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    const String& configurationPath() const { return m_configurationPath; }
+    const String& configurationPath() const LIFETIME_BOUND { return m_configurationPath; }
     void setConfigurationPath(const String& path) { m_configurationPath = path; }
 #endif
 #elif HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)

--- a/Source/WebCore/platform/ContentType.h
+++ b/Source/WebCore/platform/ContentType.h
@@ -50,7 +50,7 @@ public:
     WEBCORE_EXPORT String containerType() const;
     Vector<String> codecs() const;
     Vector<String> profiles() const;
-    const String& raw() const { return m_type; }
+    const String& raw() const LIFETIME_BOUND { return m_type; }
     bool isEmpty() const { return m_type.isEmpty(); }
 
     bool typeWasInferredFromExtension() const { return m_typeWasInferredFromExtension; }

--- a/Source/WebCore/platform/ContextMenu.h
+++ b/Source/WebCore/platform/ContextMenu.h
@@ -44,7 +44,7 @@ public:
     ContextMenu();
 
     void setItems(const Vector<ContextMenuItem>& items) { m_items = items; }
-    const Vector<ContextMenuItem>& items() const { return m_items; }
+    const Vector<ContextMenuItem>& items() const LIFETIME_BOUND { return m_items; }
 
     void appendItem(const ContextMenuItem& item) { m_items.append(item); } 
 

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -222,9 +222,9 @@ public:
 
     void setTitle(String&& title) { m_title = WTF::move(title); }
     void setTitle(const String& title) { m_title = title; }
-    const String& title() const { return m_title; }
+    const String& title() const LIFETIME_BOUND { return m_title; }
 
-    const Vector<ContextMenuItem>& subMenuItems() const { return m_subMenuItems; }
+    const Vector<ContextMenuItem>& subMenuItems() const LIFETIME_BOUND { return m_subMenuItems; }
 private:
     ContextMenuItemType m_type;
     ContextMenuAction m_action;

--- a/Source/WebCore/platform/Cursor.h
+++ b/Source/WebCore/platform/Cursor.h
@@ -156,7 +156,7 @@ public:
 
     Type type() const;
     RefPtr<Image> image() const { return m_image; }
-    const IntPoint& hotSpot() const { return m_hotSpot; }
+    const IntPoint& hotSpot() const LIFETIME_BOUND { return m_hotSpot; }
 
 #if ENABLE(MOUSE_CURSOR_SCALE)
     // Image scale in image pixels per logical (UI) pixel.

--- a/Source/WebCore/platform/Decimal.h
+++ b/Source/WebCore/platform/Decimal.h
@@ -158,7 +158,7 @@ public:
     {
     }
 
-    const EncodedData& value() const { return m_data; }
+    const EncodedData& value() const LIFETIME_BOUND { return m_data; }
 
     friend bool operator==(const Decimal&, const Decimal&);
     friend bool operator!=(const Decimal&, const Decimal&);

--- a/Source/WebCore/platform/DragData.h
+++ b/Source/WebCore/platform/DragData.h
@@ -98,8 +98,8 @@ public:
     void getDragFileDescriptorData(int& size, String& pathname);
     void getDragFileContentData(int size, void* dataBlob);
 #endif
-    const IntPoint& clientPosition() const { return m_clientPosition; }
-    const IntPoint& globalPosition() const { return m_globalPosition; }
+    const IntPoint& clientPosition() const LIFETIME_BOUND { return m_clientPosition; }
+    const IntPoint& globalPosition() const LIFETIME_BOUND { return m_globalPosition; }
     void setClientPosition(const IntPoint& clientPosition) { m_clientPosition = clientPosition; }
     OptionSet<DragApplicationFlags> flags() const { return m_applicationFlags; }
     DragDataRef platformData() const { return m_platformDragData; }
@@ -117,12 +117,12 @@ public:
     unsigned numberOfFiles() const;
     OptionSet<DragDestinationAction> dragDestinationActionMask() const { return m_dragDestinationActionMask; }
     void setFileNames(Vector<String>& fileNames) { m_fileNames = WTF::move(fileNames); }
-    const Vector<String>& fileNames() const { return m_fileNames; }
+    const Vector<String>& fileNames() const LIFETIME_BOUND { return m_fileNames; }
     void setPromisedFileMIMETypes(Vector<String>&& types) { m_promisedFileMIMETypes = WTF::move(types); }
-    const Vector<String>& promisedFileMIMETypes() const { return m_promisedFileMIMETypes; }
+    const Vector<String>& promisedFileMIMETypes() const LIFETIME_BOUND { return m_promisedFileMIMETypes; }
     void disallowFileAccess();
 #if PLATFORM(COCOA)
-    const String& pasteboardName() const { return m_pasteboardName; }
+    const String& pasteboardName() const LIFETIME_BOUND { return m_pasteboardName; }
     bool containsURLTypeIdentifier() const;
     bool containsPromise() const;
 #endif

--- a/Source/WebCore/platform/DragImage.h
+++ b/Source/WebCore/platform/DragImage.h
@@ -128,7 +128,7 @@ public:
 
     void setVisiblePath(const Path& path) { m_visiblePath = path; }
     bool hasVisiblePath() const { return !!m_visiblePath; }
-    const std::optional<Path>& visiblePath() const { return m_visiblePath; }
+    const std::optional<Path>& visiblePath() const LIFETIME_BOUND { return m_visiblePath; }
 
     explicit operator bool() const { return !!m_dragImageRef; }
     DragImageRef get() const { return m_dragImageRef; }

--- a/Source/WebCore/platform/FileChooser.h
+++ b/Source/WebCore/platform/FileChooser.h
@@ -91,7 +91,7 @@ public:
     // FIXME: We should probably just pass file paths that could be virtual paths with proper display names rather than passing structs.
     void chooseFiles(const Vector<FileChooserFileInfo>& files);
 
-    const FileChooserSettings& settings() const { return m_settings; }
+    const FileChooserSettings& settings() const LIFETIME_BOUND { return m_settings; }
 
 private:
     FileChooser(FileChooserClient&, const FileChooserSettings&);

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -46,7 +46,7 @@ public:
         : m_supportedImageMIMETypesForEncoding(WTF::move(supportedImageMIMETypesForEncoding))
     { }
 
-    const HashSet<String, ASCIICaseInsensitiveHash>& supportedImageMIMETypesForEncoding() const { return m_supportedImageMIMETypesForEncoding; }
+    const HashSet<String, ASCIICaseInsensitiveHash>& supportedImageMIMETypesForEncoding() const LIFETIME_BOUND { return m_supportedImageMIMETypesForEncoding; }
 
 private:
     HashSet<String, ASCIICaseInsensitiveHash> m_supportedImageMIMETypesForEncoding;

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -172,7 +172,7 @@ public:
     virtual bool readDataBuffer(SharedBuffer&, const String& type, const AtomString& name, PresentationSize preferredPresentationSize = { }) = 0;
 #endif
 
-    const String& contentOrigin() const { return m_contentOrigin; }
+    const String& contentOrigin() const LIFETIME_BOUND { return m_contentOrigin; }
     void setContentOrigin(const String& contentOrigin) { m_contentOrigin = contentOrigin; }
 
 private:
@@ -287,7 +287,7 @@ public:
 #if PLATFORM(MAC)
     explicit Pasteboard(std::unique_ptr<PasteboardContext>&&, const String& pasteboardName, const Vector<String>& promisedFilePaths = { }, const Vector<String>& promisedFileMIMETypes = { });
 #endif
-    const Vector<String>& promisedFileMIMETypes() const { return m_promisedFileMIMETypes; }
+    const Vector<String>& promisedFileMIMETypes() const LIFETIME_BOUND { return m_promisedFileMIMETypes; }
 
 #if PLATFORM(COCOA)
 #if ENABLE(DRAG_SUPPORT)
@@ -305,9 +305,9 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    const String& name() const { return m_pasteboardName; }
+    const String& name() const LIFETIME_BOUND { return m_pasteboardName; }
 #elif PLATFORM(GTK) || PLATFORM(WPE)
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 #else
     const String& name() const { return emptyString(); }
 #endif
@@ -321,7 +321,7 @@ public:
 #if PLATFORM(WIN)
     COMPtr<IDataObject> dataObject() const { return m_dataObject; }
     WEBCORE_EXPORT void setExternalDataObject(IDataObject*);
-    const DragDataMap& dragDataMap() const { return m_dragDataMap; }
+    const DragDataMap& dragDataMap() const LIFETIME_BOUND { return m_dragDataMap; }
     void writeURLToWritableDataObject(const URL&, const String&);
     COMPtr<WCDataObject> writableDataObject() const { return m_writableDataObject; }
     void writeImageToDataObject(Element&, const URL&); // FIXME: Layering violation.

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -62,9 +62,9 @@ public:
         bool isAcceleratedEffectKeyframe() const final { return true; }
 
         void clearProperty(AcceleratedEffectProperty);
-        const OptionSet<AcceleratedEffectProperty>& animatedProperties() const { return m_animatedProperties; }
+        const OptionSet<AcceleratedEffectProperty>& animatedProperties() const LIFETIME_BOUND { return m_animatedProperties; }
         const RefPtr<TimingFunction>& timingFunction() const { return m_timingFunction; }
-        const AcceleratedEffectValues& values() const { return m_values; }
+        const AcceleratedEffectValues& values() const LIFETIME_BOUND { return m_values; }
 
     private:
         double m_offset;
@@ -88,21 +88,21 @@ public:
     void clearProperty(AcceleratedEffectProperty);
 
     // Encoding and decoding support
-    const AnimationEffectTiming& timing() const { return m_timing; }
+    const AnimationEffectTiming& timing() const LIFETIME_BOUND { return m_timing; }
     const RefPtr<AcceleratedTimeline>& timeline() const { return m_timeline; }
-    const TimelineIdentifier& timelineIdentifier() const { return m_timelineIdentifier; }
-    const Vector<Keyframe>& keyframes() const { return m_keyframes; }
+    const TimelineIdentifier& timelineIdentifier() const LIFETIME_BOUND { return m_timelineIdentifier; }
+    const Vector<Keyframe>& keyframes() const LIFETIME_BOUND { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
     CompositeOperation compositeOperation() const final { return m_compositeOperation; }
     const RefPtr<TimingFunction>& defaultKeyframeTimingFunction() const { return m_defaultKeyframeTimingFunction; }
-    const OptionSet<AcceleratedEffectProperty>& animatedProperties() const { return m_animatedProperties; }
+    const OptionSet<AcceleratedEffectProperty>& animatedProperties() const LIFETIME_BOUND { return m_animatedProperties; }
     bool paused() const { return m_paused; }
     double playbackRate() const { return m_playbackRate; }
     std::optional<WebAnimationTime> startTime() const { return m_startTime; }
     std::optional<WebAnimationTime> holdTime() const { return m_holdTime; }
 
-    const OptionSet<AcceleratedEffectProperty>& disallowedProperties() const { return m_disallowedProperties; }
-    const OptionSet<AcceleratedEffectProperty>& replacedProperties() const { return m_replacedProperties; }
+    const OptionSet<AcceleratedEffectProperty>& disallowedProperties() const LIFETIME_BOUND { return m_disallowedProperties; }
+    const OptionSet<AcceleratedEffectProperty>& replacedProperties() const LIFETIME_BOUND { return m_replacedProperties; }
 
     bool animatesTransformRelatedProperty() const;
     WEBCORE_EXPORT bool hasHighImpact() const;

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -40,11 +40,11 @@ public:
     static Ref<AcceleratedEffectStack> create();
 
     bool hasEffects() const;
-    const AcceleratedEffects& primaryLayerEffects() const { return m_primaryLayerEffects; }
-    const AcceleratedEffects& backdropLayerEffects() const { return m_backdropLayerEffects; }
+    const AcceleratedEffects& primaryLayerEffects() const LIFETIME_BOUND { return m_primaryLayerEffects; }
+    const AcceleratedEffects& backdropLayerEffects() const LIFETIME_BOUND { return m_backdropLayerEffects; }
     void setEffects(AcceleratedEffects&&);
 
-    const AcceleratedEffectValues& baseValues() const { return m_baseValues; }
+    const AcceleratedEffectValues& baseValues() const LIFETIME_BOUND { return m_baseValues; }
     void setBaseValues(AcceleratedEffectValues&&);
 
     virtual ~AcceleratedEffectStack() = default;

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.h
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.h
@@ -55,8 +55,8 @@ public:
     // Encoding support.
     using Data = Variant<Seconds, ProgressResolutionData>;
     WEBCORE_EXPORT static Ref<AcceleratedTimeline> create(TimelineIdentifier&&, Data&&);
-    const TimelineIdentifier& identifier() const { return m_identifier; }
-    const Data& data() const { return m_data; }
+    const TimelineIdentifier& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const Data& data() const LIFETIME_BOUND { return m_data; }
 
     virtual ~AcceleratedTimeline() = default;
 

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -84,7 +84,7 @@ public:
         return otherLinear && m_points == otherLinear->m_points;
     }
 
-    const Vector<Point>& points() const { return m_points; }
+    const Vector<Point>& points() const LIFETIME_BOUND { return m_points; }
 
     static const LinearTimingFunction& identity()
     {

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -75,10 +75,10 @@ public:
     // Channels
     unsigned numberOfChannels() const { return m_channels.size(); }
 
-    AudioChannel* channel(unsigned channel) { return m_channels[channel].get(); }
-    const AudioChannel* channel(unsigned channel) const { return m_channels[channel].get(); }
-    AudioChannel* channelByType(unsigned type);
-    const AudioChannel* channelByType(unsigned type) const;
+    AudioChannel* channel(unsigned channel) LIFETIME_BOUND { return m_channels[channel].get(); }
+    const AudioChannel* channel(unsigned channel) const LIFETIME_BOUND { return m_channels[channel].get(); }
+    AudioChannel* channelByType(unsigned type) LIFETIME_BOUND;
+    const AudioChannel* channelByType(unsigned type) const LIFETIME_BOUND;
 
     // Number of sample-frames
     size_t length() const { return m_length; }

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -89,12 +89,12 @@ public:
 
     void callRenderCallback(AudioBus& destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition);
 
-    const String& inputDeviceId() const { return m_inputDeviceId; }
+    const String& inputDeviceId() const LIFETIME_BOUND { return m_inputDeviceId; }
     unsigned numberOfInputChannels() const { return m_numberOfInputChannels; }
     unsigned numberOfOutputChannels() const { return m_numberOfOutputChannels; }
 
 #if PLATFORM(IOS_FAMILY)
-    const String& sceneIdentifier() const { return m_sceneIdentifier; }
+    const String& sceneIdentifier() const LIFETIME_BOUND { return m_sceneIdentifier; }
     virtual void setSceneIdentifier(const String& identifier) { m_sceneIdentifier = identifier; }
 #endif
 

--- a/Source/WebCore/platform/audio/FFTFrame.h
+++ b/Source/WebCore/platform/audio/FFTFrame.h
@@ -65,10 +65,10 @@ public:
     void multiply(const FFTFrame& frame); // multiplies ourself with frame : effectively operator*=()
     void scaleFFT(float factor);
 
-    AudioFloatArray& realData() { return m_realData; }
-    AudioFloatArray& imagData() { return m_imagData; }
-    const AudioFloatArray& realData() const { return m_realData; }
-    const AudioFloatArray& imagData() const { return m_imagData; }
+    AudioFloatArray& realData() LIFETIME_BOUND { return m_realData; }
+    AudioFloatArray& imagData() LIFETIME_BOUND { return m_imagData; }
+    const AudioFloatArray& realData() const LIFETIME_BOUND { return m_realData; }
+    const AudioFloatArray& imagData() const LIFETIME_BOUND { return m_imagData; }
 
     static int minFFTSize();
     static int maxFFTSize();
@@ -95,7 +95,7 @@ private:
     void interpolateFrequencyComponents(const FFTFrame& frame1, const FFTFrame& frame2, double x);
 
 #if USE(ACCELERATE)
-    DSPSplitComplex& dspSplitComplex() { return m_frame; }
+    DSPSplitComplex& dspSplitComplex() LIFETIME_BOUND { return m_frame; }
     DSPSplitComplex dspSplitComplex() const { return m_frame; }
 
     static FFTSetup fftSetupForSize(unsigned fftSize);

--- a/Source/WebCore/platform/audio/HRTFDatabaseLoader.h
+++ b/Source/WebCore/platform/audio/HRTFDatabaseLoader.h
@@ -57,7 +57,7 @@ public:
     // waitForLoaderThreadCompletion() may be called more than once and is thread-safe.
     void waitForLoaderThreadCompletion();
     
-    HRTFDatabase* database() { return m_hrtfDatabase.get(); }
+    HRTFDatabase* database() LIFETIME_BOUND { return m_hrtfDatabase.get(); }
 
     float databaseSampleRate() const { return m_databaseSampleRate; }
     

--- a/Source/WebCore/platform/audio/HRTFElevation.h
+++ b/Source/WebCore/platform/audio/HRTFElevation.h
@@ -64,8 +64,8 @@ public:
     static std::unique_ptr<HRTFElevation> createByInterpolatingSlices(HRTFElevation* hrtfElevation1, HRTFElevation* hrtfElevation2, float x, float sampleRate);
 
     // Returns the list of left or right ear HRTFKernels for all the azimuths going from 0 to 360 degrees.
-    HRTFKernelList* kernelListL() { return m_kernelListL.get(); }
-    HRTFKernelList* kernelListR() { return m_kernelListR.get(); }
+    HRTFKernelList* kernelListL() LIFETIME_BOUND { return m_kernelListL.get(); }
+    HRTFKernelList* kernelListR() LIFETIME_BOUND { return m_kernelListR.get(); }
 
     double elevationAngle() const { return m_elevationAngle; }
     unsigned numberOfAzimuths() const { return NumberOfTotalAzimuths; }

--- a/Source/WebCore/platform/audio/HRTFKernel.h
+++ b/Source/WebCore/platform/audio/HRTFKernel.h
@@ -62,7 +62,7 @@ public:
     // Given two HRTFKernels, and an interpolation factor x: 0 -> 1, returns an interpolated HRTFKernel.
     static RefPtr<HRTFKernel> createInterpolatedKernel(HRTFKernel* kernel1, HRTFKernel* kernel2, float x);
   
-    FFTFrame* fftFrame() { return m_fftFrame.get(); }
+    FFTFrame* fftFrame() LIFETIME_BOUND { return m_fftFrame.get(); }
     
     size_t fftSize() const;
     float frameDelay() const { return m_frameDelay; }

--- a/Source/WebCore/platform/audio/ReverbConvolver.h
+++ b/Source/WebCore/platform/audio/ReverbConvolver.h
@@ -60,7 +60,7 @@ public:
 
     size_t impulseResponseLength() const { return m_impulseResponseLength; }
 
-    ReverbInputBuffer* inputBuffer() { return &m_inputBuffer; }
+    ReverbInputBuffer& inputBuffer() LIFETIME_BOUND { return m_inputBuffer; }
 
     bool useBackgroundThreads() const { return m_useBackgroundThreads; }
 

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
@@ -108,8 +108,7 @@ ReverbConvolverStage::~ReverbConvolverStage() = default;
 
 void ReverbConvolverStage::processInBackground(ReverbConvolver* convolver, size_t framesToProcess)
 {
-    ReverbInputBuffer* inputBuffer = convolver->inputBuffer();
-    auto source = inputBuffer->directReadFrom(&m_inputReadIndex, framesToProcess);
+    auto source = convolver->inputBuffer().directReadFrom(&m_inputReadIndex, framesToProcess);
     process(source);
 }
 

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
@@ -58,9 +58,9 @@ public:
     OSStatus mixFrom(const AudioBufferList&, size_t count = SIZE_MAX);
     OSStatus copyTo(AudioBufferList&, size_t count = SIZE_MAX);
 
-    const AudioStreamBasicDescription& streamDescription() const { return m_internalFormat.streamDescription(); }
-    const WebAudioBufferList& bufferList() const { return m_bufferList; }
-    WebAudioBufferList& bufferList() { return m_bufferList; }
+    const AudioStreamBasicDescription& streamDescription() const LIFETIME_BOUND { return m_internalFormat.streamDescription(); }
+    const WebAudioBufferList& bufferList() const LIFETIME_BOUND { return m_bufferList; }
+    WebAudioBufferList& bufferList() LIFETIME_BOUND { return m_bufferList; }
 
     uint32_t sampleCapacity() const { return m_sampleCapacity; }
     uint32_t sampleCount() const { return m_sampleCount; }

--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -44,7 +44,7 @@ public:
     CAAudioStreamDescription(double sampleRate, uint32_t channels, PCMFormat, IsInterleaved);
     ~CAAudioStreamDescription();
 
-    const PlatformDescription& platformDescription() const final;
+    const PlatformDescription& platformDescription() const LIFETIME_BOUND final;
 
     PCMFormat format() const final;
 
@@ -67,8 +67,8 @@ public:
     bool operator==(const AudioStreamBasicDescription&) const;
     bool operator==(const AudioStreamDescription&) const;
 
-    const AudioStreamBasicDescription& streamDescription() const;
-    AudioStreamBasicDescription& streamDescription();
+    const AudioStreamBasicDescription& streamDescription() const LIFETIME_BOUND;
+    AudioStreamBasicDescription& streamDescription() LIFETIME_BOUND;
 
 private:
     AudioStreamBasicDescription m_streamDescription;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -123,12 +123,12 @@ public:
     WEBCORE_EXPORT static std::unique_ptr<InProcessCARingBuffer> allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount);
     WEBCORE_EXPORT ~InProcessCARingBuffer();
 
-    TimeBoundsBuffer& timeBoundsBufferForTesting() { return timeBoundsBuffer(); }
+    TimeBoundsBuffer& timeBoundsBufferForTesting() LIFETIME_BOUND { return timeBoundsBuffer(); }
 
 protected:
     WEBCORE_EXPORT InProcessCARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams, Vector<uint8_t>&& buffer);
-    void* data() final { return m_buffer.mutableSpan().data(); }
-    TimeBoundsBuffer& timeBoundsBuffer() final { return m_timeBoundsBuffer; }
+    void* data() LIFETIME_BOUND final { return m_buffer.mutableSpan().data(); }
+    TimeBoundsBuffer& timeBoundsBuffer() LIFETIME_BOUND final { return m_timeBoundsBuffer; }
 
 private:
     Vector<uint8_t> m_buffer;

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.h
@@ -54,7 +54,7 @@ public:
 
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::AVFObjC; }
 
-    const CAAudioStreamDescription& description() const;
+    const CAAudioStreamDescription& description() const LIFETIME_BOUND;
     CMSampleBufferRef sampleBuffer() const;
 
 private:

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -55,7 +55,7 @@ public:
     void reset();
     WEBCORE_EXPORT void setSampleCount(size_t);
 
-    AudioBufferList* list() const { return m_list.get(); }
+    AudioBufferList* list() const LIFETIME_BOUND { return m_list.get(); }
     operator AudioBufferList&() const { return *m_list; }
 
     uint32_t bufferCount() const;

--- a/Source/WebCore/platform/audio/gstreamer/GStreamerAudioData.h
+++ b/Source/WebCore/platform/audio/gstreamer/GStreamerAudioData.h
@@ -52,7 +52,7 @@ public:
 
     void setSample(GRefPtr<GstSample>&& sample) { m_sample = WTF::move(sample); }
     const GRefPtr<GstSample>& getSample() const { return m_sample; }
-    const GstAudioInfo& getAudioInfo() const { return m_audioInfo; }
+    const GstAudioInfo& getAudioInfo() const LIFETIME_BOUND { return m_audioInfo; }
     uint32_t channelCount() const { return GST_AUDIO_INFO_CHANNELS(&m_audioInfo); }
 
 private:

--- a/Source/WebCore/platform/audio/gstreamer/GStreamerAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/gstreamer/GStreamerAudioStreamDescription.h
@@ -52,7 +52,7 @@ public:
 
     ~GStreamerAudioStreamDescription() = default;
 
-    const PlatformDescription& platformDescription() const
+    const PlatformDescription& platformDescription() const LIFETIME_BOUND
     {
         m_platformDescription = { PlatformDescription::GStreamerAudioStreamDescription, reinterpret_cast<const AudioStreamBasicDescription*>(&m_info) };
 
@@ -101,7 +101,7 @@ public:
             m_caps = adoptGRef(gst_audio_info_to_caps(&m_info));
         return m_caps;
     }
-    const GstAudioInfo& getInfo() const { return m_info; }
+    const GstAudioInfo& getInfo() const LIFETIME_BOUND { return m_info; }
 
 private:
     GstAudioInfo m_info;

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
@@ -47,7 +47,7 @@ public:
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::GStreamer; }
 
     const GRefPtr<GstSample>& sample() const { return m_sample; }
-    const GstAudioInfo* info() const { return &m_info; }
+    const GstAudioInfo* info() const LIFETIME_BOUND { return &m_info; }
 
     bool isInterleaved() const;
     std::optional<Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<std::span<int32_t>>, Vector<std::span<float>>>> planesOfSamples(size_t);

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -75,7 +75,7 @@ private:
     void updateSpatialExperience();
 
     void setSceneIdentifier(const String&) final;
-    const String& sceneIdentifier() const final { return m_sceneIdentifier; }
+    const String& sceneIdentifier() const LIFETIME_BOUND final { return m_sceneIdentifier; }
 
     void setSoundStageSize(SoundStageSize) final;
     SoundStageSize soundStageSize() const final { return m_soundStageSize; }

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -122,7 +122,7 @@ public:
     MediaDeviceRouteClient* client() const { return m_client.get(); }
     void setClient(MediaDeviceRouteClient* client) { m_client = client; }
 
-    const WTF::UUID& identifier() const { return m_identifier; }
+    const WTF::UUID& identifier() const LIFETIME_BOUND { return m_identifier; }
     String deviceName() const;
     WebMediaDevicePlatformRoute *platformRoute() const;
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.h
@@ -39,17 +39,17 @@ class VideoPresentationLayerProvider {
 public:
     WEBCORE_EXPORT virtual ~VideoPresentationLayerProvider();
 
-    CocoaView *layerHostView() const { return m_layerHostView.get(); }
+    CocoaView *layerHostView() const LIFETIME_BOUND { return m_layerHostView.get(); }
     void setLayerHostView(RetainPtr<CocoaView>&& layerHostView) { m_layerHostView = WTF::move(layerHostView); }
 
-    WebAVPlayerLayer *playerLayer() const { return m_playerLayer.get(); }
+    WebAVPlayerLayer *playerLayer() const LIFETIME_BOUND { return m_playerLayer.get(); }
     virtual void setPlayerLayer(RetainPtr<WebAVPlayerLayer>&& layer) { m_playerLayer = WTF::move(layer); }
 
 #if PLATFORM(IOS_FAMILY)
-    WebAVPlayerLayerView *playerLayerView() const { return m_playerLayerView.get(); }
+    WebAVPlayerLayerView *playerLayerView() const LIFETIME_BOUND { return m_playerLayerView.get(); }
     void setPlayerLayerView(RetainPtr<WebAVPlayerLayerView>&& playerLayerView) { m_playerLayerView = WTF::move(playerLayerView); }
 
-    CocoaView *videoView() const { return m_videoView.get(); }
+    CocoaView *videoView() const LIFETIME_BOUND { return m_videoView.get(); }
     void setVideoView(RetainPtr<CocoaView>&& videoView) { m_videoView = WTF::move(videoView); }
 #endif
 

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -75,9 +75,9 @@ public:
 
     bool takeValueIfDifferent(KeyHandleValueVariant&&);
 
-    const KeyIDType& id() const { return m_id; }
-    const KeyHandleValueVariant& value() const { return m_value; }
-    KeyHandleValueVariant& value() { return m_value; }
+    const KeyIDType& id() const LIFETIME_BOUND { return m_id; }
+    const KeyHandleValueVariant& value() const LIFETIME_BOUND { return m_value; }
+    KeyHandleValueVariant& value() LIFETIME_BOUND { return m_value; }
     KeyStatus status() const { return m_status; }
     bool isStatusCurrentlyValid()
     {

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.h
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.h
@@ -49,12 +49,12 @@ class PlatformGamepad : public CanMakeWeakPtr<PlatformGamepad>, public CanMakeCh
 public:
     virtual ~PlatformGamepad() = default;
 
-    const String& id() const { return m_id; }
-    const String& mapping() const { return m_mapping; }
+    const String& id() const LIFETIME_BOUND { return m_id; }
+    const String& mapping() const LIFETIME_BOUND { return m_mapping; }
     unsigned index() const { return m_index; }
     virtual MonotonicTime lastUpdateTime() const { return m_lastUpdateTime; }
     MonotonicTime connectTime() const { return m_connectTime; }
-    const GamepadHapticEffectTypeSet& supportedEffectTypes() const { return m_supportedEffectTypes; }
+    const GamepadHapticEffectTypeSet& supportedEffectTypes() const LIFETIME_BOUND { return m_supportedEffectTypes; }
     
     virtual const Vector<SharedGamepadValue>& axisValues() const = 0;
     virtual const Vector<SharedGamepadValue>& buttonValues() const = 0;

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -48,8 +48,8 @@ class GameControllerGamepad final : public PlatformGamepad {
 public:
     GameControllerGamepad(GCController *, unsigned index);
 
-    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
-    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
     void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(CompletionHandler<void()>&&) final;
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -53,7 +53,7 @@ public:
 
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() LIFETIME_BOUND final { return m_gamepadVector; }
     void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -53,10 +53,10 @@ public:
 
     void stop(CompletionHandler<void()>&&);
 
-    CHHapticEngine *leftHandleEngine() { return m_leftHandleEngine.get(); }
-    CHHapticEngine *rightHandleEngine() { return m_rightHandleEngine.get(); }
-    CHHapticEngine *leftTriggerEngine() { return m_leftTriggerEngine.get(); }
-    CHHapticEngine *rightTriggerEngine() { return m_rightTriggerEngine.get(); }
+    CHHapticEngine *leftHandleEngine() LIFETIME_BOUND { return m_leftHandleEngine.get(); }
+    CHHapticEngine *rightHandleEngine() LIFETIME_BOUND { return m_rightHandleEngine.get(); }
+    CHHapticEngine *leftTriggerEngine() LIFETIME_BOUND { return m_leftTriggerEngine.get(); }
+    CHHapticEngine *rightTriggerEngine() LIFETIME_BOUND { return m_rightTriggerEngine.get(); }
 
 private:
     explicit GameControllerHapticEngines(GCController *);

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h
@@ -43,8 +43,8 @@ public:
     GamepadLibWPE(struct wpe_gamepad_provider*, uintptr_t, unsigned);
     virtual ~GamepadLibWPE();
 
-    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
-    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
 
     const struct wpe_gamepad* wpeGamepad() const { return m_gamepad.get(); }
 

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -55,7 +55,7 @@ public:
 
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() LIFETIME_BOUND final { return m_gamepadVector; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
@@ -43,13 +43,13 @@ class HIDGamepad : public PlatformGamepad {
 public:
     static std::unique_ptr<HIDGamepad> create(IOHIDDeviceRef, unsigned index);
 
-    const HIDDevice& hidDevice() const { return m_device; }
+    const HIDDevice& hidDevice() const LIFETIME_BOUND { return m_device; }
 
     void initialize();
     HIDInputType valueChanged(IOHIDValueRef);
 
-    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
-    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
 
     ASCIILiteral source() const final { return "HID"_s; }
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -56,7 +56,7 @@ public:
 
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() LIFETIME_BOUND final { return m_gamepadVector; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -51,7 +51,7 @@ public:
     // GamepadProvider
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() LIFETIME_BOUND final { return m_gamepadVector; }
     bool isMockGamepadProvider() const { return false; }
     void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
@@ -72,8 +72,8 @@ public:
     ManetteGamepad(ManetteDevice*, unsigned index);
     virtual ~ManetteGamepad();
 
-    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
-    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
 
     void absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis, double value);
     void buttonPressedOrReleased(ManetteDevice*, StandardGamepadButton, bool pressed);

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -53,7 +53,7 @@ public:
 
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() LIFETIME_BOUND final { return m_gamepadVector; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 

--- a/Source/WebCore/platform/glib/SelectionData.h
+++ b/Source/WebCore/platform/glib/SelectionData.h
@@ -31,24 +31,24 @@ class SelectionData {
     WTF_MAKE_TZONE_ALLOCATED(SelectionData);
 public:
     void setText(const String&);
-    const String& text() const { return m_text; }
+    const String& text() const LIFETIME_BOUND { return m_text; }
     bool hasText() const { return !m_text.isEmpty(); }
     void clearText() { m_text = emptyString(); }
 
     void setMarkup(const String& newMarkup) { m_markup = newMarkup; }
-    const String& markup() const { return m_markup; }
+    const String& markup() const LIFETIME_BOUND { return m_markup; }
     bool hasMarkup() const { return !m_markup.isEmpty(); }
     void clearMarkup() { m_markup = emptyString(); }
 
     void setURL(const URL&, const String&);
-    const URL& url() const { return m_url; }
-    const String& urlLabel() const;
+    const URL& url() const LIFETIME_BOUND { return m_url; }
+    const String& urlLabel() const LIFETIME_BOUND;
     bool hasURL() const { return !m_url.isEmpty() && m_url.isValid(); }
     void clearURL() { m_url = URL(); }
 
     void setURIList(const String&);
-    const String& uriList() const { return m_uriList; }
-    const Vector<String>& filenames() const { return m_filenames; }
+    const String& uriList() const LIFETIME_BOUND { return m_uriList; }
+    const Vector<String>& filenames() const LIFETIME_BOUND { return m_filenames; }
     bool hasURIList() const { return !m_uriList.isEmpty(); }
     bool hasFilenames() const { return !m_filenames.isEmpty(); }
     void clearURIList() { m_uriList = emptyString(); }
@@ -62,7 +62,7 @@ public:
     bool canSmartReplace() const { return m_canSmartReplace; }
 
     void addBuffer(const String& type, const Ref<SharedBuffer>& buffer) { m_buffers.add(type, buffer.get()); }
-    const HashMap<String, Ref<SharedBuffer>>& buffers() const { return m_buffers; }
+    const HashMap<String, Ref<SharedBuffer>>& buffers() const LIFETIME_BOUND { return m_buffers; }
     SharedBuffer* buffer(const String& type) { return m_buffers.get(type); }
     void clearBuffers() { m_buffers.clear(); }
 

--- a/Source/WebCore/platform/glib/SystemSettings.h
+++ b/Source/WebCore/platform/glib/SystemSettings.h
@@ -65,7 +65,7 @@ public:
 
     void updateSettings(const SystemSettings::State&);
 
-    const State& settingsState() const { return m_state; }
+    const State& settingsState() const LIFETIME_BOUND { return m_state; }
 
     void addObserver(Function<void(const State&)>&&, void* context);
     void removeObserver(void* context);

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -71,7 +71,7 @@ public:
     // ImageFrame
     unsigned primaryFrameIndex() const final { return m_descriptor.primaryFrameIndex(); }
 
-    const Vector<ImageFrame>& frames() const { return m_frames; }
+    const Vector<ImageFrame>& frames() const LIFETIME_BOUND { return m_frames; }
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& subsamplingLevel = std::nullopt) final { return frameAtIndexCacheIfNeeded(primaryFrameIndex(), subsamplingLevel); }
 
     // NativeImage

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -598,7 +598,7 @@ void ComplexTextController::advance(unsigned offset, GlyphBuffer* glyphBuffer, G
         unsigned glyphCount = complexTextRun->glyphCount();
         unsigned glyphIndexIntoCurrentRun = ltr ? m_glyphInCurrentRun : glyphCount - 1 - m_glyphInCurrentRun;
         unsigned glyphIndexIntoComplexTextController = indexOfLeftmostGlyphInCurrentRun + glyphIndexIntoCurrentRun;
-        if (fallbackFonts && &complexTextRun->font() != m_fontCascade->primaryFont().ptr())
+        if (fallbackFonts && &complexTextRun->font() != &m_fontCascade->primaryFont())
             fallbackFonts->add(protect(complexTextRun->font()));
 
         // We must store the initial advance for the first glyph we are going to draw.

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -118,7 +118,7 @@ public:
 
     static Ref<Font> createSystemFallbackFontPlaceholder() { return adoptRef(*new Font(IsSystemFallbackFontPlaceholder::Yes)); }
     bool isSystemFontFallbackPlaceholder() const { return m_isSystemFontFallbackPlaceholder; }
-    const FontPlatformData& platformData() const { return m_platformData; }
+    const FontPlatformData& platformData() const LIFETIME_BOUND { return m_platformData; }
 #if ENABLE(MATHML)
     const OpenTypeMathData* mathData() const;
 #endif
@@ -162,7 +162,7 @@ public:
     bool hasVerticalGlyphs() const { return m_hasVerticalGlyphs; }
     bool isTextOrientationFallback() const { return m_attributes.isTextOrientationFallback == IsOrientationFallback::Yes; }
 
-    const FontMetrics& fontMetrics() const { return m_fontMetrics; }
+    const FontMetrics& fontMetrics() const LIFETIME_BOUND { return m_fontMetrics; }
     float sizePerUnit() const { return platformData().size() / (fontMetrics().unitsPerEm() ? fontMetrics().unitsPerEm() : 1); }
 
     float maxCharWidth() const { return m_maxCharWidth; }
@@ -266,7 +266,7 @@ public:
     bool isUsedInSystemFallbackFontCache() const { return m_isUsedInSystemFallbackFontCache; }
 
     using Attributes = FontInternalAttributes;
-    const Attributes& attributes() const { return m_attributes; }
+    const Attributes& attributes() const LIFETIME_BOUND { return m_attributes; }
 
     ColorGlyphType colorGlyphType(Glyph) const;
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -395,7 +395,7 @@ float FontCascade::widthForSimpleTextWithFixedPitch(StringView text, bool whites
     if (text.isEmpty())
         return 0;
 
-    auto monospaceCharacterWidth = primaryFont()->spaceWidth();
+    auto monospaceCharacterWidth = primaryFont().spaceWidth();
     if (whitespaceIsCollapsed)
         return text.length() * monospaceCharacterWidth;
 
@@ -550,7 +550,7 @@ bool FontCascade::fastAverageCharWidthIfAvailable(float& width) const
 {
     bool success = hasValidAverageCharWidth();
     if (success)
-        width = roundf(primaryFont()->avgCharWidth()); // FIXME: primaryFont() might not correspond to firstFamily().
+        width = roundf(primaryFont().avgCharWidth()); // FIXME: primaryFont() might not correspond to firstFamily().
     return success;
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -105,8 +105,8 @@ public:
 
     WEBCORE_EXPORT bool operator==(const FontCascade& other) const;
 
-    const FontCascadeDescription& fontDescription() const { return m_fontDescription; }
-    FontCascadeDescription& mutableFontDescription() const { return m_fontDescription; }
+    const FontCascadeDescription& fontDescription() const LIFETIME_BOUND { return m_fontDescription; }
+    FontCascadeDescription& mutableFontDescription() const LIFETIME_BOUND { return m_fontDescription; }
 
     float size() const { return fontDescription().computedSize(); }
 
@@ -165,7 +165,7 @@ public:
 
     bool isPlatformFont() const { return m_fonts->isForPlatformFont(); }
 
-    const FontMetrics& metricsOfPrimaryFont() const { return primaryFont()->fontMetrics(); }
+    const FontMetrics& metricsOfPrimaryFont() const { return primaryFont().fontMetrics(); }
     float zeroWidth() const;
     float tabWidth(const Font&, const TabSize&, float, Font::SyntheticBoldInclusion) const;
     bool hasValidAverageCharWidth() const;
@@ -176,7 +176,7 @@ public:
     int emphasisMarkHeight(const AtomString&) const;
     float floatEmphasisMarkHeight(const AtomString&) const;
 
-    Ref<const Font> primaryFont() const;
+    const Font& primaryFont() const;
     const FontRanges& fallbackRangesAt(unsigned) const;
     WEBCORE_EXPORT GlyphData glyphDataForCharacter(char32_t, bool mirror, FontVariant = AutoVariant, std::optional<ResolvedEmojiPolicy> = std::nullopt) const;
     bool canUseSimplifiedTextMeasuring(char32_t, FontVariant, bool whitespaceIsCollapsed, const Font&) const;
@@ -384,10 +384,10 @@ private:
     mutable WTF::BitSet<256 * bitsPerCharacterInCanUseSimplifiedTextMeasuringForAutoVariantCache> m_canUseSimplifiedTextMeasuringForAutoVariantCache;
 };
 
-inline Ref<const Font> FontCascade::primaryFont() const
+inline const Font& FontCascade::primaryFont() const
 {
-    Ref font = protect(m_fonts)->primaryFont(m_fontDescription, protect(fontSelector()).get());
-    m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(font);
+    WeakRef font = protect(m_fonts)->primaryFont(m_fontDescription, protect(fontSelector()).get());
+    m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(protect(font));
     return font;
 }
 

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -314,8 +314,8 @@ public:
         {
         }
 
-        const String& name() const { return m_name; }
-        const String& tag() const { return m_tag; }
+        const String& name() const LIFETIME_BOUND { return m_name; }
+        const String& tag() const LIFETIME_BOUND { return m_tag; }
         float defaultValue() const { return m_defaultValue; }
         float minimumValue() const { return m_minimumValue; }
         float maximumValue() const { return m_maximumValue; }
@@ -407,10 +407,10 @@ public:
 #if USE(CAIRO)
     cairo_scaled_font_t* scaledFont() const { return m_scaledFont.get(); }
 #elif USE(SKIA)
-    const SkFont& skFont() const { return m_font; }
+    const SkFont& skFont() const LIFETIME_BOUND { return m_font; }
     SkiaHarfBuzzFont* skiaHarfBuzzFont() const { return m_hbFont.get(); }
     hb_font_t* hbFont() const;
-    const Vector<hb_feature_t>& features() const { return m_features; }
+    const Vector<hb_feature_t>& features() const LIFETIME_BOUND { return m_features; }
     static bool skiaTypefaceHasAnySupportedColorTable(const SkTypeface&);
 #endif
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -144,7 +144,7 @@ public:
     GraphicsLayerClient& client() const { return *m_client; }
 
     // Layer name. Only used to identify layers in debug output
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
     virtual void setName(const String& name) { m_name = name; }
     WEBCORE_EXPORT virtual String debugName() const;
 
@@ -154,8 +154,8 @@ public:
     // Returns true if the layer has the given layer as an ancestor (excluding self).
     bool hasAncestor(GraphicsLayer*) const;
     
-    const Vector<Ref<GraphicsLayer>>& children() const { return m_children; }
-    Vector<Ref<GraphicsLayer>>& children() { return m_children; }
+    const Vector<Ref<GraphicsLayer>>& children() const LIFETIME_BOUND { return m_children; }
+    Vector<Ref<GraphicsLayer>>& children() LIFETIME_BOUND { return m_children; }
 
     // Returns true if the child list changed.
     WEBCORE_EXPORT virtual bool setChildren(Vector<Ref<GraphicsLayer>>&&);
@@ -187,7 +187,7 @@ public:
     // The layer that replicates this layer (if any).
     GraphicsLayer* replicaLayer() const { return m_replicaLayer.get(); }
 
-    const FloatPoint& replicatedLayerPosition() const { return m_replicatedLayerPosition; }
+    const FloatPoint& replicatedLayerPosition() const LIFETIME_BOUND { return m_replicatedLayerPosition; }
     void setReplicatedLayerPosition(const FloatPoint& p) { m_replicatedLayerPosition = p; }
 
     // Offset is origin of the renderer minus origin of the graphics layer.
@@ -204,7 +204,7 @@ public:
 #endif
 
     // The position of the layer (the location of its top-left corner in its parent)
-    const FloatPoint& position() const { return m_position; }
+    const FloatPoint& position() const LIFETIME_BOUND { return m_position; }
     virtual void setPosition(const FloatPoint& p) { m_approximatePosition = std::nullopt; m_position = p; }
 
     // approximatePosition, if set, overrides position() and is used during coverage rect computation.
@@ -216,15 +216,15 @@ public:
 
     // Anchor point: (0, 0) is top left, (1, 1) is bottom right. The anchor point
     // affects the origin of the transforms.
-    const FloatPoint3D& anchorPoint() const { return m_anchorPoint; }
+    const FloatPoint3D& anchorPoint() const LIFETIME_BOUND { return m_anchorPoint; }
     virtual void setAnchorPoint(const FloatPoint3D& p) { m_anchorPoint = p; }
 
     // The size of the layer.
-    const FloatSize& size() const { return m_size; }
+    const FloatSize& size() const LIFETIME_BOUND { return m_size; }
     WEBCORE_EXPORT virtual void setSize(const FloatSize&);
 
     // The boundOrigin affects the offset at which content is rendered, and sublayers are positioned.
-    const FloatPoint& boundsOrigin() const { return m_boundsOrigin; }
+    const FloatPoint& boundsOrigin() const LIFETIME_BOUND { return m_boundsOrigin; }
     virtual void setBoundsOrigin(const FloatPoint& origin) { m_boundsOrigin = origin; }
 
     // For platforms that move underlying platform layers on a different thread for scrolling; just update the GraphicsLayer state.
@@ -292,7 +292,7 @@ public:
     // The color used to paint the layer background. Pass an invalid color to remove it.
     // Note that this covers the entire layer. Use setContentsToSolidColor() if the color should
     // only cover the contentsRect.
-    const Color& backgroundColor() const { return m_backgroundColor; }
+    const Color& backgroundColor() const LIFETIME_BOUND { return m_backgroundColor; }
     WEBCORE_EXPORT virtual void setBackgroundColor(const Color&);
 
     // opaque means that we know the layer contents have no alpha
@@ -305,15 +305,15 @@ public:
     float opacity() const { return m_opacity; }
     WEBCORE_EXPORT virtual void setOpacity(float);
 
-    const FilterOperations& filters() const { return m_filters; }
+    const FilterOperations& filters() const LIFETIME_BOUND { return m_filters; }
     // Returns true if filter can be rendered by the compositor.
     WEBCORE_EXPORT virtual bool setFilters(const FilterOperations&);
 
-    const FilterOperations& backdropFilters() const { return m_backdropFilters; }
+    const FilterOperations& backdropFilters() const LIFETIME_BOUND { return m_backdropFilters; }
     virtual bool setBackdropFilters(const FilterOperations& filters) { m_backdropFilters = filters; return true; }
 
     virtual void setBackdropFiltersRect(const FloatRoundedRect& backdropFiltersRect) { m_backdropFiltersRect = backdropFiltersRect; }
-    const FloatRoundedRect& backdropFiltersRect() const { return m_backdropFiltersRect; }
+    const FloatRoundedRect& backdropFiltersRect() const LIFETIME_BOUND { return m_backdropFiltersRect; }
 
     BlendMode blendMode() const { return m_blendMode; }
     virtual void setBlendMode(BlendMode blendMode) { m_blendMode = blendMode; }
@@ -359,7 +359,7 @@ public:
     WindRule shapeLayerWindRule() const;
     WEBCORE_EXPORT virtual void setShapeLayerWindRule(WindRule);
 
-    const EventRegion& eventRegion() const { return m_eventRegion; }
+    const EventRegion& eventRegion() const LIFETIME_BOUND { return m_eventRegion; }
     WEBCORE_EXPORT virtual void setEventRegion(EventRegion&&);
 
     // Transitions are identified by a special animation name that cannot clash with a keyframe identifier.
@@ -531,7 +531,7 @@ public:
     bool renderingIsSuppressedIncludingDescendants() const { return m_renderingIsSuppressedIncludingDescendants; }
     void setRenderingIsSuppressedIncludingDescendants(bool suppressed) { m_renderingIsSuppressedIncludingDescendants = suppressed; }
 
-    const std::optional<FloatRect>& animationExtent() const { return m_animationExtent; }
+    const std::optional<FloatRect>& animationExtent() const LIFETIME_BOUND { return m_animationExtent; }
     void setAnimationExtent(std::optional<FloatRect> animationExtent) { m_animationExtent = animationExtent; }
 
     static void traverse(GraphicsLayer&, NOESCAPE const Function<void(GraphicsLayer&)>&);

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -178,7 +178,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade->primaryFont(), characters, stringLocation, 0, characters.size(), m_run->ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(protect(m_fontCascade->primaryFont()), characters, stringLocation, 0, characters.size(), m_run->ltr()));
         return;
     }
 
@@ -272,17 +272,17 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
                 if (!runFont) {
                     RetainPtr fontName = adoptCF(CTFontCopyPostScriptName(runCTFont.get()));
                     if (CFEqual(fontName.get(), CFSTR("LastResort"))) {
-                        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade->primaryFont(), characters, stringLocation, runRange.location, runRange.location + runRange.length, m_run->ltr()));
+                        m_complexTextRuns.append(ComplexTextRun::create(protect(m_fontCascade->primaryFont()), characters, stringLocation, runRange.location, runRange.location + runRange.length, m_run->ltr()));
                         continue;
                     }
                     FontPlatformData runFontPlatformData(runCTFont.get(), CTFontGetSize(runCTFont.get()));
                     runFont = FontCache::forCurrentThread()->fontForPlatformData(runFontPlatformData).ptr();
                 }
-                if (m_fallbackFonts && runFont != m_fontCascade->primaryFont().ptr())
+                if (m_fallbackFonts && runFont != &m_fontCascade->primaryFont())
                     m_fallbackFonts->add(*runFont);
             }
         }
-        if (m_fallbackFonts && runFont != m_fontCascade->primaryFont().ptr())
+        if (m_fallbackFonts && runFont != &m_fontCascade->primaryFont())
             m_fallbackFonts->add(*effectiveFont);
 
         LOG_WITH_STREAM(TextShaping, stream << "Run " << r << ":");

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -119,7 +119,7 @@ public:
     {
     }
 
-    const FloatSize& amount() const { return m_size; }
+    const FloatSize& amount() const LIFETIME_BOUND { return m_size; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -137,7 +137,7 @@ public:
     {
     }
 
-    const AffineTransform& transform() const { return m_transform; }
+    const AffineTransform& transform() const LIFETIME_BOUND { return m_transform; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -155,7 +155,7 @@ public:
     {
     }
 
-    const AffineTransform& transform() const { return m_transform; }
+    const AffineTransform& transform() const LIFETIME_BOUND { return m_transform; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -179,7 +179,7 @@ public:
     }
 
     Color color() const { return { asSRGBA(colorData()) }; }
-    const PackedColor::RGBA& colorData() const { return m_colorData; }
+    const PackedColor::RGBA& colorData() const LIFETIME_BOUND { return m_colorData; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -227,8 +227,8 @@ public:
 
     WEBCORE_EXPORT SetState(const GraphicsContextState&);
 
-    GraphicsContextState& state() { return m_state; }
-    const GraphicsContextState& state() const { return m_state; }
+    GraphicsContextState& state() LIFETIME_BOUND { return m_state; }
+    const GraphicsContextState& state() const LIFETIME_BOUND { return m_state; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -265,7 +265,7 @@ public:
     {
     }
 
-    const DashArray& dashArray() const { return m_dashArray; }
+    const DashArray& dashArray() const LIFETIME_BOUND { return m_dashArray; }
     float dashOffset() const { return m_dashOffset; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
@@ -321,7 +321,7 @@ public:
     {
     }
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -339,7 +339,7 @@ public:
     {
     }
 
-    const FloatRoundedRect& rect() const { return m_rect; }
+    const FloatRoundedRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -357,7 +357,7 @@ public:
     {
     }
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -375,7 +375,7 @@ public:
     {
     }
 
-    const FloatRoundedRect& rect() const { return m_rect; }
+    const FloatRoundedRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -419,7 +419,7 @@ public:
     {
     }
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -444,7 +444,7 @@ public:
     {
     }
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
     WindRule windRule() const { return m_windRule; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
@@ -505,8 +505,8 @@ public:
     }
 
     Ref<const Font> font() const { return m_font; }
-    const Vector<GlyphBufferGlyph>& glyphs() const { return m_glyphs; }
-    const Vector<GlyphBufferAdvance>& advances() const { return m_advances; }
+    const Vector<GlyphBufferGlyph>& glyphs() const LIFETIME_BOUND { return m_glyphs; }
+    const Vector<GlyphBufferAdvance>& advances() const LIFETIME_BOUND { return m_advances; }
     size_t length() const { return m_glyphs.size(); }
 
     FloatPoint localAnchor() const { return m_localAnchor; }
@@ -636,8 +636,8 @@ public:
     }
 
     const NativeImage& nativeImage() const { return m_image; }
-    const FloatRect& destinationRect() const { return m_destinationRect; }
-    const FloatRect& source() const { return m_srcRect; }
+    const FloatRect& destinationRect() const LIFETIME_BOUND { return m_destinationRect; }
+    const FloatRect& source() const LIFETIME_BOUND { return m_srcRect; }
     ImagePaintingOptions options() const { return m_options; }
 
     void apply(GraphicsContext&) const;
@@ -661,7 +661,7 @@ public:
     }
 
     const SystemImage& systemImage() const { return m_systemImage; }
-    const FloatRect& destinationRect() const { return m_destinationRect; }
+    const FloatRect& destinationRect() const LIFETIME_BOUND { return m_destinationRect; }
 
     void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -688,7 +688,7 @@ public:
     const NativeImage& nativeImage() const { return m_image; }
     FloatRect destRect() const { return m_destination; }
     FloatRect tileRect() const { return m_tileRect; }
-    const AffineTransform& patternTransform() const { return m_patternTransform; }
+    const AffineTransform& patternTransform() const LIFETIME_BOUND { return m_patternTransform; }
     FloatPoint phase() const { return m_phase; }
     FloatSize spacing() const { return m_spacing; }
     ImagePaintingOptions options() const { return m_options; }
@@ -723,7 +723,7 @@ public:
     ImageBuffer& imageBuffer() const { return m_imageBuffer; }
     FloatRect destRect() const { return m_destination; }
     FloatRect tileRect() const { return m_tileRect; }
-    const AffineTransform& patternTransform() const { return m_patternTransform; }
+    const AffineTransform& patternTransform() const LIFETIME_BOUND { return m_patternTransform; }
     FloatPoint phase() const { return m_phase; }
     FloatSize spacing() const { return m_spacing; }
     ImagePaintingOptions options() const { return m_options; }
@@ -835,7 +835,7 @@ public:
 
     FloatPoint point() const { return m_point; }
     float thickness() const { return m_thickness; }
-    const Vector<FloatSegment>& lineSegments() const { return m_lineSegments; }
+    const Vector<FloatSegment>& lineSegments() const LIFETIME_BOUND { return m_lineSegments; }
     bool isPrinting() const { return m_printing; }
     bool doubleLines() const { return m_doubleLines; }
     StrokeStyle style() const { return m_style; }
@@ -905,7 +905,7 @@ public:
     {
     }
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -932,9 +932,9 @@ public:
     {
     }
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
     float outlineWidth() const { return m_outlineWidth; }
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -965,10 +965,10 @@ public:
     {
     }
 
-    const Vector<FloatRect>& rects() const { return m_rects; }
+    const Vector<FloatRect>& rects() const LIFETIME_BOUND { return m_rects; }
     float outlineOffset() const { return m_outlineOffset; }
     float outlineWidth() const { return m_outlineWidth; }
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -990,7 +990,7 @@ public:
     {
     }
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
     GraphicsContext::RequiresClipToRect requiresClipToRect() const { return m_requiresClipToRect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
@@ -1012,7 +1012,7 @@ public:
     }
 
     FloatRect rect() const { return m_rect; }
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1029,7 +1029,7 @@ public:
     WEBCORE_EXPORT FillRectWithGradient(const FloatRect&, Gradient&);
     WEBCORE_EXPORT FillRectWithGradient(FloatRect&&, Ref<Gradient>&&);
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
     const Gradient& gradient() const { return m_gradient; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
@@ -1047,9 +1047,9 @@ public:
     WEBCORE_EXPORT FillRectWithGradientAndSpaceTransform(const FloatRect&, Gradient&, const AffineTransform&, GraphicsContext::RequiresClipToRect);
     WEBCORE_EXPORT FillRectWithGradientAndSpaceTransform(FloatRect&&, Ref<Gradient>&&, AffineTransform&&, GraphicsContext::RequiresClipToRect);
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
     const Gradient& gradient() const { return m_gradient; }
-    const AffineTransform& gradientSpaceTransform() const { return m_gradientSpaceTransform; }
+    const AffineTransform& gradientSpaceTransform() const LIFETIME_BOUND { return m_gradientSpaceTransform; }
     GraphicsContext::RequiresClipToRect requiresClipToRect() const { return m_requiresClipToRect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
@@ -1075,7 +1075,7 @@ public:
     }
 
     FloatRect rect() const { return m_rect; }
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
     CompositeOperator compositeOperator() const { return m_op; }
     BlendMode blendMode() const { return m_blendMode; }
 
@@ -1100,8 +1100,8 @@ public:
     {
     }
 
-    const FloatRoundedRect& roundedRect() const { return m_rect; }
-    const Color& color() const { return m_color; }
+    const FloatRoundedRect& roundedRect() const LIFETIME_BOUND { return m_rect; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
     BlendMode blendMode() const { return m_blendMode; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
@@ -1124,9 +1124,9 @@ public:
     {
     }
 
-    const FloatRect& rect() const { return m_rect; }
-    const FloatRoundedRect& roundedHoleRect() const { return m_roundedHoleRect; }
-    const Color& color() const { return m_color; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
+    const FloatRoundedRect& roundedHoleRect() const LIFETIME_BOUND { return m_roundedHoleRect; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1151,7 +1151,7 @@ public:
     {
     }
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1213,7 +1213,7 @@ public:
     {
     }
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1231,7 +1231,7 @@ public:
     {
     }
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1249,7 +1249,7 @@ public:
     {
     }
 
-    const FloatRect& rect() const { return m_rect; }
+    const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1267,7 +1267,7 @@ public:
     ControlPart& part() const { return m_part; }
     FloatRoundedRect borderRect() const { return m_borderRect; }
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
-    const ControlStyle& style() const { return m_style; }
+    const ControlStyle& style() const LIFETIME_BOUND { return m_style; }
     StyleAppearance type() const { return m_part->type(); }
 
     WEBCORE_EXPORT void apply(GraphicsContext&, ControlFactory&) const;
@@ -1327,7 +1327,7 @@ public:
     {
     }
 
-    const FloatRect& pageRect() const { return m_pageRect; }
+    const FloatRect& pageRect() const LIFETIME_BOUND { return m_pageRect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
@@ -1354,8 +1354,8 @@ public:
     {
     }
 
-    const URL& link() const { return m_link; }
-    const FloatRect& destRect() const { return m_destRect; }
+    const URL& link() const LIFETIME_BOUND { return m_link; }
+    const FloatRect& destRect() const LIFETIME_BOUND { return m_destRect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.h
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.h
@@ -73,7 +73,7 @@ public:
     bool hasAlpha() const { return !hasMetadata() || m_hasAlpha; }
     bool hasMetadata() const { return !size().isEmpty(); }
 
-    ImageBackingStore* backingStore() const { return m_backingStore ? m_backingStore.get() : nullptr; }
+    ImageBackingStore* backingStore() const LIFETIME_BOUND { return m_backingStore ? m_backingStore.get() : nullptr; }
     bool hasBackingStore() const { return backingStore(); }
 
 private:

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.h
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.h
@@ -264,12 +264,12 @@ public:
         return frame->isLocalColormapDefined ? data(frame->localColormapPosition, frame->localColormapSize * 3) : std::span<const uint8_t> { };
     }
 
-    const GIFFrameContext* frameContext() const
+    const GIFFrameContext* frameContext() const LIFETIME_BOUND
     {
         return m_currentDecodingFrame < m_frames.size() ? m_frames[m_currentDecodingFrame].get() : 0;
     }
 
-    const GIFFrameContext* frameContext(size_t frame) const
+    const GIFFrameContext* frameContext(size_t frame) const LIFETIME_BOUND
     {
         return frame < m_frames.size() ? m_frames[frame].get() : nullptr;
     }

--- a/Source/WebCore/platform/ios/LegacyTileGridTile.h
+++ b/Source/WebCore/platform/ios/LegacyTileGridTile.h
@@ -48,7 +48,7 @@ public:
     }
     ~LegacyTileGridTile();
 
-    LegacyTileLayer* tileLayer() const { return m_tileLayer.get(); }
+    LegacyTileLayer* tileLayer() const LIFETIME_BOUND { return m_tileLayer.get(); }
     void invalidateRect(const IntRect& rectInSurface);
     IntRect rect() const { return m_rect; }
     void setRect(const IntRect& tileRect);

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -174,7 +174,7 @@ public:
     void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_currentMode.hasMode(mode); }
     WEBCORE_EXPORT UIViewController *presentingViewController();
-    UIViewController *fullscreenViewController() const { return m_viewController.get(); }
+    UIViewController *fullscreenViewController() const LIFETIME_BOUND { return m_viewController.get(); }
     WEBCORE_EXPORT virtual bool pictureInPictureWasStartedWhenEnteringBackground() const = 0;
 
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -72,8 +72,8 @@ public:
 
     void invalidate();
 
-    DDHighlightRef highlight() const { return m_highlight.get(); }
-    const SimpleRange& NODELETE range() const;
+    DDHighlightRef highlight() const LIFETIME_BOUND { return m_highlight.get(); }
+    const SimpleRange& NODELETE range() const LIFETIME_BOUND;
     GraphicsLayer& layer() const { return m_graphicsLayer.get(); }
 
     enum class Type : uint8_t {

--- a/Source/WebCore/platform/mac/HIDDevice.h
+++ b/Source/WebCore/platform/mac/HIDDevice.h
@@ -43,7 +43,7 @@ class HIDDevice {
 public:
     explicit HIDDevice(IOHIDDeviceRef);
 
-    IOHIDDeviceRef rawElement() const { return m_rawDevice.get(); }
+    IOHIDDeviceRef rawElement() const LIFETIME_BOUND { return m_rawDevice.get(); }
 
     // Walks the collection tree of all elements in the device as presented by IOKit.
     // Adds each unique input element to the vector in the tree traversal order it was encountered.
@@ -53,7 +53,7 @@ public:
     uint16_t vendorID() const { return m_vendorID; }
     uint16_t productID() const { return m_productID; }
     uint32_t fullProductIdentifier() const { return m_vendorID << 16 | m_productID; }
-    const String& productName() const { return m_productName; }
+    const String& productName() const LIFETIME_BOUND { return m_productName; }
 
 private:
     RetainPtr<IOHIDDeviceRef> m_rawDevice;

--- a/Source/WebCore/platform/mac/HIDElement.h
+++ b/Source/WebCore/platform/mac/HIDElement.h
@@ -39,7 +39,7 @@ class HIDElement {
 public:
     explicit HIDElement(IOHIDElementRef);
 
-    IOHIDElementRef rawElement() const { return m_rawElement.get(); }
+    IOHIDElementRef rawElement() const LIFETIME_BOUND { return m_rawElement.get(); }
 
     CFIndex physicalMin() const { return m_physicalMin; }
     CFIndex physicalMax() const { return m_physicalMax; }

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
@@ -45,9 +45,9 @@ public:
 
     bool startRubberBandAnimationWithElapsedTime(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, Seconds alreadyElapsed, const FloatSize& targetOverscroll = { });
 
-    const FloatSize& initialVelocity() const { return m_initialVelocity; }
-    const FloatSize& initialOverscroll() const { return m_initialOverscroll; }
-    const FloatSize& targetOverscroll() const { return m_targetOverscroll; }
+    const FloatSize& initialVelocity() const LIFETIME_BOUND { return m_initialVelocity; }
+    const FloatSize& initialOverscroll() const LIFETIME_BOUND { return m_initialOverscroll; }
+    const FloatSize& targetOverscroll() const LIFETIME_BOUND { return m_targetOverscroll; }
 
 private:
     void updateScrollExtents() final;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
@@ -58,7 +58,7 @@ public:
     void stopRecording(CompletionHandler<void()>&&);
     void pauseRecording(CompletionHandler<void()>&&);
     void resumeRecording(CompletionHandler<void()>&&);
-    const String& mimeType() const { return m_mimeType; }
+    const String& mimeType() const LIFETIME_BOUND { return m_mimeType; }
 
     void setSelectTracksCallback(SelectTracksCallback&& callback) { m_selectTracksCallback = WTF::move(callback); }
 

--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -58,10 +58,10 @@ public:
     CaptureDevice() = default;
 
     void setPersistentId(const String& persistentId) { m_persistentId = persistentId; }
-    const String& persistentId() const { return m_persistentId; }
+    const String& persistentId() const LIFETIME_BOUND { return m_persistentId; }
 
     void setLabel(const String& label) { m_label = label; }
-    const String& label() const
+    const String& label() const LIFETIME_BOUND
     {
         static NeverDestroyed<String> airPods(MAKE_STATIC_STRING_IMPL("AirPods"));
 
@@ -72,7 +72,7 @@ public:
     }
 
     void setGroupId(const String& groupId) { m_groupId = groupId; }
-    const String& groupId() const { return m_groupId.isEmpty() ? m_persistentId : m_groupId; }
+    const String& groupId() const LIFETIME_BOUND { return m_groupId.isEmpty() ? m_persistentId : m_groupId; }
 
     DeviceType type() const { return m_type; }
 

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -633,28 +633,28 @@ public:
 
     void clearDeviceId() { m_deviceId = { }; }
 
-    const std::optional<IntConstraint>& width() const { return m_width; }
-    const std::optional<IntConstraint>& height() const { return m_height; }
-    const std::optional<IntConstraint>& sampleRate() const { return m_sampleRate; }
-    const std::optional<IntConstraint>& sampleSize() const { return m_sampleSize; }
+    const std::optional<IntConstraint>& width() const LIFETIME_BOUND { return m_width; }
+    const std::optional<IntConstraint>& height() const LIFETIME_BOUND { return m_height; }
+    const std::optional<IntConstraint>& sampleRate() const LIFETIME_BOUND { return m_sampleRate; }
+    const std::optional<IntConstraint>& sampleSize() const LIFETIME_BOUND { return m_sampleSize; }
 
-    const std::optional<DoubleConstraint>& aspectRatio() const { return m_aspectRatio; }
-    const std::optional<DoubleConstraint>& frameRate() const { return m_frameRate; }
-    const std::optional<DoubleConstraint>& volume() const { return m_volume; }
+    const std::optional<DoubleConstraint>& aspectRatio() const LIFETIME_BOUND { return m_aspectRatio; }
+    const std::optional<DoubleConstraint>& frameRate() const LIFETIME_BOUND { return m_frameRate; }
+    const std::optional<DoubleConstraint>& volume() const LIFETIME_BOUND { return m_volume; }
 
-    const std::optional<BooleanConstraint>& echoCancellation() const { return m_echoCancellation; }
-    const std::optional<BooleanConstraint>& displaySurface() const { return m_displaySurface; }
-    const std::optional<BooleanConstraint>& logicalSurface() const { return m_logicalSurface; }
+    const std::optional<BooleanConstraint>& echoCancellation() const LIFETIME_BOUND { return m_echoCancellation; }
+    const std::optional<BooleanConstraint>& displaySurface() const LIFETIME_BOUND { return m_displaySurface; }
+    const std::optional<BooleanConstraint>& logicalSurface() const LIFETIME_BOUND { return m_logicalSurface; }
 
-    const std::optional<StringConstraint>& facingMode() const { return m_facingMode; }
-    const std::optional<StringConstraint>& deviceId() const { return m_deviceId; }
-    const std::optional<StringConstraint>& groupId() const { return m_groupId; }
+    const std::optional<StringConstraint>& facingMode() const LIFETIME_BOUND { return m_facingMode; }
+    const std::optional<StringConstraint>& deviceId() const LIFETIME_BOUND { return m_deviceId; }
+    const std::optional<StringConstraint>& groupId() const LIFETIME_BOUND { return m_groupId; }
 
-    const std::optional<StringConstraint>& whiteBalanceMode() const { return m_whiteBalanceMode; }
-    const std::optional<DoubleConstraint>& zoom() const { return m_zoom; }
-    const std::optional<BooleanConstraint>& torch() const { return m_torch; }
-    const std::optional<BooleanConstraint>& backgroundBlur() const { return m_backgroundBlur; }
-    const std::optional<BooleanConstraint>& powerEfficient() const { return m_powerEfficient; }
+    const std::optional<StringConstraint>& whiteBalanceMode() const LIFETIME_BOUND { return m_whiteBalanceMode; }
+    const std::optional<DoubleConstraint>& zoom() const LIFETIME_BOUND { return m_zoom; }
+    const std::optional<BooleanConstraint>& torch() const LIFETIME_BOUND { return m_torch; }
+    const std::optional<BooleanConstraint>& backgroundBlur() const LIFETIME_BOUND { return m_backgroundBlur; }
+    const std::optional<BooleanConstraint>& powerEfficient() const LIFETIME_BOUND { return m_powerEfficient; }
 
     MediaTrackConstraintSetMap isolatedCopy() const;
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -102,8 +102,8 @@ public:
 
     WEBCORE_EXPORT virtual ~MediaStreamTrackPrivate();
 
-    const String& id() const { return m_id; }
-    const String& label() const { return m_label; }
+    const String& id() const LIFETIME_BOUND { return m_id; }
+    const String& label() const LIFETIME_BOUND { return m_label; }
 
     bool isActive() const { return enabled() && !ended() && !muted(); }
 
@@ -148,8 +148,8 @@ public:
     void removeObserver(MediaStreamTrackPrivateObserver&);
     bool hasObserver(MediaStreamTrackPrivateObserver& observer) const { return m_observers.contains(observer); }
 
-    const RealtimeMediaSourceSettings& settings() const { return m_settings; }
-    const RealtimeMediaSourceCapabilities& capabilities() const { return m_capabilities; }
+    const RealtimeMediaSourceSettings& settings() const LIFETIME_BOUND { return m_settings; }
+    const RealtimeMediaSourceCapabilities& capabilities() const LIFETIME_BOUND { return m_capabilities; }
 
     Ref<RealtimeMediaSource::TakePhotoNativePromise> takePhoto(PhotoSettings&&);
     Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> getPhotoCapabilities();

--- a/Source/WebCore/platform/mediastream/RTCSessionDescriptionDescriptor.h
+++ b/Source/WebCore/platform/mediastream/RTCSessionDescriptionDescriptor.h
@@ -44,7 +44,7 @@ public:
     static Ref<RTCSessionDescriptionDescriptor> create(const String& type, const String& sdp);
     virtual ~RTCSessionDescriptionDescriptor();
 
-    const String& type() const { return m_type; }
+    const String& type() const LIFETIME_BOUND { return m_type; }
     void setType(const String& type) { m_type = type; }
 
     const String& sdp() const { return m_sdp; }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -144,11 +144,11 @@ public:
     // Can be called in worker threads.
     virtual Ref<RealtimeMediaSource> clone() { return *this; }
 
-    const String& hashedId() const;
-    const String& hashedGroupId() const;
-    const MediaDeviceHashSalts& deviceIDHashSalts() const;
+    const String& hashedId() const LIFETIME_BOUND;
+    const String& hashedGroupId() const LIFETIME_BOUND;
+    const MediaDeviceHashSalts& deviceIDHashSalts() const LIFETIME_BOUND;
 
-    const String& persistentID() const { return m_device.persistentId(); }
+    const String& persistentID() const LIFETIME_BOUND { return m_device.persistentId(); }
 
     enum class Type : bool { Audio, Video };
     Type type() const { return m_type; }
@@ -171,7 +171,7 @@ public:
 
     virtual bool interrupted() const { return false; }
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
     double fitnessScore() const { return m_fitnessScore; }
 
@@ -291,7 +291,7 @@ public:
 
     std::optional<PageIdentifier> pageIdentifier() const { return m_pageIdentifier.asOptional(); }
 
-    const CaptureDevice& captureDevice() const { return m_device; }
+    const CaptureDevice& captureDevice() const LIFETIME_BOUND { return m_device; }
     bool isEphemeral() const { return m_device.isEphemeral(); }
 
     virtual double facingModeFitnessScoreAdjustment() const { return 0; }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -124,35 +124,35 @@ public:
     }
 
     bool supportsWidth() const { return m_supportedConstraints.supportsWidth(); }
-    const LongCapabilityRange& width() const { return m_width; }
+    const LongCapabilityRange& width() const LIFETIME_BOUND { return m_width; }
     void setWidth(const LongCapabilityRange& width) { m_width = width; }
 
     bool supportsHeight() const { return m_supportedConstraints.supportsHeight(); }
-    const LongCapabilityRange& height() const { return m_height; }
+    const LongCapabilityRange& height() const LIFETIME_BOUND { return m_height; }
     void setHeight(const LongCapabilityRange& height) { m_height = height; }
 
     bool supportsFrameRate() const { return m_supportedConstraints.supportsFrameRate(); }
-    const DoubleCapabilityRange& frameRate() const { return m_frameRate; }
+    const DoubleCapabilityRange& frameRate() const LIFETIME_BOUND { return m_frameRate; }
     void setFrameRate(const DoubleCapabilityRange& frameRate) { m_frameRate = frameRate; }
 
     bool supportsFacingMode() const { return m_supportedConstraints.supportsFacingMode(); }
-    const Vector<VideoFacingMode>& facingMode() const { return m_facingMode; }
+    const Vector<VideoFacingMode>& facingMode() const LIFETIME_BOUND { return m_facingMode; }
     void addFacingMode(VideoFacingMode mode) { m_facingMode.append(mode); }
 
     bool supportsAspectRatio() const { return m_supportedConstraints.supportsAspectRatio(); }
-    const DoubleCapabilityRange& aspectRatio() const { return m_aspectRatio; }
+    const DoubleCapabilityRange& aspectRatio() const LIFETIME_BOUND { return m_aspectRatio; }
     void setAspectRatio(const DoubleCapabilityRange& aspectRatio) { m_aspectRatio = aspectRatio; }
 
     bool supportsVolume() const { return m_supportedConstraints.supportsVolume(); }
-    const DoubleCapabilityRange& volume() const { return m_volume; }
+    const DoubleCapabilityRange& volume() const LIFETIME_BOUND { return m_volume; }
     void setVolume(const DoubleCapabilityRange& volume) { m_volume = volume; }
 
     bool supportsSampleRate() const { return m_supportedConstraints.supportsSampleRate(); }
-    const LongCapabilityRange& sampleRate() const { return m_sampleRate; }
+    const LongCapabilityRange& sampleRate() const LIFETIME_BOUND { return m_sampleRate; }
     void setSampleRate(const LongCapabilityRange& sampleRate) { m_sampleRate = sampleRate; }
 
     bool supportsSampleSize() const { return m_supportedConstraints.supportsSampleSize(); }
-    const LongCapabilityRange& sampleSize() const { return m_sampleSize; }
+    const LongCapabilityRange& sampleSize() const LIFETIME_BOUND { return m_sampleSize; }
     void setSampleSize(const LongCapabilityRange& sampleSize) { m_sampleSize = sampleSize; }
 
     bool supportsEchoCancellation() const { return m_supportedConstraints.supportsEchoCancellation(); }
@@ -160,23 +160,23 @@ public:
     void setEchoCancellation(EchoCancellation echoCancellation) { m_echoCancellation = echoCancellation; }
 
     bool supportsDeviceId() const { return m_supportedConstraints.supportsDeviceId(); }
-    const String& deviceId() const { return m_deviceId; }
+    const String& deviceId() const LIFETIME_BOUND { return m_deviceId; }
     void setDeviceId(const String& id)  { m_deviceId = id; }
 
     bool supportsGroupId() const { return m_supportedConstraints.supportsGroupId(); }
-    const String& groupId() const { return m_groupId; }
+    const String& groupId() const LIFETIME_BOUND { return m_groupId; }
     void setGroupId(const String& id)  { m_groupId = id; }
 
     bool supportsFocusDistance() const { return m_supportedConstraints.supportsFocusDistance(); }
-    const DoubleCapabilityRange& focusDistance() const { return m_focusDistance; }
+    const DoubleCapabilityRange& focusDistance() const LIFETIME_BOUND { return m_focusDistance; }
     void setFocusDistance(const DoubleCapabilityRange& focusDistance) { m_focusDistance = focusDistance; }
 
     bool supportsWhiteBalanceMode() const { return m_supportedConstraints.supportsWhiteBalanceMode(); }
-    const Vector<MeteringMode>& whiteBalanceModes() const { return m_whiteBalanceModes; }
+    const Vector<MeteringMode>& whiteBalanceModes() const LIFETIME_BOUND { return m_whiteBalanceModes; }
     void setWhiteBalanceModes(Vector<MeteringMode>&& modes) { m_whiteBalanceModes = WTF::move(modes); }
 
     bool supportsZoom() const { return m_supportedConstraints.supportsZoom(); }
-    const DoubleCapabilityRange& zoom() const { return m_zoom; }
+    const DoubleCapabilityRange& zoom() const LIFETIME_BOUND { return m_zoom; }
     void setZoom(const DoubleCapabilityRange& zoom) { m_zoom = zoom; }
 
     bool supportsTorch() const { return m_supportedConstraints.supportsTorch(); }
@@ -191,7 +191,7 @@ public:
     bool powerEfficient() const { return m_powerEfficient; }
     void setPowerEfficient(bool value) { m_powerEfficient = value; }
 
-    const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
+    const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const LIFETIME_BOUND { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& constraints) { m_supportedConstraints = constraints; }
 
     RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, m_backgroundBlur, m_powerEfficient, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -141,11 +141,11 @@ public:
     void setEchoCancellation(bool echoCancellation) { m_echoCancellation = echoCancellation; }
 
     bool supportsDeviceId() const { return m_supportedConstraints.supportsDeviceId(); }
-    const String& deviceId() const { return m_deviceId; }
+    const String& deviceId() const LIFETIME_BOUND { return m_deviceId; }
     void setDeviceId(const String& deviceId) { m_deviceId = deviceId; }
 
     bool supportsGroupId() const { return m_supportedConstraints.supportsGroupId(); }
-    const String& groupId() const { return m_groupId; }
+    const String& groupId() const LIFETIME_BOUND { return m_groupId; }
     void setGroupId(const String& groupId) { m_groupId = groupId; }
 
     bool supportsDisplaySurface() const { return m_supportedConstraints.supportsDisplaySurface(); }
@@ -176,10 +176,10 @@ public:
     bool powerEfficient() const { return m_powerEfficient; }
     void setPowerEfficient(bool value) { m_powerEfficient = value; }
 
-    const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
+    const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const LIFETIME_BOUND { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& supportedConstraints) { m_supportedConstraints = supportedConstraints; }
 
-    const String& label() const { return m_label; }
+    const String& label() const LIFETIME_BOUND { return m_label; }
     void setLabel(const String& label) { m_label = label; }
 
     static String convertFlagsToString(const OptionSet<RealtimeMediaSourceSettings::Flag>);

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h
@@ -65,9 +65,9 @@ public:
     static std::optional<MockMediaDevice> mockMicrophoneFromDeviceID(uint32_t);
     static std::optional<CaptureDevice> captureDeviceWithPersistentID(CaptureDevice::DeviceType, const String&);
 
-    CaptureDeviceManager& audioCaptureDeviceManager() { return m_audioCaptureDeviceManager; }
-    CaptureDeviceManager& videoCaptureDeviceManager() { return m_videoCaptureDeviceManager; }
-    DisplayCaptureManager& displayCaptureDeviceManager() { return m_displayCaptureDeviceManager; }
+    CaptureDeviceManager& audioCaptureDeviceManager() LIFETIME_BOUND { return m_audioCaptureDeviceManager; }
+    CaptureDeviceManager& videoCaptureDeviceManager() LIFETIME_BOUND { return m_videoCaptureDeviceManager; }
+    DisplayCaptureManager& displayCaptureDeviceManager() LIFETIME_BOUND { return m_displayCaptureDeviceManager; }
 
 private:
     MockRealtimeMediaSourceCenter() = default;

--- a/Source/WebCore/platform/mock/mediasource/MockBox.h
+++ b/Source/WebCore/platform/mock/mediasource/MockBox.h
@@ -49,7 +49,7 @@ public:
     static size_t peekLength(JSC::ArrayBuffer*);
 
     size_t length() const { return m_length; }
-    const String& type() const { return m_type; }
+    const String& type() const LIFETIME_BOUND { return m_type; }
 
 protected:
     MockBox(JSC::ArrayBuffer*);
@@ -74,7 +74,7 @@ public:
 
     int32_t trackID() const { return m_trackID; }
 
-    const String& codec() const { return m_codec; }
+    const String& codec() const LIFETIME_BOUND { return m_codec; }
 
     enum TrackKind { Audio, Video, Text };
     TrackKind kind() const { return m_kind; }
@@ -100,7 +100,7 @@ public:
     MockInitializationBox(JSC::ArrayBuffer*);
 
     MediaTime duration() const { return m_duration; }
-    const Vector<MockTrackBox>& tracks() const { return m_tracks; }
+    const Vector<MockTrackBox>& tracks() const LIFETIME_BOUND { return m_tracks; }
 
 private:
     MediaTime m_duration;

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -139,7 +139,7 @@ public:
     WEBCORE_EXPORT bool isNull() const;
     WEBCORE_EXPORT bool isEmpty() const;
     
-    WEBCORE_EXPORT const URL& url() const;
+    WEBCORE_EXPORT const URL& url() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setURL(URL&&, bool didFilterLinkDecoration = false);
 
     void redirectAsGETIfNeeded(const ResourceRequestBase &, const ResourceResponse&);
@@ -156,7 +156,7 @@ public:
     WEBCORE_EXPORT void setTimeoutInterval(double);
     WEBCORE_EXPORT void resetTimeoutInterval();
     
-    WEBCORE_EXPORT const URL& firstPartyForCookies() const;
+    WEBCORE_EXPORT const URL& firstPartyForCookies() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setFirstPartyForCookies(const URL&);
 
     WEBCORE_EXPORT bool isThirdParty() const;
@@ -173,10 +173,10 @@ public:
     WEBCORE_EXPORT bool isTopSite() const; // Whether this request is for a top-level navigation.
     WEBCORE_EXPORT void setIsTopSite(bool);
 
-    WEBCORE_EXPORT const String& httpMethod() const;
+    WEBCORE_EXPORT const String& httpMethod() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setHTTPMethod(const String& httpMethod);
     
-    WEBCORE_EXPORT const HTTPHeaderMap& httpHeaderFields() const;
+    WEBCORE_EXPORT const HTTPHeaderMap& httpHeaderFields() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setHTTPHeaderFields(HTTPHeaderMap);
 
     WEBCORE_EXPORT String httpHeaderField(StringView name) const;
@@ -223,7 +223,7 @@ public:
 
     WEBCORE_EXPORT void clearPurpose();
 
-    const Vector<String>& responseContentDispositionEncodingFallbackArray() const { return m_requestData.m_responseContentDispositionEncodingFallbackArray; }
+    const Vector<String>& responseContentDispositionEncodingFallbackArray() const LIFETIME_BOUND { return m_requestData.m_responseContentDispositionEncodingFallbackArray; }
     WEBCORE_EXPORT void setResponseContentDispositionEncodingFallbackArray(const String& encoding1, const String& encoding2 = String(), const String& encoding3 = String());
     void setResponseContentDispositionEncodingFallbackArray(const Vector<String>& array) { m_requestData.m_responseContentDispositionEncodingFallbackArray = array; }
 
@@ -240,7 +240,7 @@ public:
     WEBCORE_EXPORT void setPriority(ResourceLoadPriority);
 
     WEBCORE_EXPORT static String partitionName(const String& domain);
-    const String& cachePartition() const { return m_cachePartition; }
+    const String& cachePartition() const LIFETIME_BOUND { return m_cachePartition; }
     WEBCORE_EXPORT void setCachePartition(const String&);
     void setDomainForCachePartition(const String& domain) { setCachePartition(partitionName(domain)); }
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -92,30 +92,30 @@ public:
     WEBCORE_EXPORT bool isInHTTPFamily() const;
     WEBCORE_EXPORT bool isSuccessful() const;
 
-    WEBCORE_EXPORT const URL& url() const;
+    WEBCORE_EXPORT const URL& url() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setURL(URL&&);
 
-    WEBCORE_EXPORT const String& mimeType() const;
+    WEBCORE_EXPORT const String& mimeType() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setMimeType(String&&);
 
     WEBCORE_EXPORT long long expectedContentLength() const;
     WEBCORE_EXPORT void setExpectedContentLength(long long expectedContentLength);
 
-    WEBCORE_EXPORT const String& textEncodingName() const;
+    WEBCORE_EXPORT const String& textEncodingName() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setTextEncodingName(String&&);
 
     WEBCORE_EXPORT int httpStatusCode() const;
     WEBCORE_EXPORT void setHTTPStatusCode(int);
     WEBCORE_EXPORT bool isRedirection() const;
 
-    WEBCORE_EXPORT const String& httpStatusText() const;
+    WEBCORE_EXPORT const String& httpStatusText() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setHTTPStatusText(String&&);
 
-    WEBCORE_EXPORT const String& httpVersion() const;
+    WEBCORE_EXPORT const String& httpVersion() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setHTTPVersion(String&&);
     WEBCORE_EXPORT bool isHTTP09() const;
 
-    WEBCORE_EXPORT const HTTPHeaderMap& httpHeaderFields() const;
+    WEBCORE_EXPORT const HTTPHeaderMap& httpHeaderFields() const LIFETIME_BOUND;
     void setHTTPHeaderFields(HTTPHeaderMap&&);
 
     enum class SanitizationType { Redirection, RemoveCookies, CrossOriginSafe };
@@ -147,13 +147,13 @@ public:
 
     WEBCORE_EXPORT void includeCertificateInfo(std::span<const std::byte> = { }) const;
     void setCertificateInfo(CertificateInfo&& info) { m_certificateInfo = WTF::move(info); }
-    const std::optional<CertificateInfo>& certificateInfo() const { return m_certificateInfo; };
+    const std::optional<CertificateInfo>& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; };
     bool usedLegacyTLS() const { return m_usedLegacyTLS == UsedLegacyTLS::Yes; }
     void setUsedLegacyTLS(UsedLegacyTLS used) { m_usedLegacyTLS = used; }
     bool wasPrivateRelayed() const { return m_wasPrivateRelayed == WasPrivateRelayed::Yes; }
     void setWasPrivateRelayed(WasPrivateRelayed privateRelayed) { m_wasPrivateRelayed = privateRelayed; }
     void setProxyName(String&& proxyName) { m_proxyName = WTF::move(proxyName); }
-    const String& proxyName() const { return m_proxyName; }
+    const String& proxyName() const LIFETIME_BOUND { return m_proxyName; }
 
     IPAddressSpace ipAddressSpace() { return m_ipAddressSpace; }
     void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }
@@ -170,7 +170,7 @@ public:
     WEBCORE_EXPORT std::optional<Seconds> age() const;
     WEBCORE_EXPORT std::optional<WallTime> expires() const;
     WEBCORE_EXPORT std::optional<WallTime> lastModified() const;
-    const ParsedContentRange& contentRange() const;
+    const ParsedContentRange& contentRange() const LIFETIME_BOUND;
 
     static_assert(static_cast<unsigned>(Source::InspectorOverride) <= ((1U << bitWidthOfSource) - 1));
 
@@ -184,7 +184,7 @@ public:
     // FIXME: This should be eliminated from ResourceResponse.
     // Network loading metrics should be delivered via didFinishLoad
     // and should not be part of the ResourceResponse.
-    const NetworkLoadMetrics* deprecatedNetworkLoadMetricsOrNull() const
+    const NetworkLoadMetrics* deprecatedNetworkLoadMetricsOrNull() const LIFETIME_BOUND
     {
         if (m_networkLoadMetrics)
             return m_networkLoadMetrics.get();

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -126,9 +126,9 @@ public:
     void setSynchronous(SynchronousPragma);
     
     WEBCORE_EXPORT int lastError();
-    WEBCORE_EXPORT const char* lastErrorMsg();
+    WEBCORE_EXPORT const char* lastErrorMsg() LIFETIME_BOUND;
     
-    sqlite3* sqlite3Handle() const
+    sqlite3* sqlite3Handle() const LIFETIME_BOUND
     {
 #if !PLATFORM(IOS_FAMILY)
         ASSERT(m_sharable || m_openingThread == &Thread::currentSingleton() || !m_db);
@@ -138,7 +138,7 @@ public:
     
     void setAuthorizer(DatabaseAuthorizer&);
 
-    Lock& databaseMutex() { return m_lockingMutex; }
+    Lock& databaseMutex() LIFETIME_BOUND { return m_lockingMutex; }
     bool isAutoCommitOn() const;
 
     // The SQLite AUTO_VACUUM pragma can be either NONE, FULL, or INCREMENTAL.

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -67,7 +67,7 @@ public:
         m_transitions[index].fastDecrement();
     }
 
-    const Vector<Iterator>& transitions() { return m_transitions; }
+    const Vector<Iterator>& transitions() LIFETIME_BOUND { return m_transitions; }
     size_t numTransitions() const { return m_transitions.size(); }
     size_t currentTransition() const { return m_currentTransition; }
     void setCurrentTransition(size_t currentTransition) { m_currentTransition = currentTransition; }
@@ -164,7 +164,7 @@ public:
     bool reversed(bool visuallyOrdered) { return m_level % 2 && !visuallyOrdered; }
     bool dirOverride(bool visuallyOrdered) { return m_override || visuallyOrdered; }
 
-    ConcreteRunType* next() const { return m_next.get(); }
+    ConcreteRunType* next() const LIFETIME_BOUND { return m_next.get(); }
     std::unique_ptr<ConcreteRunType> takeNext() { return WTF::move(m_next); }
     void setNext(std::unique_ptr<ConcreteRunType>&& next) { m_next = WTF::move(next); }
 
@@ -194,7 +194,7 @@ enum VisualDirectionOverride {
 template<typename Iterator, typename Run, typename DerivedClass> class BidiResolverBase {
     WTF_MAKE_NONCOPYABLE(BidiResolverBase);
 public:
-    const Iterator& position() const { return m_current; }
+    const Iterator& position() const LIFETIME_BOUND { return m_current; }
     void setPositionIgnoringNestedIsolates(const Iterator& position) { m_current = position; }
     void setPosition(const Iterator& position, unsigned nestedIsolatedCount)
     {
@@ -214,10 +214,10 @@ public:
     UCharDirection dir() const { return m_direction; }
     void setDir(UCharDirection direction) { m_direction = direction; }
 
-    const BidiStatus& status() const { return m_status; }
+    const BidiStatus& status() const LIFETIME_BOUND { return m_status; }
     void setStatus(BidiStatus status) { m_status = status; }
 
-    WhitespaceCollapsingState<Iterator>& whitespaceCollapsingState() { return m_whitespaceCollapsingState; }
+    WhitespaceCollapsingState<Iterator>& whitespaceCollapsingState() LIFETIME_BOUND { return m_whitespaceCollapsingState; }
 
     // The current algorithm handles nested isolates one layer of nesting at a time.
     // But when we layout each isolated span, we will walk into (and ignore) all
@@ -231,7 +231,7 @@ public:
 
     void createBidiRunsForLine(const Iterator& end, VisualDirectionOverride = NoVisualOverride, bool hardLineBreak = false);
 
-    BidiRunList<Run>& runs() { return m_runs; }
+    BidiRunList<Run>& runs() LIFETIME_BOUND { return m_runs; }
 
     // FIXME: This used to be part of deleteRuns() but was a layering violation.
     // It's unclear if this is still needed.
@@ -296,7 +296,7 @@ public:
     void incrementInternal();
     void appendRunInternal();
     bool needsContinuePastEndInternal() const;
-    Vector<IsolateRun>& isolatedRuns() { return m_isolatedRuns; }
+    Vector<IsolateRun>& isolatedRuns() LIFETIME_BOUND { return m_isolatedRuns; }
 
 private:
     Vector<IsolateRun> m_isolatedRuns;

--- a/Source/WebCore/platform/text/BidiRunList.h
+++ b/Source/WebCore/platform/text/BidiRunList.h
@@ -41,7 +41,7 @@ public:
     // FIXME: Once BidiResolver no longer owns the BidiRunList,
     // then ~BidiRunList should call deleteRuns() automatically.
 
-    Run* firstRun() const { return m_firstRun.get(); }
+    Run* firstRun() const LIFETIME_BOUND { return m_firstRun.get(); }
     Run* lastRun() const { return m_lastRun; }
     Run* logicallyLastRun() const { return m_logicallyLastRun; }
     unsigned runCount() const { return m_runCount; }

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -114,7 +114,7 @@ public:
     }
 
     std::optional<TextCheckingRequestIdentifier> identifier() const { return m_identifier; }
-    const String& text() const { return m_text; }
+    const String& text() const LIFETIME_BOUND { return m_text; }
     OptionSet<TextCheckingType> checkingTypes() const { return m_checkingTypes; }
     TextCheckingProcessType processType() const { return m_processType; }
 

--- a/Source/WebCore/platform/win/WindowMessageBroadcaster.h
+++ b/Source/WebCore/platform/win/WindowMessageBroadcaster.h
@@ -53,7 +53,7 @@ namespace WebCore {
 
         void addListener(WindowMessageListener*);
         void removeListener(WindowMessageListener*);
-        const ListenerSet& listeners() const { return m_listeners; }
+        const ListenerSet& listeners() const LIFETIME_BOUND { return m_listeners; }
 
         void destroy();
         void unsubclassWindow();

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1920,7 +1920,7 @@ LayoutUnit RenderBlock::adjustLogicalLeftOffsetForLine(LayoutUnit offsetFromFloa
         return left;
 
     // FIXME: Should letter-spacing apply? This is complicated since it doesn't apply at the edge?
-    float maxCharWidth = lineGrid->style().fontCascade().primaryFont()->maxCharWidth();
+    float maxCharWidth = lineGrid->style().fontCascade().primaryFont().maxCharWidth();
     if (!maxCharWidth)
         return left;
 
@@ -1957,7 +1957,7 @@ LayoutUnit RenderBlock::adjustLogicalRightOffsetForLine(LayoutUnit offsetFromFlo
         return right;
 
     // FIXME: Should letter-spacing apply? This is complicated since it doesn't apply at the edge?
-    float maxCharWidth = lineGrid->style().fontCascade().primaryFont()->maxCharWidth();
+    float maxCharWidth = lineGrid->style().fontCascade().primaryFont().maxCharWidth();
     if (!maxCharWidth)
         return right;
 

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -402,7 +402,7 @@ LayoutUnit RenderTextControlSingleLine::preferredContentLogicalWidth(float charW
     if (family == "Lucida Grande"_s)
         maxCharWidth = scaleEmToUnits(4027);
     else if (style().fontCascade().hasValidAverageCharWidth())
-        maxCharWidth = roundf(style().fontCascade().primaryFont()->maxCharWidth());
+        maxCharWidth = roundf(style().fontCascade().primaryFont().maxCharWidth());
 #endif
 
     // For text inputs, IE adds some extra width.

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -129,7 +129,7 @@ LayoutUnit MathOperator::stretchSize() const
 bool MathOperator::getGlyph(const RenderStyle& style, char32_t character, GlyphData& glyph) const
 {
     glyph = style.fontCascade().glyphDataForCharacter(character, style.writingMode().isBidiRTL());
-    return glyph.font && glyph.font == style.fontCascade().primaryFont().ptr();
+    return glyph.font && glyph.font == &style.fontCascade().primaryFont();
 }
 
 void MathOperator::setSizeVariant(const GlyphData& sizeVariant)
@@ -151,7 +151,7 @@ static GlyphData glyphDataForCodePointOrFallbackGlyph(const RenderStyle& style, 
     
     if (fallbackGlyph) {
         fallback.glyph = fallbackGlyph;
-        fallback.font = style.fontCascade().primaryFont().ptr();
+        fallback.font = &style.fontCascade().primaryFont();
     }
     
     return fallback;

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -223,7 +223,7 @@ const AtomString& RenderStyle::hyphenString() const
             static MainThreadNeverDestroyed<const AtomString> hyphenMinusString(span(hyphenMinus));
             static MainThreadNeverDestroyed<const AtomString> hyphenString(span(hyphen));
 
-            return fontCascade().primaryFont()->glyphForCharacter(hyphen) ? hyphenString : hyphenMinusString;
+            return protect(fontCascade().primaryFont())->glyphForCharacter(hyphen) ? hyphenString : hyphenMinusString;
         },
         [](const AtomString& string) -> const AtomString& {
             return string;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -250,11 +250,11 @@ GraphicsLayer* PDFScrollingPresentationController::backgroundLayerForPage(PDFDoc
     if (!m_pageBackgroundsContainerLayer)
         return nullptr;
 
-    auto pageContainerLayers = m_pageBackgroundsContainerLayer->children();
+    auto& pageContainerLayers = m_pageBackgroundsContainerLayer->children();
     if (pageContainerLayers.size() <= pageIndex)
         return nullptr;
 
-    Ref pageContainerLayer = pageContainerLayers[pageIndex];
+    auto& pageContainerLayer = pageContainerLayers[pageIndex];
     if (!pageContainerLayer->children().size())
         return nullptr;
 
@@ -275,7 +275,8 @@ void PDFScrollingPresentationController::updateIsInWindow(bool isInWindow)
     protect(m_selectionLayer)->setIsInWindow(isInWindow);
 #endif
 
-    for (auto& pageLayer : protect(m_pageBackgroundsContainerLayer)->children()) {
+    RefPtr pageBackgroundsContainerLayer = m_pageBackgroundsContainerLayer;
+    for (auto& pageLayer : pageBackgroundsContainerLayer->children()) {
         if (pageLayer->children().size()) {
             Ref pageContentsLayer = pageLayer->children()[0];
             pageContentsLayer->setIsInWindow(isInWindow);

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
@@ -39,9 +39,9 @@ void WebPopupMenu::setUpPlatformData(const IntRect&, PlatformPopupMenuData& data
 {
 #if USE(APPKIT)
     RefPtr popupClient = m_popupClient;
-    std::optional<InstalledFont> font = protect(popupClient->menuStyle().font())->primaryFont()->toSerializableInstalledFont();
+    std::optional<InstalledFont> font = protect(protect(popupClient->menuStyle().font())->primaryFont())->toSerializableInstalledFont();
     if (!font) {
-        double pointSize = protect(popupClient->menuStyle().font())->primaryFont()->platformData().size();
+        double pointSize = protect(popupClient->menuStyle().font())->primaryFont().platformData().size();
         font = Font::create(FontPlatformData(bridge_cast([NSFont menuFontOfSize:pointSize]), pointSize))->toSerializableInstalledFont();
     }
     ASSERT(font);

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -650,7 +650,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* renderer = core(self)->renderer();
     if (!renderer)
         return nil;
-    return renderer->style().fontCascade().primaryFont()->ctFont();
+    return renderer->style().fontCascade().primaryFont().ctFont();
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -84,9 +84,9 @@ void PopupMenuMac::populate()
         PopupMenuStyle style = protect(m_client)->itemStyle(i);
         RetainPtr<NSMutableDictionary> attributes = adoptNS([[NSMutableDictionary alloc] init]);
         if (style.font() != FontCascade()) {
-            RetainPtr<CTFontRef> font = style.font().primaryFont()->ctFont();
+            RetainPtr font = style.font().primaryFont().ctFont();
             if (!font) {
-                CGFloat size = style.font().primaryFont()->platformData().size();
+                CGFloat size = style.font().primaryFont().platformData().size();
                 font = adoptCF(CTFontCreateUIFontForLanguage(isFontWeightBold(style.font().weight()) ? kCTFontUIFontEmphasizedSystem : kCTFontUIFontSystem, size, nullptr));
             }
             [attributes setObject:(__bridge NSFont *)(font.get()) forKey:NSFontAttributeName];
@@ -156,7 +156,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
 
     NSPoint location;
 
-    RetainPtr font = protect(m_client)->menuStyle().font().primaryFont()->ctFont();
+    RetainPtr font = protect(m_client)->menuStyle().font().primaryFont().ctFont();
 
     // These values were borrowed from AppKit to match their placement of the menu.
     const int popOverHorizontalAdjust = -13;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -51,7 +51,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
     description.setComputedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
-    auto spaceWidth = font.primaryFont()->spaceWidth();
+    auto spaceWidth = font.primaryFont().spaceWidth();
 
     Vector<FloatSize> advances = { FloatSize(), FloatSize(21.640625, 0.0), FloatSize(42.3046875, 0.0), FloatSize(55.8984375, 0.0), FloatSize(22.34375, 0.0) };
     Vector<FloatPoint> origins = { FloatPoint(-15.15625, 18.046875), FloatPoint(), FloatPoint(), FloatPoint(), FloatPoint() };
@@ -140,7 +140,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
     description.setComputedSize(80);
     FontCascade font(WTF::move(description));
     font.update();
-    auto spaceWidth = font.primaryFont()->spaceWidth();
+    auto spaceWidth = font.primaryFont().spaceWidth();
 
     Vector<FloatSize> advances = { FloatSize(76.347656, 0.000000), FloatSize(0.000000, 0.000000) };
     Vector<FloatPoint> origins = { FloatPoint(), FloatPoint(-23.281250, -8.398438) };

--- a/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
@@ -63,7 +63,7 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
                     if (!WidthIterator::characterCanUseSimplifiedTextMeasuring(character, whitespaceIsCollapsed))
                         continue;
                     auto glyphData = fontCascade.glyphDataForCharacter(character, false);
-                    if (!glyphData.isValid() || glyphData.font != fontCascade.primaryFont().ptr())
+                    if (!glyphData.isValid() || glyphData.font != &fontCascade.primaryFont())
                         continue;
                     fontCascade.fonts()->glyphGeometryCache().clear();
                     float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);


### PR DESCRIPTION
#### a74b4b24af96b639d843fe2f84c6340302e6ed1f
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=308955">https://bugs.webkit.org/show_bug.cgi?id=308955</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::fontFrom):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::attributeStringSetStyle):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::fontForSelection):
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::updateAttributes):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing):
(WebCore::Layout::InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache):
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::adjustIdeographicBaselineIfApplicable):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::singleSpaceWidth):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::baselineForBox):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::glyphOverflowInInlineDirection):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::lineGrid):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::imageSizeForRenderer const):
* Source/WebCore/platform/ContentFilterUnblockHandler.h:
(WebCore::ContentFilterUnblockHandler::unblockURLHost const): Deleted.
(WebCore::ContentFilterUnblockHandler::unreachableURL const): Deleted.
(WebCore::ContentFilterUnblockHandler::configurationPath const): Deleted.
* Source/WebCore/platform/ContentType.h:
(WebCore::ContentType::raw const): Deleted.
* Source/WebCore/platform/ContextMenu.h:
(WebCore::ContextMenu::items const): Deleted.
* Source/WebCore/platform/ContextMenuItem.h:
(WebCore::ContextMenuItem::title const): Deleted.
(WebCore::ContextMenuItem::subMenuItems const): Deleted.
* Source/WebCore/platform/Cursor.h:
(WebCore::Cursor::hotSpot const): Deleted.
* Source/WebCore/platform/Decimal.h:
(WebCore::Decimal::value const): Deleted.
* Source/WebCore/platform/DragData.h:
(WebCore::DragData::clientPosition const): Deleted.
(WebCore::DragData::globalPosition const): Deleted.
(WebCore::DragData::fileNames const): Deleted.
(WebCore::DragData::promisedFileMIMETypes const): Deleted.
(WebCore::DragData::pasteboardName const): Deleted.
* Source/WebCore/platform/DragImage.h:
* Source/WebCore/platform/FileChooser.h:
(WebCore::FileChooser::settings const): Deleted.
* Source/WebCore/platform/MIMETypeRegistry.h:
(WebCore::MIMETypeRegistryThreadGlobalData::supportedImageMIMETypesForEncoding const): Deleted.
* Source/WebCore/platform/Pasteboard.h:
(WebCore::PasteboardWebContentReader::contentOrigin const): Deleted.
(WebCore::Pasteboard::promisedFileMIMETypes const): Deleted.
(WebCore::Pasteboard::dragDataMap const): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::timing const): Deleted.
(WebCore::AcceleratedEffect::timelineIdentifier const): Deleted.
(WebCore::AcceleratedEffect::keyframes const): Deleted.
(WebCore::AcceleratedEffect::animatedProperties const): Deleted.
(WebCore::AcceleratedEffect::disallowedProperties const): Deleted.
(WebCore::AcceleratedEffect::replacedProperties const): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffectStack.h:
* Source/WebCore/platform/animation/AcceleratedTimeline.h:
(WebCore::AcceleratedTimeline::identifier const): Deleted.
(WebCore::AcceleratedTimeline::data const): Deleted.
* Source/WebCore/platform/animation/TimingFunction.h:
* Source/WebCore/platform/audio/AudioBus.h:
* Source/WebCore/platform/audio/AudioDestination.h:
(WebCore::AudioDestination::inputDeviceId const): Deleted.
(WebCore::AudioDestination::sceneIdentifier const): Deleted.
* Source/WebCore/platform/audio/FFTFrame.h:
(WebCore::FFTFrame::realData): Deleted.
(WebCore::FFTFrame::imagData): Deleted.
(WebCore::FFTFrame::realData const): Deleted.
(WebCore::FFTFrame::imagData const): Deleted.
(WebCore::FFTFrame::dspSplitComplex): Deleted.
* Source/WebCore/platform/audio/HRTFDatabaseLoader.h:
(WebCore::HRTFDatabaseLoader::database): Deleted.
* Source/WebCore/platform/audio/HRTFElevation.h:
* Source/WebCore/platform/audio/HRTFKernel.h:
(WebCore::HRTFKernel::fftFrame): Deleted.
* Source/WebCore/platform/audio/ReverbConvolver.h:
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::processInBackground):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h:
(WebCore::AudioSampleBufferList::streamDescription const): Deleted.
(WebCore::AudioSampleBufferList::bufferList const): Deleted.
(WebCore::AudioSampleBufferList::bufferList): Deleted.
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
* Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.h:
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h:
* Source/WebCore/platform/audio/gstreamer/GStreamerAudioData.h:
* Source/WebCore/platform/audio/gstreamer/GStreamerAudioStreamDescription.h:
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.h:
(WebCore::VideoPresentationLayerProvider::layerHostView const): Deleted.
(WebCore::VideoPresentationLayerProvider::playerLayer const): Deleted.
(WebCore::VideoPresentationLayerProvider::playerLayerView const): Deleted.
(WebCore::VideoPresentationLayerProvider::videoView const): Deleted.
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyHandle::id const): Deleted.
(WebCore::KeyHandle::value const): Deleted.
(WebCore::KeyHandle::value): Deleted.
* Source/WebCore/platform/gamepad/PlatformGamepad.h:
(WebCore::PlatformGamepad::id const): Deleted.
(WebCore::PlatformGamepad::mapping const): Deleted.
(WebCore::PlatformGamepad::supportedEffectTypes const): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h:
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepad.h:
(WebCore::HIDGamepad::hidDevice const): Deleted.
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebCore/platform/glib/SelectionData.h:
(WebCore::SelectionData::text const): Deleted.
(WebCore::SelectionData::markup const): Deleted.
(WebCore::SelectionData::url const): Deleted.
(WebCore::SelectionData::uriList const): Deleted.
(WebCore::SelectionData::filenames const): Deleted.
(WebCore::SelectionData::buffers const): Deleted.
* Source/WebCore/platform/glib/SystemSettings.h:
(WebCore::SystemSettings::settingsState const): Deleted.
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun):
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::platformData const): Deleted.
(WebCore::Font::fontMetrics const): Deleted.
(WebCore::Font::attributes const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleTextWithFixedPitch const):
(WebCore::FontCascade::fastAverageCharWidthIfAvailable const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::primaryFont const):
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformData::FontVariationAxis::name const): Deleted.
(WebCore::FontPlatformData::FontVariationAxis::tag const): Deleted.
(WebCore::FontPlatformData::skFont const): Deleted.
(WebCore::FontPlatformData::features const): Deleted.
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::name const): Deleted.
(WebCore::GraphicsLayer::children const): Deleted.
(WebCore::GraphicsLayer::children): Deleted.
(WebCore::GraphicsLayer::replicatedLayerPosition const): Deleted.
(WebCore::GraphicsLayer::position const): Deleted.
(WebCore::GraphicsLayer::anchorPoint const): Deleted.
(WebCore::GraphicsLayer::size const): Deleted.
(WebCore::GraphicsLayer::boundsOrigin const): Deleted.
(WebCore::GraphicsLayer::backgroundColor const): Deleted.
(WebCore::GraphicsLayer::filters const): Deleted.
(WebCore::GraphicsLayer::backdropFilters const): Deleted.
(WebCore::GraphicsLayer::backdropFiltersRect const): Deleted.
(WebCore::GraphicsLayer::eventRegion const): Deleted.
(WebCore::GraphicsLayer::animationExtent const): Deleted.
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::Scale::amount const): Deleted.
(WebCore::DisplayList::SetCTM::transform const): Deleted.
(WebCore::DisplayList::ConcatenateCTM::transform const): Deleted.
(WebCore::DisplayList::SetInlineFillColor::colorData const): Deleted.
(WebCore::DisplayList::SetState::state): Deleted.
(WebCore::DisplayList::SetState::state const): Deleted.
(WebCore::DisplayList::SetLineDash::dashArray const): Deleted.
(WebCore::DisplayList::Clip::rect const): Deleted.
(WebCore::DisplayList::ClipRoundedRect::rect const): Deleted.
(WebCore::DisplayList::ClipOut::rect const): Deleted.
(WebCore::DisplayList::ClipOutRoundedRect::rect const): Deleted.
(WebCore::DisplayList::ClipOutToPath::path const): Deleted.
(WebCore::DisplayList::ClipPath::path const): Deleted.
(WebCore::DisplayList::DrawGlyphs::glyphs const): Deleted.
(WebCore::DisplayList::DrawGlyphs::advances const): Deleted.
(WebCore::DisplayList::DrawNativeImage::destinationRect const): Deleted.
(WebCore::DisplayList::DrawNativeImage::source const): Deleted.
(WebCore::DisplayList::DrawSystemImage::destinationRect const): Deleted.
(WebCore::DisplayList::DrawPatternNativeImage::patternTransform const): Deleted.
(WebCore::DisplayList::DrawPatternImageBuffer::patternTransform const): Deleted.
(WebCore::DisplayList::DrawLinesForText::lineSegments const): Deleted.
(WebCore::DisplayList::DrawPath::path const): Deleted.
(WebCore::DisplayList::DrawFocusRingPath::path const): Deleted.
(WebCore::DisplayList::DrawFocusRingPath::color const): Deleted.
(WebCore::DisplayList::DrawFocusRingRects::rects const): Deleted.
(WebCore::DisplayList::DrawFocusRingRects::color const): Deleted.
(WebCore::DisplayList::FillRect::rect const): Deleted.
(WebCore::DisplayList::FillRectWithColor::color const): Deleted.
(WebCore::DisplayList::FillRectWithGradient::rect const): Deleted.
(WebCore::DisplayList::FillRectWithGradientAndSpaceTransform::rect const): Deleted.
(WebCore::DisplayList::FillRectWithGradientAndSpaceTransform::gradientSpaceTransform const): Deleted.
(WebCore::DisplayList::FillCompositedRect::color const): Deleted.
(WebCore::DisplayList::FillRoundedRect::roundedRect const): Deleted.
(WebCore::DisplayList::FillRoundedRect::color const): Deleted.
(WebCore::DisplayList::FillRectWithRoundedHole::rect const): Deleted.
(WebCore::DisplayList::FillRectWithRoundedHole::roundedHoleRect const): Deleted.
(WebCore::DisplayList::FillRectWithRoundedHole::color const): Deleted.
(WebCore::DisplayList::FillPath::path const): Deleted.
(WebCore::DisplayList::StrokePath::path const): Deleted.
(WebCore::DisplayList::StrokeEllipse::rect const): Deleted.
(WebCore::DisplayList::ClearRect::rect const): Deleted.
(WebCore::DisplayList::DrawControlPart::style const): Deleted.
(WebCore::DisplayList::BeginPage::pageRect const): Deleted.
(WebCore::DisplayList::SetURLForRect::link const): Deleted.
(WebCore::DisplayList::SetURLForRect::destRect const): Deleted.
* Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.h:
(WebCore::ScalableImageDecoderFrame::backingStore const): Deleted.
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.h:
(GIFImageReader::frameContext const): Deleted.
* Source/WebCore/platform/ios/LegacyTileGridTile.h:
(WebCore::LegacyTileGridTile::tileLayer const): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::fullscreenViewController const): Deleted.
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
(WebCore::DataDetectorHighlight::highlight const): Deleted.
* Source/WebCore/platform/mac/HIDDevice.h:
(WebCore::HIDDevice::rawElement const): Deleted.
(WebCore::HIDDevice::productName const): Deleted.
* Source/WebCore/platform/mac/HIDElement.h:
(WebCore::HIDElement::rawElement const): Deleted.
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h:
(WebCore::MediaRecorderPrivateBackend::mimeType const): Deleted.
* Source/WebCore/platform/mediastream/CaptureDevice.h:
(WebCore::CaptureDevice::persistentId const): Deleted.
(WebCore::CaptureDevice::label const): Deleted.
(WebCore::CaptureDevice::groupId const): Deleted.
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaTrackConstraintSetMap::width const): Deleted.
(WebCore::MediaTrackConstraintSetMap::height const): Deleted.
(WebCore::MediaTrackConstraintSetMap::sampleRate const): Deleted.
(WebCore::MediaTrackConstraintSetMap::sampleSize const): Deleted.
(WebCore::MediaTrackConstraintSetMap::aspectRatio const): Deleted.
(WebCore::MediaTrackConstraintSetMap::frameRate const): Deleted.
(WebCore::MediaTrackConstraintSetMap::volume const): Deleted.
(WebCore::MediaTrackConstraintSetMap::echoCancellation const): Deleted.
(WebCore::MediaTrackConstraintSetMap::displaySurface const): Deleted.
(WebCore::MediaTrackConstraintSetMap::logicalSurface const): Deleted.
(WebCore::MediaTrackConstraintSetMap::facingMode const): Deleted.
(WebCore::MediaTrackConstraintSetMap::deviceId const): Deleted.
(WebCore::MediaTrackConstraintSetMap::groupId const): Deleted.
(WebCore::MediaTrackConstraintSetMap::whiteBalanceMode const): Deleted.
(WebCore::MediaTrackConstraintSetMap::zoom const): Deleted.
(WebCore::MediaTrackConstraintSetMap::torch const): Deleted.
(WebCore::MediaTrackConstraintSetMap::backgroundBlur const): Deleted.
(WebCore::MediaTrackConstraintSetMap::powerEfficient const): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RTCSessionDescriptionDescriptor.h:
(WebCore::RTCSessionDescriptionDescriptor::type const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::width const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::height const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::frameRate const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::facingMode const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::aspectRatio const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::volume const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::sampleRate const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::sampleSize const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::deviceId const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::groupId const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::focusDistance const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::whiteBalanceModes const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::zoom const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::supportedConstraints const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::deviceId const): Deleted.
(WebCore::RealtimeMediaSourceSettings::groupId const): Deleted.
(WebCore::RealtimeMediaSourceSettings::supportedConstraints const): Deleted.
(WebCore::RealtimeMediaSourceSettings::label const): Deleted.
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h:
(WebCore::MockRealtimeMediaSourceCenter::audioCaptureDeviceManager): Deleted.
(WebCore::MockRealtimeMediaSourceCenter::videoCaptureDeviceManager): Deleted.
(WebCore::MockRealtimeMediaSourceCenter::displayCaptureDeviceManager): Deleted.
* Source/WebCore/platform/mock/mediasource/MockBox.h:
(WebCore::MockBox::type const): Deleted.
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::responseContentDispositionEncodingFallbackArray const): Deleted.
(WebCore::ResourceRequestBase::cachePartition const): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::certificateInfo const): Deleted.
(WebCore::ResourceResponseBase::proxyName const): Deleted.
(WebCore::ResourceResponseBase::deprecatedNetworkLoadMetricsOrNull const): Deleted.
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebCore/platform/text/BidiResolver.h:
(WebCore::WhitespaceCollapsingState::transitions): Deleted.
(WebCore::BidiCharacterRun::next const): Deleted.
(WebCore::BidiResolverBase::position const): Deleted.
(WebCore::BidiResolverBase::status const): Deleted.
(WebCore::BidiResolverBase::whitespaceCollapsingState): Deleted.
(WebCore::BidiResolverBase::runs): Deleted.
(WebCore::BidiResolverWithIsolate::isolatedRuns): Deleted.
* Source/WebCore/platform/text/BidiRunList.h:
(WebCore::BidiRunList::firstRun const): Deleted.
* Source/WebCore/platform/text/TextChecking.h:
(WebCore::TextCheckingRequestData::text const): Deleted.
* Source/WebCore/platform/win/WindowMessageBroadcaster.h:
(WebCore::WindowMessageBroadcaster::listeners const): Deleted.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::adjustLogicalLeftOffsetForLine const):
(WebCore::RenderBlock::adjustLogicalRightOffsetForLine const):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::preferredContentLogicalWidth const):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::getGlyph const):
(WebCore::glyphDataForCodePointOrFallbackGlyph):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hyphenString const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::backgroundLayerForPage const):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMElement _font]):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::populate):
(PopupMenuMac::show):
* Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp:
(TestWebKitAPI::TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)):

Canonical link: <a href="https://commits.webkit.org/308484@main">https://commits.webkit.org/308484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c1eb08e8b8e61c1bc19e96f92bbcf76fbad8ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147619 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101034 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81163 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec2016e0-de61-4068-b10a-25c7f0f5bafb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94556 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bfa39b4-ab1e-4520-a6ce-bbf5e1feb61b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15198 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12985 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3742 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158635 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1771 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121819 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122020 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31267 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76218 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9067 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83481 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19448 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->