### PR TITLE
[appearance base] Create shadow tree for `appearance: base` <meter> control

### DIFF
--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt
@@ -18,6 +18,12 @@ Both meter elements should have a nested shadow box with a width specified:
 |           id="value"
 |           style="inline-size: 70%;"
 |           useragentpart="-webkit-meter-optimum-value"
+|     <div>
+|       style="appearance: inherit;"
+|       useragentpart="slider-track"
+|       <div>
+|         style="transform: translate(-30%, 0px);"
+|         useragentpart="slider-fill"
 | "\n    "
 | <meter>
 |   high="6"
@@ -40,6 +46,12 @@ Both meter elements should have a nested shadow box with a width specified:
 |           id="value"
 |           style="inline-size: 100%;"
 |           useragentpart="-webkit-meter-suboptimum-value"
+|     <div>
+|       style="appearance: inherit;"
+|       useragentpart="slider-track"
+|       <div>
+|         style="transform: translate(0%, 0px);"
+|         useragentpart="slider-fill"
 | "\n    "
 | <meter>
 |   high="6"
@@ -62,4 +74,10 @@ Both meter elements should have a nested shadow box with a width specified:
 |           id="value"
 |           style="inline-size: 100%;"
 |           useragentpart="-webkit-meter-even-less-good-value"
+|     <div>
+|       style="appearance: inherit;"
+|       useragentpart="slider-track"
+|       <div>
+|         style="transform: translate(0%, 0px);"
+|         useragentpart="slider-fill"
 | "\n  "

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: calc(100% - 1px);
+        height: calc(100% - 2px);
+        border-radius: 999em;
+        overflow: hidden;
+        background: rgb(230, 230, 230);
+    }
+
+    .auto > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic.html
@@ -1,0 +1,105 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-30436" />
+<style>
+    /* This is supposed to be in the UA sheet. */
+    meter::slider-track {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    meter::slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    meter::slider-track {
+        height: 100%;
+    }
+
+    meter:even-less-good::slider-fill {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    meter:suboptimum::slider-fill {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    meter:optimum::slider-fill {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    /* This is the beginning of the author sheet. */
+    .auto {
+        appearance: auto;
+    }
+
+    .none {
+        appearance: none;
+    }
+
+    .base {
+        appearance: base;
+    }
+
+     meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <script>
+        function switchMetersClasses(meters, oldClass, newClass) {
+            for (const element of meters) {
+                element.classList.remove(oldClass);
+                element.classList.add(newClass);
+            }
+        }
+
+        let noneMeters = document.querySelectorAll(".none");
+        let baseMeters = document.querySelectorAll(".base");
+        let autoMeters = document.querySelectorAll(".auto");
+
+        switchMetersClasses(noneMeters, "none", "auto");
+        switchMetersClasses(autoMeters, "auto", "base");
+        switchMetersClasses(baseMeters, "base", "none");
+    </script>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: calc(100% - 1px);
+        height: calc(100% - 2px);
+        border-radius: 999em;
+        overflow: hidden;
+        background: rgb(230, 230, 230);
+    }
+
+    .auto > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial.html
@@ -1,0 +1,89 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-30416" />
+<style>
+    /* This is supposed to be in the UA sheet. */
+    meter::slider-track {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    meter::slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    meter::slider-track {
+        height: 100%;
+    }
+
+    meter:even-less-good::slider-fill {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    meter:suboptimum::slider-fill {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    meter:optimum::slider-fill {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    /* This is the beginning of the author sheet. */
+    .auto {
+        appearance: auto;
+    }
+
+    .none {
+        appearance: none;
+    }
+
+    .base {
+        appearance: base;
+    }
+
+     meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: calc(100% - 1px);
+        height: calc(100% - 2px);
+        border-radius: 999em;
+        overflow: hidden;
+        background: rgb(230, 230, 230);
+    }
+
+    .auto > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="slider-fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic.html
@@ -1,0 +1,104 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-30402" />
+<style>
+    /* This is supposed to be in the UA sheet. */
+    meter::slider-track {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    meter::slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    meter::slider-track {
+        height: 100%;
+    }
+
+    meter:even-less-good::slider-fill {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    meter:suboptimum::slider-fill {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    meter:optimum::slider-fill {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    /* This is the beginning of the author sheet. */
+    .auto {
+        appearance: auto;
+    }
+
+    .none {
+        appearance: none;
+    }
+
+    .base {
+        appearance: base;
+    }
+
+     meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <script>
+        function changeMetersValues(meters, newValue) {
+            for (const element of meters) {
+                element.setAttribute("value", newValue);
+            }
+        }
+
+        let evenLessGoodMeters = document.querySelectorAll("meter:is([value='10'])");
+        let suboptimumMeters = document.querySelectorAll("meter:is([value='33'])");
+        let optimumMeters = document.querySelectorAll("meter:is([value='66'])");
+
+        changeMetersValues(evenLessGoodMeters, 33);
+        changeMetersValues(suboptimumMeters, 66);
+        changeMetersValues(optimumMeters, 10);
+    </script>
+</body>

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt
@@ -22,6 +22,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderInline {B} at (0,0) size 16x18
@@ -33,6 +34,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 20x18
@@ -46,6 +48,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,72) size 744x18
@@ -61,6 +64,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 40x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,90) size 744x18
@@ -76,6 +80,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,108) size 744x18
@@ -91,6 +96,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 118x18
             text run at (184,0) width 118: "(should be yellow)"
         RenderListItem {LI} at (40,126) size 744x18
@@ -106,6 +112,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (203,0) size 118x18
             text run at (203,0) width 118: "(should be yellow)"
         RenderListItem {LI} at (40,144) size 744x18
@@ -121,6 +128,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,162) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 60x18
@@ -134,6 +142,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,180) size 744x18
@@ -147,6 +156,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,198) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 40x18
@@ -160,6 +170,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,216) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 40x18
@@ -173,6 +184,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,234) size 744x18
@@ -188,6 +200,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (203,0) size 110x18
             text run at (203,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,252) size 744x18
@@ -203,5 +216,6 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 40x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt
@@ -7,8 +7,10 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 18x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {METER} at (80,0) size 10x60
         RenderBlock {DIV} at (0,0) size 10x60
           RenderBlock {DIV} at (0,0) size 10x60
             RenderBlock {DIV} at (0,0) size 10x42
+        RenderBlock {DIV} at (10,0) size 0x60
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -7,11 +7,13 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (80,0) size 4x18
         text run at (80,0) width 4: " "
       RenderBlock {METER} at (84,1) size 80x17
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-optimums-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-optimums-expected.txt
@@ -21,6 +21,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,18) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -29,6 +30,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -37,6 +39,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 59x18
@@ -45,6 +48,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,72) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 83x18
@@ -53,6 +57,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {H2} at (0,253) size 784x28
         RenderText {#text} at (0,0) size 143x27
           text run at (0,0) width 143: "optimum=150"
@@ -65,6 +70,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,18) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -73,6 +79,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -81,6 +88,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 59x18
@@ -89,6 +97,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,72) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 83x18
@@ -97,6 +106,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {H2} at (0,409) size 784x28
         RenderText {#text} at (0,0) size 143x27
           text run at (0,0) width 143: "optimum=750"
@@ -109,6 +119,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,18) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -117,6 +128,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -125,6 +137,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 59x18
@@ -133,6 +146,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,72) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 83x18
@@ -141,3 +155,4 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-expected.txt
@@ -12,35 +12,41 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (80,0) size 4x18
             text run at (80,0) width 4: " "
           RenderBlock {METER} at (84,1) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (164,0) size 4x18
             text run at (164,0) width 4: " "
           RenderBlock {METER} at (168,1) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (43,21) size 732x41
           RenderBlock {METER} at (0,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 8x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (30,22) size 4x18
             text run at (30,22) width 4: " "
           RenderBlock {METER} at (34,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 14x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (64,22) size 4x18
             text run at (64,22) width 4: " "
           RenderBlock {METER} at (68,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 23x40
+            RenderBlock {DIV} at (0,40) size 30x0
       RenderBlock {H2} at (3,85) size 778x19
         RenderText {#text} at (0,0) size 150x18
           text run at (0,0) width 150: "Providing meter styles"
@@ -51,6 +57,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 70x18
               text run at (80,0) width 70: " has border"
           RenderListItem {LI} at (43,21) size 732x19
@@ -58,6 +65,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 80x18
               text run at (80,0) width 80: " has padding"
           RenderListItem {LI} at (43,42) size 732x27
@@ -65,6 +73,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (110,8) size 73x18
               text run at (110,8) width 73: " has margin"
       RenderBlock {H2} at (3,178) size 778x19
@@ -80,6 +89,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 212x18
               text run at (80,0) width 212: " has bar style but should ignore it."
           RenderListItem {LI} at (43,42) size 732x19
@@ -87,6 +97,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 226x18
               text run at (80,0) width 226: " has value style but should ignore it."
           RenderListItem {LI} at (43,63) size 732x19
@@ -94,6 +105,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 249x18
               text run at (80,0) width 249: " has both styles but should ignore them."
         RenderBlock {UL} at (3,84) size 778x83
@@ -105,6 +117,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 270x18
               text run at (80,0) width 270: " has bar style, should have solid value part."
           RenderListItem {LI} at (43,42) size 732x19
@@ -112,6 +125,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 255x18
               text run at (80,0) width 255: " has value style, should be solid bar part."
           RenderListItem {LI} at (43,63) size 732x19
@@ -119,6 +133,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 235x18
               text run at (80,0) width 235: " should have solid bar and value part."
       RenderBlock {H2} at (3,369) size 778x19
@@ -131,6 +146,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 375x18
               text run at (80,0) width 375: " has \"none\" appearance, should be styled with default style."
           RenderListItem {LI} at (43,21) size 732x19
@@ -138,6 +154,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 276x18
               text run at (80,0) width 276: " has \"meter\" appearance, should be themed."
       RenderBlock {H2} at (3,433) size 778x19
@@ -148,5 +165,6 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (5,5) size 35x6
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (80,0) size 165x18
           text run at (80,0) width 165: " has \"padding\" on the bar."

--- a/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -10,5 +10,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-expected.txt
@@ -12,35 +12,41 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (80,0) size 4x20
             text run at (80,0) width 4: " "
           RenderBlock {METER} at (84,2) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (164,0) size 4x20
             text run at (164,0) width 4: " "
           RenderBlock {METER} at (168,2) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (43,23) size 732x42
           RenderBlock {METER} at (0,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 8x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (30,21) size 4x20
             text run at (30,21) width 4: " "
           RenderBlock {METER} at (34,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 14x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (64,21) size 4x20
             text run at (64,21) width 4: " "
           RenderBlock {METER} at (68,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 23x40
+            RenderBlock {DIV} at (0,40) size 30x0
       RenderBlock {H2} at (3,90) size 778x21
         RenderText {#text} at (0,0) size 153x20
           text run at (0,0) width 153: "Providing meter styles"
@@ -51,6 +57,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 72x20
               text run at (80,0) width 72: " has border"
           RenderListItem {LI} at (43,23) size 732x21
@@ -58,6 +65,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 81x20
               text run at (80,0) width 81: " has padding"
           RenderListItem {LI} at (43,46) size 732x28
@@ -65,6 +73,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (110,7) size 75x20
               text run at (110,7) width 75: " has margin"
       RenderBlock {H2} at (3,190) size 778x21
@@ -96,6 +105,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 276x20
               text run at (80,0) width 276: " has bar style, should have solid value part."
           RenderListItem {LI} at (43,46) size 732x21
@@ -103,6 +113,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 261x20
               text run at (80,0) width 261: " has value style, should be solid bar part."
           RenderListItem {LI} at (43,69) size 732x21
@@ -110,6 +121,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 240x20
               text run at (80,0) width 240: " should have solid bar and value part."
       RenderBlock {H2} at (3,399) size 778x21
@@ -122,6 +134,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 381x20
               text run at (80,0) width 381: " has \"none\" appearance, should be styled with default style."
           RenderListItem {LI} at (43,23) size 732x21
@@ -136,5 +149,6 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (5,5) size 35x6
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (80,0) size 166x20
           text run at (80,0) width 166: " has \"padding\" on the bar."

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: 100%;
+        height: 41%;
+        overflow: hidden;
+        box-sizing: border-box;
+        background: rgb(237, 237, 237);
+        border: 0.5px solid rgb(206, 206, 206);
+    }
+
+    .auto > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient silder-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient silder-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient silder-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient silder-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient silder-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient silder-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: 100%;
+        height: 41%;
+        overflow: hidden;
+        box-sizing: border-box;
+        background: rgb(237, 237, 237);
+        border: 0.5px solid rgb(206, 206, 206);
+    }
+
+    .auto > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient silder-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient silder-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient silder-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient silder-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient silder-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient silder-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: 100%;
+        height: 41%;
+        overflow: hidden;
+        box-sizing: border-box;
+        background: rgb(237, 237, 237);
+        border: 0.5px solid rgb(206, 206, 206);
+    }
+
+    .auto > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .silder-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient silder-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient silder-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient silder-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient silder-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="silder-fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient silder-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient silder-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -10,5 +10,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-expected.txt
@@ -7,8 +7,10 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 18x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {METER} at (80,0) size 10x60
         RenderBlock {DIV} at (0,0) size 10x60
           RenderBlock {DIV} at (0,0) size 10x60
             RenderBlock {DIV} at (0,0) size 10x42
+        RenderBlock {DIV} at (10,0) size 0x60
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -13,5 +13,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .slider-fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient slider-fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient slider-fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient slider-fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -22,18 +23,12 @@
 #include "HTMLMeterElement.h"
 
 #include "Attribute.h"
-#include "ContainerNodeInlines.h"
-#include "ElementInlines.h"
-#include "ElementIterator.h"
 #include "HTMLDivElement.h"
-#include "HTMLFormElement.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLStyleElement.h"
 #include "NodeName.h"
-#include "Page.h"
 #include "RenderMeter.h"
-#include "RenderStyle+GettersInlines.h"
 #include "RenderTheme.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
@@ -84,7 +79,7 @@ void HTMLMeterElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::lowAttr:
     case AttributeNames::highAttr:
     case AttributeNames::optimumAttr:
-        didElementStateChange();
+        didChangeElementValue();
         break;
     default:
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
@@ -189,14 +184,17 @@ static void setValueClass(HTMLElement& element, HTMLMeterElement::GaugeRegion ga
     ASSERT_NOT_REACHED();
 }
 
-void HTMLMeterElement::didElementStateChange()
+void HTMLMeterElement::didChangeElementValue()
 {
-    Ref valueElement = *m_valueElement;
-    valueElement->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio() * 100, CSSUnitType::CSS_PERCENTAGE);
-    setValueClass(valueElement, gaugeRegion());
+    if (RefPtr valueElement = m_valueElement) {
+        valueElement->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio() * 100, CSSUnitType::CSS_PERCENTAGE);
+        setValueClass(*valueElement, gaugeRegion());
+    }
 
-    if (CheckedPtr renderer = renderMeter())
-        renderer->updateFromElement();
+    if (RefPtr fillElement = m_fillElement) {
+        fillElement->setInlineStyleProperty(CSSPropertyTransform, makeString("translate(-"_s, (1 - valueRatio()) * 100, "%, 0)"_s));
+        fillElement->invalidateStyleInternal();
+    }
 }
 
 RenderMeter* HTMLMeterElement::renderMeter() const
@@ -204,39 +202,61 @@ RenderMeter* HTMLMeterElement::renderMeter() const
     return dynamicDowncast<RenderMeter>(renderer());
 }
 
-void HTMLMeterElement::didAddUserAgentShadowRoot(ShadowRoot& root)
+void HTMLMeterElement::appendShadowTreeForAutoAppearance(ShadowRoot& root)
 {
-    ASSERT(!m_valueElement);
-
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(meterElementShadowUserAgentStyleSheet));
 
     Ref document = this->document();
-    Ref style = HTMLStyleElement::create(document);
-    ScriptDisallowedScope::EventAllowedScope styleScope { style };
-    style->setTextContent(String { shadowStyle });
+    Ref styleElement = HTMLStyleElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope styleScope { styleElement };
+    styleElement->setTextContent(String { shadowStyle });
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
-    root.appendChild(WTF::move(style));
+    root.appendChild(WTF::move(styleElement));
 
     // Pseudos are set to allow author styling.
-    Ref inner = HTMLDivElement::create(document);
-    ScriptDisallowedScope::EventAllowedScope innerScope { inner };
-    inner->setIdAttribute("inner"_s);
-    inner->setUserAgentPart(UserAgentParts::webkitMeterInnerElement());
-    root.appendChild(inner);
+    Ref innerElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope innerScope { innerElement };
+    innerElement->setIdAttribute("inner"_s);
+    innerElement->setUserAgentPart(UserAgentParts::webkitMeterInnerElement());
+    innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none) !important"_s);
+    root.appendChild(innerElement);
 
-    Ref bar = HTMLDivElement::create(document);
-    ScriptDisallowedScope::EventAllowedScope barScope { bar };
-    bar->setIdAttribute("bar"_s);
-    bar->setUserAgentPart(UserAgentParts::webkitMeterBar());
-    inner->appendChild(bar);
+    Ref barElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope barScope { barElement };
+    barElement->setIdAttribute("bar"_s);
+    barElement->setUserAgentPart(UserAgentParts::webkitMeterBar());
+    innerElement->appendChild(barElement);
 
     Ref valueElement = HTMLDivElement::create(document);
     ScriptDisallowedScope::EventAllowedScope valueElementScope { valueElement };
     valueElement->setIdAttribute("value"_s);
-    bar->appendChild(valueElement);
-    m_valueElement = WTF::move(valueElement);
+    barElement->appendChild(valueElement);
+    m_valueElement = valueElement;
+}
 
-    didElementStateChange();
+void HTMLMeterElement::appendShadowTreeForBaseAppearance(ShadowRoot& root)
+{
+    Ref document = this->document();
+    Ref trackElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope trackScope { trackElement };
+    trackElement->setUserAgentPart(UserAgentParts::sliderTrack());
+    trackElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
+    trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block) !important"_s);
+    root.appendChild(trackElement);
+
+    Ref fillElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope fillScope { fillElement };
+    fillElement->setUserAgentPart(UserAgentParts::sliderFill());
+    trackElement->appendChild(fillElement);
+    m_fillElement = fillElement;
+}
+
+void HTMLMeterElement::didAddUserAgentShadowRoot(ShadowRoot& root)
+{
+    appendShadowTreeForAutoAppearance(root);
+    if (document().settings().cssAppearanceBaseEnabled())
+        appendShadowTreeForBaseAppearance(root);
+    didChangeElementValue();
 }
 
 } // namespace

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -65,10 +66,14 @@ private:
     bool childShouldCreateRenderer(const Node&) const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
-    void didElementStateChange();
+    void appendShadowTreeForAutoAppearance(ShadowRoot&);
+    void appendShadowTreeForBaseAppearance(ShadowRoot&);
+
+    void didChangeElementValue();
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
-    RefPtr<HTMLElement> m_valueElement;
+    WeakPtr<HTMLDivElement, WeakPtrImplWithEventTargetData> m_valueElement;
+    WeakPtr<HTMLDivElement, WeakPtrImplWithEventTargetData> m_fillElement;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### b8740d47b8bc10cab68b5fa79a6fa48dca78e0b4
<pre>
[appearance base] Create shadow tree for `appearance: base` &lt;meter&gt; control
<a href="https://bugs.webkit.org/show_bug.cgi?id=309021">https://bugs.webkit.org/show_bug.cgi?id=309021</a>
<a href="https://rdar.apple.com/171569997">rdar://171569997</a>

Reviewed by Anne van Kesteren.

Support appearance: base for the &lt;meter&gt; element. Create shadow tree elements
for the the pseudo elements: ::slider-track and ::slider-fill. These new shadow
tree elements have to coexist with the shadow tree elements of the appearance:
none case. Only a shadow sub-tree should be shown at any time. This can will
be handled by using `-internal-auto-base()` for the CSS `display` property.

Tests: fast/forms/appearance-base/appearance-base-meter-dynamic.html
       fast/forms/appearance-base/appearance-base-meter-initial.html
       fast/forms/appearance-base/appearance-base-meter-value-dynamic.html

* LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt:
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic.html: Added.
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-optimums-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-expected.txt:
* LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::attributeChanged):
(WebCore::HTMLMeterElement::didChangeElementValue):
(WebCore::HTMLMeterElement::appendShadowTreeForAutoAppearance):
(WebCore::HTMLMeterElement::appendShadowTreeForBaseAppearance):
(WebCore::HTMLMeterElement::didAddUserAgentShadowRoot):
(WebCore::HTMLMeterElement::didElementStateChange): Deleted.
* Source/WebCore/html/HTMLMeterElement.h:

Canonical link: <a href="https://commits.webkit.org/308587@main">https://commits.webkit.org/308587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c165b6a96b3497bb9dd0dcb3c8feb312c8ca0ce4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156562 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101295 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec234483-38fe-40a7-881d-16edadae55fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81302 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/016bd6d7-b446-425f-b4a2-d2a6c882edaa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94767 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67687182-6e74-4d34-80b9-bc089275fcef) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147201 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13192 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4002 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139849 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125033 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158897 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8669 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2031 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122037 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/147280 "Failed to checkout and rebase branch from PR 59752") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31335 "Built successfully and passed tests") | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20374 "Failed to checkout and rebase branch from PR 59752") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76517 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9321 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179302 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83741 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19859 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19767 "Failed to checkout and rebase branch from PR 59752") | | | | 
<!--EWS-Status-Bubble-End-->