### PR TITLE
REGRESSION (306632@main): webrtc/candidate-stats.html is a flaky failure

### DIFF
--- a/LayoutTests/webrtc/candidate-stats.html
+++ b/LayoutTests/webrtc/candidate-stats.html
@@ -30,6 +30,12 @@ promise_test(async (test) => {
 
     stats = await getTypedStats(firstConnection, "remote-candidate");
 
+    if (stats.protocol === "tcp") {
+        assert_equals(stats.tcpType, "active");
+        // We delete the key so that we can check udp and tcp remote candidate stats in the same way.
+        delete stats.tcpType;
+    }
+
     // For now, we do not want to expose address or networkType.
     assert_true(!stats.address, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");


### PR DESCRIPTION
#### fdb557e81e0f18b25d558f99e6877ffc72c13b84
<pre>
REGRESSION (306632@main): webrtc/candidate-stats.html is a flaky failure
<a href="https://rdar.apple.com/170829395">rdar://170829395</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308329">https://bugs.webkit.org/show_bug.cgi?id=308329</a>

Reviewed by Eric Carlson.

Libwebrtc is storing stats in a map that does not guarantee ordering.
UDP candidates are gathered first so stats for those candidates are also usually generated first,
but this is not guaranteed.

To make the test non flaky, we check whether the stat report is TCP or UDP.
If TCP, we do additional checks on the TCP specific field and remove it before doing generic checks.

Canonical link: <a href="https://commits.webkit.org/308527@main">https://commits.webkit.org/308527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6fe7ea406d63086e387f2572eebd3e32bf0947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101044 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7eb5399-40f0-4b1a-b357-d1c1375c9634) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113801 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81168 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1107b1e-da67-43db-8e9e-89d89a68abf0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94562 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df40eea4-9e73-4f81-97d4-e0d152aced01) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12994 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3752 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158645 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121828 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31290 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76228 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9075 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19728 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->