### PR TITLE
[audit-spi] Method from unloaded library in the cache clobbers allowlist entries with different class name

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -478,7 +478,8 @@ class SDKDB:
                     '           ew.input_file IS NOT NULL) as export_found, '
                     '       sum(a.name IS NOT NULL AND '
                     '           a.cond_id IS c.nextid AND '
-                    '           (a.class_name = e.class_name IS NOT FALSE) AND '
+                    '           (ew.input_file IS NULL OR '
+                    '            a.class_name = e.class_name IS NOT FALSE) AND '
                     '           aw.input_file IS NOT NULL) as allow_found '
                     'FROM imports AS i '
                     'LEFT JOIN exports AS e USING (name, kind) '
@@ -495,13 +496,18 @@ class SDKDB:
                     # selector, or different allowlists that allow the same
                     # name. Coalesce the results and only return entries where
                     # an import name has *no* exports found, or an allowed name
-                    # comes from at least one loaded file.
+                    # comes from at least one loaded file. Ignore ObjC methods
+                    # in allowlists which partially match an exported method
+                    # (i.e. selector matches but class does not).
                     #
                     # This is sufficient to remove all rows in the common
                     # case--imported API that matches an exported delcaration.
-                    # The remaining logic to identify problem is done in Python below.
+                    # The remaining logic to identify problem is done in Python
+                    # below.
                     'GROUP BY i.kind, a.kind, i.name, a.name, i.input_file '
-                    'HAVING export_found = 0 OR allow_found > 0 '
+                    'HAVING export_found = 0 OR '
+                    '   (allow_found > 0 AND '
+                    '    e.class_name = a.class_name IS NOT FALSE) '
                     'ORDER BY i.input_file, i.kind, a.kind, i.name, a.name')
         for (arch, import_kind, input_path, import_name,
              allowed_kind, allowlist_paths, allowed_name, allow_unused,

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -303,6 +303,31 @@ class TestSDKDB(TestCase):
         self.add_allowlist(A_QualifiedSelector)
         self.assertEmpty(self.audit_with(R_Client))
 
+    def test_audit_allowed_fully_qualified_selector_with_bystander(self):
+        # Same test as above but with an additional, unloaded, unrelated
+        # library exporting a method with the same selector.
+        bystander = APIReport(file=F, arch='arm64e',
+                              platform='iOS', min_os='1.0', sdk='1.0',
+                              methods={APIReport.Selector('initWithData:',
+                                                          'UnrelatedClass')})
+        self.add_library(bystander, file=F, file_hash=F_Hash)
+        self.reconnect()
+
+        self.add_partial_sdkdb()  # -[NSData initWithData:]
+        self.add_allowlist(A_QualifiedSelector)  # -[WKDoesntExist initWithData:]
+        self.assertEmpty(self.audit_with(R_Client))
+
+    def test_audit_allowed_fully_qualified_selector_with_different_class_unloaded(self):
+        # Add -[NSData initWithData:] to the exports table, then reconnect to
+        # move it out of the window.
+        self.add_partial_sdkdb()
+        self.reconnect()
+        # Add -[WKDoesntExist initWithData:] to the allow table.
+        self.add_allowlist(A_QualifiedSelector)
+        # A client that sends "initWithData:" should have no audit issues
+        # (it's covered by the WKDoesntExist entry).
+        self.assertEmpty(self.audit_with(R_Client))
+
     def test_audit_unused_allow_from_loaded_allowlist(self):
         self.add_allowlist()
         self.assertIn(A_UnusedAllow, self.sdkdb.audit())


### PR DESCRIPTION
#### f6a26193b8b843d822a84ceb0a78331f20d06437
<pre>
[audit-spi] Method from unloaded library in the cache clobbers allowlist entries with different class name
<a href="https://bugs.webkit.org/show_bug.cgi?id=308998">https://bugs.webkit.org/show_bug.cgi?id=308998</a>
<a href="https://rdar.apple.com/171546166">rdar://171546166</a>

Reviewed by Mike Wyrzykowski.

Leads to &quot;error: unrecognized selector ...&quot; build failures for ObjC
selectors that we clearly have allowlist entries for. Because the error
comes from old, inactive data in the cache, it usually goes away by
deleting audit-spi&apos;s sqlite database and letting it rebuild from
scratch.

Fix by qualifying the `allow_found` portion of the query to only check
against loaded libraries (i.e. entries from the exports table that are
in the window).

This change reveals a different issue, where two different methods with
the same selector that are allowed AND exported as API can be flagged as
a `UnnecessaryAllowedName`. Fix this edge case by checking class name
before emitting this diagnostic.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB.audit):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.test_audit_allowed_fully_qualified_selector_with_bystander):
(TestSDKDB):
(TestSDKDB.test_audit_allowed_fully_qualified_selector_with_different_class_unloaded):

Canonical link: <a href="https://commits.webkit.org/308652@main">https://commits.webkit.org/308652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceea7e8458fd41c35435a3cb3ee618fd28b2952e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101119 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d799b8a-49ab-426d-a928-1cbbe20fe855) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113859 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81206 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ecc1b5d-e9e7-4b6f-add4-a0585b273ac7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94619 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a797ba34-48ae-41de-b3e3-d79f877b7c36) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147026 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13048 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3827 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158721 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121887 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122088 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31322 "Failed to checkout and rebase branch from PR 59733") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76314 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17611 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9143 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19804 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19533 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19591 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->