### PR TITLE
[GStreamer][LibWebRTC] Misc fixes for the video decoder factory

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -86,6 +86,7 @@ public:
     {
         m_src = makeElement("appsrc"_s);
         g_object_set(m_src.get(), "is-live", TRUE, "do-timestamp", TRUE, "max-buffers", static_cast<guint64>(2), "max-bytes", static_cast<guint64>(0), nullptr);
+        m_rtpTimestampCaps = adoptGRef(gst_caps_new_empty_simple("timestamp/x-rtp"));
 
         auto decoder = makeElement("decodebin"_s);
 
@@ -211,12 +212,18 @@ public:
 
         GST_TRACE_OBJECT(pipeline(), "Pushing encoded image with RTP timestamp %u", inputImage.RtpTimestamp());
         auto encodedData = inputImage.GetEncodedData();
+        if (!encodedData) {
+            GST_ERROR_OBJECT(pipeline(), "Encoded image has no data buffer");
+            return WEBRTC_VIDEO_CODEC_ERROR;
+        }
         encodedData->AddRef();
         auto data = const_cast<uint8_t*>(encodedData->data());
         auto dataSize = encodedData->size();
         auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, data, dataSize, 0, dataSize, static_cast<gpointer>(encodedData.get()), [](gpointer data) {
             static_cast<webrtc::EncodedImageBufferInterface*>(data)->Release();
         }));
+        if (!m_requireParse)
+            gst_buffer_add_reference_timestamp_meta(buffer.get(), m_rtpTimestampCaps.get(), inputImage.RtpTimestamp(), GST_CLOCK_TIME_NONE);
 
         auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
         switch (gst_app_src_push_sample(GST_APP_SRC_CAST(m_src.get()), sample.get())) {
@@ -228,13 +235,21 @@ public:
             return WEBRTC_VIDEO_CODEC_ERROR;
         }
 
-        auto pulledSample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK_CAST(m_sink.get())));
+        auto pulledSample = adoptGRef(gst_app_sink_try_pull_sample(GST_APP_SINK_CAST(m_sink.get()), GST_SECOND));
         if (!pulledSample) {
-            GST_DEBUG_OBJECT(pipeline(), "Needs more data");
+            GST_WARNING_OBJECT(pipeline(), "No decoded frame within timeout");
             return WEBRTC_VIDEO_CODEC_OK;
         }
 
-        auto frame = convertGStreamerSampleToLibWebRTCVideoFrame(WTF::move(pulledSample), inputImage.RtpTimestamp());
+        auto pulledBuffer = gst_sample_get_buffer(pulledSample.get());
+        uint32_t rtpTimestamp = inputImage.RtpTimestamp();
+        if (!m_requireParse) {
+            if (auto meta = gst_buffer_get_reference_timestamp_meta(pulledBuffer, m_rtpTimestampCaps.get()))
+                rtpTimestamp = static_cast<uint32_t>(meta->timestamp);
+        }
+        GST_TRACE_OBJECT(pipeline(), "Pulled video frame with RTP timestamp %u from %" GST_PTR_FORMAT, rtpTimestamp, pulledBuffer);
+        auto frame = convertGStreamerSampleToLibWebRTCVideoFrame(WTF::move(pulledSample), rtpTimestamp);
+
         m_imageReadyCb->Decoded(frame);
         return WEBRTC_VIDEO_CODEC_OK;
     }
@@ -281,6 +296,7 @@ private:
     GRefPtr<GstElement> m_pipeline;
     GRefPtr<GstElement> m_sink;
     GRefPtr<GstElement> m_src;
+    GRefPtr<GstCaps> m_rtpTimestampCaps;
 
     webrtc::DecodedImageCallback* m_imageReadyCb;
 };


### PR DESCRIPTION
#### ae71c24d33d0d36eb29302c0302c186daf554b18
<pre>
[GStreamer][LibWebRTC] Misc fixes for the video decoder factory
<a href="https://bugs.webkit.org/show_bug.cgi?id=308984">https://bugs.webkit.org/show_bug.cgi?id=308984</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch restores the reference timestamp meta for storing RTP timestamps in case the pipeline is
doing actual decoding. Also passing by, exit early if the input image has no encoded data buffer and
pull samples from the sink using a timeout, solving potential deadlocks if the pipeline has a decoder.

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:

Canonical link: <a href="https://commits.webkit.org/308528@main">https://commits.webkit.org/308528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b105b46650a7897b132454ae593eec31f7d9ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156349 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113832 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81191 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15243 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3790 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158683 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121860 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122060 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31293 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132330 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76277 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9109 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83529 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->