### PR TITLE
removeAttribute for width/height on svg root element is trying to set an empty invalid string

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-002-expected.txt
@@ -1,18 +1,18 @@
 
 
 PASS no sizing attributes set
-FAIL specified width assert_equals: checking width. expected 100 but got 300
-FAIL modified specified width assert_equals: checking width. expected 400 but got 300
-FAIL specified width and height assert_equals: checking width. expected 400 but got 300
-FAIL specified width and modified specified height assert_equals: checking width. expected 400 but got 300
-FAIL specified height assert_equals: checking height. expected 200 but got 150
-FAIL modified specified height assert_equals: checking height. expected 250 but got 150
+PASS specified width
+PASS modified specified width
+PASS specified width and height
+PASS specified width and modified specified height
+PASS specified height
+PASS modified specified height
 PASS no specified sizing attrs (after setting & removing them)
-FAIL set a 10x8 viewBox assert_equals: checking width. expected 500 but got 300
-FAIL modified viewBox to 50x20 assert_equals: checking width. expected 500 but got 300
-FAIL adding specified width, in presence of specified viewBox assert_equals: checking width. expected 100 but got 300
-FAIL modifiying specified viewBox, in presence of specified width assert_equals: checking width. expected 100 but got 300
-FAIL removing specified width, in presence of specified viewBox assert_equals: checking width. expected 500 but got 300
-FAIL adding specified height, in presence of specified viewBox assert_equals: checking width. expected 80 but got 300
-FAIL modifiying specified viewBox, in presence of specified height assert_equals: checking width. expected 50 but got 300
+PASS set a 10x8 viewBox
+PASS modified viewBox to 50x20
+PASS adding specified width, in presence of specified viewBox
+PASS modifiying specified viewBox, in presence of specified width
+PASS removing specified width, in presence of specified viewBox
+PASS adding specified height, in presence of specified viewBox
+PASS modifiying specified viewBox, in presence of specified height
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -470,9 +470,11 @@ void RenderReplaced::computeAspectRatioInformationForRenderBox(RenderBox* conten
         intrinsicSize = RenderReplaced::computeIntrinsicSize();
         preferredAspectRatio = RenderReplaced::preferredAspectRatio();
     } else if (contentRenderer) {
+        bool contentIsRenderReplaced = false;
         if (auto* renderReplaced = dynamicDowncast<RenderReplaced>(contentRenderer)) {
             intrinsicSize = renderReplaced->computeIntrinsicSize();
             preferredAspectRatio = renderReplaced->preferredAspectRatio();
+            contentIsRenderReplaced = true;
         }
         if (style().aspectRatio().isRatio() || (style().aspectRatio().isAutoAndRatio() && preferredAspectRatio.isEmpty()))
             preferredAspectRatio = FloatSize::narrowPrecision(style().aspectRatio().width().value, style().aspectRatio().height().value);
@@ -486,7 +488,20 @@ void RenderReplaced::computeAspectRatioInformationForRenderBox(RenderBox* conten
         // Update our intrinsic size to match what the content renderer has computed, so that when we
         // constrain the size below, the correct intrinsic size will be obtained for comparison against
         // min and max widths.
-        if (!preferredAspectRatio.isEmpty() && !intrinsicSize.isZero())
+        if (contentIsRenderReplaced && isRenderWidget()) {
+            // For RenderWidget content (e.g. <object> embedding an SVG document), always update
+            // m_intrinsicSize to reflect current intrinsic dimensions, applying CSS default fallback
+            // values (300x150) for dimensions with no intrinsic value (e.g. percentage-sized or
+            // removed attributes). This prevents stale cached sizes when attributes like width/height
+            // are removed. Note: this does not apply to RenderImage (<img src="svg">), which manages
+            // its own intrinsic size via setIntrinsicSize() during image load.
+            auto sizeToCache = intrinsicSize;
+            if (!sizeToCache.width())
+                sizeToCache.setWidth(cDefaultWidth);
+            if (!sizeToCache.height())
+                sizeToCache.setHeight(cDefaultHeight);
+            m_intrinsicSize = LayoutSize(sizeToCache);
+        } else if (!preferredAspectRatio.isEmpty() && !intrinsicSize.isZero())
             m_intrinsicSize = LayoutSize(intrinsicSize);
 
         if (!isHorizontalWritingMode()) {

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -244,8 +244,13 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
         if (attrName == SVGNames::widthAttr || attrName == SVGNames::heightAttr) {
             // FIXME: try to get rid of this custom handling of embedded SVG invalidation, maybe through abstraction.
             if (CheckedPtr renderer = this->renderer()) {
-                if (isEmbeddedThroughFrameContainingSVGDocument(*renderer))
+                if (isEmbeddedThroughFrameContainingSVGDocument(*renderer)) {
                     protect(renderer->view())->setNeedsLayout(MarkOnlyThis);
+                    if (RefPtr frame = document().frame()) {
+                        if (CheckedPtr ownerRenderer = frame->ownerRenderer())
+                            ownerRenderer->setNeedsLayoutAndPreferredWidthsUpdate();
+                    }
+                }
             }
         }
         invalidateResourceImageBuffersIfNeeded();
@@ -264,17 +269,26 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
 
             // TODO: [LBSE] Avoid relayout upon transform changes (not possible in legacy, but should be in LBSE).
             updateSVGRendererForElementChange();
-            return;
+        } else {
+            if (CheckedPtr renderer = this->renderer()) {
+                renderer->setNeedsTransformUpdate();
+                if (CheckedPtr svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(*renderer))
+                    svgRoot->setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
+            }
+
+            invalidateResourceImageBuffersIfNeeded();
+            updateSVGRendererForElementChange();
         }
 
+        // FIXME: try to get rid of this custom handling of embedded SVG invalidation, maybe through abstraction.
         if (CheckedPtr renderer = this->renderer()) {
-            renderer->setNeedsTransformUpdate();
-            if (CheckedPtr svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(*renderer))
-                svgRoot->setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
+            if (isEmbeddedThroughFrameContainingSVGDocument(*renderer)) {
+                if (RefPtr frame = document().frame()) {
+                    if (CheckedPtr ownerRenderer = frame->ownerRenderer())
+                        ownerRenderer->setNeedsLayoutAndPreferredWidthsUpdate();
+                }
+            }
         }
-
-        invalidateResourceImageBuffersIfNeeded();
-        updateSVGRendererForElementChange();
         return;
     }
 


### PR DESCRIPTION
#### 15ab792bb311c8bf7603e992ac922c06f3dba0e2
<pre>
removeAttribute for width/height on svg root element is trying to set an empty invalid string
<a href="https://bugs.webkit.org/show_bug.cgi?id=307677">https://bugs.webkit.org/show_bug.cgi?id=307677</a>
<a href="https://rdar.apple.com/170233990">rdar://170233990</a>

Reviewed by Nikolas Zimmermann.

When removeAttribute(&quot;width&quot;) or removeAttribute(&quot;height&quot;) was called on
an &lt;svg&gt; root element embedded via &lt;object&gt;, the parent renderer was not
notified and m_intrinsicSize in RenderReplaced became stale, causing the
old explicit value to persist instead of reverting to the CSS default
(300×150).

Three related issues are fixed:

1. SVGSVGElement::svgAttributeChanged — when widthAttr/heightAttr changes
   on an SVG embedded through a frame, notify the owner renderer in the
   parent document so it re-lays out with updated intrinsic dimensions.

2. SVGSVGElement::svgAttributeChanged — when a viewBox attribute changes,
   similarly notify the owner renderer in the parent document, so that
   aspect-ratio-derived sizes are recomputed correctly.

3. RenderReplaced::computeAspectRatioInformationForRenderBox — when
   content is a RenderWidget (e.g. an &lt;object&gt; embedding an SVG document),
   always update m_intrinsicSize rather than only when an aspect ratio
   exists. Apply CSS default fallback dimensions (300×150) for zero values
   so stale cached sizes are never returned. This is intentionally scoped
   to RenderWidget and does not affect RenderImage (&lt;img src=&quot;svg&quot;&gt;),
   which manages its intrinsic size independently via setIntrinsicSize()
   during image load.

* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-002-expected.txt:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/308906@main">https://commits.webkit.org/308906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e57d0b2ffa83befb492ca4692bcad93f3681bd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9363554-48fd-495d-a98d-8ba41a2764d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81224 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec4f5f86-abd3-496f-af83-71b149574729) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2734e190-4545-4ad4-babb-2193f70766a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13080 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3867 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158762 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121924 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122125 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76354 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9170 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83606 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19573 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19724 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->