### PR TITLE
Upgrade ASSERT to RELEASE_ASSERT in copyElements

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1100,7 +1100,7 @@ template<typename ElementType>
 inline void copyElements(std::span<ElementType> destinationSpan, std::span<const ElementType> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     if (sourceSpan.size() == 1)
@@ -1112,7 +1112,7 @@ inline void copyElements(std::span<ElementType> destinationSpan, std::span<const
 inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const uint8_t> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();
@@ -1166,7 +1166,7 @@ inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const ui
 inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uint16_t> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();
@@ -1249,7 +1249,7 @@ inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uin
 inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const uint32_t> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();
@@ -1279,7 +1279,7 @@ inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const ui
 inline void copyElements(std::span<uint32_t> destinationSpan, std::span<const uint64_t> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();
@@ -1309,7 +1309,7 @@ inline void copyElements(std::span<uint32_t> destinationSpan, std::span<const ui
 inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const uint64_t> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();
@@ -1339,7 +1339,7 @@ inline void copyElements(std::span<uint16_t> destinationSpan, std::span<const ui
 inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uint64_t> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();
@@ -1371,7 +1371,7 @@ inline void copyElements(std::span<uint8_t> destinationSpan, std::span<const uin
 inline void copyElements(std::span<float> destinationSpan, std::span<const double> sourceSpan)
 {
     ASSERT(!spansOverlap(destinationSpan, sourceSpan));
-    ASSERT(destinationSpan.size() >= sourceSpan.size());
+    RELEASE_ASSERT(destinationSpan.size() >= sourceSpan.size());
     auto* __restrict destination = destinationSpan.data();
     auto* __restrict source = sourceSpan.data();
     size_t length = sourceSpan.size();


### PR DESCRIPTION
#### ae886594e2a2cf52c42f0b276a528be12f582299
<pre>
Upgrade ASSERT to RELEASE_ASSERT in copyElements
<a href="https://bugs.webkit.org/show_bug.cgi?id=308993">https://bugs.webkit.org/show_bug.cgi?id=308993</a>
<a href="https://rdar.apple.com/171524293">rdar://171524293</a>

Reviewed by Ryosuke Niwa.

Consistent with our Safe Buffers / SaferCPP strategy.

* Source/WTF/wtf/text/StringCommon.h:
(WTF::copyElements):

Canonical link: <a href="https://commits.webkit.org/308548@main">https://commits.webkit.org/308548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/409b0164e7648d96a46c7adc7d764af6cd10dd05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101099 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae1c0957-0852-49de-91ba-e0ea70765968) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81197 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f64174c6-277e-4b13-999b-225f6a058c36) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94608 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7110e2d1-4192-4ca0-a367-9b3d3fc351ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15251 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13036 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3807 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139654 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158700 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8472 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1836 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121878 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76294 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22776 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9122 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179106 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83546 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->