### PR TITLE
Integer underflow in AudioResamplerKernel::getSourceSpan()

### DIFF
--- a/JSTests/stress/private-names-seal-freeze.js
+++ b/JSTests/stress/private-names-seal-freeze.js
@@ -1,0 +1,18 @@
+class C {
+  #field;
+  setField(v) {
+    this.#field = v;
+  }
+}
+
+for (let i = 0; i < 10000; i++) {
+  let c = new C();
+  Object.seal(c);
+  c.setField(i);
+}
+
+for (let i = 0; i < 10000; i++) {
+  let c = new C();
+  Object.freeze(c);
+  c.setField(i);
+}

--- a/LayoutTests/workers/worker-set-delete-terminate-crash-expected.txt
+++ b/LayoutTests/workers/worker-set-delete-terminate-crash-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/workers/worker-set-delete-terminate-crash.html
+++ b/LayoutTests/workers/worker-set-delete-terminate-crash.html
@@ -1,0 +1,83 @@
+<body>
+<script src="../resources/js-test-pre.js"></script>
+<script>
+
+const WORKER_CODE = `
+self.onmessage = e => {
+    const ctrl = e.data;
+
+    const s = new Set();
+
+    Object.prototype.return = Set.prototype.add.bind(s, 1);
+
+    const pairs = [{
+        get 0() {
+            for (let i = 0; i < 0x10000; i++) {
+                s.add(i);
+            }
+
+            for (let i = 0; i < 0xc000; i++) {
+                s.delete(i);
+            }
+
+            Atomics.store(ctrl, 0, 1);
+
+            while (ctrl[0] === 1) {
+                ctrl[1] = 1;
+            }
+
+            s.delete(0xc000);
+        }
+    }];
+
+    new Map(pairs);
+};
+`;
+
+const WORKER_URL = URL.createObjectURL(new Blob([WORKER_CODE], { type: 'text/javascript' }));
+
+async function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function main() {
+    for (let i = 0; i < 100; ++i) {
+        const ctrl = new Int32Array(new SharedArrayBuffer(4));
+        const worker = new Worker(WORKER_URL);
+
+        worker.postMessage(ctrl);
+
+        await new Promise(resolve => {
+            const id = setInterval(() => {
+                if (Atomics.load(ctrl, 0) !== 0) {
+                    clearInterval(id);
+
+                    resolve();
+                }
+            }, 0);
+        });
+
+        const timeout = Math.floor(Math.random() * 20);
+        const start = Date.now();
+
+        ctrl[0] = 2;
+
+        while (Date.now() - start < timeout) {
+
+        }
+
+        worker.terminate();
+    }
+}
+
+globalThis.testRunner?.waitUntilDone();
+
+main().catch(e => {
+    console.log(e);
+}).finally(() => {
+    testRunner.notifyDone();
+});
+
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -421,6 +421,9 @@ public:
     ALWAYS_INLINE static void addImpl(JSGlobalObject* globalObject, HashTable* owner, Storage& base, JSValue key, JSValue value, FindResult& result)
     {
         VM& vm = getVM(globalObject);
+        // We're transitioning between states here, if a termination comes in we could leave the storage
+        // in an inconsistent state. It's much easier to pause termination until the storage is updated.
+        DeferTerminationForAWhile noTermination(vm);
         auto scope = DECLARE_THROW_SCOPE(vm);
         ASSERT(!isObsolete(base));
         ASSERT(!isValidTableIndex(result.entryKeyIndex));
@@ -475,6 +478,9 @@ public:
     ALWAYS_INLINE static void shrinkIfNeeded(JSGlobalObject* globalObject, HashTable* owner, Storage& base)
     {
         VM& vm = globalObject->vm();
+        // We're transitioning between states here, if a termination comes in we could leave the storage
+        // in an inconsistent state. It's much easier to pause termination until the storage is updated.
+        DeferTerminationForAWhile noTermination(vm);
         auto scope = DECLARE_THROW_SCOPE(vm);
         ASSERT(!isObsolete(base));
         TableSize capacity = Helper::capacity(base);

--- a/Source/JavaScriptCore/runtime/PropertyTable.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyTable.cpp
@@ -159,7 +159,8 @@ PropertyTable::~PropertyTable()
 void PropertyTable::seal()
 {
     forEachPropertyMutable([&](auto& entry) {
-        entry.setAttributes(entry.attributes() | static_cast<unsigned>(PropertyAttribute::DontDelete));
+        if (!PropertyName(entry.key()).isPrivateName())
+            entry.setAttributes(entry.attributes() | static_cast<unsigned>(PropertyAttribute::DontDelete));
         return IterationStatus::Continue;
     });
 }
@@ -167,10 +168,12 @@ void PropertyTable::seal()
 void PropertyTable::freeze()
 {
     forEachPropertyMutable([&](auto& entry) {
-        if (!(entry.attributes() & PropertyAttribute::Accessor))
-            entry.setAttributes(entry.attributes() | static_cast<unsigned>(PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
-        else
-            entry.setAttributes(entry.attributes() | static_cast<unsigned>(PropertyAttribute::DontDelete));
+        if (!PropertyName(entry.key()).isPrivateName()) {
+            if (!(entry.attributes() & PropertyAttribute::Accessor))
+                entry.setAttributes(entry.attributes() | static_cast<unsigned>(PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
+            else
+                entry.setAttributes(entry.attributes() | static_cast<unsigned>(PropertyAttribute::DontDelete));
+        }
         return IterationStatus::Continue;
     });
 }
@@ -179,7 +182,7 @@ bool PropertyTable::isSealed() const
 {
     bool result = true;
     forEachProperty([&](const auto& entry) {
-        if ((entry.attributes() & PropertyAttribute::DontDelete) != static_cast<unsigned>(PropertyAttribute::DontDelete)) {
+        if (!PropertyName(entry.key()).isPrivateName() && (entry.attributes() & PropertyAttribute::DontDelete) != static_cast<unsigned>(PropertyAttribute::DontDelete)) {
             result = false;
             return IterationStatus::Done;
         }
@@ -192,13 +195,15 @@ bool PropertyTable::isFrozen() const
 {
     bool result = true;
     forEachProperty([&](const auto& entry) {
-        if (!(entry.attributes() & PropertyAttribute::DontDelete)) {
-            result = false;
-            return IterationStatus::Done;
-        }
-        if (!(entry.attributes() & (PropertyAttribute::ReadOnly | PropertyAttribute::Accessor))) {
-            result = false;
-            return IterationStatus::Done;
+        if (!PropertyName(entry.key()).isPrivateName()) {
+            if (!(entry.attributes() & PropertyAttribute::DontDelete)) {
+                result = false;
+                return IterationStatus::Done;
+            }
+            if (!(entry.attributes() & (PropertyAttribute::ReadOnly | PropertyAttribute::Accessor))) {
+                result = false;
+                return IterationStatus::Done;
+            }
         }
         return IterationStatus::Continue;
     });

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
@@ -31,6 +31,7 @@
 #include "AudioResampler.h"
 #include "AudioUtilities.h"
 #include <algorithm>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -58,7 +59,10 @@ std::span<float> AudioResamplerKernel::getSourceSpan(size_t framesToProcess, siz
 
     // Determine how many input frames we'll need.
     // We need to fill the buffer up to and including endIndex (so add 1) but we've already buffered m_fillIndex frames from last time.
-    size_t framesNeeded = 1 + endIndex - m_fillIndex;
+    size_t framesNeeded;
+    if (!WTF::safeSub(1 + endIndex, m_fillIndex, framesNeeded))
+        return { };
+
     if (numberOfSourceFramesNeededP)
         *numberOfSourceFramesNeededP = framesNeeded;
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -87,7 +87,7 @@ AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogge
     : m_logger(originalLogger)
     , m_logIdentifier(logSiteIdentifier)
     , m_videoLayerManager(makeUniqueRef<VideoLayerManagerObjC>(originalLogger, logSiteIdentifier))
-    , m_synchronizer([adoptNS(PAL::allocAVSampleBufferRenderSynchronizerInstance()) init])
+    , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstance() init]))
     , m_listener(WebAVSampleBufferListener::create(*this))
     , m_startupTime(MonotonicTime::now())
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
@@ -932,7 +932,7 @@ void AudioVideoRendererAVFObjC::addAudioRenderer(TrackIdentifier trackId)
     if (!m_audioTracksMap.add(trackId, AudioTrackProperties()).isNewEntry)
         return;
 
-    RetainPtr renderer = [adoptNS(PAL::allocAVSampleBufferAudioRendererInstance()) init];
+    RetainPtr renderer = adoptNS([PAL::allocAVSampleBufferAudioRendererInstance() init]);
 
     if (!renderer) {
         ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer init] returned nil! bailing!");
@@ -1181,9 +1181,11 @@ void AudioVideoRendererAVFObjC::ensureLayer()
         return;
     }
 
-    m_sampleBufferDisplayLayer = [adoptNS(PAL::allocAVSampleBufferDisplayLayerInstance()) init];
+    m_sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
     if (!m_sampleBufferDisplayLayer) {
         ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferDisplayLayer init] returned nil! bailing!");
+        ASSERT_NOT_REACHED();
+        notifyError(PlatformMediaError::VideoDecodingError);
         return;
     }
     [m_sampleBufferDisplayLayer setName:@"AudioVideoRendererAVFObjC AVSampleBufferDisplayLayer"];
@@ -1224,9 +1226,11 @@ void AudioVideoRendererAVFObjC::ensureVideoRenderer()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_sampleBufferVideoRenderer = [adoptNS(PAL::allocAVSampleBufferVideoRendererInstance()) init];
+    m_sampleBufferVideoRenderer = adoptNS([PAL::allocAVSampleBufferVideoRendererInstance() init]);
     if (!m_sampleBufferVideoRenderer) {
         ERROR_LOG(LOGIDENTIFIER, "-[VSampleBufferVideoRenderer init] returned nil! bailing!");
+        ASSERT_NOT_REACHED();
+        notifyError(PlatformMediaError::VideoDecodingError);
         return;
     }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -481,8 +481,11 @@ public:
 
     ~ImageAnalysisGestureDeferralToken()
     {
-        if (auto view = m_view.get())
-            [view _endImageAnalysisGestureDeferral:m_shouldPreventTextSelection ? WebKit::ShouldPreventGestures::Yes : WebKit::ShouldPreventGestures::No];
+        auto shouldPreventGestures = m_shouldPreventTextSelection ? WebKit::ShouldPreventGestures::Yes : WebKit::ShouldPreventGestures::No;
+        ensureOnMainRunLoop([weakView = m_view, shouldPreventGestures] {
+            if (RetainPtr view = weakView.get())
+                [view _endImageAnalysisGestureDeferral:shouldPreventGestures];
+        });
     }
 
     void setShouldPreventTextSelection()


### PR DESCRIPTION
#### 7afdc436a98c9771c5eb23a00db3211b7dcb3575
<pre>
Integer underflow in AudioResamplerKernel::getSourceSpan()
<a href="https://rdar.apple.com/162552376">rdar://162552376</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303959">https://bugs.webkit.org/show_bug.cgi?id=303959</a>

Reviewed by Eric Carlson.

Protect against underflows when calculating the number of
source frames needed using WTF::safeSub().

* Source/WebCore/platform/audio/AudioResamplerKernel.cpp:
(WebCore::AudioResamplerKernel::getSourceSpan):

Originally-landed-as: 301765.369@safari-7623-branch (ee36b92f6f9f). <a href="https://rdar.apple.com/171558934">rdar://171558934</a>
Canonical link: <a href="https://commits.webkit.org/308516@main">https://commits.webkit.org/308516@main</a>
</pre>
----------------------------------------------------------------------
#### f37a6731b01fb0ea991fddc7091d9c9680daf9c2
<pre>
com.apple.WebKit.GPU at WebCore:  WebCore::AudioVideoRendererAVFObjC::addTrack
<a href="https://bugs.webkit.org/show_bug.cgi?id=302044">https://bugs.webkit.org/show_bug.cgi?id=302044</a>
<a href="https://rdar.apple.com/163901063">rdar://163901063</a>

Reviewed by Youenn Fablet.

To get around a SaferCPP static analyser false-positive we had switched the
order of where the retain was being applied.
The underlying SaferCPP false positive has been silenced 299825@main
we no longer need that workaround.

In addition, should we fail to allocate the related layer (audio or video)
we will treat it as an error rather than fail silently and break playback.

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::addAudioRenderer):
(WebCore::AudioVideoRendererAVFObjC::ensureLayer):
(WebCore::AudioVideoRendererAVFObjC::ensureVideoRenderer):

Originally-landed-as: 301765.360@safari-7623-branch (ab343b737e64). <a href="https://rdar.apple.com/171559110">rdar://171559110</a>
Canonical link: <a href="https://commits.webkit.org/308515@main">https://commits.webkit.org/308515@main</a>
</pre>
----------------------------------------------------------------------
#### f45f20af9c44bf1de287a53dbfd644a7e75e3b38
<pre>
[JSC] Modifying storage in OrderedHashTableHelper should DeferTerminationForAWhile
<a href="https://bugs.webkit.org/show_bug.cgi?id=303658">https://bugs.webkit.org/show_bug.cgi?id=303658</a>
<a href="https://rdar.apple.com/162356649">rdar://162356649</a>

Reviewed by Keith Miller.

When resizing storage in OrderedHashTableHelper (via addImpl or shinkIfNeeded),
it&apos;s possible to leave the storage in an inconsistent state if we handle a
termination exception. For consistency, we should DeferTerminationForAWhile
until the storage has been fully updated.

Test: workers/worker-set-delete-terminate-crash.html

* LayoutTests/workers/worker-set-delete-terminate-crash-expected.txt: Added.
* LayoutTests/workers/worker-set-delete-terminate-crash.html: Added.
* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::addImpl):
(JSC::OrderedHashTableHelper::shrinkIfNeeded):

Originally-landed-as: 301765.357@safari-7623-branch (eccc2eed44f9). <a href="https://rdar.apple.com/171559517">rdar://171559517</a>
Canonical link: <a href="https://commits.webkit.org/308514@main">https://commits.webkit.org/308514@main</a>
</pre>
----------------------------------------------------------------------
#### 199f8663c39b5b9ff9dfd0be6369ac6ada7e9d87
<pre>
UI process crash due to non-main thread UIGestureRecognizer access in ImageAnalysisGestureDeferralToken
<a href="https://rdar.apple.com/165459416">rdar://165459416</a>

Reviewed by Ryosuke Niwa and Aditya Keerthi.

Due to system changes (likely under VKCImageAnalyzer), completions
passed to -processRequest:progressHandler:completionHandler: can now be
dispatched on background threads.

This means that ~ImageAnalysisGestureDeferralToken ends up executing on
said background thread, which ends up in a non-main thread access/write
of WKDeferringGestureRecognizer. This is against the UIGestureRecognizer
API contract.

To fix this, we simply ensure a main runloop hop before executing the
business logic in ~ImageAnalysisGestureDeferralToken.

No test since I was unable to force the request processing cleanup to
fire in a non-main thread.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Originally-landed-as: 301765.349@safari-7623-branch (2da2d8c81eb9). <a href="https://rdar.apple.com/171559882">rdar://171559882</a>
Canonical link: <a href="https://commits.webkit.org/308513@main">https://commits.webkit.org/308513@main</a>
</pre>
----------------------------------------------------------------------
#### 672cdd38781cce183724930a1d2e31ca4dc2008d
<pre>
[JSC] Don&apos;t set attributes on private fields when sealing/freezing
<a href="https://bugs.webkit.org/show_bug.cgi?id=303357">https://bugs.webkit.org/show_bug.cgi?id=303357</a>
<a href="https://rdar.apple.com/165252763">rdar://165252763</a>

Reviewed by Yusuke Suzuki and Mark Lam.

This PR makes it such that when sealing and freezing objects, entries in the
PropertyTable that are private fields do not change their attributes.  Private
fields are not properties from the spec&apos;s point of view, and thus don&apos;t have
attributes.

Ensuring private field entries simplifies assumptions in the JITs, as they can
assume having attributes when setting a property results in a structure
transition.

Test: JSTests/stress/private-names-seal-freeze.js

Originally-landed-as: 301765.343@safari-7623-branch (b6b02057f0c4). <a href="https://rdar.apple.com/171560076">rdar://171560076</a>
Canonical link: <a href="https://commits.webkit.org/308512@main">https://commits.webkit.org/308512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03dad21245c88b5dee11aac0713197ca21a4981

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156426 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101158 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5977c61b-f998-4d24-91e9-19626c013982) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81223 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe843b04-3ab9-4c2c-95b9-6aa5ed6a3c01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94659 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5b2a7af-517d-4a34-8ebc-6067a209374c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13079 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3866 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139713 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158761 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8531 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121925 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76353 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9172 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179165 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19843 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83605 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19572 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19723 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->