### PR TITLE
REGRESSION(307744@main): [iOS debug] css3/filters/effect-drop-shadow.html is a constant crash

### DIFF
--- a/LayoutTests/css3/filters/effect-drop-shadow.html
+++ b/LayoutTests/css3/filters/effect-drop-shadow.html
@@ -3,12 +3,6 @@
 <head>
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
-    <script>
-    if (window.internals) {
-        // Force software rendering mode.
-        window.internals.settings.setAcceleratedCompositingEnabled(false);
-    }
-    </script>
 </head>
 <body>
     <script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8490,6 +8490,4 @@ webkit.org/b/308658 compositing/geometry/fixed-position-composited-page-scale-sm
 
 webkit.org/b/308667 webanimations/threaded-animations/scroll-timeline-root-scroller.html [ Pass Failure ]
 
-webkit.org/b/308849 css3/filters/effect-drop-shadow.html [ Skip ]
-
 webkit.org/b/308326 imported/w3c/web-platform-tests/fetch/api/basic/error-after-response.any.html [ Pass Failure ]


### PR DESCRIPTION
#### a395421472e837b2a505ded25f2eee89dacd223d
<pre>
REGRESSION(307744@main): [iOS debug] css3/filters/effect-drop-shadow.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=308849">https://bugs.webkit.org/show_bug.cgi?id=308849</a>
<a href="https://rdar.apple.com/171385160">rdar://171385160</a>

Unreviewed test cleanup.

Remove the `window.internals.settings.setAcceleratedCompositingEnabled(false)` from the
test; this doesn&apos;t actually make the filters composited, and is an unsupported configuration;
here it caused a scrolling node assertion.

The test is already marked as an ImageOnlyFailure because of webkit.org/b/207586.

* LayoutTests/css3/filters/effect-drop-shadow.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308491@main">https://commits.webkit.org/308491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69a283a6f02a3ce4f125a909b085220027742d09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/faae88f9-66e2-42b1-a7bf-732c54d955b4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81200 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/417df8a1-ab4c-4fc7-8c06-90c04c03a008) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94611 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3575603-6f24-4804-aedd-5faef5de3fca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15269 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13042 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3812 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158706 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121879 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31272 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76299 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9126 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19788 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19576 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->