### PR TITLE
WebContentRestrictionsAskTo Runtime Flag should not be hard-coded to false

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9431,7 +9431,7 @@ WebContentRestrictionsAskToEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: defaultWebContentRestrictionsAskToEnabled()
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -84,6 +84,13 @@ bool defaultContentChangeObserverEnabled()
 }
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+bool NODELETE defaultWebContentRestrictionsAskToEnabled()
+{
+    return false;
+}
+#endif
+
 }
 
 #endif // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -234,4 +234,8 @@ bool NODELETE defaultShouldEnableScreenCapture();
 bool defaultContentChangeObserverEnabled();
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+bool NODELETE defaultWebContentRestrictionsAskToEnabled();
+#endif
+
 } // namespace WebKit


### PR DESCRIPTION
#### 573d332590d54627458bf9601ecbf9afd822c8bd
<pre>
WebContentRestrictionsAskTo Runtime Flag should not be hard-coded to false
<a href="https://bugs.webkit.org/show_bug.cgi?id=308996">https://bugs.webkit.org/show_bug.cgi?id=308996</a>
<a href="https://rdar.apple.com/171054954">rdar://171054954</a>

Reviewed by Sihui Liu and Tadeu Zagallo.

We should dynamically set the value of the WebContentRestrictionsAskT&apos;s runtime flag based on
the system&apos;s value.

No new tests needed.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultWebContentRestrictionsAskToEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:

Canonical link: <a href="https://commits.webkit.org/308488@main">https://commits.webkit.org/308488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac4234e6160136ea19e01a738427c1bfbb3deeb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20426 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20326 "Failed to checkout and rebase branch from PR 59731") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/156424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150703 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/14018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139711 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158759 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8529 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/20326 "Failed to checkout and rebase branch from PR 59731") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22756 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179163 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/19841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->