### PR TITLE
[Site Isolation] [intersection-observer] Re-land 305560@main, 305911@main

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7673,9 +7673,6 @@ imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-transactions-ta
 
 imported/w3c/web-platform-tests/css/css-color/deprecated-sameas-002.html [ ImageOnlyFailure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=301431
-http/tests/site-isolation/page-zoom.html [ Skip ]
-
 http/tests/site-isolation/touch-events [ Skip ]
 http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2029,6 +2029,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/RemoteFrame.h
     page/RemoteFrameClient.h
     page/RemoteFrameGeometryTransformer.h
+    page/RemoteFrameLayoutInfo.h
     page/RemoteFrameView.h
     page/RemoteUserInputEventData.h
     page/ScreenOrientationLockType.h

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -380,6 +380,35 @@ SecurityOrigin& Frame::topOrigin() const
     return SecurityOrigin::opaqueOrigin();
 }
 
+float Frame::frameScaleFactor() const
+{
+    RefPtr page = this->page();
+
+    if (!page)
+        return 1.0;
+
+    // https://github.com/w3c/csswg-drafts/issues/9644
+    // Check if this frame's owner element (iframe) has CSS zoom applied.
+    if (!isMainFrame()) {
+        auto rootZoom = 1.0;
+
+        // FIXME: maybe pageZoomFactor should be available in remote frames?
+        if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame()))
+            rootZoom = localMainFrame->pageZoomFactor();
+
+        if (RefPtr parentFrame = tree().parent())
+            rootZoom = parentFrame->usedZoomForChild(*this) / rootZoom;
+
+        return rootZoom;
+    }
+
+    // Main frame is scaled with respect to the container.
+    if (page->delegatesScaling())
+        return 1;
+
+    return page->pageScaleFactor();
+}
+
 TextStream& operator<<(TextStream& ts, const Frame& frame)
 {
     ts << frame.debugDescription();

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -155,6 +155,12 @@ public:
     WEBCORE_EXPORT virtual std::optional<DocumentSecurityPolicy> frameDocumentSecurityPolicy() const = 0;
     WEBCORE_EXPORT virtual String frameURLProtocol() const = 0;
 
+    // Scale factor of this frame with respect to the container.
+    WEBCORE_EXPORT float frameScaleFactor() const;
+
+    // Scale factor of a child frame with respect to this frame.
+    virtual float usedZoomForChild(const Frame&) const = 0;
+
     WEBCORE_EXPORT virtual void setPrinting(bool printing, FloatSize pageSize, FloatSize originalPageSize, float maximumShrinkRatio, AdjustViewSize, NotifyUIProcess = NotifyUIProcess::Yes);
 
     WEBCORE_EXPORT bool NODELETE isPrinting() const;

--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -31,3 +31,10 @@ FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Headers=<WebCore/
 FrameDocumentSecurityPolicy : std::optional<WebCore::DocumentSecurityPolicy> [Headers=<WebCore/DocumentSecurityPolicy.h>]
 FrameURLProtocol : String [Headers=<wtf/text/WTFString.h>]
 FrameRect : WebCore::IntRect [Headers=<WebCore/IntRect.h>]
+
+## Layout information for Intersection Observer
+
+FrameLayoutViewportRect : WebCore::LayoutRect [Headers=<WebCore/LayoutRect.h>]
+
+# Collection of layout info regarding children frames of this frame.
+ChildrenFrameLayoutInfo : HashMap<WebCore::FrameIdentifier, WebCore::RemoteFrameLayoutInfo> [Headers=<WebCore/FrameIdentifier.h>,<WebCore/RemoteFrameLayoutInfo.h>]

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -284,6 +284,47 @@ FloatRect FrameView::convertFromContainingViewToRenderer(const RenderElement* re
 
 // MARK: -
 
+FloatPoint FrameView::absoluteToLayoutViewportPoint(FloatPoint p) const
+{
+    Ref frame = this->frame();
+
+    ASSERT(frame->settings().visualViewportEnabled());
+    p.scale(1 / frame->frameScaleFactor());
+    p.moveBy(-layoutViewportRect().location());
+    return p;
+}
+
+FloatPoint FrameView::layoutViewportToAbsolutePoint(FloatPoint p) const
+{
+    Ref frame = this->frame();
+
+    ASSERT(frame->settings().visualViewportEnabled());
+    p.moveBy(layoutViewportRect().location());
+    return p.scaled(frame->frameScaleFactor());
+}
+
+FloatRect FrameView::layoutViewportToAbsoluteRect(FloatRect rect) const
+{
+    Ref frame = this->frame();
+
+    ASSERT(frame->settings().visualViewportEnabled());
+    rect.moveBy(layoutViewportRect().location());
+    rect.scale(frame->frameScaleFactor());
+    return rect;
+}
+
+FloatRect FrameView::absoluteToLayoutViewportRect(FloatRect rect) const
+{
+    Ref frame = this->frame();
+
+    ASSERT(frame->settings().visualViewportEnabled());
+    rect.scale(1 / frame->frameScaleFactor());
+    rect.moveBy(-layoutViewportRect().location());
+    return rect;
+}
+
+// MARK: -
+
 IntPoint FrameView::convertToContainingView(IntPoint localPoint) const
 {
     if (RefPtr parentScrollView = parent()) {

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -99,6 +99,12 @@ public:
     WEBCORE_EXPORT IntRect convertFromContainingViewToRenderer(const RenderElement*, const IntRect&) const;
     WEBCORE_EXPORT FloatRect convertFromContainingViewToRenderer(const RenderElement*, const FloatRect&) const;
 
+    WEBCORE_EXPORT FloatPoint absoluteToLayoutViewportPoint(FloatPoint) const;
+    FloatPoint layoutViewportToAbsolutePoint(FloatPoint) const;
+
+    WEBCORE_EXPORT FloatRect absoluteToLayoutViewportRect(FloatRect) const;
+    FloatRect layoutViewportToAbsoluteRect(FloatRect) const;
+
     // Override ScrollView methods to do point conversion via renderers, in order to take transforms into account.
     IntPoint convertToContainingView(IntPoint) const final;
     FloatPoint convertToContainingView(FloatPoint) const final;

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -657,8 +657,7 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
                 RefPtr targetFrameView = target->document().view();
                 targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, target->renderer()->style().usedZoom());
-                // FIXME: compute this when hostFrameView is not local.
-                clientRootBounds = downcast<LocalFrameView>(hostFrameView)->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
+                clientRootBounds = hostFrameView->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
 
                 if (intersectionState.isIntersecting) {
                     ASSERT(intersectionState.absoluteIntersectionRect);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1111,29 +1111,12 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
     }
 }
 
-float LocalFrame::frameScaleFactor() const
+float LocalFrame::usedZoomForChild(const Frame& child) const
 {
-    RefPtr page = this->page();
+    if (CheckedPtr ownerRenderer = child.ownerRenderer())
+        return ownerRenderer->style().usedZoom();
 
-    if (!page)
-        return 1;
-
-    // https://github.com/w3c/csswg-drafts/issues/9644
-    // Check if this frame's owner element (iframe) has CSS zoom applied.
-    if (!isMainFrame()) {
-        auto rootZoom = rootFrame().pageZoomFactor();
-        if (RefPtr ownerElement = this->ownerElement()) {
-            if (auto* ownerRenderer = ownerElement->renderer())
-                return ownerRenderer->style().usedZoom() / rootZoom;
-        }
-        return rootZoom;
-    }
-
-    // Main frame is scaled with respect to the container.
-    if (page->delegatesScaling())
-        return 1;
-
-    return page->pageScaleFactor();
+    return 1.0;
 }
 
 void LocalFrame::suspendActiveDOMObjectsAndAnimations()

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -223,8 +223,7 @@ public:
     float pageZoomFactor() const { return m_pageZoomFactor; }
     float textZoomFactor() const { return m_textZoomFactor; }
 
-    // Scale factor of this frame with respect to the container.
-    WEBCORE_EXPORT float frameScaleFactor() const;
+    float usedZoomForChild(const Frame&) const final;
 
     void deviceOrPageScaleFactorChanged();
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2037,6 +2037,11 @@ LayoutRect LocalFrameView::layoutViewportRect() const
     return LayoutRect(m_layoutViewportOrigin, baseLayoutViewportSize());
 }
 
+void LocalFrameView::updateLayoutViewportRect()
+{
+    m_frame->loader().client().broadcastFrameLayoutViewportRectToOtherProcesses(layoutViewportRect());
+}
+
 // visibleContentRect is in the bounds of the scroll view content. That consists of an
 // optional header, the document, and an optional footer. Only the document is scaled,
 // so we have to compute the visible part of the document in unscaled document coordinates.
@@ -6235,37 +6240,6 @@ FloatPoint LocalFrameView::clientToDocumentPoint(FloatPoint point) const
 {
     point.move(-documentToClientOffset());
     return point;
-}
-
-FloatPoint LocalFrameView::absoluteToLayoutViewportPoint(FloatPoint p) const
-{
-    ASSERT(m_frame->settings().visualViewportEnabled());
-    p.scale(1 / m_frame->frameScaleFactor());
-    p.moveBy(-layoutViewportRect().location());
-    return p;
-}
-
-FloatPoint LocalFrameView::layoutViewportToAbsolutePoint(FloatPoint p) const
-{
-    ASSERT(m_frame->settings().visualViewportEnabled());
-    p.moveBy(layoutViewportRect().location());
-    return p.scaled(m_frame->frameScaleFactor());
-}
-
-FloatRect LocalFrameView::layoutViewportToAbsoluteRect(FloatRect rect) const
-{
-    ASSERT(m_frame->settings().visualViewportEnabled());
-    rect.moveBy(layoutViewportRect().location());
-    rect.scale(m_frame->frameScaleFactor());
-    return rect;
-}
-
-FloatRect LocalFrameView::absoluteToLayoutViewportRect(FloatRect rect) const
-{
-    ASSERT(m_frame->settings().visualViewportEnabled());
-    rect.scale(1 / m_frame->frameScaleFactor());
-    rect.moveBy(-layoutViewportRect().location());
-    return rect;
 }
 
 FloatRect LocalFrameView::clientToLayoutViewportRect(FloatRect rect) const

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -313,6 +313,7 @@ public:
 
     // These are in document coordinates, unaffected by page scale (but affected by zooming).
     WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
+    void updateLayoutViewportRect();
     WEBCORE_EXPORT LayoutRect visualViewportRect() const;
 
     LayoutRect layoutViewportRectIncludingObscuredInsets() const;
@@ -541,12 +542,6 @@ public:
     DoublePoint documentToClientPoint(DoublePoint) const;
     WEBCORE_EXPORT FloatRect clientToDocumentRect(FloatRect) const;
     WEBCORE_EXPORT FloatPoint clientToDocumentPoint(FloatPoint) const;
-
-    WEBCORE_EXPORT FloatPoint absoluteToLayoutViewportPoint(FloatPoint) const;
-    FloatPoint layoutViewportToAbsolutePoint(FloatPoint) const;
-
-    WEBCORE_EXPORT FloatRect absoluteToLayoutViewportRect(FloatRect) const;
-    FloatRect layoutViewportToAbsoluteRect(FloatRect) const;
 
     // Unlike client coordinates, layout viewport coordinates are affected by page zoom.
     WEBCORE_EXPORT FloatRect clientToLayoutViewportRect(FloatRect) const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -153,6 +153,7 @@
 #include "RTCController.h"
 #include "Range.h"
 #include "RemoteFrame.h"
+#include "RemoteFrameLayoutInfo.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderImage.h"
@@ -2160,6 +2161,31 @@ unsigned NODELETE Page::renderingUpdateCount() const
     return m_renderingUpdateCount;
 }
 
+void Page::syncLocalFrameInfoToRemote()
+{
+    forEachLocalFrame([] (LocalFrame& frame) {
+        CheckedPtr frameView = frame.view();
+
+        frameView->updateLayoutViewportRect();
+
+        {
+            HashMap<FrameIdentifier, RemoteFrameLayoutInfo> childrenFrameLayoutInfo;
+
+            for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+                auto visibleRect = frameView->visibleRectOfChild(*child.get());
+
+                float usedZoom = 1.0;
+                if (CheckedPtr ownerRenderer = child->ownerRenderer())
+                    usedZoom = ownerRenderer->style().usedZoom();
+
+                childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo { .visibleRectInParent = visibleRect, .usedZoom = usedZoom });
+            }
+
+            frame.loader().client().broadcastChildrenFrameLayoutInfoToOtherProcesses(childrenFrameLayoutInfo);
+        }
+    });
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering
 void Page::updateRendering()
 {
@@ -2450,6 +2476,9 @@ void Page::doAfterUpdateRendering()
     }
 
     computeSampledPageTopColorIfNecessary();
+
+    if (settings().siteIsolationEnabled())
+        syncLocalFrameInfoToRemote();
 }
 
 void Page::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> flags)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1386,6 +1386,8 @@ public:
     AcceleratedTimelinesUpdater& ensureAcceleratedTimelinesUpdater();
 #endif
 
+    void syncLocalFrameInfoToRemote();
+
 private:
     explicit Page(PageConfiguration&&);
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -215,6 +215,12 @@ AutoplayPolicy RemoteFrame::autoplayPolicy() const
     return m_autoplayPolicy;
 }
 
+float RemoteFrame::usedZoomForChild(const Frame& child) const
+{
+    auto maybeInfo = frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID());
+    return maybeInfo.transform([] (auto& info) { return info.usedZoom; }).value_or(1.0);
+}
+
 String RemoteFrame::debugDescription() const
 {
     StringBuilder builder;

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -107,6 +107,7 @@ private:
     SecurityOrigin* NODELETE frameDocumentSecurityOrigin() const final;
     std::optional<DocumentSecurityPolicy> NODELETE frameDocumentSecurityPolicy() const final;
     String NODELETE frameURLProtocol() const final;
+    float usedZoomForChild(const Frame&) const final;
 
     FrameView* NODELETE virtualView() const final;
     void disconnectView() final;

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/LayoutRect.h>
+
+namespace WebCore {
+
+// Collection of layout info regarding a (potentially remote) frame.
+// This is synchronized from LocalFrame in one process to RemoteFrames
+// in other processes using FrameTreeSyncData. Currently, it is used by
+// Intersection Observer to compute the intersection rectangle from any processes.
+struct RemoteFrameLayoutInfo {
+    // Rectangle of the visible portion of the frame in its parent frame,
+    // in the coordinate space of the document of the parent frame.
+    std::optional<LayoutRect> visibleRectInParent;
+
+    // RenderStyle::usedZoom of the owner renderer of the frame.
+    float usedZoom;
+};
+
+};

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -55,14 +55,15 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
 
 LayoutRect RemoteFrameView::layoutViewportRect() const
 {
-    ASSERT_NOT_REACHED();
-    return { };
+    return m_frame->frameTreeSyncData().frameLayoutViewportRect;
 }
 
-std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame&) const
+std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame& child) const
 {
-    // FIXME: implement this.
-    return { };
+    auto maybeInfo = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID());
+    return maybeInfo.and_then([] (auto& info) {
+        return info.visibleRectInParent;
+    });
 }
 
 // FIXME: Implement all the stubs below.

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -45,7 +45,7 @@ public:
     RemoteFrame& frame() const final { return m_frame; }
 
     WEBCORE_EXPORT LayoutRect NODELETE layoutViewportRect() const final;
-    std::optional<LayoutRect> NODELETE visibleRectOfChild(const Frame&) const final;
+    std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
 
     // Set the frame rectangle, like setFrameRect, without synching the new rect to other Local/RemoteFrameViews.
     // When frameRect of a RemoteFrameView changes, it syncs the new rect to other Local/RemoteFrameViews.

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2194,6 +2194,11 @@ class WebCore::LayoutRect {
     WebCore::LayoutSize m_size;
 };
 
+struct WebCore::RemoteFrameLayoutInfo {
+    std::optional<WebCore::LayoutRect> visibleRectInParent;
+    float usedZoom;
+};
+
 header: <WebCore/VP9Utilities.h>
 [CustomHeader] struct WebCore::ScreenDataOverrides {
     double width;

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -65,6 +65,7 @@
 #include <WebCore/LayoutRect.h>
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/NavigationScheduler.h>
+#include <WebCore/RemoteFrameLayoutInfo.h>
 #include <WebCore/ShareableBitmapHandle.h>
 #include <WebCore/WebKitJSHandle.h>
 #include <stdio.h>
@@ -688,7 +689,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, url().protocol().toString(), IntRect { });
+    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, url().protocol().toString(), IntRect { }, LayoutRect { }, HashMap<FrameIdentifier, RemoteFrameLayoutInfo> { });
 }
 
 Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7999,8 +7999,12 @@ void WebPageProxy::broadcastFrameTreeSyncData(IPC::Connection& connection, Frame
 
     // FIXME: This could instead be an option in FrameTreeSyncData.in to allow
     // certain properties to be mutable from non-frame-owning processes.
-    if (frameTreePropertyIsRestrictedToFrameOwningProcess(data.type))
-        MESSAGE_CHECK(process, &webFrameProxy->process() == &process.get());
+    if (frameTreePropertyIsRestrictedToFrameOwningProcess(data.type)) {
+        if (&webFrameProxy->process() != &process.get()) {
+            // FIXME: make this a MESSAGE_CHECK.
+            return;
+        }
+    }
 
     if (data.type == WebCore::FrameTreeSyncDataType::FrameRect)
         webFrameProxy->setRemoteFrameRect(std::get<IntRect>(data.value));


### PR DESCRIPTION
#### fac0fa9d8dfc8f9c108327685861ff971c25ce2d
<pre>
[Site Isolation] [intersection-observer] Re-land 305560@main, 305911@main
<a href="https://rdar.apple.com/171536928">rdar://171536928</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308988">https://bugs.webkit.org/show_bug.cgi?id=308988</a>

Reviewed by Alan Baradlay.

307298@main reverts 305560@main/305911@main because of Speedometer 3 regression.
This is a clean revert of 307298@main to re-land those commits.
No changes to the code, the regression goes away after re-collecting PGO profiles.

* LayoutTests/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::frameScaleFactor const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameTreeSyncData.in:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::absoluteToLayoutViewportPoint const):
(WebCore::FrameView::layoutViewportToAbsolutePoint const):
(WebCore::FrameView::layoutViewportToAbsoluteRect const):
(WebCore::FrameView::absoluteToLayoutViewportRect const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::updateObservations):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::usedZoomForChild const):
(WebCore::LocalFrame::frameScaleFactor const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateLayoutViewportRect):
(WebCore::LocalFrameView::absoluteToLayoutViewportPoint const): Deleted.
(WebCore::LocalFrameView::layoutViewportToAbsolutePoint const): Deleted.
(WebCore::LocalFrameView::layoutViewportToAbsoluteRect const): Deleted.
(WebCore::LocalFrameView::absoluteToLayoutViewportRect const): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
(WebCore::Page::doAfterUpdateRendering):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::usedZoomForChild const):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameLayoutInfo.h: Added.
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::layoutViewportRect const):
(WebCore::RemoteFrameView::visibleRectOfChild const):
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::broadcastFrameTreeSyncData):

Canonical link: <a href="https://commits.webkit.org/308576@main">https://commits.webkit.org/308576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6edbcae5e9b97abcad8a4d6907e354d4020c0db5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101136 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c420453-9504-4cee-9da6-6677c94d79b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81213 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94641 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13063 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3844 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158742 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121908 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31326 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76331 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9152 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83583 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19550 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19701 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->