### PR TITLE
REGRESSION(308379@main): Build with assertions disabled is broken

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -47,7 +47,7 @@ AddressType::AddressType(TypeKind typeKind)
         m_type = AddressType::I64;
         break;
     default:
-        ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
+        RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
     }
 }
 
@@ -58,9 +58,8 @@ TypeKind AddressType::asTypeKind() const
         return TypeKind::I32;
     case AddressType::I64:
         return TypeKind::I64;
-    default:
-        ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
     }
+    RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
 }
 
 bool operator==(const AddressType& lhs, const AddressType& rhs)


### PR DESCRIPTION
#### fe5e9c826dceccf6994b4b5d9c67f2e74f82336e
<pre>
REGRESSION(308379@main): Build with assertions disabled is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=308960">https://bugs.webkit.org/show_bug.cgi?id=308960</a>

Reviewed by Anne van Kesteren.

The following code was added in 308379@main:

```
TypeKind AddressType::asTypeKind() const
{
    switch (m_type) {
    case AddressType::I32:
        return TypeKind::I32;
    case AddressType::I64:
        return TypeKind::I64;
    default:
        ASSERT_NOT_REACHED(&quot;Invalid Wasm Type to AddressType conversion&quot;);
    }
}
```

When assertions are disabled `ASSERT_NOT_REACHED` expands to `((void)0)`,
which causes a compile error because the function is expected to return
a value.

Because `m_type` can only have one of two possible values, this patch
removes the default case from the switch. This should trigger a warning
if another value will be added to the `AddressType` enum in the future.

`RELEASE_ASSERT_NOT_REACHED` is added to the end to suppress the compile
error for the compilers that don&apos;t understand that all code paths are
handled.

* Source/JavaScriptCore/wasm/WasmAddressType.cpp:
(JSC::Wasm::AddressType::AddressType):
(JSC::Wasm::AddressType::asTypeKind const):

Canonical link: <a href="https://commits.webkit.org/308469@main">https://commits.webkit.org/308469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/013a545ffb852ab71aa0d63448d700a40dc7006f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113800 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15202 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3751 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139598 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124798 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158644 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8416 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121827 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31249 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76227 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9073 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179050 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83490 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45893 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->