### PR TITLE
[AutoFill Debugging] Improve text recognition filtering performance when extracting visible text

### DIFF
--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.h
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.h
@@ -95,7 +95,9 @@ void prepareImageAnalysisForOverlayView(PlatformImageAnalysisObject *);
 
 #if HAVE(VISION)
 void requestPayloadForQRCode(CGImageRef, CompletionHandler<void(NSString *)>&&);
-void recognizeText(CGImageRef, CompletionHandler<void(NSString *, NSError *)>&&);
+
+enum class TextRecognitionLevel : bool { Accurate, Fast };
+void recognizeText(CGImageRef, std::optional<TextRecognitionLevel>, CompletionHandler<void(NSString *, NSError *)>&&);
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -443,9 +443,9 @@ static WorkQueue& textRecognitionQueueSingleton()
     return queue.get();
 }
 
-void recognizeText(CGImageRef image, CompletionHandler<void(NSString *, NSError *)>&& completion)
+void recognizeText(CGImageRef image, std::optional<TextRecognitionLevel> level, CompletionHandler<void(NSString *, NSError *)>&& completion)
 {
-    textRecognitionQueueSingleton().dispatch([image = retainPtr(image), completion = WTF::move(completion)] mutable {
+    textRecognitionQueueSingleton().dispatch([level, image = retainPtr(image), completion = WTF::move(completion)] mutable {
         __block RetainPtr<NSString> resultText;
         __block RetainPtr<NSError> error;
         RetainPtr request = adoptNS([PAL::allocVNRecognizeTextRequestInstance() initWithCompletionHandler:^(VNRequest *request, NSError *requestError) {
@@ -474,6 +474,17 @@ void recognizeText(CGImageRef image, CompletionHandler<void(NSString *, NSError 
 
             resultText = resultBuffer;
         }]);
+
+        if (level) {
+            switch (*level) {
+            case TextRecognitionLevel::Accurate:
+                [request setRecognitionLevel:VNRequestTextRecognitionLevelAccurate];
+                break;
+            case TextRecognitionLevel::Fast:
+                [request setRecognitionLevel:VNRequestTextRecognitionLevelFast];
+                break;
+            }
+        }
 
         [request setAutomaticallyDetectsLanguage:YES];
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -192,6 +192,7 @@
 #import <WebCore/StringUtilities.h>
 #import <WebCore/TextAnimationTypes.h>
 #import <WebCore/TextExtractionTypes.h>
+#import <WebCore/TextIterator.h>
 #import <WebCore/TextManipulationController.h>
 #import <WebCore/TextManipulationItem.h>
 #import <WebCore/ViewportArguments.h>
@@ -6926,6 +6927,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         _textExtractionURLCache = WebKit::TextExtractionURLCache::create();
 
     [self _requestTextExtractionInternal:configuration completion:[
+        startTime = MonotonicTime::now(),
         completionHandler = makeBlockPtr(completionHandler),
         weakSelf = WeakObjCPtr<WKWebView>(self),
         mainFrameIdentifier = mainFrame->frameID(),
@@ -7076,11 +7078,12 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             outputFormat,
             urlCache.get(),
         };
-        WebKit::convertToText(WTF::move(result->rootItem), WTF::move(options), [weakSelf, urlCache, completionHandler = WTF::move(completionHandler), endTextExtractionScope = WTF::move(endTextExtractionScope)](auto&& result) {
+        WebKit::convertToText(WTF::move(result->rootItem), WTF::move(options), [weakSelf, startTime, urlCache, completionHandler = WTF::move(completionHandler), endTextExtractionScope = WTF::move(endTextExtractionScope)](auto&& result) {
             RetainPtr strongSelf = weakSelf.get();
             if (!strongSelf)
                 return completionHandler(createEmptyTextExtractionResult().get());
 
+            RELEASE_LOG(TextExtraction, "<%@: %p> Extraction complete (%.0f ms)", [strongSelf class], strongSelf.get(), (MonotonicTime::now() - startTime).milliseconds());
             auto [text, filteredOutAnyText, shortenedURLStrings] = result;
             RetainPtr shortenedURLs = adoptNS([[NSMutableDictionary alloc] initWithCapacity:shortenedURLStrings.size()]);
             for (auto& string : shortenedURLStrings) {
@@ -7420,21 +7423,92 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
         additionalFrames.add(frame.releaseNonNull());
     }
 
+    WeakObjCPtr weakSelf = self;
+    auto startTime = MonotonicTime::now();
+    RELEASE_LOG(TextExtraction, "<%@: %p> Starting text extraction", [self class], self);
     auto results = Box<WebCore::TextExtraction::PageResults>::create();
     auto aggregator = MainRunLoopCallbackAggregator::create([results, completion = WTF::move(completion)] mutable {
         completion(WebCore::TextExtraction::collatePageResults(WTF::move(*results)));
     });
 
-    mainFrame->requestTextExtraction(makeRequest({ *mainFrame }), [aggregator, results](auto&& result) {
+    mainFrame->requestTextExtraction(makeRequest({ *mainFrame }), [weakSelf, startTime, aggregator, results](auto&& result) {
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf)
+            return;
+
+        RELEASE_LOG(TextExtraction, "<%@: %p> • Mainframe items received (%.0f ms)", [strongSelf class], strongSelf.get(), (MonotonicTime::now() - startTime).milliseconds());
         results->mainFrameResult = WTF::move(result);
     });
 
     for (auto& frame : additionalFrames) {
-        frame->requestTextExtraction(makeRequest(frame.copyRef()), [frameID = frame->frameID(), aggregator, results](auto&& result) {
+        frame->requestTextExtraction(makeRequest(frame.copyRef()), [weakSelf, startTime, frameID = frame->frameID(), aggregator, results](auto&& result) {
+            RetainPtr strongSelf = weakSelf.get();
+            if (!strongSelf)
+                return;
+
+            RELEASE_LOG(TextExtraction, "<%@: %p> • Subframe items received (%.0f ms)", [strongSelf class], strongSelf.get(), (MonotonicTime::now() - startTime).milliseconds());
             auto addResult = results->subFrameResults.add(frameID, makeUniqueRef<WebCore::TextExtraction::Result>(WTF::move(result)));
             ASSERT_UNUSED(addResult, addResult.isNewEntry);
         });
     }
+
+#if ENABLE(TEXT_EXTRACTION_FILTER) && HAVE(VISION)
+    if (!_textExtractionRecognizedWords && preferences->textExtractionFilterEnabled() && (configuration.filterOptions & _WKTextExtractionFilterTextRecognition)) {
+        protect(_page)->callAfterNextPresentationUpdate([rectInWebView, weakSelf, aggregator, startTime] mutable {
+            RetainPtr strongSelf = weakSelf.get();
+            if (!strongSelf)
+                return;
+
+            WebCore::FloatRect snapshotRect { rectInWebView };
+            if (CGRectIsNull(rectInWebView)) {
+#if PLATFORM(IOS_FAMILY)
+                snapshotRect = [strongSelf convertRect:[strongSelf->_contentView bounds] fromView:strongSelf->_contentView.get()];
+#else
+                auto scrollPosition = strongSelf->_page->mainFrameScrollPosition();
+                snapshotRect = NSMakeRect(-scrollPosition.x(), -scrollPosition.y(), strongSelf->_lastContentSize.width, strongSelf->_lastContentSize.height);
+#endif
+            }
+
+            static constexpr OptionSet snapshotOptions { WebKit::SnapshotOption::FullContentRect, WebKit::SnapshotOption::ExcludeSelectionHighlighting };
+
+            strongSelf->_page->takeSnapshot(WebCore::enclosingIntRect(snapshotRect), { }, snapshotOptions, [weakSelf, aggregator = WTF::move(aggregator), startTime](CGImageRef image) mutable {
+                RetainPtr strongSelf = weakSelf.get();
+                if (!strongSelf)
+                    return;
+
+                auto snapshotEndTime = MonotonicTime::now();
+                auto millisecondsSpent = (snapshotEndTime - startTime).milliseconds();
+                if (!image) {
+                    RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> • Failed to take full snapshot (%.0f ms)", [strongSelf class], strongSelf.get(), millisecondsSpent);
+                    return;
+                }
+
+                RELEASE_LOG(TextExtraction, "<%@: %p> • Took full snapshot (%.0f ms)", [strongSelf class], strongSelf.get(), millisecondsSpent);
+                WebKit::recognizeText(image, WebKit::TextRecognitionLevel::Fast, [weakSelf, snapshotEndTime, aggregator = WTF::move(aggregator)](NSString *text, NSError *error) mutable {
+                    RetainPtr strongSelf = weakSelf.get();
+                    if (!strongSelf)
+                        return;
+
+                    auto millisecondsSpent = (MonotonicTime::now() - snapshotEndTime).milliseconds();
+                    if (error) {
+                        RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> • Failed to recognize text in full snapshot: %@ (%.0f ms)", [strongSelf class], strongSelf.get(), error, millisecondsSpent);
+                        return;
+                    }
+
+                    __block HashSet<String> recognizedWords;
+                    [text enumerateSubstringsInRange:NSMakeRange(0, text.length) options:NSStringEnumerationByWords usingBlock:^(NSString *word, NSRange, NSRange, BOOL *) {
+                        if (!word.length)
+                            return;
+
+                        recognizedWords.add(WebCore::foldQuoteMarks(word.lowercaseString));
+                    }];
+                    RELEASE_LOG(TextExtraction, "<%@: %p> • Recognized text in full snapshot (%.0f ms) - %u words", [strongSelf class], strongSelf.get(), millisecondsSpent, recognizedWords.size());
+                    strongSelf->_textExtractionRecognizedWords = { WTF::move(recognizedWords) };
+                });
+            });
+        });
+    }
+#endif // ENABLE(TEXT_EXTRACTION_FILTER) && HAVE(VISION)
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
 }
 
@@ -7541,6 +7615,30 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
     if (!mainFrame)
         return completionHandler(text);
 
+    if (_textExtractionRecognizedWords) {
+        __block unsigned totalWords = 0;
+        __block unsigned matchedWords = 0;
+        [text.createNSString() enumerateSubstringsInRange:NSMakeRange(0, text.length()) options:NSStringEnumerationByWords usingBlock:^(NSString *word, NSRange, NSRange, BOOL *) {
+            if (!word.length)
+                return;
+
+            totalWords += 1;
+            if (_textExtractionRecognizedWords->contains(WebCore::foldQuoteMarks(word.lowercaseString)))
+                matchedWords += 1;
+        }];
+
+        if (!totalWords)
+            return completionHandler(text);
+
+        static constexpr auto minimumMatchRatio = 0.9;
+        if (static_cast<double>(matchedWords) / totalWords >= minimumMatchRatio) {
+            RELEASE_LOG_INFO(TextExtraction, "<%@: %p> • Skipping text recognition for paragraph with length: %u", [self class], self, text.length());
+            _textValidationCache.add(textHash, TextValidationMapValue { SimilarToOriginalTextTag::Value });
+            return completionHandler(text);
+        }
+    }
+
+    RELEASE_LOG_INFO(TextExtraction, "<%@: %p> • Snapshotting paragraph with length: %u", [self class], self, text.length());
     mainFrame->takeSnapshotOfExtractedText({ text, WTF::move(nodeIdentifier) }, [text = text, completionHandler = WTF::move(completionHandler), view = retainPtr(self), textHash](auto textIndicator) mutable {
         if (!textIndicator)
             return completionHandler(text);
@@ -7557,7 +7655,7 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
         if (!cgImage)
             return completionHandler(text);
 
-        WebKit::recognizeText(cgImage.get(), [text = WTF::move(text), completionHandler = WTF::move(completionHandler), view = WTF::move(view), textHash](NSString *recognizedText, NSError *error) mutable {
+        WebKit::recognizeText(cgImage.get(), WebKit::TextRecognitionLevel::Fast, [text = WTF::move(text), completionHandler = WTF::move(completionHandler), view = WTF::move(view), textHash](NSString *recognizedText, NSError *error) mutable {
             if (error)
                 return completionHandler(text);
 
@@ -7573,7 +7671,7 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
                 completionHandler(recognizedText);
             } else {
                 view->_textValidationCache.add(textHash, TextValidationMapValue { SimilarToOriginalTextTag::Value });
-                return completionHandler(text);
+                completionHandler(text);
             }
         });
     });
@@ -7591,6 +7689,7 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
         _textExtractionURLCache->clear();
 
     _textValidationCache.clear();
+    _textExtractionRecognizedWords = { };
 }
 
 #endif // ENABLE(TEXT_EXTRACTION_FILTER)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -371,6 +371,7 @@ struct PerWebProcessState {
 #if HAVE(NSVIEW_CORNER_CONFIGURATION)
     WebCore::CornerRadii _lastViewCornerRadii;
 #endif
+    NSSize _lastContentSize;
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)
@@ -540,6 +541,7 @@ struct PerWebProcessState {
 
 #if ENABLE(TEXT_EXTRACTION_FILTER)
     HashMap<unsigned /* string hash */, TextValidationMapValue> _textValidationCache;
+    std::optional<HashSet<String>> _textExtractionRecognizedWords;
 #endif
     RefPtr<WebKit::TextExtractionURLCache> _textExtractionURLCache;
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1391,6 +1391,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_web_didChangeContentSize:(NSSize)newSize
 {
+    _lastContentSize = newSize;
 }
 
 - (BOOL)_web_hasActiveIntelligenceTextEffects


### PR DESCRIPTION
#### a31ae8e1e6d32c432efb43b3524917a41d6621be
<pre>
[AutoFill Debugging] Improve text recognition filtering performance when extracting visible text
<a href="https://bugs.webkit.org/show_bug.cgi?id=309008">https://bugs.webkit.org/show_bug.cgi?id=309008</a>
<a href="https://rdar.apple.com/170845857">rdar://170845857</a>

Reviewed by Abrar Rahman Protyasha.

Speed up performance of OCR-based visible text filtering when the `.textRecognition` flag is set in
`filterOptions`. Right now, we scan every paragraph in the DOM that&apos;s longer than a certain (short)
threshold by snapshotting the corresponding `SimpleRange` and running that through the Vision
framework. This can be wasteful if there are many paragraphs that require filtering, since we&apos;ll end
up taking a snapshot for each one, and then pass that through to `mediaanalysisd` through Vision for
analysis.

Instead, we can avoid performing redundant OCR in many cases by simply doing one up-front OCR pass
over the whole web page (or just the extraction target rect) to collect a lexicon of recognized
words that appear in the page, and then bail when validating text for any paragraphs that are
comprised mostly (arbitrarily, ≥90%) of words that appear in the up-front page OCR lexicon.

* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::recognizeText):

Also set `VNRequestTextRecognitionLevelFast` as the recognition level; this is necessary to
reliably recognize small text in otherwise very tall page snapshots.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
(-[WKWebView _requestTextExtractionInternal:completion:]):
(-[WKWebView _validateText:inFrame:inNode:completionHandler:]):
(-[WKWebView _clearTextExtractionFilterCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _web_didChangeContentSize:]):

Keep track of the last known page content size on macOS.

Canonical link: <a href="https://commits.webkit.org/308504@main">https://commits.webkit.org/308504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3169c053724669bececacf97dc4ea06d03bf2c3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156422 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dde75ad2-8aa0-4b09-98c1-2d3f03cf494b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94652 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15298 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3862 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124894 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1891 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121921 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31279 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76349 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9167 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83601 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19568 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->