### PR TITLE
[JSC] Async stack trace can have nullptr CodeBlock*

### DIFF
--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -79,6 +79,13 @@ public:
         return nullptr;
     }
 
+    JSCell* callee() const
+    {
+        if (auto* jsFrame = std::get_if<JSFrameData>(&m_frameData))
+            return jsFrame->callee.get();
+        return nullptr;
+    }
+
     bool isAsyncFrameWithoutCodeBlock() const
     {
         if (auto* jsFrame = std::get_if<JSFrameData>(&m_frameData))

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -204,10 +204,13 @@ String JSVMClientData::overrideSourceURL(const JSC::StackFrame& frame, const Str
     if (originalSourceURL.isEmpty())
         return nullString();
 
-    auto* codeBlock = frame.codeBlock();
-    RELEASE_ASSERT(codeBlock);
+    JSGlobalObject* globalObject = nullptr;
+    if (auto* codeBlock = frame.codeBlock())
+        globalObject = codeBlock->globalObject();
+    else if (auto* callee = jsDynamicCast<JSObject*>(frame.callee()))
+        globalObject = callee->globalObject();
+    RELEASE_ASSERT(globalObject);
 
-    auto* globalObject = codeBlock->globalObject();
     if (!globalObject->inherits<JSDOMWindowBase>())
         return nullString();
 


### PR DESCRIPTION
#### 2f9b3951c5651e58a6296fcbff19c0c931951739
<pre>
[JSC] Async stack trace can have nullptr CodeBlock*
<a href="https://bugs.webkit.org/show_bug.cgi?id=308997">https://bugs.webkit.org/show_bug.cgi?id=308997</a>
<a href="https://rdar.apple.com/171401201">rdar://171401201</a>

Reviewed by Yijia Huang and Sosuke Suzuki.

Async stack trace is having nullptr CodeBlock*, but
WebCore::JSVMClientData::overrideSourceURL is strongly assuming that
CodeBlock* is not nullptr. Since only use of that is obtaining
JSGlobalObject*, let&apos;s have JSCell* callee and get JSGlobalObject* if
CodeBlock* is nullptr.

The reason why CodeBlock becomes nullptr is because we can jettison
CodeBlock* when it is not executed right now: if it can be found in the
stack, we keep it, but otherwise, we may discard to reduce memory when
it is not executed recently. And async stack trace is not actually
putting CodeBlock* in the stack so that can be discarded. This is
expected and totally fine since (1) async function will not be returned
via `ret`. It is resumed with a call, thus we do not need to keep it and
(2) CodeBlock* generation is idempotent, so we are discarding it when it
is not recently executed and we would like to reduce memory size.

* Source/JavaScriptCore/runtime/StackFrame.h:
(JSC::StackFrame::callee const):
* Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
(WebCore::JSVMClientData::overrideSourceURL const):

Canonical link: <a href="https://commits.webkit.org/308486@main">https://commits.webkit.org/308486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/706581b09ff2ffbde40743506938e8f019e6f46d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156391 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52582aa9-c401-488e-b7a6-70847bc3f913) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113866 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7eff6f96-708e-45c8-ae24-b3a2ca7d6cf6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16112 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87e2cb6c-ef4d-4447-8fae-8800bb99814f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3831 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139678 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158725 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8496 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121892 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122093 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76318 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22753 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9146 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179130 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83570 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45907 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->