### PR TITLE
RealtimeOutgoingAudioSourceCocoa::pullAudioData should check for its buffer size before trying to grow it

### DIFF
--- a/LayoutTests/webrtc/audio-replace-track-to-webaudio-expected.txt
+++ b/LayoutTests/webrtc/audio-replace-track-to-webaudio-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Use replaceTrack to migrate from web audio to microphone
+

--- a/LayoutTests/webrtc/audio-replace-track-to-webaudio.html
+++ b/LayoutTests/webrtc/audio-replace-track-to-webaudio.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src ="routines.js"></script>
+</head>
+<body>
+<video id=video autoplay muted></video>
+<script>
+
+const noiseContext = new AudioContext();
+const buffer = noiseContext.createBuffer(2, 10 * noiseContext.sampleRate, noiseContext.sampleRate);
+const source = new AudioBufferSourceNode(noiseContext, { buffer });
+const audioStreamDestination = noiseContext.createMediaStreamDestination({ channelCount : 2 });
+const audioTrack = audioStreamDestination.stream.getAudioTracks()[0];
+source.connect(audioStreamDestination);
+
+promise_test(async test => {
+    const localStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => localStream.getAudioTracks()[0].stop());
+    test.add_cleanup(() => localStream.getVideoTracks()[0].stop());
+
+    let audioSender;
+
+    video.srcObject = await new Promise((resolve, reject) => {
+        createConnections(firstConnection => {
+            audioSender = firstConnection.addTrack(audioTrack, localStream);
+            firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+        }, secondConnection => {
+            secondConnection.ontrack = trackEvent => { resolve(trackEvent.streams[0]); };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+    await video.play();
+
+    let useWebAudio = false;
+    for (let i = 0; i < 100; i++) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        await audioSender.replaceTrack(useWebAudio ? localStream.getAudioTracks()[0] : audioTrack);
+        useWebAudio = !useWebAudio;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+}, "Use replaceTrack to migrate from web audio to microphone");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
@@ -143,7 +143,8 @@ void RealtimeOutgoingAudioSourceCocoa::pullAudioData()
     constexpr size_t chunkSampleCount = LibWebRTCAudioFormat::sampleRate / 100;
     size_t numberOfChannels = m_outputStreamDescription->numberOfChannels();
     size_t bufferSize = chunkSampleCount * LibWebRTCAudioFormat::sampleByteSize * numberOfChannels;
-    m_audioBuffer.grow(bufferSize);
+    if (bufferSize > m_audioBuffer.size())
+        m_audioBuffer.grow(bufferSize);
 
     AudioBufferList bufferList;
     bufferList.mNumberBuffers = 1;


### PR DESCRIPTION
#### 55a08bb37494eb87f9e38396b7fc57b8b38a1050
<pre>
RealtimeOutgoingAudioSourceCocoa::pullAudioData should check for its buffer size before trying to grow it
<a href="https://rdar.apple.com/171286464">rdar://171286464</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308967">https://bugs.webkit.org/show_bug.cgi?id=308967</a>

Reviewed by Eric Carlson.

Vector::growImpl checks that the new size is above the current size and asserts if not the case.
We add a similar check at call site.

Canonical link: <a href="https://commits.webkit.org/308543@main">https://commits.webkit.org/308543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/583b0bd312f98efc16fe7593d8674ca5fc113c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101261 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dd4854a-d38e-4c0b-85fa-ee85420ad4a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113980 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e75abd2-c055-4625-80ae-d71d7c03e8c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94741 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adeae208-5367-428e-9b7d-b62d86acce24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3969 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158864 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1998 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122010 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31301 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76480 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17716 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9260 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19946 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83708 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19675 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->