### PR TITLE
[GStreamer][Qualcomm] Video rendering improvements

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -33,9 +33,11 @@
 #include <wtf/MathExtras.h>
 
 #if USE(GSTREAMER) && USE(GBM)
+#include <drm_fourcc.h>
 #include <epoxy/egl.h>
 #include <epoxy/gl.h>
 #include <gst/allocators/gstfdmemory.h>
+#include <gst/video/gstvideometa.h>
 #endif
 
 namespace WebCore {
@@ -82,18 +84,65 @@ void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapp
     if (!gst_is_fd_memory(memory)) [[unlikely]]
         return;
 
+    int fd = gst_fd_memory_get_fd(memory);
+
+    // Use stride and plane offsets from GstVideoMeta if available. The Qualcomm decoder
+    // populates these from the C2HandleGBM with the exact values for the allocated GBM buffer,
+    // including the correct UV plane offset (which accounts for slice height alignment).
+    // Providing explicit plane 1 attributes avoids the EGL driver needing to consult the
+    // GBM metadata buffer (meta_buffer_fd) to locate the UV plane, which it cannot access
+    // when importing via EGL_LINUX_DMA_BUF_EXT, causing intermittent green frames.
     EGLint stride = WTF::roundUpToMultipleOf(128, m_size.width());
+    EGLint uvStride = stride;
+    std::optional<EGLAttrib> uvOffset;
+    if (const auto videoMeta = gst_buffer_get_video_meta(m_buffer.get()); videoMeta && videoMeta->n_planes >= 2) {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN; // GLib port
+        stride = videoMeta->stride[0];
+        uvStride = videoMeta->stride[1];
+        uvOffset = static_cast<EGLAttrib>(videoMeta->offset[1]);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END; // GLib port
+    }
+
     Vector<EGLAttrib> attributes {
         EGL_WIDTH, m_size.width(),
         EGL_HEIGHT, m_size.height(),
         EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(m_fourcc),
-        EGL_DMA_BUF_PLANE0_FD_EXT, gst_fd_memory_get_fd(memory),
+        EGL_DMA_BUF_PLANE0_FD_EXT, fd,
         EGL_DMA_BUF_PLANE0_OFFSET_EXT, 0,
         EGL_DMA_BUF_PLANE0_PITCH_EXT, stride,
-        EGL_NONE
     };
 
+    // Specify DRM_FORMAT_MOD_LINEAR to tell the driver the buffer uses a linear layout.
+    // Without this, the Qualcomm Adreno driver tries to query the GBM metadata buffer
+    // to determine the buffer format (linear vs UBWC/compressed), which fails because
+    // meta_buffer_fd is unavailable through the standard DMA-BUF import path.
     auto& display = PlatformDisplay::sharedDisplay();
+    if (display.eglExtensions().EXT_image_dma_buf_import_modifiers) {
+        std::array<EGLAttrib, 4> plane0Modifier {
+            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR >> 32),
+            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR & 0xffffffff),
+        };
+        attributes.append(std::span<const EGLAttrib> { plane0Modifier });
+    }
+
+    if (uvOffset) {
+        std::array<EGLAttrib, 6> plane1Attributes {
+            EGL_DMA_BUF_PLANE1_FD_EXT, static_cast<EGLAttrib>(fd),
+            EGL_DMA_BUF_PLANE1_OFFSET_EXT, *uvOffset,
+            EGL_DMA_BUF_PLANE1_PITCH_EXT, static_cast<EGLAttrib>(uvStride),
+        };
+        attributes.append(std::span<const EGLAttrib> { plane1Attributes });
+        if (display.eglExtensions().EXT_image_dma_buf_import_modifiers) {
+            std::array<EGLAttrib, 4> plane1Modifier {
+                EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR >> 32),
+                EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT, static_cast<EGLAttrib>(DRM_FORMAT_MOD_LINEAR & 0xffffffff),
+            };
+            attributes.append(std::span<const EGLAttrib> { plane1Modifier });
+        }
+    }
+
+    attributes.append(EGL_NONE);
+
     auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
     if (!image) [[unlikely]]
         return;


### PR DESCRIPTION
#### 7f8b44462cb6d38d0131534d9d770d1a70984768
<pre>
[GStreamer][Qualcomm] Video rendering improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=308983">https://bugs.webkit.org/show_bug.cgi?id=308983</a>

Reviewed by Miguel Gomez.

Retrieve the UV plane offset and stride from the video meta and explicitly specify linear DRM
modifiers in order to avoid the driver querying them.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper):

Canonical link: <a href="https://commits.webkit.org/308973@main">https://commits.webkit.org/308973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a790206dedd33b9d42e0273d39faf1be798d1767

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113827 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15234 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13019 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158677 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121855 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33489 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132324 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76269 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9103 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19760 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83523 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->