### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE guards from WebMemorySamplerLinux

### DIFF
--- a/Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp
+++ b/Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp
@@ -55,9 +55,7 @@ static inline String nextToken(FILE* file)
     if (!file)
         return String();
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Linux port
-    char buffer[maxBuffer] = {0, };
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    std::array<char, maxBuffer> buffer = { 0, };
     unsigned int index = 0;
     while (index < maxBuffer) {
         int ch = fgetc(file);
@@ -69,7 +67,7 @@ static inline String nextToken(FILE* file)
         }
     }
 
-    return String::fromLatin1(buffer);
+    return String::fromLatin1(buffer.data());
 }
 
 static inline void appendKeyValuePair(WebMemoryStatistics& stats, const String& key, size_t value)


### PR DESCRIPTION
#### 7f0510e18f0aa216f2b063d6ad148897c023bf7f
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE guards from WebMemorySamplerLinux
<a href="https://bugs.webkit.org/show_bug.cgi?id=308980">https://bugs.webkit.org/show_bug.cgi?id=308980</a>

Reviewed by Fujii Hironori.

* Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp:
(WebKit::nextToken):

Canonical link: <a href="https://commits.webkit.org/308530@main">https://commits.webkit.org/308530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae4b2e10ddc022d087a15601df42b5d61cc8eab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13014 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3778 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124822 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158671 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121848 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122049 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76262 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9099 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83517 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->