### PR TITLE
[webkit-bot] Add support for making reverts with git-webkit pr

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -57,6 +57,15 @@ function parseBugId(string)
     return null;
 }
 
+export function parsePRUrl(string)
+{
+    if (!string)
+        return null;
+
+    let match = string.match(/https:\/\/github\.com\/WebKit\/WebKit\/pull\/\d+/im);
+    return match ? match[0] : null;
+}
+
 function extractRevision(text)
 {
     let revisions = [];
@@ -156,6 +165,15 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
 \`dry-revert 260220,260221 Ensure it is working after refactoring\``,
             operation: this.dryRevertCommand.bind(this),
         });
+        if (process.env.USE_GIT_WEBKIT_REVERT === "true") {
+            this._commands.set("revert-with-pr", {
+                description: "Creates a GitHub PR to revert the specified revision.",
+                usage: `\`revert-with-pr SVN_REVISION [SVN_REVISIONS] REASON\`
+e.g. \`revert-with-pr 260220 Ensure it is working after refactoring\`
+\`revert-with-pr 260220,260221 Ensure it is working after refactoring\``,
+                operation: this.revertWithPRCommand.bind(this),
+            });
+        }
         this._commands.set("ping", {
             description: "Responds with pong to check if WebKitBot is alive/working",
             usage: "`ping`",
@@ -215,7 +233,7 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
         }, defaultPullPeriod);
     }
 
-    async revertCommand(event, command, args)
+    async revertCommand(event, command, args, usePR = false)
     {
         let {revisions, reason} = extractRevisionsAndReason(args);
 
@@ -239,14 +257,21 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
                         return `<${escapeForSlackText(`https://commits.webkit.org/${revRepr}|${revRepr}`)}>`;
                     }).join(" ")} ...`,
                 });
-                let bugId = await this._taskQueue.postOrFailWhenExceedingLimit({
-                    command: "revert",
+                let result = await this._taskQueue.postOrFailWhenExceedingLimit({
+                    command: usePR ? "revert-with-pr" : "revert",
                     revisions,
                     reason,
                 });
+
+                let successMessage;
+                if (result.startsWith("https://github.com/"))
+                    successMessage = `<@${event.user}> Created revert PR: ${escapeForSlackText(result)}`;
+                else
+                    successMessage = `<@${event.user}> Created a revert patch https://webkit.org/b/${escapeForSlackText(result)}`;
+
                 await this._web.chat.postMessage({
                     channel: event.channel,
-                    text: `<@${event.user}> Created a revert patch https://webkit.org/b/${escapeForSlackText(bugId)}`,
+                    text: successMessage,
                 });
             } catch (error) {
                 console.error(error);
@@ -290,7 +315,6 @@ ${escapeForSlackText(files.join("\n"))}\`\`\``,
                             });
                             return;
                         }
-
                     }
                 }
                 await this._web.chat.postMessage({
@@ -329,10 +353,30 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
             return;
         }
 
+        let message = `revisions = \`${escapeForSlackText(revisions.join(","))}\`, reason = \`${escapeForSlackText(reason)}\``;
+
+        if (process.env.USE_GIT_WEBKIT_REVERT === "true") {
+            const gitWebkitPath = path.resolve("BotWebKit", "Tools", "Scripts", "git-webkit");
+            let gitWebkitArgs = [
+                gitWebkitPath,
+                "revert",
+                ...revisions,
+                "--reason", reason,
+                "--pr",
+                "--draft",
+            ];
+            message += `\nRevert command: \`${escapeForSlackText(gitWebkitArgs.join(" "))}\``;
+        }
+
         await this._web.chat.postMessage({
             channel: event.channel,
-            text: `<@${event.user}> revisions = \`${escapeForSlackText(revisions.join(","))}\`, reason = \`${escapeForSlackText(reason)}\``,
+            text: `<@${event.user}> ${message}`,
         });
+    }
+
+    async revertWithPRCommand(event, command, args)
+    {
+        return this.revertCommand(event, command, args, true);
     }
 
     async pullCommand(event, command, args)
@@ -458,7 +502,72 @@ Type \`help COMMAND\` for help on my individual commands.`,
         await this.execInWebKitDirectorySimple("git", ["checkout", "origin/main", "-b", "main"]);
     }
 
-    async generateRevertingPatch(revisions, reason)
+    async generateRevertingPatchWithGitWebkit(revisions, reason, issueUrl = null)
+    {
+        dataLogLn("Reverting with git-webkit: ", revisions, reason);
+
+        if (reason.startsWith("-"))
+            throw new Error(`The revert reason may not begin with - ("${reason}")`);
+
+        await this.cleanUpWorkingCopy();
+
+        dataLogLn("Creating revert PR with git-webkit");
+        let results;
+        try {
+            const gitWebkitPath = path.resolve("BotWebKit", "Tools", "Scripts", "git-webkit");
+            var pythonPath = which.sync("python3");
+
+            let args = [
+                gitWebkitPath,
+                "revert",
+                ...revisions,
+                "--reason", reason,
+                "--pr",
+                "--draft",
+            ];
+
+            if (issueUrl)
+                args.push("--issue", issueUrl);
+
+            results = await execFileAsync(pythonPath, args, {
+                cwd: process.env.webkitWorkingDirectory,
+                env: {
+                    GIT_AUTHOR_NAME: "WebKit Revert Bot",
+                    GIT_AUTHOR_EMAIL: "revert-bot@webkit.org",
+                    GIT_COMMITTER_NAME: "WebKit Revert Bot",
+                    GIT_COMMITTER_EMAIL: "revert-bot@webkit.org",
+                    GIT_EDITOR: "true",
+                    GITHUB_COM_USERNAME: process.env.GITHUB_COM_USERNAME,
+                    GITHUB_COM_TOKEN: process.env.GITHUB_COM_TOKEN,
+                    BUGS_WEBKIT_ORG_USERNAME: process.env.BUGS_WEBKIT_ORG_USERNAME,
+                    BUGS_WEBKIT_ORG_PASSWORD: process.env.BUGS_WEBKIT_ORG_PASSWORD,
+                    http_proxy: process.env.http_proxy,
+                    https_proxy: process.env.http_proxy,
+                    PATH: process.env.PATH,
+                    HOME: process.env.HOME || "/root",
+                },
+                timeout: defaultTimeoutForRevert,
+                maxBuffer: 1024 * 1024 * 50,
+            });
+        } catch (error) {
+            dataLogLn(error);
+            let newError = new Error("git-webkit revert command failed");
+            newError.stderr = error.stderr;
+            newError.stdout = error.stdout;
+            throw newError;
+        }
+
+        let {stdout, stderr} = results;
+        dataLogLn(stdout);
+        dataLogLn(stderr);
+        let prUrl = parsePRUrl(stdout) || parsePRUrl(stderr);
+        if (prUrl)
+            return prUrl;
+
+        throw new Error("PR URL not found in git-webkit output");
+    }
+
+    async generateRevertingPatch(revisions, reason, issueUrl = null)
     {
         dataLogLn("Reverting ", revisions, reason);
         let revisionsArgument = revisions.join(" ");
@@ -526,6 +635,10 @@ Type \`help COMMAND\` for help on my individual commands.`,
         case "revert": {
             let {revisions, reason} = task;
             return this.generateRevertingPatch(revisions, reason);
+        }
+        case "revert-with-pr": {
+            let {revisions, reason} = task;
+            return this.generateRevertingPatchWithGitWebkit(revisions, reason);
         }
         case "pull":
             return this.cleanUpWorkingCopy();


### PR DESCRIPTION
#### d6d87ef4023c57d5f1a296521ee28859272fe3dc
<pre>
[webkit-bot] Add support for making reverts with git-webkit pr
<a href="https://bugs.webkit.org/show_bug.cgi?id=309015">https://bugs.webkit.org/show_bug.cgi?id=309015</a>
<a href="https://rdar.apple.com/171562627">rdar://171562627</a>

Reviewed by Aakash Jain.

Add a revert-with-pr command to webkit-bot.
This is currently locked behind the USE_GIT_WEBKIT_REVERT env variable.

* Tools/WebKitBot/src/WebKitBot.mjs:
    - Add parsePRUrl function to find the url within command output
    - Handle PR flow in revertCommand and dryRevertCommand
    - Add revertWithPRCommand that calls revertCommand with usePR = True
    - Add generateRevertingPatchWithGitWebKit
          -&gt; This sets up the environment and calls git-webkit revert

Canonical link: <a href="https://commits.webkit.org/308736@main">https://commits.webkit.org/308736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53ae11a9b8601f1aef316f9d4b5ed0992b3cbbcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20420 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14012 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149608 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/20320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/156418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150697 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132688 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/14012 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3858 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158753 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12083 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121917 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20219 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/20320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122118 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20230 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132392 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76345 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22859 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9163 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/19835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19564 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19715 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19622 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->