### PR TITLE
Zoom.com: Copy Invitation button is difficult to click.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-003-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE HTML>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-003.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#definite-sizes">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk" title="Number 4">
+</head>
+<body>
+<p style="margin-top: 1em">Test passes if there is a filled green square.</p>
+<div style="display: flex; width: 100px; height: 100px; flex-direction: column;">
+  <div style="flex-grow: 1; height: 0;">
+    <div style="display: flex; flex-direction: column; height: 100%;">
+      <div style="width: 100px; height: 50px; background-color: green;"></div>
+      <div style="flex: 1;">
+          <div style="height: 100%; background-color: green;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3760,6 +3760,9 @@ bool RenderBox::skipContainingBlockForPercentHeightCalculation(const RenderBox& 
     if (isPerpendicularWritingMode)
         return false;
     
+    if (containingBlock.isFlexItem() && downcast<RenderFlexibleBox>(containingBlock.parent())->canUseFlexItemForPercentageResolution(containingBlock))
+        return false;
+
     // Anonymous blocks should not impede percentage resolution on a child.
     // Examples of such anonymous blocks are blocks wrapped around inlines that
     // have block siblings (from the CSS spec) and multicol flow threads (an

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -679,7 +679,7 @@ protected:
     const RenderElement* pushMappingToContainer(const RenderLayerModelObject*, RenderGeometryMap&) const override;
     void mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode>, TransformState&) const override;
 
-    bool NODELETE skipContainingBlockForPercentHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const;
+    bool skipContainingBlockForPercentHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const;
 
     void incrementVisuallyNonEmptyPixelCountIfNeeded(const IntSize&);
 


### PR DESCRIPTION
#### aeb2eadcea86e57867cfcb4d3208628a0b15ea84
<pre>
Zoom.com: Copy Invitation button is difficult to click.
<a href="https://bugs.webkit.org/show_bug.cgi?id=210791">https://bugs.webkit.org/show_bug.cgi?id=210791</a>
<a href="https://rdar.apple.com/170479667">rdar://170479667</a>

Reviewed by Alan Baradlay.

While inside a Zoom conference call, users can click an “Invite,&quot;
button inside the participants panel, which opens up a new dialog with
an option to &quot;Copy URL,&quot; that can be shared with others. However, it is
sometimes a bit difficult to click the button to copy the URL unless you
hover over it in the right spot. When looking at the content in the web
inspector, it looks like this is due to some other content in the DOM
that becomes too tall and protrudes into the &quot;Copy URL,&quot; button.

This content ends up reducing into the attached test case, which is
about how percentage heights are supposed to resolve in a document that
is in quirks mode. In the reduced test case, the percentage height box is
inside of a flex item that gets flexed to take up the remaining space.
The problem is that in quirks mode, we fail to detect that this flex item
has a definite logical height that comes from the fact that its main
size, which is its logical height, has been resolved and end up skipping
it and continuing up the containing block chain in quirks mode.

RenderFlexibleBox keeps track of which part of flex layout it is in by
tracking each of the steps individually and setting them to to active
via SetForScope for a specific period of time. It then figures out which
step we are in by using this information in canUseFlexItemForPercentageResolution
since the sizes of the flex item may become definite depending where we
are in flex layout. We can use this mechanism to decide if we can use
the flex item to resolve its descendants&apos; percentage height.

Test: imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-003.html
Canonical link: <a href="https://commits.webkit.org/310254@main">https://commits.webkit.org/310254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/446848ff9978d3674a15145ec42ed89989cfb733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106692 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd1fe9a4-e9a8-4176-a3c3-c91ea42265b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/83889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc482e5b-8a9b-49ef-b928-59546ffb155d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99176 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e351d89-1b19-4c3a-8cee-7ad98761413a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19776 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9814 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164453 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7588 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126523 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25813 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21756 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34365 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82484 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14020 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89718 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25124 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->