### PR TITLE
[GStreamer][1.28] Gardening after update from 1.26

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1677,7 +1677,8 @@ webkit.org/b/306457 http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Crash Timeout Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Failure Pass ]
 
-webkit.org/b/307032 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Pass Failure ]
+# Timeout due to webkit.org/b/312138
+webkit.org/b/307032 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Timeout Failure ]
 
 # No support for Matroska container in GStreamer port.
 http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
@@ -1858,6 +1859,24 @@ webkit.org/b/281343 media/media-source/media-managedmse-webvtt-track.html [ Skip
 webkit.org/b/307142 media/video-currentTime.html [ Failure Pass ]
 
 webkit.org/b/184457 media/video-aspect-ratio.html [ Pass Failure ]
+
+webkit.org/b/256768 fast/mediastream/captureStream/canvas3d.html [ Pass Failure ]
+webkit.org/b/312138 http/wpt/mediasession/setCaptureState.html [ Pass Failure ]
+webkit.org/b/312138 fast/mediastream/MediaStream-add-remove-tracks.html [ Pass Timeout ]
+webkit.org/b/312138 fast/mediastream/MediaStreamTrack-kind.html [ Pass Timeout ]
+webkit.org/b/312138 fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html [ Failure ]
+webkit.org/b/312138 imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html?interop-2026 [ Failure ]
+webkit.org/b/312138 [ Debug ] media/media-preload-no-delay-loadevent.html [ Failure Pass ]
+webkit.org/b/312138 [ Debug ] media/track/webvtt-parser-does-not-leak.html [ Failure Pass ]
+webkit.org/b/312138 [ Debug ] http/wpt/webcodecs/videoFrame-video-element-compressed.html [ Failure ]
+webkit.org/b/312138 [ Debug ] imported/w3c/web-platform-tests/media-source/mediasource-append-buffer.html [ Failure ]
+webkit.org/b/312138 [ Debug ] media/audio-concurrent-supported.html [ Failure ]
+webkit.org/b/312138 [ Debug ] media/media-event-listeners.html [ Failure ]
+webkit.org/b/312138 [ Debug ] media/media-source/media-source-webm-configuration-change.html [ Failure ]
+webkit.org/b/312138 [ Debug ] media/video-background-playback.html [ Failure ]
+webkit.org/b/312138 [ Debug ] webrtc/video-rotation-black.html [ Failure ]
+webkit.org/b/312138 [ Debug ] http/tests/media/video-play-waiting.html [ Timeout ]
+webkit.org/b/312138 [ Debug ] imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html [ Crash ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs
@@ -2817,7 +2836,6 @@ fast/mediastream/getDisplayMedia-max-constraints5.html [ Skip ]
 
 # DataChannel GstWebRTC implementation incomplete, missing stats support.
 webkit.org/b/235885 webrtc/datachannel/datachannel-stats.html [ Skip ]
-webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [ Failure ]
 # Crash due to webkit.org/b/286859
 webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html [ Failure Crash ]
 
@@ -2890,13 +2908,6 @@ webrtc/video-replace-track.html [ Pass Failure Timeout Crash ]
 
 # GStreamerRtpSenderBackend::setMediaStreamIds() unimplemented.
 webkit.org/b/235885 webrtc/video.html [ Skip ]
-
-# Expected to pass when updating SDK to GStreamer 1.28.
-webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html?interop-2026 [ Failure ]
-imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html [ Skip ]
 
 # Pending investigation.
 webkit.org/b/235885 fast/mediastream/mediastreamtrack-video-clone.html [ Failure ]
@@ -3029,7 +3040,7 @@ imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-of
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html [ Skip ] # Timeout
-imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-simulcast.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-simulcast.https.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-transceivers.https.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-transport-stats.https.html [ Failure ]
@@ -3058,13 +3069,14 @@ imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stop.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stopping.https.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-constructor.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-events.html [ Skip ] # Timeout
-imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxChannels.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxChannels.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxMessageSize.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCTrackEvent-constructor.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCTrackEvent-fire.html  [ Skip ] # Timeout
 webkit.org/b/307440 imported/w3c/web-platform-tests/webrtc/simplecall.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/toJSON.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html [ Skip ] # Timeout
 
 # Triggers an assert in webrtcbin.
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer.html [ Skip ] # Crash
@@ -3102,11 +3114,8 @@ imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel.html [ Fail
 # set-up, so rtpbin doesn't create src pads and thus neither is webrtcbin.
 imported/w3c/web-platform-tests/webrtc/protocol/msid-parse.html [ Failure Timeout ]
 
-# Expected to pass when our SDK ships GStreamer 1.28. See also:
-# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/80e663d5605124fbd7e4b69e69060749a541e491
-# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/ea69849cd89a9d1a69c98bd9c640452a5deb72c2
-imported/w3c/web-platform-tests/webrtc/protocol/ice-state.https.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/protocol/ice-ufragpwd.html [ Failure ]
+# Still failing after update to GStreamer 1.28, to be investigated.
+imported/w3c/web-platform-tests/webrtc/protocol/ice-state.https.html [ Skip ] # Timeout
 
 # Missing support for multiple MediaStreams per track/transceiver.
 # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3954
@@ -3121,9 +3130,6 @@ imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-codecs.html [ Failure ]
 # The 'Can demux two video tracks with the same payload type on an unbundled connection' test times
 # out, the metadataToBeLoaded promise never resolves.
 webkit.org/b/286481 imported/w3c/web-platform-tests/webrtc/protocol/rtp-demuxing.html [ Failure ]
-
-# webrtcbin expects mid in its offer/answer SDP, this is not spec compliant, it's an optional field.
-imported/w3c/web-platform-tests/webrtc/protocol/missing-fields.html [ Failure ]
 
 # Simulcast support is not complete yet.
 imported/w3c/web-platform-tests/webrtc/simulcast [ Pass ]
@@ -3196,7 +3202,7 @@ webkit.org/b/306207 imported/w3c/web-platform-tests/webrtc-stats/hardware-capabi
 # The main difference is that in this test an additional message is sent on the data-channel.
 webkit.org/b/264936 imported/w3c/web-platform-tests/webrtc-extensions/transfer-datachannel-service-worker.https.html [ Failure ]
 
-webkit.org/b/276587 webrtc/video-av1.html [ Pass Timeout ]
+webkit.org/b/276587 webrtc/video-av1.html [ Pass Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebRTC-related bugs

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -11,7 +11,7 @@ o=- {session-id:OK} 0 IN IP4 0.0.0.0
 s=-
 t=0 0
 a=ice-options:trickle
-m=audio 9 UDP/TLS/RTP/SAVPF 96
+m=audio 9 UDP/TLS/RTP/SAVPF 96 9 0 8 97 98
 c=IN IP4 0.0.0.0
 a=ice-ufrag:{ice-ufrag:OK}
 a=ice-pwd:{ice-password:OK}
@@ -21,6 +21,16 @@ a=setup:active
 a=rtpmap:96 opus/48000/2
 a=rtcp-fb:96 transport-cc
 a=fmtp:96 minptime=10;useinbandfec=1
+a=rtpmap:9 G722/8000
+a=rtcp-fb:9 transport-cc
+a=rtpmap:0 PCMU/8000
+a=rtcp-fb:0 transport-cc
+a=rtpmap:8 PCMA/8000
+a=rtcp-fb:8 transport-cc
+a=rtpmap:97 TELEPHONE-EVENT/48000
+a=rtcp-fb:97 transport-cc
+a=rtpmap:98 TELEPHONE-EVENT/8000
+a=rtcp-fb:98 transport-cc
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
@@ -39,7 +49,7 @@ o=- {session-id:OK} 1 IN IP4 0.0.0.0
 s=-
 t=0 0
 a=ice-options:trickle
-m=audio 9 UDP/TLS/RTP/SAVPF 96
+m=audio 9 UDP/TLS/RTP/SAVPF 96 9 0 8 97 98
 c=IN IP4 0.0.0.0
 a=ice-ufrag:{ice-ufrag:OK}
 a=ice-pwd:{ice-password:OK}
@@ -49,6 +59,16 @@ a=setup:active
 a=rtpmap:96 opus/48000/2
 a=rtcp-fb:96 transport-cc
 a=fmtp:96 minptime=10;useinbandfec=1
+a=rtpmap:9 G722/8000
+a=rtcp-fb:9 transport-cc
+a=rtpmap:0 PCMU/8000
+a=rtcp-fb:0 transport-cc
+a=rtpmap:8 PCMA/8000
+a=rtcp-fb:8 transport-cc
+a=rtpmap:97 TELEPHONE-EVENT/48000
+a=rtcp-fb:97 transport-cc
+a=rtpmap:98 TELEPHONE-EVENT/8000
+a=rtcp-fb:98 transport-cc
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
@@ -57,7 +77,7 @@ a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=extmap:5 urn:ietf:params:rtp-hdrext:ntp-64
 a=extmap:6 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-m=video 9 UDP/TLS/RTP/SAVPF 99 96
+m=video 9 UDP/TLS/RTP/SAVPF 99 96 100 97 101 98 102 114 103 115 104 116 105 117 106 118 107 119 108 120 109 121 110 122 111 123 112 124 113 125
 c=IN IP4 0.0.0.0
 a=ice-ufrag:{ice-ufrag:OK}
 a=ice-pwd:{ice-password:OK}
@@ -69,9 +89,118 @@ a=rtcp-fb:99 nack
 a=rtcp-fb:99 nack pli
 a=rtcp-fb:99 ccm fir
 a=rtcp-fb:99 transport-cc
-a=fmtp:99 packetization-mode=1;level-asymmetry-allowed=1
+a=fmtp:99 packetization-mode=1;profile-level-id=42c01f;level-asymmetry-allowed=1
 a=rtpmap:96 rtx/90000
 a=fmtp:96 apt=99
+a=rtpmap:100 H264/90000
+a=rtcp-fb:100 nack
+a=rtcp-fb:100 nack pli
+a=rtcp-fb:100 ccm fir
+a=rtcp-fb:100 transport-cc
+a=fmtp:100 packetization-mode=0;profile-level-id=42c01f;level-asymmetry-allowed=1
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=100
+a=rtpmap:101 H264/90000
+a=rtcp-fb:101 nack
+a=rtcp-fb:101 nack pli
+a=rtcp-fb:101 ccm fir
+a=rtcp-fb:101 transport-cc
+a=fmtp:101 packetization-mode=1;profile-level-id=42e01f;level-asymmetry-allowed=1
+a=rtpmap:98 rtx/90000
+a=fmtp:98 apt=101
+a=rtpmap:102 H264/90000
+a=rtcp-fb:102 nack
+a=rtcp-fb:102 nack pli
+a=rtcp-fb:102 ccm fir
+a=rtcp-fb:102 transport-cc
+a=fmtp:102 packetization-mode=0;profile-level-id=42e01f;level-asymmetry-allowed=1
+a=rtpmap:114 rtx/90000
+a=fmtp:114 apt=102
+a=rtpmap:103 H264/90000
+a=rtcp-fb:103 nack
+a=rtcp-fb:103 nack pli
+a=rtcp-fb:103 ccm fir
+a=rtcp-fb:103 transport-cc
+a=fmtp:103 packetization-mode=1;profile-level-id=640c1f;level-asymmetry-allowed=1
+a=rtpmap:115 rtx/90000
+a=fmtp:115 apt=103
+a=rtpmap:104 H264/90000
+a=rtcp-fb:104 nack
+a=rtcp-fb:104 nack pli
+a=rtcp-fb:104 ccm fir
+a=rtcp-fb:104 transport-cc
+a=fmtp:104 packetization-mode=0;profile-level-id=640c1f;level-asymmetry-allowed=1
+a=rtpmap:116 rtx/90000
+a=fmtp:116 apt=104
+a=rtpmap:105 H264/90000
+a=rtcp-fb:105 nack
+a=rtcp-fb:105 nack pli
+a=rtcp-fb:105 ccm fir
+a=rtcp-fb:105 transport-cc
+a=fmtp:105 packetization-mode=1;profile-level-id=42001f;level-asymmetry-allowed=1
+a=rtpmap:117 rtx/90000
+a=fmtp:117 apt=105
+a=rtpmap:106 H264/90000
+a=rtcp-fb:106 nack
+a=rtcp-fb:106 nack pli
+a=rtcp-fb:106 ccm fir
+a=rtcp-fb:106 transport-cc
+a=fmtp:106 packetization-mode=0;profile-level-id=42001f;level-asymmetry-allowed=1
+a=rtpmap:118 rtx/90000
+a=fmtp:118 apt=106
+a=rtpmap:107 H264/90000
+a=rtcp-fb:107 nack
+a=rtcp-fb:107 nack pli
+a=rtcp-fb:107 ccm fir
+a=rtcp-fb:107 transport-cc
+a=fmtp:107 packetization-mode=1;profile-level-id=4d001f;level-asymmetry-allowed=1
+a=rtpmap:119 rtx/90000
+a=fmtp:119 apt=107
+a=rtpmap:108 H264/90000
+a=rtcp-fb:108 nack
+a=rtcp-fb:108 nack pli
+a=rtcp-fb:108 ccm fir
+a=rtcp-fb:108 transport-cc
+a=fmtp:108 packetization-mode=0;profile-level-id=4d001f;level-asymmetry-allowed=1
+a=rtpmap:120 rtx/90000
+a=fmtp:120 apt=108
+a=rtpmap:109 H265/90000
+a=rtcp-fb:109 nack
+a=rtcp-fb:109 nack pli
+a=rtcp-fb:109 ccm fir
+a=rtcp-fb:109 transport-cc
+a=rtpmap:121 rtx/90000
+a=fmtp:121 apt=109
+a=rtpmap:110 AV1/90000
+a=rtcp-fb:110 nack
+a=rtcp-fb:110 nack pli
+a=rtcp-fb:110 ccm fir
+a=rtcp-fb:110 transport-cc
+a=rtpmap:122 rtx/90000
+a=fmtp:122 apt=110
+a=rtpmap:111 VP8/90000
+a=rtcp-fb:111 nack
+a=rtcp-fb:111 nack pli
+a=rtcp-fb:111 ccm fir
+a=rtcp-fb:111 transport-cc
+a=rtpmap:123 rtx/90000
+a=fmtp:123 apt=111
+a=rtpmap:112 VP9/90000
+a=rtcp-fb:112 nack
+a=rtcp-fb:112 nack pli
+a=rtcp-fb:112 ccm fir
+a=rtcp-fb:112 transport-cc
+a=fmtp:112 profile-id=0
+a=rtpmap:124 rtx/90000
+a=fmtp:124 apt=112
+a=rtpmap:113 VP9/90000
+a=rtcp-fb:113 nack
+a=rtcp-fb:113 nack pli
+a=rtcp-fb:113 ccm fir
+a=rtcp-fb:113 transport-cc
+a=fmtp:113 profile-id=2
+a=rtpmap:125 rtx/90000
+a=fmtp:125 apt=113
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1261,8 +1261,6 @@ webkit.org/b/143153 imported/w3c/web-platform-tests/css/css-text/text-transform/
 
 webkit.org/b/245900 [ Debug ] fast/inline/inline-box-adjust-position-crash2.html [ Skip ]
 
-webkit.org/b/256768 fast/mediastream/captureStream/canvas3d.html [ Failure Pass ]
-
 webkit.org/b/249477 media/audioSession/audioSessionType.html [ Skip ]
 
 media/media-source/media-detachablemse-append.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -552,7 +552,8 @@ webkit.org/b/307143 imported/w3c/web-platform-tests/preload/preload-in-data-doc.
 
 # Flaky tests detected from 29Jan2023 to 23Feb2023
 webkit.org/b/252878 gamepad/gamepad-event-handlers.html [ Pass Timeout ]
-webkit.org/b/252878 http/tests/media/video-play-waiting.html [ Failure Pass ]
+# timeout due to webkit.org/b/312138
+webkit.org/b/252878 http/tests/media/video-play-waiting.html [ Timeout ]
 webkit.org/b/281053 http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Failure ]
 webkit.org/b/252878 http/wpt/service-workers/controlled-sharedworker.https.html [ Failure Pass ]
 webkit.org/b/252878 imported/blink/fast/transforms/transform-update-frame-overflow.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### bb268639645ac417d6007de5f8da057070d663f0
<pre>
[GStreamer][1.28] Gardening after update from 1.26
<a href="https://bugs.webkit.org/show_bug.cgi?id=308957">https://bugs.webkit.org/show_bug.cgi?id=308957</a>

Unreviewed, update test expectations after the deployment of GStreamer 1.28 in Linux SDKs.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt:

Canonical link: <a href="https://commits.webkit.org/311079@main">https://commits.webkit.org/311079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6d2e4cecf244e8c04c95af7d25631125510f53c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/156035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/29370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164797 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29503 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29371 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164797 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/158993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29503 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/22552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164797 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29503 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29371 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12628 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29503 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/22552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28971 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/29371 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28893 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/22552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86643 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23748 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28893 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22552 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28129 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28253 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->