### PR TITLE
[cleanup] Move shouldExtendSelectionToTargetNode to EventHandler

### DIFF
--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1030,44 +1030,6 @@ void HTMLElement::setHidden(const std::optional<Variant<bool, double, String>>& 
     });
 }
 
-
-// Determines if two nodes share the same nearest out-of-flow positioned ancestor.
-static bool haveSameOutOfFlowAncestor(const Node& anchorNode, const Node& targetNode)
-{
-    const CheckedPtr anchorRenderer = anchorNode.renderer();
-    const CheckedPtr targetRenderer = targetNode.renderer();
-    if (!anchorRenderer || !targetRenderer)
-        return true;
-
-    auto nearestOutOfFlowAncestor = [](CheckedPtr<RenderObject> renderer) -> CheckedPtr<RenderObject> {
-        while (renderer) {
-            if (renderer->isOutOfFlowPositioned())
-                return renderer;
-            renderer = renderer->containingBlock();
-        }
-        return nullptr;
-    };
-
-    CheckedPtr anchorOutOfFlowAncestor = nearestOutOfFlowAncestor(anchorRenderer);
-    CheckedPtr targetOutOfFlowAncestor = nearestOutOfFlowAncestor(targetRenderer);
-    return targetOutOfFlowAncestor == anchorOutOfFlowAncestor;
-}
-
-bool HTMLElement::shouldExtendSelectionToTargetNode(const Node& targetNode, const VisibleSelection& selectionBeforeUpdate)
-{
-    if (auto range = selectionBeforeUpdate.range(); range && ImageOverlay::isInsideOverlay(*range))
-        return ImageOverlay::isOverlayText(targetNode);
-
-    if (Position::nodeIsUserSelectNone(&targetNode)) {
-        if (RefPtr anchorNode = selectionBeforeUpdate.anchor().anchorNode()) {
-            // Don't extend selection to a user-select: none node if they are not in the same flow.
-            return haveSameOutOfFlowAncestor(*anchorNode, targetNode);
-        }
-    }
-
-    return true;
-}
-
 ExceptionOr<Ref<ElementInternals>> HTMLElement::attachInternals()
 {
     CheckedPtr queue = reactionQueue();

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -33,7 +33,6 @@ class FormListedElement;
 class FormAssociatedElement;
 class HTMLButtonElement;
 class HTMLFormElement;
-class VisibleSelection;
 
 struct SRGBADescriptor;
 template<typename, typename> struct BoundedGammaEncoded;
@@ -138,8 +137,6 @@ public:
     bool isHiddenUntilFound() const;
     std::optional<Variant<bool, double, String>> hidden() const;
     void setHidden(const std::optional<Variant<bool, double, String>>&);
-
-    WEBCORE_EXPORT static bool shouldExtendSelectionToTargetNode(const Node& targetNode, const VisibleSelection& selectionBeforeUpdate);
 
     WEBCORE_EXPORT ExceptionOr<Ref<ElementInternals>> attachInternals();
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1120,7 +1120,7 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
     if (!target)
         return;
 
-    if (!HTMLElement::shouldExtendSelectionToTargetNode(*target, m_frame->selection().selection()))
+    if (!EventHandler::shouldExtendSelectionToTargetNode(*target, m_frame->selection().selection()))
         return;
 
     VisiblePosition targetPosition = selectionExtentRespectingEditingBoundary(m_frame->selection().selection(), hitTestResult.localPoint(), target.get());
@@ -5712,5 +5712,42 @@ HandleUserInputEventResult EventHandler::passMouseMoveEventToSubframe(MouseEvent
     return true;
 }
 #endif // !PLATFORM(COCOA) && !PLATFORM(WIN)
+
+// Determines if two nodes share the same nearest out-of-flow positioned ancestor.
+static bool haveSameOutOfFlowAncestor(const Node& anchorNode, const Node& targetNode)
+{
+    const CheckedPtr anchorRenderer = anchorNode.renderer();
+    const CheckedPtr targetRenderer = targetNode.renderer();
+    if (!anchorRenderer || !targetRenderer)
+        return true;
+
+    auto nearestOutOfFlowAncestor = [](CheckedPtr<RenderObject> renderer) -> CheckedPtr<RenderObject> {
+        while (renderer) {
+            if (renderer->isOutOfFlowPositioned())
+                return renderer;
+            renderer = renderer->containingBlock();
+        }
+        return nullptr;
+    };
+
+    CheckedPtr anchorOutOfFlowAncestor = nearestOutOfFlowAncestor(anchorRenderer);
+    CheckedPtr targetOutOfFlowAncestor = nearestOutOfFlowAncestor(targetRenderer);
+    return targetOutOfFlowAncestor == anchorOutOfFlowAncestor;
+}
+
+bool EventHandler::shouldExtendSelectionToTargetNode(const Node& targetNode, const VisibleSelection& selectionBeforeUpdate)
+{
+    if (auto range = selectionBeforeUpdate.range(); range && ImageOverlay::isInsideOverlay(*range))
+        return ImageOverlay::isOverlayText(targetNode);
+
+    if (Position::nodeIsUserSelectNone(&targetNode)) {
+        if (RefPtr anchorNode = selectionBeforeUpdate.anchor().anchorNode()) {
+            // Don't extend selection to a user-select: none node if they are not in the same flow.
+            return haveSameOutOfFlowAncestor(*anchorNode, targetNode);
+        }
+    }
+
+    return true;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -431,6 +431,8 @@ public:
 
     ScrollableArea* enclosingScrollableArea(Node*) const;
 
+    WEBCORE_EXPORT static bool shouldExtendSelectionToTargetNode(const Node& targetNode, const VisibleSelection& selectionBeforeUpdate);
+
 private:
 #if ENABLE(DRAG_SUPPORT)
     static DragState& dragState();

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1331,7 +1331,7 @@ static std::pair<std::optional<SimpleRange>, SelectionWasFlipped> rangeForPointI
     });
 
     RefPtr targetNode = hitTest.targetNode();
-    if (targetNode && !HTMLElement::shouldExtendSelectionToTargetNode(*targetNode, existingSelection))
+    if (targetNode && !EventHandler::shouldExtendSelectionToTargetNode(*targetNode, existingSelection))
         return { std::nullopt, SelectionWasFlipped::No };
 
     VisiblePosition result;


### PR DESCRIPTION
#### e91c6538d8a88685781ca4f9771ab61d103468ae
<pre>
[cleanup] Move shouldExtendSelectionToTargetNode to EventHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=308968">https://bugs.webkit.org/show_bug.cgi?id=308968</a>

Reviewed by NOBODY (OOPS!).

Function shouldExtendSelectionToTargetNode() is more related to EventHandler.
Move it to EventHandler.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::haveSameOutOfFlowAncestor): Deleted.
(WebCore::HTMLElement::shouldExtendSelectionToTargetNode): Deleted.
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDrag):
(WebCore::haveSameOutOfFlowAncestor):
(WebCore::EventHandler::shouldExtendSelectionToTargetNode):
* Source/WebCore/page/EventHandler.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::rangeForPointInRootViewCoordinates):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e91c6538d8a88685781ca4f9771ab61d103468ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81174 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15217 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13004 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158657 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11999 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121838 "Found 1 new test failure: swipe/swipe-disables-view-transition.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122039 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76245 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9088 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83503 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->