### PR TITLE
IPCTestingAPI: make JSIPC::serializeEnumInfo GC safe

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2817,55 +2817,43 @@ JSValueRef JSIPC::serializedEnumInfo(JSContextRef context, JSObjectRef thisObjec
         JSC::JSObject* enumObject = constructEmptyObject(globalObject, globalObject->objectPrototype());
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-        JSObjectRef jsEnumObject = JSValueToObject(context, toRef(vm, enumObject), exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
-
         // Create validValues array for backward compatibility
-        auto validValuesArray = WTF::map(enumeration.valueMap, [&](auto& valueInfo) -> JSValueRef {
-            return JSValueMakeNumber(context, valueInfo.value);
-        });
-        JSObjectRef jsValidValues = JSObjectMakeArray(context, enumeration.valueMap.size(), validValuesArray.span().data(), exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
+        JSC::JSObject* validValuesArray = JSC::constructEmptyArray(globalObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+        for (size_t i = 0; i < enumeration.valueMap.size(); i++) {
+            validValuesArray->putDirectIndex(globalObject, i, JSC::jsNumber(enumeration.valueMap[i].value));
+            RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+        }
 
-        JSObjectSetProperty(context, jsEnumObject, adopt(JSStringCreateWithUTF8CString("validValues")).get(), jsValidValues, kJSPropertyAttributeNone, exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
+        enumObject->putDirect(vm, JSC::Identifier::fromString(vm, "validValues"_s), validValuesArray);
+        RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
         // Create valueMap array with both values and names
-        auto valueMapArray = WTF::map(enumeration.valueMap, [&](auto& valueInfo) -> JSValueRef {
-            auto* globalObject = toJS(context);
-            auto& vm = globalObject->vm();
-            JSC::JSLockHolder lock(vm);
-            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-
+        JSC::JSObject* valueMapArray = JSC::constructEmptyArray(globalObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+        for (size_t i = 0; i < enumeration.valueMap.size(); i++) {
+            auto& valueInfo = enumeration.valueMap[i];
             JSC::JSObject* valueObject = constructEmptyObject(globalObject, globalObject->objectPrototype());
             RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-            valueObject->putDirect(vm, JSC::Identifier::fromString(vm, "value"_s), JSC::JSValue(valueInfo.value));
+            valueObject->putDirect(vm, JSC::Identifier::fromString(vm, "value"_s), JSC::jsNumber(valueInfo.value));
             RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
             valueObject->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), JSC::jsString(vm, String(valueInfo.name)));
             RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-            return toRef(globalObject, valueObject);
-        });
-        JSObjectRef jsValueMap = JSObjectMakeArray(context, enumeration.valueMap.size(), valueMapArray.span().data(), exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
+            valueMapArray->putDirectIndex(globalObject, i, valueObject);
+            RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+        }
 
-        JSObjectSetProperty(context, jsEnumObject, adopt(JSStringCreateWithUTF8CString("valueMap")).get(), jsValueMap, kJSPropertyAttributeNone, exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
+        enumObject->putDirect(vm, JSC::Identifier::fromString(vm, "valueMap"_s), valueMapArray);
+        RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-        JSObjectSetProperty(context, jsEnumObject, adopt(JSStringCreateWithUTF8CString("isOptionSet")).get(), JSValueMakeNumber(context, enumeration.isOptionSet), kJSPropertyAttributeNone, exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
+        enumObject->putDirect(vm, JSC::Identifier::fromString(vm, "isOptionSet"_s), JSC::jsNumber(enumeration.isOptionSet));
+        RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-        JSObjectSetProperty(context, jsEnumObject, adopt(JSStringCreateWithUTF8CString("size")).get(), JSValueMakeNumber(context, enumeration.size), kJSPropertyAttributeNone, exception);
-        if (*exception)
-            return JSValueMakeUndefined(context);
+        enumObject->putDirect(vm, JSC::Identifier::fromString(vm, "size"_s), JSC::jsNumber(enumeration.size));
+        RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
         object->putDirect(vm, JSC::Identifier::fromString(vm, String(enumeration.name)), enumObject);
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));


### PR DESCRIPTION
#### 4300f716829054e43e61528f023cb0b7856667a4
<pre>
IPCTestingAPI: make JSIPC::serializeEnumInfo GC safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=308994">https://bugs.webkit.org/show_bug.cgi?id=308994</a>
<a href="https://rdar.apple.com/171529170">rdar://171529170</a>

Reviewed by Yusuke Suzuki.

304461@main introduced an unsafe use of WTF::map. The returned
vector contains GC object references that are unrooted.

Fix this by updating the JS array directly so that all GC objects
are reachable while constructing the objects and populating the array.

Testing: found by debug build layout tests with --collectContinuously=1 --useZombieMode=1 ENABLE_GC_VALIDATION=1
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::serializedEnumInfo):

Canonical link: <a href="https://commits.webkit.org/308492@main">https://commits.webkit.org/308492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8292dc09adcf756b5da53a483f92c895b71f624d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101108 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98fffd6d-420b-4803-b522-76657e202dae) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113854 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81203 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1ffbc7b-eea8-48bc-b4ef-5cbc62855f57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94614 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1ad45d7-9615-4189-98ad-8e1b96e04f16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3816 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124852 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158710 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121881 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122081 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31271 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76303 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9129 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19522 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->