### PR TITLE
Accept none and normal values for position-anchor CSS property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-implicit-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-implicit-001.html
@@ -9,8 +9,7 @@
   position: fixed;
   width: 100px;
   height: 50px;
-  left: anchor(left);
-  top: anchor(bottom);
+  position-area: center bottom;
   background: green;
   border: none;
   padding: 0;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-implicit-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-implicit-002.html
@@ -9,8 +9,7 @@
   position: absolute;
   width: 100px;
   height: 50px;
-  left: anchor(left);
-  top: anchor(bottom);
+  position-area: center bottom;
   background: green;
   border: none;
   padding: 0;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-001-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-001.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>position-anchor auto for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+    .anchor {
+        width: 100px;
+        height: 50px;
+        background: green;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 50px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: auto;
+        position-area: block-end;
+    }
+</style>
+<div class="anchor"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-002-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-002.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>position-anchor auto for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+    .anchor {
+        width: 100px;
+        height: 50px;
+        background: green;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 50px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: auto;
+        top: anchor(bottom);
+    }
+</style>
+<div class="anchor"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics-expected.txt
@@ -1,5 +1,6 @@
 
-FAIL e.style['position-anchor'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['position-anchor'] = "normal" should set the property value
+PASS e.style['position-anchor'] = "none" should set the property value
 PASS e.style['position-anchor'] = "auto" should set the property value
 PASS e.style['position-anchor'] = "--foo" should set the property value
 PASS e.style['position-anchor'] = "foo-bar" should not set the property value
@@ -7,10 +8,11 @@ PASS e.style['position-anchor'] = "--foo --bar" should not set the property valu
 PASS e.style['position-anchor'] = "--foo, --bar" should not set the property value
 PASS e.style['position-anchor'] = "100px" should not set the property value
 PASS e.style['position-anchor'] = "100%" should not set the property value
-FAIL Property position-anchor value 'none' assert_true: 'none' is a supported value for position-anchor. expected true got false
+PASS Property position-anchor value 'normal'
+PASS Property position-anchor value 'none'
 PASS Property position-anchor value 'auto'
 PASS Property position-anchor value '--foo'
-FAIL Property position-anchor has initial value none assert_equals: expected "none" but got "auto"
+PASS Property position-anchor has initial value normal
 PASS Property position-anchor does not inherit
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics.html
@@ -15,7 +15,8 @@
 
 <script>
 // position-anchor: <anchor-element>
-// <anchor-element> = none | auto | <dashed-ident>
+// <anchor-element> = normal | none | auto | <dashed-ident>
+test_valid_value('position-anchor', 'normal');
 test_valid_value('position-anchor', 'none');
 test_valid_value('position-anchor', 'auto');
 test_valid_value('position-anchor', '--foo');
@@ -26,13 +27,14 @@ test_invalid_value('position-anchor', '100px');
 test_invalid_value('position-anchor', '100%');
 
 // Computed value: as specified
+test_computed_value('position-anchor', 'normal');
 test_computed_value('position-anchor', 'none');
 test_computed_value('position-anchor', 'auto');
 test_computed_value('position-anchor', '--foo');
 
-// Initial: none
+// Initial: normal
 // Inherited: no
-assert_not_inherited('position-anchor', 'none', '--foo');
+assert_not_inherited('position-anchor', 'normal', '--foo');
 
 // Animation type: discrete
 test_no_interpolation({

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-001-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-001.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>position-anchor none for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+<style>
+    .anchor {
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 100px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: none;
+        position-area: block-end;
+    }
+</style>
+<div class="anchor"></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-002-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-002.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>position-anchor none for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+<style>
+    .anchor {
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 100px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: none;
+        top: anchor(bottom);
+    }
+</style>
+<div class="anchor"></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-named-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-named-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-named.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-named.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>position-anchor none for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+    .anchor {
+        width: 100px;
+        height: 50px;
+        background: green;
+        anchor-name: --a1;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 50px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: none;
+        top: anchor(--a1 bottom)
+    }
+</style>
+<div class="anchor"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-001-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-001.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>position-anchor normal for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+    .anchor {
+        width: 100px;
+        height: 50px;
+        background: green;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 50px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: normal;
+        position-area: block-end;
+    }
+</style>
+<div class="anchor"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-002-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-002.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>position-anchor normal for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    .anchor {
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 100px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: normal;
+        top: anchor(bottom);
+    }
+</style>
+<div class="anchor"></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-003-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<style>
+    div {
+        background-color: green;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-003.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>position-anchor normal for ::after pseudo element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor"/>
+<link rel="author" title="Suraj Thanugundla" href="mailto:contact@surajt.com" />
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+    .anchor {
+        width: 100px;
+        height: 50px;
+        background: green;
+    }
+
+    .anchor::after {
+        width: 100px;
+        height: 50px;
+        background: green;
+        content: "";
+        position: absolute;
+        position-anchor: normal;
+        top: anchor(bottom);
+        position-area: center;
+    }
+</style>
+<div class="anchor"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative.html
@@ -22,6 +22,7 @@ body {
   width: 100px;
   height: 100px;
   background: lime;
+  position-anchor: auto;
 }
 #target::before{
   content: '';

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3249,6 +3249,7 @@ style/values/align/StyleAlignSelf.cpp @header:RenderStyleGetters
 style/values/align/StyleJustifyContent.cpp
 style/values/align/StyleJustifyItems.cpp
 style/values/align/StyleJustifySelf.cpp @header:RenderStyleGetters
+style/values/anchor-position/StylePositionAnchor.cpp
 style/values/anchor-position/StylePositionAreaAxis.cpp
 style/values/anchor-position/StylePositionAreaSelf.cpp
 style/values/anchor-position/StylePositionAreaSpan.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13099,8 +13099,10 @@
        },
         "position-anchor": {
             "animation-type": "discrete",
-            "initial": "auto",
+            "initial": "normal",
             "values": [
+                "normal",
+                "none",
                 "auto"
             ],
             "codegen-properties": {
@@ -13108,7 +13110,7 @@
                 "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::PositionAnchor",
-                "parser-grammar": "auto | <dashed-ident>"
+                "parser-grammar": "normal | none | auto | <dashed-ident>"
             },
             "specification": {
                 "category": "css-anchor-position",

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1222,11 +1222,17 @@ static AnchorsForAnchorName collectAnchorsForAnchorName(const Document& document
     return anchorsForAnchorName;
 }
 
-static AnchorElements findAnchorsForAnchorPositionedElement(const Styleable& anchorPositioned, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
+static AnchorElements findAnchorsForAnchorPositionedElement(const Styleable& anchorPositioned, const RenderStyle& anchorPositionedStyle, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
 {
     AnchorElements anchorElements;
 
     for (auto& anchorName : anchorNames) {
+        auto isImplicitAnchorName = anchorName.name() == implicitAnchorElementName().name;
+        auto isDefaultAnchorNone = anchorPositionedStyle.positionAnchor().isNone()
+            || (anchorPositionedStyle.positionAnchor().isNormal() && anchorPositionedStyle.positionArea().isNone());
+        if (isImplicitAnchorName && isDefaultAnchorNone)
+            continue;
+
         auto anchor = findLastAcceptableAnchorWithName(anchorName, anchorPositioned, anchorsForAnchorName);
         anchorElements.add(anchorName, anchor);
     }
@@ -1255,7 +1261,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
         case AnchorPositionResolutionStage::FindAnchors: {
             if (renderer) {
                 // FIXME: Remove the redundant anchorElements member. The mappings are available in anchorPositionedToAnchorMap.
-                state->anchorElements = findAnchorsForAnchorPositionedElement(*anchorPositioned, state->anchorNames, anchorsForAnchorName);
+                state->anchorElements = findAnchorsForAnchorPositionedElement(*anchorPositioned, renderer->style(), state->anchorNames, anchorsForAnchorName);
                 if (isLayoutTimeAnchorPositioned(renderer->style()))
                     renderer->setNeedsLayout();
 
@@ -1699,7 +1705,7 @@ bool AnchorPositionEvaluator::isImplicitAnchor(const RenderStyle& style)
         if (!pseudoElementStyle)
             return false;
         // If we have an explicit anchor name then there is no need for an implicit anchor.
-        if (!pseudoElementStyle->positionAnchor().isAuto())
+        if (pseudoElementStyle->positionAnchor().isName())
             return false;
 
         return pseudoElementStyle->usesAnchorFunctions() || isLayoutTimeAnchorPositioned(*pseudoElementStyle);

--- a/Source/WebCore/style/values/anchor-position/StylePositionAnchor.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionAnchor.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Suraj Thanugundla <contact@surajt.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StylePositionAnchor.h"
+
+#include "CSSKeywordValue.h"
+#include "StyleBuilderState.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<PositionAnchor>::operator()(BuilderState& state, const CSSValue& value) -> PositionAnchor
+{
+    if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
+        switch (keywordValue->valueID()) {
+        case CSSValueNormal:
+            return CSS::Keyword::Normal { };
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        default:
+            break;
+        }
+    }
+
+    return { toStyleFromCSSValue<AnchorName>(state, value) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/anchor-position/StylePositionAnchor.h
+++ b/Source/WebCore/style/values/anchor-position/StylePositionAnchor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Suraj Thanugundla <contact@surajt.com>
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,14 +31,56 @@
 namespace WebCore {
 namespace Style {
 
-// <'position-anchor'> = auto | <anchor-name>
+// <'position-anchor'> = normal | none | auto | <anchor-name>
 // https://drafts.csswg.org/css-anchor-position-1/#propdef-position-anchor
-struct PositionAnchor : ValueOrKeyword<AnchorName, CSS::Keyword::Auto> {
-    using Base::Base;
+struct PositionAnchor {
+    PositionAnchor(CSS::Keyword::Normal keyword)
+        : m_value { keyword }
+    {
+    }
 
-    bool isAuto() const { return isKeyword(); }
-    bool isName() const { return isValue(); }
-    std::optional<AnchorName> tryName() const { return tryValue(); }
+    PositionAnchor(CSS::Keyword::None keyword)
+        : m_value { keyword }
+    {
+    }
+
+    PositionAnchor(CSS::Keyword::Auto keyword)
+        : m_value { keyword }
+    {
+    }
+
+    PositionAnchor(AnchorName&& value)
+        : m_value { WTF::move(value) }
+    {
+    }
+
+    bool isNormal() const { return WTF::holdsAlternative<CSS::Keyword::Normal>(m_value); }
+    bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
+    bool isAuto() const { return WTF::holdsAlternative<CSS::Keyword::Auto>(m_value); }
+    bool isName() const { return WTF::holdsAlternative<AnchorName>(m_value); }
+
+    std::optional<AnchorName> tryName() const
+    {
+        if (auto* name = std::get_if<AnchorName>(&m_value))
+            return *name;
+        return { };
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const PositionAnchor&) const = default;
+
+private:
+    Variant<CSS::Keyword::Normal, CSS::Keyword::None, CSS::Keyword::Auto, AnchorName> m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<PositionAnchor> {
+    auto operator()(BuilderState&, const CSSValue&) -> PositionAnchor;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/filter-effects/StyleAppleColorFilter.h
+++ b/Source/WebCore/style/values/filter-effects/StyleAppleColorFilter.h
@@ -38,6 +38,8 @@
 
 namespace WebCore {
 
+class Color;
+
 namespace CSS {
 struct AppleColorFilter;
 struct AppleColorFilterValue;


### PR DESCRIPTION
#### 91728e0e57bb8b1344d63e29f5f2c981d0d0dd0e
<pre>
Accept none and normal values for position-anchor CSS property

<a href="https://bugs.webkit.org/show_bug.cgi?id=308981">https://bugs.webkit.org/show_bug.cgi?id=308981</a>

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor">https://drafts.csswg.org/css-anchor-position-1/#position-anchor</a>
Add support for parsing, style computation and layout of none and normal
values for position-anchor CSS property. The new default value is normal.
position-anchor: normal and position-area: none is equivalent to position-anchor: none.

Update tests that expected position-anchor:auto by default.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-implicit-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-implicit-002.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative.html:

Update parsing and computed style tests
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics.html:

Add new layout tests
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-auto-pseudo-element-implicit-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-implicit-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-named-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-none-pseudo-element-named.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-normal-pseudo-element-implicit-003.html: Added.

Layout Changes
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
If the element has none as it&apos;s default anchor then do not add the implicit anchor
to the anchorToAnchorPositionedMap
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::isImplicitAnchor):

Parsing and style computation
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/values/anchor-position/StylePositionAnchor.cpp: Copied from Source/WebCore/style/values/anchor-position/StylePositionAnchor.h.
(WebCore::Style::CSSValueConversion&lt;PositionAnchor&gt;::operator):
* Source/WebCore/style/values/anchor-position/StylePositionAnchor.h:
(WebCore::Style::PositionAnchor::PositionAnchor):
(WebCore::Style::PositionAnchor::isNormal const):
(WebCore::Style::PositionAnchor::isNone const):
(WebCore::Style::PositionAnchor::isAuto const):
(WebCore::Style::PositionAnchor::isName const):
(WebCore::Style::PositionAnchor::tryName const):
(WebCore::Style::PositionAnchor::switchOn const):

Fix for failing build
* Source/WebCore/style/values/filter-effects/StyleAppleColorFilter.h:

Add new header and source file
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

# Conflicts:
#       Source/WebCore/Sources.txt

Canonical link: <a href="https://commits.webkit.org/312378@main">https://commits.webkit.org/312378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0e8a76a95a7a8340caf1299036793a0ac0b1f51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168589 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123767 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104409 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16353 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171082 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132024 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132080 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35745 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143037 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90947 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19850 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32372 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98768 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->