### PR TITLE
Restore parts of previous JS->UIProcess serialization behavior

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -270,9 +270,6 @@ std::optional<JSObjectID> JavaScriptEvaluationResult::JSExtractor::addObjectToMa
 
     auto identifier = JSObjectID::generate();
 
-    if (nestingLevel > maximumNestingLevel)
-        return std::nullopt;
-
     auto extractedValue = jsValueToExtractedValue(context, rootValue);
     if (!extractedValue)
         return std::nullopt;
@@ -280,7 +277,7 @@ std::optional<JSObjectID> JavaScriptEvaluationResult::JSExtractor::addObjectToMa
     if (std::holds_alternative<Vector<JSObjectID>>(*extractedValue))
         m_unprocessedContainers.append(PendingContainer { identifier, { context, rootValue }, nestingLevel, PendingContainer::ContainerType::Array });
     else if (std::holds_alternative<ObjectMap>(*extractedValue))
-        m_unprocessedContainers.append(PendingContainer { identifier, { context, rootValue }, nestingLevel , PendingContainer::ContainerType::Dictionary });
+        m_unprocessedContainers.append(PendingContainer { identifier, { context, rootValue }, nestingLevel, PendingContainer::ContainerType::Dictionary });
 
     m_valuesInMap.set({ context, rootValue }, identifier);
     auto result = m_map.set(identifier, WTF::move(*extractedValue));
@@ -295,6 +292,10 @@ bool JavaScriptEvaluationResult::JSExtractor::processContainersWithoutRecursion(
         auto pendingContainer = m_unprocessedContainers.takeLast();
         JSObjectRef object = JSValueToObject(context, pendingContainer.containerValue.get(), nullptr);
         size_t nextNestingLevel = pendingContainer.nestingLevel + 1;
+
+        if (nextNestingLevel > maximumNestingLevel)
+            return false;
+
         switch (pendingContainer.containerType) {
         case PendingContainer::ContainerType::Dictionary: {
             JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(context, object);
@@ -314,10 +315,10 @@ bool JavaScriptEvaluationResult::JSExtractor::processContainersWithoutRecursion(
                     continue;
                 auto keyIdentifier = addObjectToMap(context, keyJSValue, nextNestingLevel);
                 if (!keyIdentifier)
-                    return false;
+                    continue;
                 auto valueIdentifier = addObjectToMap(context, valueJSValue, nextNestingLevel);
                 if (!valueIdentifier)
-                    return false;
+                    continue;
                 map.add(*keyIdentifier, *valueIdentifier);
             }
             m_map.set(pendingContainer.objectIdentifier, WTF::move(map));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -1305,7 +1305,7 @@ TEST(EvaluateJavaScript, Serialization)
     // The full deepObject is 40,001 nesting levels deep, which should not be able to serialize.
     NSError *error = nil;
     result = [webView objectByCallingAsyncFunction:@"return window.deepObject" withArguments:nil error:&error];
-    EXPECT_TRUE(!!error);
+    EXPECT_NOT_NULL(error);
 
     // Returning an object 40,000 nesting levels deep should succeed.
     error = nil;
@@ -1327,7 +1327,11 @@ TEST(EvaluateJavaScript, Serialization)
 
     // One of the object values is not serializable, so it should be missing from the result.
     result = [webView objectByCallingAsyncFunction:@"return window.objectObject" withArguments:nil error:&error];
-    EXPECT_NOT_NULL(error);
-    EXPECT_NULL(result);
+    EXPECT_NULL(error);
+    NSDictionary *expectedDictionary = @{
+        @"bar" : @17,
+        @"foo" : @"bar"
+    };
+    EXPECT_TRUE([result isEqual:expectedDictionary]);
 }
 


### PR DESCRIPTION
#### 1d814c884dcbd1110a920a9a245831f0662a7631
<pre>
Restore parts of previous JS-&gt;UIProcess serialization behavior
<a href="https://rdar.apple.com/170984489">rdar://170984489</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308978">https://bugs.webkit.org/show_bug.cgi?id=308978</a>

Reviewed by Tim Horton.

We&apos;ve been making large changes to JavaScript object serialization over the past ~6 months to support
much richer messaging between web content processes and the UI process.

One side effect has been a much richer support for objects being serialized that previously were not.
This caused some regressions in some apps because they were successfully serializing much more
complicated objects than before, which made their serialization slow down significantly.

We tried to fix one such case in 306677@main by explicitly changing object -&gt; dictionary serialization
such that if any key or value fails to serialize, then the entire dictionary should fail to serialize.

This was a change from our long standing JS serialization behavior - in at least some cases - and
caused serialization failures in more apps that broke more functionality.

The number of apps where we identified the perf concern was small, and the new behavior simply breaking
apps is much worse. Additionally, we&apos;d actually already confirmed with authors of some of those other
apps a change they could make in their application JavaScript to fix the perf issue.

So it follows:
This patch restores the behavior of allowing a JavaScript object to successfully serialize to a
dictionary even if specific key/value pairs cannot.
This restores important binary compatibility.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm

* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JSExtractor::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::JSExtractor::processContainersWithoutRecursion):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
((EvaluateJavaScript, Serialization)):

Canonical link: <a href="https://commits.webkit.org/308477@main">https://commits.webkit.org/308477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfda436655c9df3b49957c87c09e441fc574e38a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63136054-be77-4806-80d3-8d8795f224c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81184 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6452294b-5c32-459e-b2c9-34e31caf3a82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94581 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd93a1f9-4ca5-4439-b4e3-908f0678e321) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15227 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13015 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentStartEnd (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3777 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158670 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121847 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31257 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76261 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17585 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9098 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83516 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19634 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->