### PR TITLE
getScreenCTM() should include CSS transforms and zoom contributions in legacy SVG path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL getScreenCTM with padding-left and rotation assert_equals: expected 50 but got -50
-FAIL getScreenCTM with padding-top and rotation assert_equals: expected 50 but got -50
-FAIL getScreenCTM with padding-right and rotation assert_equals: expected 62 but got -62
-FAIL getScreenCTM with padding and rotation assert_approx_equals: expected 74 +/- 0.1 but got -74
-FAIL getScreenCTM with padding-left, rotation and content-box assert_equals: expected 62 but got -62
-FAIL getScreenCTM with padding-left, scale assert_equals: expected 47 but got 82
-FAIL getScreenCTM with border-width and rotation assert_equals: expected 50 but got -50
+PASS getScreenCTM with padding-left and rotation
+PASS getScreenCTM with padding-top and rotation
+PASS getScreenCTM with padding-right and rotation
+PASS getScreenCTM with padding and rotation
+PASS getScreenCTM with padding-left, rotation and content-box
+FAIL getScreenCTM with padding-left, scale assert_equals: expected 47 but got 41
+PASS getScreenCTM with border-width and rotation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getScreenCTM-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getScreenCTM-expected.txt
@@ -1,10 +1,10 @@
 
 PASS <svg> should give correct screen CTM for transform:translate(...) on ancestor elem, combined with margin on <body>
 PASS <rect> should give correct screen CTM for transform:translate(...) on ancestor elem, combined with margin on <body>
-FAIL <svg> should give correct screen CTM for transform:scale(2,1) on ancestor assert_equals: CTM component a expected 2 but got 1
-FAIL <svg> should give correct screen CTM for transform:scale(0.5) on self assert_equals: CTM component a expected 0.5 but got 1
+PASS <svg> should give correct screen CTM for transform:scale(2,1) on ancestor
+PASS <svg> should give correct screen CTM for transform:scale(0.5) on self
 PASS <svg> should give correct screen CTM with many forms of offsets on ancestor and self
 PASS <svg> should give identity screen CTM with friendly rotations on ancestor and self that add up to 360deg
-FAIL <svg> should give correct screen CTM with many forms of offsets on self, and rotated self assert_equals: CTM component a expected -1 but got 1
-FAIL <svg> should give correct screen CTM with many forms of offsets on self, and rotated ancestor assert_equals: CTM component a expected -1 but got 1
+PASS <svg> should give correct screen CTM with many forms of offsets on self, and rotated self
+PASS <svg> should give correct screen CTM with many forms of offsets on self, and rotated ancestor
 

--- a/LayoutTests/svg/zoom/page/zoom-get-screen-ctm-expected.txt
+++ b/LayoutTests/svg/zoom/page/zoom-get-screen-ctm-expected.txt
@@ -1,14 +1,3 @@
-This test checks getScreenCTM() on zoomed pages.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS CTM1 is "1, 0, 0, 1, 0, 100"
-PASS CTM2 is "1, 0, 0, 1, 100, 200"
-PASS CTM3 is "1, 0, 0, 1, 200, 300"
-PASS CTM4 is "1, 0, 0, 1, 300, 400"
-
-PASS successfullyParsed is true
-
-TEST COMPLETE
+PASS SVGGraphicsElement.getScreenCTM subject to page zoom
 

--- a/LayoutTests/svg/zoom/page/zoom-get-screen-ctm.html
+++ b/LayoutTests/svg/zoom/page/zoom-get-screen-ctm.html
@@ -1,51 +1,43 @@
 <!DOCTYPE html>
-<html>
-<body style="margin: 0px; padding: 0px;" onload="runRepaintTest()">
-  <div style="width: 100px; height: 100px;"></div>
-  <svg id="svg1" xmlns="http://www.w3.org/2000/svg" width="400" height="400">
+<title>SVGGraphicsElement.getScreenCTM subject to page zoom</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+</style>
+<div style="width: 100px; height: 100px;"></div>
+<svg id="svg1" width="400" height="400">
+  <rect width="100" height="100" fill="green"/>
+  <svg id="svg2" x="100" y="100" width="300" height="300">
     <rect width="100" height="100" fill="green"/>
-    <svg id="svg2" x="100" y="100" width="300" height="300">
+    <svg id="svg3" x="100" y="100" width="200" height="200">
       <rect width="100" height="100" fill="green"/>
-      <svg id="svg3" x="100" y="100" width="200" height="200">
+      <svg id="svg4" x="100" y="100" width="100" height="100">
         <rect width="100" height="100" fill="green"/>
-        <svg id="svg4" x="100" y="100" width="100" height="100">
-          <rect width="100" height="100" fill="green"/>
-        </svg>
       </svg>
     </svg>
   </svg>
-
+</svg>
 <script>
-  var zoomCount = 2;
+function assert_matrix_approx_equals(actual, expected) {
+  for (let prop of [ 'a', 'b', 'c', 'd', 'e', 'f'])
+    assert_approx_equals(actual[prop], expected[prop], 5e-6, prop);
+}
 
-  if (window.testRunner) {
-    testRunner.waitUntilDone();
-    window.postZoomCallback = executeTest;
-  }
+test(() => {
+  if (!window.eventSender)
+    return;
 
-  function ctmToString(ctm) {
-    return [ ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f ].join(', ');
-  }
+  eventSender.zoomPageIn();
+  eventSender.zoomPageIn();
 
-  function executeTest() {
-    CTM1 = ctmToString(document.getElementById('svg1').getScreenCTM());
-    CTM2 = ctmToString(document.getElementById('svg2').getScreenCTM());
-    CTM3 = ctmToString(document.getElementById('svg3').getScreenCTM());
-    CTM4 = ctmToString(document.getElementById('svg4').getScreenCTM());
-
-    description("This test checks getScreenCTM() on zoomed pages.");
-
-    shouldBeEqualToString('CTM1', '1, 0, 0, 1, 0, 100');
-    shouldBeEqualToString('CTM2', '1, 0, 0, 1, 100, 200');
-    shouldBeEqualToString('CTM3', '1, 0, 0, 1, 200, 300');
-    shouldBeEqualToString('CTM4', '1, 0, 0, 1, 300, 400');
-    debug('');
-  }
-
+  assert_matrix_approx_equals(document.getElementById('svg1').getScreenCTM(),
+                              { a: 1, b: 0, c: 0, d: 1, e: 0, f: 100 });
+  assert_matrix_approx_equals(document.getElementById('svg2').getScreenCTM(),
+                              { a: 1, b: 0, c: 0, d: 1, e: 100, f: 200 });
+  assert_matrix_approx_equals(document.getElementById('svg3').getScreenCTM(),
+                              { a: 1, b: 0, c: 0, d: 1, e: 200, f: 300 });
+  assert_matrix_approx_equals(document.getElementById('svg4').getScreenCTM(),
+                              { a: 1, b: 0, c: 0, d: 1, e: 300, f: 400 });
+});
 </script>
-<script src="../../../resources/js-test-pre.js"></script>
-<script src="../../../fast/repaint/resources/repaint.js"></script>
-<script src="../resources/testPageZoom.js"></script>
-
-</body>
-</html>

--- a/LayoutTests/svg/zoom/zoomed-inline-svg-getscreenctm-expected.txt
+++ b/LayoutTests/svg/zoom/zoomed-inline-svg-getscreenctm-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVGGraphicsElement.getScreenCTM subject to the 'zoom' property
+

--- a/LayoutTests/svg/zoom/zoomed-inline-svg-getscreenctm.html
+++ b/LayoutTests/svg/zoom/zoomed-inline-svg-getscreenctm.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>SVGGraphicsElement.getScreenCTM subject to the 'zoom' property</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+svg { margin: 25px 0 0 50px; }
+</style>
+<svg width="100" height="100" style="zoom: 2">
+  <rect width="100" height="100" fill="blue"/>
+</svg>
+<script>
+function assert_matrix_approx_equals(actual, expected) {
+  for (let prop of [ 'a', 'b', 'c', 'd', 'e', 'f'])
+    assert_approx_equals(actual[prop], expected[prop], 5e-6, prop);
+}
+
+test(t => {
+  const svg = document.querySelector('svg');
+  assert_matrix_approx_equals(svg.getScreenCTM(),
+                              { a: 2, b: 0, c: 0, d: 2, e: 100, f: 50 });
+});
+</script>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "LegacyRenderSVGShape.h"
 
+#include "ContainerNodeInlines.h"
 #include "FloatPoint.h"
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
@@ -37,6 +38,7 @@
 #include "LayoutRepainter.h"
 #include "LegacyRenderSVGResourceMarker.h"
 #include "LegacyRenderSVGResourceSolidColor.h"
+#include "LegacyRenderSVGRoot.h"
 #include "LegacyRenderSVGShapeInlines.h"
 #include "PointerEventsHitRules.h"
 #include "RenderStyle+GettersInlines.h"
@@ -44,6 +46,7 @@
 #include "SVGRenderingContext.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
+#include "SVGSVGElement.h"
 #include "SVGURIReference.h"
 #include "SVGVisitedRendererTracking.h"
 #include <wtf/StackStats.h>
@@ -196,9 +199,49 @@ bool LegacyRenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeT
     return true;
 }
 
+static AffineTransform legacyNonScalingStrokeCTM(const Ref<SVGGraphicsElement>& element)
+{
+    // We intentionally do NOT use getScreenCTM() here. getScreenCTM() now returns
+    // the full accumulated CSS transform matrix (including transforms from HTML
+    // ancestors like a scaled <body>). However, the legacy SVG paint context only
+    // includes SVG-internal transforms plus position offsets — HTML ancestor CSS
+    // transforms are applied at the compositing/layer level. Using the full
+    // getScreenCTM() would cause non-scaling-stroke to over-compensate for
+    // transforms that are already handled by the layer system.
+    //
+    // Instead, walk the SVG ancestor chain accumulating SVG-internal transforms,
+    // and at the outermost <svg>, use localToAbsolute (point-mapping only) which
+    // correctly discards the rotation/scale components of HTML ancestor CSS transforms.
+    AffineTransform ctm;
+    RefPtr<SVGSVGElement> outermostSVG;
+    for (RefPtr<Element> current = element.ptr(); current; current = current->parentOrShadowHostElement()) {
+        RefPtr svgElement = dynamicDowncast<SVGElement>(*current);
+        if (!svgElement)
+            break;
+        ctm = svgElement->localCoordinateSpaceTransform(CTMScope::NearestViewportScope).multiply(ctm);
+        if (auto* svgSVGElement = dynamicDowncast<SVGSVGElement>(*svgElement))
+            outermostSVG = svgSVGElement;
+    }
+
+    // Now add the outermost SVG's screen position as a translation.
+    if (outermostSVG) {
+        if (CheckedPtr renderer = outermostSVG->renderer()) {
+            if (CheckedPtr legacyRoot = dynamicDowncast<LegacyRenderSVGRoot>(*renderer)) {
+                FloatPoint location = legacyRoot->localToBorderBoxTransform().mapPoint(FloatPoint());
+                float zoomFactor = 1 / renderer->style().usedZoom();
+                location = renderer->localToAbsolute(location, UseTransforms);
+                location.scale(zoomFactor);
+                ctm = AffineTransform::makeTranslation(toFloatSize(location)) * ctm;
+            }
+        }
+    }
+
+    return ctm;
+}
+
 AffineTransform LegacyRenderSVGShape::nonScalingStrokeTransform() const
 {
-    return protect(graphicsElement())->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
+    return legacyNonScalingStrokeCTM(protect(graphicsElement()));
 }
 
 void LegacyRenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& originalContext)

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -59,6 +59,7 @@
 #include "SVGViewSpec.h"
 #include "Settings.h"
 #include "StaticNodeList.h"
+#include "TransformState.h"
 #include "TreeScopeInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -429,31 +430,55 @@ AffineTransform SVGSVGElement::localCoordinateSpaceTransform(CTMScope mode) cons
         transform.translate(x().value(lengthContext), y().value(lengthContext));
     } else if (mode == CTMScope::ScreenScope) {
         if (CheckedPtr renderer = this->renderer()) {
-            FloatPoint location;
-            float zoomFactor = 1;
+            float pageZoomFactor = 1;
 
-            // At the SVG/HTML boundary (aka LegacyRenderSVGRoot), we apply the localToBorderBoxTransform
-            // to map an element from SVG viewport coordinates to CSS box coordinates.
-            // LegacyRenderSVGRoot's localToAbsolute method expects CSS box coordinates.
-            // We also need to adjust for the zoom level factored into CSS coordinates (bug #96361).
             if (CheckedPtr legacyRenderSVGRoot = dynamicDowncast<LegacyRenderSVGRoot>(*renderer)) {
-                location = legacyRenderSVGRoot->localToBorderBoxTransform().mapPoint(location);
-                zoomFactor = 1 / renderer->style().usedZoom();
+                // Only undo page zoom (from the RenderView), preserving any CSS 'zoom'
+                // contributions on this element or its ancestors in the result to match
+                // the rendered transform (bug #96361).
+                float effectiveZoom = renderer->style().usedZoom();
+                pageZoomFactor = renderer->view().pageZoomFactor();
+                float cssZoomScale = effectiveZoom / pageZoomFactor;
+
+                TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint());
+                renderer->mapLocalToContainer(nullptr, transformState, { UseTransforms, ApplyContainerFlip });
+
+                auto accumulatedMatrix = transformState.releaseTrackedTransform();
+                AffineTransform cssTransform = accumulatedMatrix->toAffineTransform();
+
+                if (pageZoomFactor != 1) {
+                    cssTransform.setE(cssTransform.e() / pageZoomFactor);
+                    cssTransform.setF(cssTransform.f() / pageZoomFactor);
+                }
+
+                // The accumulated matrix maps from the border-box origin to the screen.
+                // SVG content starts at the content box (after border+padding), so we
+                // must include that offset. Convert to CSS pixels (divide by page zoom)
+                // before composing. Compose BEFORE scaling a,b,c,d by CSS zoom, so the
+                // border+padding offset is not multiplied by the CSS zoom scale.
+                FloatSize borderAndPadding(legacyRenderSVGRoot->borderLeft() + legacyRenderSVGRoot->paddingLeft(), legacyRenderSVGRoot->borderTop() + legacyRenderSVGRoot->paddingTop());
+                // Border+padding values are in layout units; use reciprocal
+                // because FloatSize::scale() only multiplies, not divides.
+                borderAndPadding.scale(1.0f / pageZoomFactor);
+                cssTransform = cssTransform * AffineTransform::makeTranslation(borderAndPadding);
+
+                // The a, b, c, d components from mapLocalToContainer reflect only CSS
+                // transforms, not the CSS 'zoom' property. Scale them by the CSS zoom
+                // so the CTM reflects the visual scaling from 'zoom'.
+                if (cssZoomScale != 1)
+                    cssTransform = cssTransform * AffineTransform::makeScale({ cssZoomScale, cssZoomScale });
+
+                transform = cssTransform;
+            } else {
+                // Non-legacy SVG root (e.g., inner <svg>) — fallback to point mapping.
+                FloatPoint location = renderer->localToAbsolute(FloatPoint(), UseTransforms);
+                transform.translate(location.x() - viewBoxTransform.e(), location.y() - viewBoxTransform.f());
             }
-
-            // Translate in our CSS parent coordinate space
-            // FIXME: This doesn't work correctly with CSS transforms.
-            location = renderer->localToAbsolute(location, UseTransforms);
-            location.scale(zoomFactor);
-
-            // Be careful here! localToBorderBoxTransform() included the x/y offset coming from the viewBoxToViewTransform(),
-            // so we have to subtract it here (original cause of bug #27183)
-            transform.translate(location.x() - viewBoxTransform.e(), location.y() - viewBoxTransform.f());
 
             // Respect scroll offset.
             if (RefPtr view = document().view()) {
                 LayoutPoint scrollPosition = view->scrollPosition();
-                scrollPosition.scale(zoomFactor);
+                scrollPosition.scale(1 / pageZoomFactor);
                 transform.translate(-scrollPosition);
             }
         }


### PR DESCRIPTION
#### 87ba7d11a1e8aac065e906b3ef1d04999e812535
<pre>
getScreenCTM() should include CSS transforms and zoom contributions in legacy SVG path
<a href="https://bugs.webkit.org/show_bug.cgi?id=308970">https://bugs.webkit.org/show_bug.cgi?id=308970</a>
<a href="https://rdar.apple.com/171525696">rdar://171525696</a>

Reviewed by Brent Fulgham.

getScreenCTM() used localToAbsolute() which only returns a point,
discarding rotation/scale from CSS transforms on HTML ancestors.
It also divided by usedZoom() (page zoom × CSS zoom) instead of
just page zoom, incorrectly stripping CSS zoom from the result.

This patch:

1. Uses mapLocalToContainer() + TransformState to preserve the
full accumulated CSS transform matrix.

2. Divides only by page zoom (RenderView::pageZoomFactor()), keeping
CSS zoom contributions in the CTM.

3. Drops the viewBox translation subtraction, unnecessary since
mapLocalToContainer works in CSS box coordinates.

4. Adds legacyNonScalingStrokeCTM() for non-scaling-stroke, which
needs the SVG-internal-only CTM since legacy paint doesn&apos;t
include HTML ancestor CSS transforms.

Merge (Zoom Test): <a href="https://chromium.googlesource.com/chromium/src/+/7254890a169ba91d8ad6f61374cd93ec59029441">https://chromium.googlesource.com/chromium/src/+/7254890a169ba91d8ad6f61374cd93ec59029441</a>

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::legacyNonScalingStrokeCTM):
(WebCore::LegacyRenderSVGShape::nonScalingStrokeTransform const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::localCoordinateSpaceTransform const):
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement-padding-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getScreenCTM-expected.txt: Ditto
* LayoutTests/svg/zoom/zoomed-inline-svg-getscreenctm-expected.txt: Added.
* LayoutTests/svg/zoom/zoomed-inline-svg-getscreenctm.html: Added.
* LayoutTests/svg/zoom/page/zoom-get-screen-ctm-expected.txt:
* LayoutTests/svg/zoom/page/zoom-get-screen-ctm.html: Synced from Blink - which has tolerance for any floating point conversions

Canonical link: <a href="https://commits.webkit.org/309354@main">https://commits.webkit.org/309354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3da2cb0accdcd51ac9821058ea17d236eb1c25db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159126 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26d54b2f-bb93-4747-b0b6-4aa398dcfd1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/348dc467-fc6e-4e48-b4c7-fc462b89ec08) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15204 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6974 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161600 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33733 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79331 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11396 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22565 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22278 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->