### PR TITLE
[WebKit][Main+SU] [292b7257c3a80358] ASAN_SEGV | WebCore::RenderBox::localRectsForRepaint; WebCore::RenderObject::clippedOverflowRect; WebCore::RenderObject::repaintSlowRepaintObject

### DIFF
--- a/JSTests/wasm/gc/validate-unreachable-unset-local.js
+++ b/JSTests/wasm/gc/validate-unreachable-unset-local.js
@@ -1,0 +1,31 @@
+import { instantiate } from "./wast-wrapper.js";
+
+const wat = `
+(module
+  (func $test (export "test") (result i32)
+    (local $x (ref i31))
+    (if (result i32)
+      (i32.const 0)
+      (then
+        unreachable
+        (local.set $x (ref.i31 (i32.const 42)))
+        (i31.get_u (local.get $x))
+      )
+      (else
+        (i31.get_u (local.get $x))
+      )
+    )
+  )
+)
+`;
+
+let caughtError;
+try {
+  await instantiate(wat);
+} catch (e) {
+  caughtError = e;
+}
+if (caughtError == undefined ||
+    caughtError.constructor !== WebAssembly.CompileError) {
+    throw new Error("Expected validation error");
+}

--- a/LayoutTests/fast/forms/onformdata-navigate-crash-expected.txt
+++ b/LayoutTests/fast/forms/onformdata-navigate-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/forms/onformdata-navigate-crash.html
+++ b/LayoutTests/fast/forms/onformdata-navigate-crash.html
@@ -1,0 +1,10 @@
+<script>
+  testRunner?.dumpAsText();
+  function runTest() {
+    form.requestSubmit();
+  }
+</script>
+<body onload=runTest()>
+  <form id="form" onformdata="navigation.navigate('http://foo/bar');">
+  PASS if no crash.
+</body>

--- a/LayoutTests/fast/rendering/collapsed-scrollbar-crash-expected.txt
+++ b/LayoutTests/fast/rendering/collapsed-scrollbar-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/rendering/collapsed-scrollbar-crash.html
+++ b/LayoutTests/fast/rendering/collapsed-scrollbar-crash.html
@@ -1,0 +1,17 @@
+<style>
+ ::-webkit-scrollbar {
+     background: fixed url();
+     visibility: collapse;
+ }
+</style>
+<script>
+ window.testRunner?.dumpAsText();
+ function main()
+ {
+     document.documentElement.appendChild(document.createElement('ul'));
+     window.scrollBy(10, 2)
+ }
+</script>
+<body onload="main()">
+    This test passes if it doesn't crash.
+</body>

--- a/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash.html
+++ b/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+const iframe = document.createElement("iframe");
+iframe.srcdoc=`<!DOCTYPE html>
+<script>
+window.addEventListener("load", _ => {
+  const video = document.createElement("video");
+  video.src = "about:blank";
+  if ("AudioDecoder" in window) {
+    const decoder = new AudioDecoder({output: _ => {}, error: _ => {}});
+    decoder.configure({ codec: "a", sampleRate: 441000, numberOfChannels: 2 });
+    decoder.reset();
+  }
+  parent.postMessage('reload', '*');
+});
+<\u002Fscript>`;
+var reloadCount = 0;
+window.addEventListener("message", e => {
+  if (e.data === 'reload') {
+    if (reloadCount++ < 200) {
+      iframe.contentWindow.location.reload();
+    } else {
+      window.testRunner?.notifyDone();
+    }
+  }
+});
+document.body.appendChild(iframe);
+</script>

--- a/LayoutTests/fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash.html
+++ b/LayoutTests/fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+const iframe = document.createElement("iframe");
+iframe.srcdoc=`<!DOCTYPE html>
+<script>
+window.addEventListener("load", _ => {
+  const video = document.createElement("video");
+  video.src = "about:blank";
+  if ("AudioEncoder" in window) {
+    const encoder = new AudioEncoder({output: _ => {}, error: _ => {}});
+    encoder.configure({ codec: "a", sampleRate: 441000, numberOfChannels: 2 });
+    encoder.reset();
+  }
+  parent.postMessage('reload', '*');
+});
+<\u002Fscript>`;
+var reloadCount = 0;
+window.addEventListener("message", e => {
+  if (e.data === 'reload') {
+    if (reloadCount++ < 200) {
+      iframe.contentWindow.location.reload();
+    } else {
+      window.testRunner?.notifyDone();
+    }
+  }
+});
+document.body.appendChild(iframe);
+</script>

--- a/LayoutTests/fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash.html
+++ b/LayoutTests/fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+const iframe = document.createElement("iframe");
+iframe.srcdoc=`<!DOCTYPE html>
+<script>
+window.addEventListener("load", _ => {
+  const video = document.createElement("video");
+  video.src = "about:blank";
+  if ("VideoDecoder" in window) {
+    const decoder = new VideoDecoder({output: _ => {}, error: _ => {}});
+    decoder.configure({ codec: "a" });
+    decoder.reset();
+  }
+  parent.postMessage('reload', '*');
+});
+<\u002Fscript>`;
+var reloadCount = 0;
+window.addEventListener("message", e => {
+  if (e.data === 'reload') {
+    if (reloadCount++ < 200) {
+      iframe.contentWindow.location.reload();
+    } else {
+      window.testRunner?.notifyDone();
+    }
+  }
+});
+document.body.appendChild(iframe);
+</script>

--- a/LayoutTests/fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash.html
+++ b/LayoutTests/fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+const iframe = document.createElement("iframe");
+iframe.srcdoc=`<!DOCTYPE html>
+<script>
+window.addEventListener("load", _ => {
+  const video = document.createElement("video");
+  video.src = "about:blank";
+  if ("VideoEncoder" in window) {
+    const encoder = new VideoEncoder({output: _ => {}, error: _ => {}});
+    encoder.configure({ codec: "a", width: 800, height: 600 });
+    encoder.reset();
+  }
+  parent.postMessage('reload', '*');
+});
+<\u002Fscript>`;
+var reloadCount = 0;
+window.addEventListener("message", e => {
+  if (e.data === 'reload') {
+    if (reloadCount++ < 200) {
+      iframe.contentWindow.location.reload();
+    } else {
+      window.testRunner?.notifyDone();
+    }
+  }
+});
+document.body.appendChild(iframe);
+</script>

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -3833,6 +3833,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(data.controlData), "else block isn't associated to an if");
         WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
         m_expressionStack = WTF::move(data.elseBlockStack);
+        resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
     }
 
@@ -3861,6 +3862,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
                 m_context.notifyFunctionUsesSIMD();
             m_expressionStack.constructAndAppend(argumentType, results[i]);
         }
+        resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
     }
 
@@ -3873,6 +3875,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         m_expressionStack = { };
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(data.controlData), "catch block isn't associated to a try");
         WASM_TRY_ADD_TO_CONTEXT(addCatchAllToUnreachable(data.controlData));
+        resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
     }
 
@@ -3893,6 +3896,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             Stack emptyStack;
             WASM_TRY_ADD_TO_CONTEXT(addEndToUnreachable(controlEntry, emptyStack));
             m_expressionStack.swap(controlEntry.enclosedExpressionStack);
+            resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         }
         m_unreachableBlocks--;
         return { };
@@ -3912,6 +3916,8 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             }
 
             m_expressionStack.swap(data.enclosedExpressionStack);
+            if (!ControlType::isTopLevel(data.controlData))
+                resetLocalInitStackToHeight(data.localInitStackHeight);
         }
         m_unreachableBlocks--;
         return { };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -130,6 +130,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext&, WebC
         if (!isSupportedCodec) {
             postTaskToCodec<WebCodecsAudioDecoder>(identifier, *this, [] (auto& decoder) {
                 decoder.closeDecoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
+                decoder.unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         }
@@ -154,6 +155,9 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext&, WebC
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
+            auto scopeExit = makeScopeExit([protectedThis] {
+                protectedThis->unblockControlMessageQueue();
+            });
 
             if (!result) {
                 protectedThis->closeDecoder(Exception { ExceptionCode::NotSupportedError, WTF::move(result.error()) });
@@ -161,7 +165,6 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext&, WebC
             }
 
             protectedThis->setInternalDecoder(WTF::move(*result));
-            protectedThis->unblockControlMessageQueue();
         });
         return WebCodecsControlMessageOutcome::Processed;
     } });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -185,11 +185,12 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
+                auto scopeExit = makeScopeExit([protectedThis] {
+                    protectedThis->unblockControlMessageQueue();
+                });
 
                 if (protectedThis->state() == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
                     return;
-
-                protectedThis->unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         } });
@@ -203,6 +204,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
         if (!isSupportedCodec) {
             postTaskToCodec<WebCodecsAudioEncoder>(identifier, *this, [] (auto& encoder) {
                 encoder.closeEncoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
+                encoder.unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         }
@@ -211,6 +213,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
         if (encoderConfig.hasException()) {
             postTaskToCodec<WebCodecsAudioEncoder>(identifier, *this, [message = encoderConfig.releaseException().message()] (auto& encoder) mutable {
                 encoder.closeEncoder(Exception { ExceptionCode::NotSupportedError, WTF::move(message) });
+                encoder.unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         }
@@ -241,6 +244,9 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
+            auto scopeExit = makeScopeExit([protectedThis] {
+                protectedThis->unblockControlMessageQueue();
+            });
 
             if (!result) {
                 protectedThis->closeEncoder(Exception { ExceptionCode::NotSupportedError, WTF::move(result.error()) });
@@ -248,7 +254,6 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
             }
             protectedThis->setInternalEncoder(WTF::move(*result));
             protectedThis->m_hasNewActiveConfiguration = true;
-            protectedThis->unblockControlMessageQueue();
         });
 
         return WebCodecsControlMessageOutcome::Processed;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
@@ -143,7 +143,7 @@ void WebCodecsBase::unblockControlMessageQueue()
 
 bool WebCodecsBase::virtualHasPendingActivity() const
 {
-    return m_state == WebCodecsCodecState::Configured && (m_codecControlMessagesPending || m_isMessageQueueBlocked);
+    return m_codecControlMessagesPending || m_isMessageQueueBlocked;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -155,6 +155,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
         if (!isSupportedCodec) {
             postTaskToCodec<WebCodecsVideoDecoder>(identifier, *this, [] (auto& decoder) {
                 decoder.closeDecoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
+                decoder.unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         }
@@ -188,12 +189,14 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
             auto protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
+            auto scopeExit = makeScopeExit([protectedThis] {
+                protectedThis->unblockControlMessageQueue();
+            });
             if (!result) {
                 protectedThis->closeDecoder(Exception { ExceptionCode::NotSupportedError, WTF::move(result.error()) });
                 return;
             }
             protectedThis->setInternalDecoder(WTF::move(*result));
-            protectedThis->unblockControlMessageQueue();
         });
 
         return WebCodecsControlMessageOutcome::Processed;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -187,6 +187,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
         if (!isSupportedCodec) {
             postTaskToCodec<WebCodecsVideoEncoder>(identifier, *this, [] (auto& encoder) {
                 encoder.closeEncoder(Exception { ExceptionCode::NotSupportedError, "Codec is not supported"_s });
+                encoder.unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         }
@@ -195,6 +196,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
         if (encoderConfig.hasException()) {
             postTaskToCodec<WebCodecsVideoEncoder>(identifier, *this, [message = encoderConfig.releaseException().message()] (auto& encoder) mutable {
                 encoder.closeEncoder(Exception { ExceptionCode::NotSupportedError, WTF::move(message) });
+                encoder.unblockControlMessageQueue();
             });
             return WebCodecsControlMessageOutcome::Processed;
         }
@@ -225,13 +227,15 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
             auto protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
+            auto scopeExit = makeScopeExit([protectedThis] {
+                protectedThis->unblockControlMessageQueue();
+            });
             if (!result) {
                 protectedThis->closeEncoder(Exception { ExceptionCode::NotSupportedError, WTF::move(result.error()) });
                 return;
             }
             protectedThis->setInternalEncoder(WTF::move(*result));
             protectedThis->m_hasNewActiveConfiguration = true;
-            protectedThis->unblockControlMessageQueue();
         });
 
         return WebCodecsControlMessageOutcome::Processed;

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -404,7 +404,7 @@ void HTMLFormElement::submit(Event* event, bool processingUserGesture, FormSubmi
     auto shouldLockHistory = processingUserGesture ? LockHistory::No : LockHistory::Yes;
     auto formSubmission = FormSubmission::create(*this, submitter, m_attributes, event, shouldLockHistory, trigger);
 
-    if (!isConnected())
+    if (!formSubmission || !isConnected())
         return;
 
     auto relAttributes = parseFormRelAttributes(getAttribute(HTMLNames::relAttr));
@@ -416,9 +416,9 @@ void HTMLFormElement::submit(Event* event, bool processingUserGesture, FormSubmi
     m_plannedFormSubmission = formSubmission;
 
     if (formSubmission->method() == FormSubmission::Method::Dialog)
-        submitDialog(WTF::move(formSubmission));
+        submitDialog(formSubmission.releaseNonNull());
     else
-        frame->loader().submitForm(WTF::move(formSubmission));
+        frame->loader().submitForm(formSubmission.releaseNonNull());
 
     m_shouldSubmit = false;
     m_isSubmittingOrPreparingForSubmission = false;

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -170,7 +170,7 @@ static PAL::TextEncoding encodingFromAcceptCharset(const String& acceptCharset, 
     return document.textEncoding();
 }
 
-Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormControlElement* overrideSubmitter, const Attributes& attributes, Event* event, LockHistory lockHistory, FormSubmissionTrigger trigger)
+RefPtr<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormControlElement* overrideSubmitter, const Attributes& attributes, Event* event, LockHistory lockHistory, FormSubmissionTrigger trigger)
 {
     auto copiedAttributes = attributes;
 
@@ -217,6 +217,9 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
 
     auto result = form.constructEntryList(submitter.copyRef(), WTF::move(domFormData), &formValues);
     RELEASE_ASSERT(result);
+    // Calling form.constructEntryList can run JavaScript and potentially detach the frame.
+    if (!document->frame())
+        return nullptr;
     domFormData = result.releaseNonNull();
 
     RefPtr<FormData> formData;

--- a/Source/WebCore/loader/FormSubmission.h
+++ b/Source/WebCore/loader/FormSubmission.h
@@ -78,7 +78,7 @@ public:
         String m_acceptCharset;
     };
 
-    static Ref<FormSubmission> create(HTMLFormElement&, HTMLFormControlElement* overrideSubmitter, const Attributes&, Event*, LockHistory, FormSubmissionTrigger);
+    static RefPtr<FormSubmission> create(HTMLFormElement&, HTMLFormControlElement* overrideSubmitter, const Attributes&, Event*, LockHistory, FormSubmissionTrigger);
 
     void populateFrameLoadRequest(FrameLoadRequest&);
     URL requestURL() const;

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -182,7 +182,7 @@ public:
     bool isVisibleIgnoringGeometry() const;
     bool mayCauseRepaintInsideViewport(const IntRect* visibleRect = nullptr) const;
     bool isVisibleInDocumentRect(const IntRect& documentRect) const;
-    bool isInsideEntirelyHiddenLayer() const;
+    virtual bool isInsideEntirelyHiddenLayer() const;
 
     // Returns true if this renderer requires a new stacking context.
     static bool createsGroupForStyle(const RenderStyle&); // Defined in RenderElementStyleInlines.h.

--- a/Source/WebCore/rendering/RenderScrollbarPart.h
+++ b/Source/WebCore/rendering/RenderScrollbarPart.h
@@ -44,6 +44,8 @@ public:
     
     bool requiresLayer() const override { return false; }
 
+    bool isInsideEntirelyHiddenLayer() const override { return false; }
+
     void layout() override;
     
     void paintIntoRect(GraphicsContext&, const LayoutPoint&, const LayoutRect&);

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -727,15 +727,9 @@ static size_t computeSize(HashSet<uint64_t, DefaultHash<uint64_t>, WTF::Unsigned
 
 bool Buffer::needsIndexValidation(uint32_t maxUnsignedIndex, uint16_t maxUshortIndex)
 {
-    bool needsUpdate = false;
-    if (maxUnsignedIndex > m_maxUnsignedIndex) {
-        m_maxUnsignedIndex = maxUnsignedIndex;
-        needsUpdate = true;
-    }
-    if (m_maxUshortIndex > maxUshortIndex) {
-        m_maxUshortIndex = maxUshortIndex;
-        needsUpdate = true;
-    }
+    const bool needsUpdate = maxUnsignedIndex > m_maxUnsignedIndex || maxUshortIndex > m_maxUshortIndex;
+    m_maxUnsignedIndex = std::max(m_maxUnsignedIndex, maxUnsignedIndex);
+    m_maxUshortIndex = std::max(m_maxUshortIndex, maxUshortIndex);
 
     return needsUpdate;
 }


### PR DESCRIPTION
#### eaf2c797417f3da6687f4654bfed09bd9b1e955f
<pre>
[WebKit][Main+SU] [292b7257c3a80358] ASAN_SEGV | WebCore::RenderBox::localRectsForRepaint; WebCore::RenderObject::clippedOverflowRect; WebCore::RenderObject::repaintSlowRepaintObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=302377">https://bugs.webkit.org/show_bug.cgi?id=302377</a>
<a href="https://rdar.apple.com/164467732">rdar://164467732</a>

Reviewed by Simon Fraser.

RenderScrollbarPart doesn&apos;t have an enclosing layer,
so we can short-circuit the check in RenderElement
and return false always.

Test: fast/rendering/collapsed-scrollbar-crash.html

* LayoutTests/fast/rendering/collapsed-scrollbar-crash-expected.txt: Added.
* LayoutTests/fast/rendering/collapsed-scrollbar-crash.html: Added.
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderScrollbarPart.h:

Originally-landed-as: 302196.7@webkit-2025.11-embargoed (db1ee7ac4ada). <a href="https://rdar.apple.com/171558367">rdar://171558367</a>
Canonical link: <a href="https://commits.webkit.org/308641@main">https://commits.webkit.org/308641@main</a>
</pre>
----------------------------------------------------------------------
#### 15ddef0e0842077aa6ce74a5819ed8604d4ed7e4
<pre>
Incorrect logic in Buffer::needsIndexValidation leads to shader OOB access
<a href="https://bugs.webkit.org/show_bug.cgi?id=304184">https://bugs.webkit.org/show_bug.cgi?id=304184</a>
<a href="https://rdar.apple.com/166533571">rdar://166533571</a>

Reviewed by Dan Glastonbury.

Comparison was flipped, leading to potential OOB shader loads from vertex buffers
during drawIndexed calls.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::needsIndexValidation):

Originally-landed-as: 301765.376@safari-7623-branch (9093f17975f8). <a href="https://rdar.apple.com/171558280">rdar://171558280</a>
Canonical link: <a href="https://commits.webkit.org/308640@main">https://commits.webkit.org/308640@main</a>
</pre>
----------------------------------------------------------------------
#### 4555be60f06736997fbc80298daa23e3f6614e26
<pre>
ASAN_SEGV | WebCore::JSCallbackData::invokeCallback; WebCore::JSWebCodecsErrorCallback::invoke; WebCore::WebCodecsVideoDecoder::closeDecoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=300958">https://bugs.webkit.org/show_bug.cgi?id=300958</a>
<a href="https://rdar.apple.com/158135449">rdar://158135449</a>

Reviewed by Youenn Fablet.

When calling configure() on a webcodec with an unsupported config,
postTaskToCodec() is called to &quot;queue a task to run the Close
AudioDecoder algorithm with NotSupportedError&quot; as per
<a href="https://www.w3.org/TR/webcodecs.">https://www.w3.org/TR/webcodecs.</a>

If reset() is called before that task in dequeued, then the codec state
becomes Unconfigured and WebCodecsBase::virtualHasPendingActivity() no
longer ensures the JS wrapper stay alive, potentially causing a nullptr
crash when trying to execute the associated error callback:

```
bool WebCodecsBase::virtualHasPendingActivity() const
{
 return m_state == WebCodecsCodecState::Configured &amp;&amp; (m_codecControlMessagesPending || m_isMessageQueueBlocked);
}
```

This patch removes the assumption that the codec state must be
Configured in order to keep the JS wrapper alive and that addresses the
nullptr crash here. It makes sure that virtualHasPendingActivity()
would eventually be reset to false though.

Tests: fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash.html
       fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash.html
       fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash.html
       fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash.html
* LayoutTests/fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/resetting-audio-decoder-with-unsupported-codec-crash.html: Added.
* LayoutTests/fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/resetting-audio-encoder-with-unsupported-codec-crash.html: Added.
* LayoutTests/fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/resetting-video-decoder-with-unsupported-codec-crash.html: Added.
* LayoutTests/fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/resetting-video-encoder-with-unsupported-codec-crash.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp:
(WebCore::WebCodecsBase::virtualHasPendingActivity const): Don&apos;t release the codec when it&apos;s not in configured state.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::configure): Ensure we clear m_isMessageQueueBlocked when done.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure): Ditto.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure): Ditto.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure): Ditto.

Originally-landed-as: 301765.374@safari-7623-branch (13f8cb5f9bd5). <a href="https://rdar.apple.com/171558400">rdar://171558400</a>
Canonical link: <a href="https://commits.webkit.org/308639@main">https://commits.webkit.org/308639@main</a>
</pre>
----------------------------------------------------------------------
#### a850dfefa3e9092788ad14637f911097b98488ce
<pre>
[WebKit][Main+SU] [ea2e11e05711c082] ASAN_ILL | WebCore::FormState::create; WebCore::FormSubmission::create; WebCore::HTMLFormElement::submit
<a href="https://bugs.webkit.org/show_bug.cgi?id=301645">https://bugs.webkit.org/show_bug.cgi?id=301645</a>
<a href="https://rdar.apple.com/163480500">rdar://163480500</a>

Reviewed by Chris Dumez.

When constructing FormSubmission the formdata event is dispatched. When combined
with the Navigation API the event handling can cause the document frame to be
detached, triggering a release assert in the FormState constructor. To fix this
detect the frame removal after dispatching and end the submit operation early.

* LayoutTests/fast/forms/onformdata-navigate-crash-expected.txt: Added.
* LayoutTests/fast/forms/onformdata-navigate-crash.html: Added.
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submit):
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::create):
* Source/WebCore/loader/FormSubmission.h:

Originally-landed-as: 301765.373@safari-7623-branch (1acabe11a6b0). <a href="https://rdar.apple.com/171558526">rdar://171558526</a>
Canonical link: <a href="https://commits.webkit.org/308638@main">https://commits.webkit.org/308638@main</a>
</pre>
----------------------------------------------------------------------
#### 024280c2ff921692b8d08bc06bb2a03a4c91e84f
<pre>
[JSC] Fix Wasm validation of unreachable locals
<a href="https://bugs.webkit.org/show_bug.cgi?id=304086">https://bugs.webkit.org/show_bug.cgi?id=304086</a>
<a href="https://rdar.apple.com/166283484">rdar://166283484</a>

Reviewed by Dan Hecht.

WebAssembly requires non-defaultable locals (i.e. locals with non-nullable ref
types) to be set before they&apos;re used by local.get. Current implementation
incorrectly performs this validation in the case the local.get/set are
unreachable. While initialization is tracked in such unreachable local
instructions, the locals stack is not correctly reset at control flow merge
points. This PR resets the stack at such points.

Test: JSTests/wasm/gc/validate-unreachable-unset-local.js

Originally-landed-as: 301765.372@safari-7623-branch (e2b2223e8a58). <a href="https://rdar.apple.com/171558798">rdar://171558798</a>
Canonical link: <a href="https://commits.webkit.org/308637@main">https://commits.webkit.org/308637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0047d87c2d12b471510044de98abfc2e7800653b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101161 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17f0c1a2-f4e7-4aaf-a0a6-a5ecf17d3108) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113901 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81226 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3817b55-8081-4e72-872c-6ffa8d166af5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94661 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eddf66b1-20ea-4ce8-a4ad-55427e0c4f8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15303 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13084 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesBold (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3869 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139716 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158764 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8534 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121931 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122132 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76356 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9176 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179168 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19846 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83608 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->