### PR TITLE
[GTK][WPE] Add single-entry GPU atlas cache to SkiaPaintingEngine

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -115,7 +115,7 @@ bool SkiaGPUAtlas::uploadImages()
             if (!writeScope)
                 return false;
 
-            for (const auto& entry : m_layout.entries()) {
+            for (const auto& entry : m_layout->entries()) {
                 if (auto pixels = pixelDataInSRGB(entry.rasterImage))
                     gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
             }
@@ -126,7 +126,7 @@ bool SkiaGPUAtlas::uploadImages()
 #endif
 
     // GL fallback: use BitmapTexture::updateContents() per entry.
-    for (const auto& entry : m_layout.entries()) {
+    for (const auto& entry : m_layout->entries()) {
         if (auto pixels = pixelDataInSRGB(entry.rasterImage))
             m_atlasTexture->updateContents(pixels->first, entry.atlasRect, IntPoint::zero(), pixels->second, PixelFormat::BGRA8);
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -71,7 +71,7 @@ private:
     Ref<BitmapTexture> m_atlasTexture;
     GrBackendTexture m_backendTexture;
     ImageToRectMap m_imageToRect;
-    const SkiaImageAtlasLayout& m_layout;
+    Ref<const SkiaImageAtlasLayout> m_layout;
     IntSize m_size;
 };
 

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -165,6 +165,24 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
     return atlas;
 }
 
+bool SkiaPaintingEngine::tryReuseCachedAtlases(SkiaRecordingResult& result)
+{
+    if (m_cachedGPUAtlases.isEmpty())
+        return false;
+
+    // Verify every current image exists in a cached atlas's imageToRect map.
+    for (const auto& layout : result.atlasLayouts()) {
+        for (const auto& entry : layout->entries()) {
+            if (!m_cachedGPUAtlases.containsIf([&](const auto& cachedAtlas) { return cachedAtlas->imageToRect().contains(entry.rasterImage.get()); }))
+                return false;
+        }
+    }
+
+    // Cache hit — reuse GPU atlases.
+    result.setGPUAtlases(copyToVectorOf<Ref<SkiaGPUAtlas>>(m_cachedGPUAtlases));
+    return true;
+}
+
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::paint(const GraphicsLayerCoordinated& layer, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale)
 {
     // ### Synchronous rendering on main thread ###
@@ -219,34 +237,43 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     // Prepare GPU atlases on main thread before dispatching to workers.
     // Textures are acquired from BitmapTexturePool which handles recycling.
     if (result->hasAtlasLayouts()) {
-        PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
+        // Fast path: reuse cached atlases if the image set is unchanged.
+        if (!tryReuseCachedAtlases(result.get())) {
+            PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
 
-        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-        RELEASE_ASSERT(grContext);
+            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+            RELEASE_ASSERT(grContext);
 
-        Vector<Ref<SkiaGPUAtlas>> gpuAtlases;
-        auto uploadCondition = AtlasUploadCondition::create();
-        gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
+            Vector<Ref<SkiaGPUAtlas>> gpuAtlases;
+            auto uploadCondition = AtlasUploadCondition::create();
+            gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
 
-        for (const auto& layout : result->atlasLayouts()) {
-            if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
-                gpuAtlases.append(atlas.releaseNonNull());
+            for (const auto& layout : result->atlasLayouts()) {
+                if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
+                    gpuAtlases.append(atlas.releaseNonNull());
+            }
+
+            if (!gpuAtlases.isEmpty()) {
+                // Update cache for next frame.
+                m_cachedGPUAtlases = copyToVectorOf<Ref<SkiaGPUAtlas>>(gpuAtlases);
+
+                result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
+
+                // Flush and fence for the GL upload path, where
+                // BitmapTexture::updateContents() issues GL upload commands.
+                // On the DMA-buf path, uploading is CPU-side (memory-mapped),
+                // so this is a no-op flush but harmless.
+                auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
+                if (GLFence::isSupported(glDisplay)) {
+                    grContext->flushAndSubmit(GrSyncCpu::kNo);
+                    result->setUploadFence(GLFence::create(glDisplay));
+                } else
+                    grContext->flushAndSubmit(GrSyncCpu::kYes);
+            }
         }
-
-        if (!gpuAtlases.isEmpty()) {
-            result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
-
-            // Flush and fence for the GL upload path, where
-            // BitmapTexture::updateContents() issues GL upload commands.
-            // On the DMA-buf path, uploading is CPU-side (memory-mapped),
-            // so this is a no-op flush but harmless.
-            auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
-            if (GLFence::isSupported(glDisplay)) {
-                grContext->flushAndSubmit(GrSyncCpu::kNo);
-                result->setUploadFence(GLFence::create(glDisplay));
-            } else
-                grContext->flushAndSubmit(GrSyncCpu::kYes);
-        }
+    } else {
+        // No atlas layouts — clear cache to release GPU memory.
+        m_cachedGPUAtlases.clear();
     }
 
     return result;

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -70,9 +70,11 @@ private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
     RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
+    bool tryReuseCachedAtlases(SkiaRecordingResult&);
 
     RefPtr<WorkerPool> m_paintingWorkerPool;
     RefPtr<WorkQueue> m_uploadWorkQueue;
+    Vector<Ref<SkiaGPUAtlas>> m_cachedGPUAtlases;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -104,7 +104,7 @@ public:
     const Vector<Ref<SkiaImageAtlasLayout>>& atlasLayouts() const { return m_atlasLayouts; }
 
     // GPU atlases prepared on main thread for worker threads to rewrap.
-    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases, Ref<AtlasUploadCondition>&& condition)
+    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases, RefPtr<AtlasUploadCondition>&& condition = nullptr)
     {
         m_gpuAtlases = WTF::move(atlases);
         m_uploadCondition = WTF::move(condition);
@@ -134,7 +134,7 @@ private:
     Vector<Ref<SkiaImageAtlasLayout>> m_atlasLayouts;
     Vector<Ref<SkiaGPUAtlas>> m_gpuAtlases;
     std::unique_ptr<GLFence> m_uploadFence; // Fence for async GPU upload
-    RefPtr<AtlasUploadCondition> m_uploadCondition; // Non-null when m_gpuAtlases is non-empty.
+    RefPtr<AtlasUploadCondition> m_uploadCondition;
     IntRect m_recordRect;
     RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
     bool m_contentsOpaque : 1 { true };


### PR DESCRIPTION
#### a13de3d752945ff8888bf38f86b045eed8c79966
<pre>
[GTK][WPE] Add single-entry GPU atlas cache to SkiaPaintingEngine
<a href="https://bugs.webkit.org/show_bug.cgi?id=309005">https://bugs.webkit.org/show_bug.cgi?id=309005</a>

Reviewed by Carlos Garcia Campos.

When the image set is unchanged between frames reuse the GPU atlas from
the previous frame GPU instead of allocating new textures, uploading pixels
and re-creating the atlas. The cache is cleared when atlas layouts change
or disappear -- ensure the memory usage cannot grow unbounded.

Covered by existing tests.

* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::uploadImages):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::tryReuseCachedAtlases):
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:

Canonical link: <a href="https://commits.webkit.org/308627@main">https://commits.webkit.org/308627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a08b221fb106ca69ece9b750cae4782f5065695

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81324 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15429 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13226 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158940 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122072 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122275 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31367 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76560 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9323 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83785 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->