### PR TITLE
Many animated images in the web page can freeze its rendering

### DIFF
--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -136,7 +136,8 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
 
     LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation at index = %d will be started.", __FUNCTION__, this, sourceUTF8().data(), m_currentFrameIndex);
 
-    if (options.decodingMode() == DecodingMode::Asynchronous) {
+    static constexpr unsigned maxAnimatedWorkQueues = 50;
+    if (options.decodingMode() == DecodingMode::Asynchronous && ImageFrameWorkQueue::instanceCount() <= maxAnimatedWorkQueues) {
         LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), nextFrameIndex());
         source->requestNativeImageAtIndexIfNeeded(nextFrameIndex(), subsamplingLevel, ImageAnimatingState::Yes, options);
     }

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -118,12 +118,16 @@ void ImageFrameWorkQueue::dispatch(const Request& request)
     decodeQueue().append(request);
 
     start();
+    ++s_instanceCount;
 }
 
 void ImageFrameWorkQueue::stop()
 {
     ASSERT(isMainThread());
+    if (!m_workQueue)
+        return;
 
+    ASSERT(s_instanceCount);
     Ref source = m_source.get();
 
     for (auto& request : m_decodeQueue) {
@@ -138,6 +142,7 @@ void ImageFrameWorkQueue::stop()
 
     m_decodeQueue.clear();
     m_workQueue = nullptr;
+    --s_instanceCount;
 }
 
 bool ImageFrameWorkQueue::isPendingDecodingAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,6 +57,8 @@ public:
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_minimumDecodingDurationForTesting = duration; }
     void dump(TextStream&) const;
 
+    static unsigned instanceCount() { return s_instanceCount; }
+
 private:
     ImageFrameWorkQueue(BitmapImageSource&);
 
@@ -76,6 +78,8 @@ private:
     RefPtr<WorkQueue> m_workQueue;
 
     Seconds m_minimumDecodingDurationForTesting;
+
+    static inline unsigned s_instanceCount = 0;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 41d6ed80d990a71a6a59353a1fc810b8a7a1bd7d
<pre>
Many animated images in the web page can freeze its rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=308730">https://bugs.webkit.org/show_bug.cgi?id=308730</a>
<a href="https://rdar.apple.com/171283025">rdar://171283025</a>

Reviewed by NOBODY (OOPS!).

Creating many ImageFrameWorkQueues for decoding many animated images can be block
the page rendering and make it unresponsive.

To fix this issue, decoding animated images has be be done synchronously when the
instances count of ImageFrameWorkQueue exceeds a certain limit.

* Source/WebCore/platform/graphics/ImageFrameAnimator.cpp:
(WebCore::ImageFrameAnimator::startAnimation):
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp:
(WebCore::ImageFrameWorkQueue::dispatch):
(WebCore::ImageFrameWorkQueue::stop):
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.h:
(WebCore::ImageFrameWorkQueue::instanceCount):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41d6ed80d990a71a6a59353a1fc810b8a7a1bd7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14042 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156448 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101180 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b071bbd3-c60c-4d72-99a2-7bc865e83e5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81236 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9319ea3-25f9-4821-8a03-2fb1232938ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dab85a8-2b60-4eb2-964c-650c0094f141) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13099 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3888 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158783 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121942 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132418 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76375 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17654 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9188 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->