### PR TITLE
[WGSL] webgpu:shader,validation,shader_io,interpolate:* is failing

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284937.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284937.html
@@ -3002,13 +3002,13 @@ struct T0 {
 fn unconst_i32(v: i32) -> i32 { return v; }
 
 struct VertexOutput0 {
-  @location(6) @interpolate(flat, sample) f0: i32,
+  @location(6) @interpolate(flat) f0: i32,
   @invariant @builtin(position) f1: vec4f,
-  @location(10) @interpolate(flat, sample) f2: u32,
-  @location(8) f3: vec2u,
+  @location(10) @interpolate(flat) f2: u32,
+  @location(8) @interpolate(flat) f3: vec2u,
   @location(15) f4: vec2f,
   @location(14) @interpolate(flat) f5: vec2i,
-  @location(3) @interpolate(flat, center) f6: vec4u,
+  @location(3) @interpolate(flat) f6: vec4u,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -7847,7 +7847,7 @@ alias vec3b = vec3<bool>;
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 struct VertexOutput1 {
-  @location(0) @interpolate(flat, center) f7: vec2i,
+  @location(0) @interpolate(flat) f7: vec2i,
   @invariant @builtin(position) f8: vec4f,
 }
 
@@ -7858,7 +7858,7 @@ fn unconst_f32(v: f32) -> f32 { return v; }
 fn unconst_u32(v: u32) -> u32 { return v; }
 
 struct T0 {
-  @size(304) f0: array<vec2h>,
+  f0: array<vec2h>,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -7889,7 +7889,7 @@ fn vertex1(@location(12) a0: vec4h) -> VertexOutput1 {
 }
 
 @fragment
-fn fragment0(@location(0) a0: vec2i, @builtin(position) a1: vec4f) -> FragmentOutput0 {
+fn fragment0(@location(0) @interpolate(flat) a0: vec2i, @builtin(position) a1: vec4f) -> FragmentOutput0 {
   var out: FragmentOutput0;
   let ptr7: ptr<storage, array<array<f16, 1>, 19>, read_write> = &(*&buffer78)[0][u32(unconst_u32(176))][u32(unconst_u32(194))][3][u32(unconst_u32(17))][0][u32(unconst_u32(42))][0];
   let ptr8: ptr<storage, f16, read_write> = &(*&buffer78)[0][u32(unconst_u32(15))][u32(unconst_u32(3))][3][0][u32(unconst_u32(132))][0][u32((*&buffer78)[0][u32(unconst_u32(168))][u32(unconst_u32(105))][3][0][0][0][u32(unconst_u32(142))][u32(unconst_u32(202))][u32(unconst_u32(307))])][u32(unconst_u32(176))][0];
@@ -11839,7 +11839,7 @@ struct T0 {
 }
 
 struct T2 {
-  @align(16) @size(16) f0: array<u32>,
+  @align(16) f0: array<u32>,
 }
 
 fn unconst_f32(v: f32) -> f32 { return v; }
@@ -11850,14 +11850,14 @@ alias vec3b = vec3<bool>;
 
 struct FragmentOutput1 {
   @location(2) f0: vec4i,
-  @location(1) @interpolate(flat, sample) f1: vec4u,
+  @location(1) @interpolate(flat) f1: vec4u,
   @location(0) f2: vec4f,
   @builtin(frag_depth) f3: f32,
-  @location(3) @interpolate(flat, center) f4: vec2u,
+  @location(3) @interpolate(flat) f4: vec2u,
 }
 
 struct T1 {
-  @align(16) @size(16) f0: array<mat2x2h>,
+  @align(16) f0: array<mat2x2h>,
 }
 
 fn fn0() -> array<array<mat2x2f, 2>, 1> {
@@ -11882,7 +11882,7 @@ fn unconst_i32(v: i32) -> i32 { return v; }
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 struct FragmentOutput2 {
-  @location(3) @interpolate(flat, sample) f0: u32,
+  @location(3) @interpolate(flat) f0: u32,
   @location(0) @interpolate(perspective) f1: vec2f,
 }
 
@@ -11902,7 +11902,7 @@ fn fn1() -> FragmentOutput1 {
 }
 
 @vertex
-fn vertex2(@location(13) @interpolate(flat, sample) a0: i32) -> @builtin(position) vec4f {
+fn vertex2(@location(13) @interpolate(flat) a0: i32) -> @builtin(position) vec4f {
   var out: vec4f;
   var vf39 = fn1();
   fn1();
@@ -13368,7 +13368,7 @@ struct FragmentOutput4 {
 }
 
 struct T3 {
-  @size(16) f0: array<f32>,
+  f0: array<f32>,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -13380,11 +13380,7 @@ fn unconst_f32(v: f32) -> f32 { return v; }
 var<workgroup> vw5: array<array<VertexOutput3, 1>, 1>;
 
 struct T0 {
-  @align(16) @size(16) f0: array<array<f32, 1>>,
-}
-
-struct T1 {
-  f0: T0,
+  @align(16) f0: array<array<f32, 1>>,
 }
 
 var<workgroup> vw9: mat3x3h;
@@ -13396,7 +13392,7 @@ var<private> vp6: array<array<vec4u, 1>, 13> = array(array<vec4u, 1>(), array<ve
 alias vec3b = vec3<bool>;
 
 struct T2 {
-  @align(16) @size(16) f0: array<atomic<u32>>,
+  @align(16) f0: array<atomic<u32>>,
 }
 
 var<private> vp7 = array(array(modf(f16(5169.9))));
@@ -13406,10 +13402,10 @@ fn unconst_i32(v: i32) -> i32 { return v; }
 var<workgroup> vw6: mat3x2f;
 
 struct VertexOutput3 {
-  @location(8) @interpolate(flat, sample) f10: vec2u,
+  @location(8) @interpolate(flat) f10: vec2u,
   @location(2) f11: vec2f,
   @location(5) @interpolate(linear, sample) f12: vec4h,
-  @location(6) @interpolate(flat, sample) f13: vec2h,
+  @location(6) @interpolate(flat) f13: vec2h,
   @builtin(position) f14: vec4f,
 }
 
@@ -13436,7 +13432,7 @@ fn fn0() -> mat2x2f {
 }
 
 @vertex
-fn vertex4(@location(3) @interpolate(flat, sample) a0: vec4i, @location(2) @interpolate(perspective) a1: vec4f, @location(5) a2: vec4u, @location(10) a3: f16, @location(7) a4: u32) -> VertexOutput3 {
+fn vertex4(@location(3) @interpolate(flat) a0: vec4i, @location(2) @interpolate(perspective) a1: vec4f, @location(5) a2: vec4u, @location(10) a3: f16, @location(7) a4: u32) -> VertexOutput3 {
   var out: VertexOutput3;
   out.f12 = vec4h(f16(countTrailingZeros(u32(unconst_u32(183)))));
   let ptr43: ptr<private, vec4u> = &vp6[u32(unconst_u32(38))][0];
@@ -13618,7 +13614,7 @@ requires readonly_and_readwrite_storage_textures;
 var<workgroup> vw13: mat4x4h;
 
 struct T3 {
-  @size(224) f0: array<T1>,
+  f0: array<T1>,
 }
 
 fn unconst_i32(v: i32) -> i32 { return v; }
@@ -15544,10 +15540,10 @@ struct T5 {
 }
 
 struct FragmentOutput7 {
-  @location(2) @interpolate(flat, sample) f0: vec4u,
+  @location(2) @interpolate(flat) f0: vec4u,
   @location(0) @interpolate(flat) f1: vec4i,
   @location(1) @interpolate(flat) f2: vec4u,
-  @location(7) @interpolate(flat, center) f3: i32,
+  @location(7) @interpolate(flat) f3: i32,
 }
 
 fn fn0(a0: ptr<function, FragmentOutput6>) -> f32 {
@@ -15579,7 +15575,7 @@ fn fn0(a0: ptr<function, FragmentOutput6>) -> f32 {
 @group(0) @binding(95) var<storage, read_write> buffer151: array<array<array<array<array<atomic<i32>, 1>, 1>, 3>, 1>>;
 
 struct T1 {
-  @size(12) f0: array<u32>,
+  f0: array<u32>,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -15608,11 +15604,11 @@ fn fn1() -> array<T5, 1> {
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 struct VertexOutput5 {
-  @location(7) f16: vec4i,
+  @location(7) @interpolate(flat) f16: vec4i,
   @location(10) f17: f16,
   @location(2) f18: f32,
-  @location(13) f19: vec2u,
-  @location(6) f20: u32,
+  @location(13) @interpolate(flat) f19: vec2u,
+  @location(6) @interpolate(flat) f20: u32,
   @location(14) f21: vec2f,
   @location(11) @interpolate(flat) f22: vec4u,
   @invariant @builtin(position) f23: vec4f,
@@ -15627,7 +15623,7 @@ struct VertexOutput5 {
 @group(0) @binding(82) var st0: texture_storage_3d<r32float, read_write>;
 
 struct T2 {
-  @size(512) f0: array<atomic<u32>>,
+  f0: array<atomic<u32>>,
 }
 
 @group(0) @binding(13) var sam2: sampler;
@@ -15638,7 +15634,7 @@ var<workgroup> vw15: VertexOutput5;
 
 struct T3 {
   @align(128) @size(256) f0: atomic<i32>,
-  @align(64) @size(2048) f1: array<T0>,
+  @align(64) f1: array<T0>,
 }
 
 struct T4 {
@@ -15647,7 +15643,7 @@ struct T4 {
 
 struct FragmentOutput6 {
   @location(1) f0: vec4u,
-  @location(2) @interpolate(flat, centroid) f1: vec4u,
+  @location(2) @interpolate(flat) f1: vec4u,
   @location(0) @interpolate(flat) f2: vec4i,
   @location(5) @interpolate(perspective) f3: vec4f,
 }
@@ -16210,7 +16206,7 @@ fn unconst_bool(v: bool) -> bool { return v; }
 @group(0) @binding(95) var<storage, read_write> buffer157: array<T1, 6>;
 
 struct T0 {
-  @size(12) f0: array<u32>,
+  f0: array<u32>,
 }
 
 struct T1 {
@@ -16291,7 +16287,7 @@ fn fn0() -> vec2i {
 }
 
 struct FragmentOutput8 {
-  @location(2) @interpolate(flat, center) f0: vec4i,
+  @location(2) @interpolate(flat) f0: vec4i,
   @location(0) @interpolate(linear, centroid) f1: vec4f,
   @location(1) @interpolate(flat) f2: vec4u,
   @location(3) f3: vec2u,
@@ -17767,13 +17763,13 @@ var<workgroup> vw17: mat4x2h;
 @group(0) @binding(95) var<storage, read_write> buffer168: array<array<array<f16, 3>, 2>>;
 
 struct VertexOutput6 {
-  @location(3) @interpolate(flat, centroid) f24: i32,
-  @location(8) @interpolate(flat, centroid) f25: vec2u,
+  @location(3) @interpolate(flat) f24: i32,
+  @location(8) @interpolate(flat) f25: vec2u,
   @location(5) @interpolate(linear, centroid) f26: f32,
   @builtin(position) f27: vec4f,
   @location(12) f28: f32,
-  @location(1) @interpolate(flat, sample) f29: vec4u,
-  @location(15) f30: vec2u,
+  @location(1) @interpolate(flat) f29: vec4u,
+  @location(15) @interpolate(flat) f30: vec2u,
 }
 
 var<workgroup> vw19: atomic<i32>;
@@ -17811,7 +17807,7 @@ fn fn2(a0: VertexOutput6, a1: ptr<uniform, vec2h>) -> array<array<array<array<ar
 @group(0) @binding(93) var<storage, read> buffer167: array<array<array<f16, 1>, 1>, 1>;
 
 struct T1 {
-  @size(16) f0: array<vec2f>,
+  f0: array<vec2f>,
 }
 
 var<workgroup> vw21: VertexOutput6;
@@ -19766,7 +19762,7 @@ fn fn0() {
 @group(0) @binding(0) var<uniform> buffer187: mat4x3f;
 
 struct VertexOutput7 {
-  @location(2) @interpolate(flat, sample) f31: f16,
+  @location(2) @interpolate(flat) f31: f16,
   @invariant @builtin(position) f32: vec4f,
 }
 
@@ -20388,7 +20384,7 @@ struct FragmentOutput10 {
 fn unconst_f32(v: f32) -> f32 { return v; }
 
 struct T1 {
-  @align(8) @size(88) f0: array<u32>,
+  @align(8) f0: array<u32>,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -20426,7 +20422,7 @@ fn vertex9(@location(12) a0: vec4h) -> VertexOutput8 {
 }
 
 @fragment
-fn fragment11(@location(3) a0: vec4u, @location(14) @interpolate(flat, sample) a1: vec2i, @builtin(position) a2: vec4f, @location(15) a3: vec2f) -> FragmentOutput10 {
+fn fragment11(@location(3) @interpolate(flat) a0: vec4u, @location(14) @interpolate(flat) a1: vec2i, @builtin(position) a2: vec4f, @location(15) a3: vec2f) -> FragmentOutput10 {
   var out: FragmentOutput10;
   fn1();
   out.f0 = unpack4xU8(a0[u32(unconst_u32(63))]);
@@ -21065,7 +21061,7 @@ fn unconst_bool(v: bool) -> bool { return v; }
 fn unconst_u32(v: u32) -> u32 { return v; }
 
 struct T0 {
-  @align(4) @size(12) f0: array<f16>,
+  @align(4) f0: array<f16>,
 }
 
 var<workgroup> vw30: VertexOutput9;
@@ -22816,7 +22812,7 @@ enable f16;
 
 struct T2 {
   @size(8) f0: atomic<u32>,
-  @align(8) @size(80) f1: array<vec2h>,
+  @align(8) f1: array<vec2h>,
 }
 
 @group(0) @binding(0) var<uniform> buffer226: array<VertexOutput10, 1>;
@@ -22837,7 +22833,7 @@ struct FragmentOutput11 {
 }
 
 struct T0 {
-  @align(32) @size(544) f0: array<vec2i>,
+  @align(32) f0: array<vec2i>,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -22884,7 +22880,7 @@ alias vec3b = vec3<bool>;
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 @vertex
-fn vertex11(@location(0) @interpolate(flat, centroid) a0: vec2i) -> VertexOutput10 {
+fn vertex11(@location(0) @interpolate(flat) a0: vec2i) -> VertexOutput10 {
   var out: VertexOutput10;
   vp22 = mat3x2h(vec2h(buffer226[u32(unconst_u32(121))].f35.yz), vec2h(buffer226[u32(unconst_u32(121))].f35.ga), vec2h(buffer226[u32(unconst_u32(121))].f35.ra));
   vp19.whole *= vp22[u32(unconst_u32(57))][u32(unconst_u32(67))];
@@ -23675,10 +23671,10 @@ struct T0 {
 fn unconst_bool(v: bool) -> bool { return v; }
 
 struct VertexOutput11 {
-  @location(14) @interpolate(flat, sample) f36: vec2u,
+  @location(14) @interpolate(flat) f36: vec2u,
   @location(12) @interpolate(flat) f37: u32,
   @builtin(position) f38: vec4f,
-  @location(5) f39: vec4i,
+  @location(5) @interpolate(flat) f39: vec4i,
   @location(7) @interpolate(linear, sample) f40: f16,
 }
 
@@ -23714,10 +23710,10 @@ fn fn1(a0: VertexOutput11) {
 
 struct FragmentOutput12 {
   @location(3) @interpolate(flat) f0: vec4u,
-  @location(1) @interpolate(flat, centroid) f1: vec4u,
+  @location(1) @interpolate(flat) f1: vec4u,
   @location(0) @interpolate(perspective) f2: vec4f,
   @location(2) @interpolate(flat) f3: vec4i,
-  @location(6) @interpolate(flat, centroid) f4: u32,
+  @location(6) @interpolate(flat) f4: u32,
   @builtin(sample_mask) f5: u32,
 }
 
@@ -23740,7 +23736,7 @@ fn unconst_f16(v: f16) -> f16 { return v; }
 fn unconst_u32(v: u32) -> u32 { return v; }
 
 @vertex @must_use
-fn vertex12(@location(0) @interpolate(flat) a0: i32, @location(2) @interpolate(flat) a1: vec4i, a2: S0, @location(15) @interpolate(flat) a3: vec4h, @location(12) a4: vec2u, @location(10) @interpolate(flat) a5: vec4i, @location(11) @interpolate(flat, centroid) a6: vec4i, @location(3) @interpolate(flat, center) a7: vec4h, @location(5) a8: f32) -> VertexOutput11 {
+fn vertex12(@location(0) @interpolate(flat) a0: i32, @location(2) @interpolate(flat) a1: vec4i, a2: S0, @location(15) @interpolate(flat) a3: vec4h, @location(12) a4: vec2u, @location(10) @interpolate(flat) a5: vec4i, @location(11) @interpolate(flat) a6: vec4i, @location(3) @interpolate(flat) a7: vec4h, @location(5) a8: f32) -> VertexOutput11 {
   var out: VertexOutput11;
   out.f39 -= vec4i(vp26.f39[u32(unconst_u32(414))]);
   out = VertexOutput11(vec2u(u32(a3[u32(unconst_u32(67))])), u32(a3[u32(unconst_u32(67))]), vec4f(f32(a3[u32(unconst_u32(67))])), vec4i(i32(a3[u32(unconst_u32(67))])), a3[u32(unconst_u32(67))]);
@@ -25102,7 +25098,7 @@ var<workgroup> vw36: array<mat2x4f, 1>;
 var<workgroup> vw35: array<mat2x3f, 1>;
 
 struct T0 {
-  @align(8) @size(7488) f0: array<u32>,
+  @align(8) f0: array<u32>,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -25122,7 +25118,7 @@ fn unconst_u32(v: u32) -> u32 { return v; }
 @group(2) @binding(476) var<uniform> buffer247: array<array<array<array<mat2x3h, 1>, 2>, 3>, 15>;
 
 @vertex
-fn vertex13(@builtin(instance_index) a0: u32, @location(4) a1: vec2i, @location(11) @interpolate(flat, center) a2: vec2i) -> @builtin(position) vec4f {
+fn vertex13(@builtin(instance_index) a0: u32, @location(4) a1: vec2i, @location(11) @interpolate(flat) a2: vec2i) -> @builtin(position) vec4f {
   var out: vec4f;
   out = vec4f(reverseBits(vec4u(unconst_u32(512), unconst_u32(96), unconst_u32(12), unconst_u32(412))));
   let vf285: vec4f = quantizeToF16(vec4f(f32(floor(f16(unconst_f16(156.9))))));
@@ -26405,22 +26401,22 @@ fn unconst_f32(v: f32) -> f32 { return v; }
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 struct VertexOutput13 {
-  @location(13) f49: vec4u,
-  @location(10) f50: vec2u,
-  @location(5) @interpolate(flat, centroid) f51: f32,
-  @location(12) @interpolate(flat, center) f52: vec4u,
+  @location(13) @interpolate(flat) f49: vec4u,
+  @location(10) @interpolate(flat) f50: vec2u,
+  @location(5) @interpolate(flat) f51: f32,
+  @location(12) @interpolate(flat) f52: vec4u,
   @location(0) f53: f16,
   @builtin(position) f54: vec4f,
-  @location(11) @interpolate(flat, centroid) f55: u32,
-  @location(7) @interpolate(flat, centroid) f56: vec4h,
+  @location(11) @interpolate(flat) f55: u32,
+  @location(7) @interpolate(flat) f56: vec4h,
   @location(14) @interpolate(perspective, centroid) f57: vec4h,
   @location(1) f58: vec4f,
   @location(9) @interpolate(linear, centroid) f59: vec2f,
-  @location(3) f60: vec4u,
-  @location(4) @interpolate(flat, sample) f61: vec4f,
-  @location(15) @interpolate(flat, sample) f62: vec4u,
+  @location(3) @interpolate(flat) f60: vec4u,
+  @location(4) @interpolate(flat) f61: vec4f,
+  @location(15) @interpolate(flat) f62: vec4u,
   @location(2) f63: f32,
-  @location(6) f64: u32,
+  @location(6) @interpolate(flat) f64: u32,
   @location(8) @interpolate(linear, sample) f65: vec4f,
 }
 
@@ -26431,9 +26427,9 @@ var<workgroup> vw39: atomic<u32>;
 struct VertexOutput12 {
   @location(12) @interpolate(perspective, centroid) f41: vec2h,
   @location(7) @interpolate(perspective, sample) f42: vec4f,
-  @location(0) f43: vec4u,
-  @location(4) f44: vec4i,
-  @location(3) @interpolate(flat, centroid) f45: vec2i,
+  @location(0) @interpolate(flat) f43: vec4u,
+  @location(4) @interpolate(flat) f44: vec4i,
+  @location(3) @interpolate(flat) f45: vec2i,
   @location(9) @interpolate(flat) f46: i32,
   @location(8) @interpolate(flat) f47: f32,
   @builtin(position) f48: vec4f,
@@ -27057,7 +27053,7 @@ var<workgroup> vw41: T0;
 struct FragmentOutput13 {
   @location(1) @interpolate(flat) f0: vec4u,
   @location(2) @interpolate(flat) f1: vec4u,
-  @location(0) @interpolate(flat, center) f2: vec4i,
+  @location(0) @interpolate(flat) f2: vec4i,
 }
 
 struct VertexOutput14 {
@@ -27065,7 +27061,7 @@ struct VertexOutput14 {
 }
 
 struct T1 {
-  @size(88) f0: array<atomic<u32>>,
+  f0: array<atomic<u32>>,
 }
 
 var<workgroup> vw43: atomic<i32>;

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-293750.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-293750.html
@@ -391,9 +391,9 @@ struct FragmentInput2 {
 struct VertexOutput0 {
   @location(14) location_14: vec2h,
   @location(3) location_3: f16,
-  @location(12) @interpolate(linear, either) location_12: f16,
-  @location(7) location_7: vec2u,
-  @location(1) @interpolate(flat, either) location_1: vec4h,
+  @location(12) @interpolate(linear) location_12: f16,
+  @location(7) @interpolate(flat) location_7: vec2u,
+  @location(1) @interpolate(flat) location_1: vec4h,
   @invariant @builtin(position) position: vec4f,
 }
 
@@ -491,14 +491,14 @@ struct FragmentOutput0 {
 fn unconst_u32(v: u32) -> u32 { return v; }
 
 struct VertexInput1 {
-  @location(0) @interpolate(flat, centroid) location_0: vec2i,
+  @location(0) @interpolate(flat) location_0: vec2i,
   @location(9) location_9: f16,
   @location(7) location_7: f32,
   @location(11) location_11: vec4h,
 }
 
 struct VertexInput3 {
-  @location(2) @interpolate(perspective, sample) location_2: vec2f,
+  @location(2) @interpolate(perspective) location_2: vec2f,
 }
 
 struct FragmentInput0 {
@@ -580,7 +580,7 @@ fn vertex0(@location(5) location_5: vec4u, @builtin(vertex_index) vertex_index: 
 
 /* used global variables: st4 */
 @fragment
-fn fragment0(a0: FragmentInput0, @location(1) location_1: vec4h, @location(12) @interpolate(linear, centroid) location_12: f16, @location(7) location_7: vec2u, @builtin(sample_index) sample_index: u32, a5: FragmentInput1, a6: FragmentInput2) -> FragmentOutput0 {
+fn fragment0(a0: FragmentInput0, @location(1) location_1: vec4h, @location(12) @interpolate(linear) location_12: f16, @location(7) @interpolate(flat) location_7: vec2u, @builtin(sample_index) sample_index: u32, a5: FragmentInput1, a6: FragmentInput2) -> FragmentOutput0 {
   var out: FragmentOutput0;
   fn0();
   fn0();
@@ -716,7 +716,7 @@ diagnostic(info, xyz);
 struct VertexInput8 {
   @builtin(vertex_index) vertex_index: u32,
   @location(2) @interpolate(flat) location_2: f32,
-  @location(3) @interpolate(flat, centroid) location_3: vec4f,
+  @location(3) @interpolate(flat) location_3: vec4f,
 }
 
 struct VertexInput9 {
@@ -737,22 +737,22 @@ struct T5 {
 var<private> vp4: vec4f = vec4f(0.01749, 0.1178, -0.4250, 0.3171e-21);
 
 struct FragmentOutput1 {
-  @location(3) @interpolate(linear, sample) location_3: vec4f,
+  @location(3) @interpolate(linear) location_3: vec4f,
   @location(0) location_0: vec2i,
 }
 
 var<private> vp2: vec2h = vec2h(13532.3, 23009.7);
 
 struct VertexInput6 {
-  @location(10) @interpolate(flat, centroid) location_10: vec4i,
+  @location(10) @interpolate(flat) location_10: vec4i,
   @location(14) location_14: vec2h,
-  @location(0) @interpolate(flat, center) location_0: i32,
+  @location(0) @interpolate(flat) location_0: i32,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
 
 struct FragmentInput4 {
-  @location(3) @interpolate(flat, sample) location_3: vec2u,
+  @location(3) @interpolate(flat) location_3: vec2u,
 }
 
 
@@ -767,7 +767,7 @@ struct T1 {
 struct VertexOutput1 {
   @builtin(position) position: vec4f,
   @location(8) location_8: f32,
-  @location(3) @interpolate(flat, sample) location_3: vec2u,
+  @location(3) @interpolate(flat) location_3: vec2u,
 }
 
 fn unconst_i32(v: i32) -> i32 { return v; }
@@ -806,16 +806,16 @@ var<private> vp1 = array(array(array(modf(f16(6815.6))), array(modf(f16(-4138.0)
 @id(44503) override override5: u32 = (338259277 % 103) + 1;
 
 struct FragmentInput5 {
-  @location(12) @interpolate(linear, either) location_12: f16,
+  @location(12) @interpolate(linear) location_12: f16,
   @align(16) @size(1152) f0: vec2i,
   @size(624) f1: array<T5, 2>,
 }
 
 
 struct VertexInput7 {
-  @location(15) @interpolate(flat, either) location_15: i32,
+  @location(15) @interpolate(flat) location_15: i32,
   @builtin(instance_index) instance_index: u32,
-  @location(12) @interpolate(linear, center) location_12: vec4f,
+  @location(12) @interpolate(linear) location_12: vec4f,
 }
 
 /* used global variables: buffer12 */
@@ -829,7 +829,7 @@ fn fn1() -> array<array<array<f16, 1>, 4>, 1> {
 
 /* zero global variables used */
 @vertex
-fn vertex1(a0: VertexInput6, a1: VertexInput7, @location(5) location_5: vec4u, @location(9) @interpolate(linear) location_9: vec4f, @location(6) location_6: vec4i, @location(4) location_4: vec2f, @location(8) location_8: vec2h, a7: VertexInput8, a8: VertexInput9, @location(7) @interpolate(flat, either) location_7: vec2u, @location(13) @interpolate(flat, center) location_13: u32, @location(11) location_11: f32) -> VertexOutput1 {
+fn vertex1(a0: VertexInput6, a1: VertexInput7, @location(5) location_5: vec4u, @location(9) @interpolate(linear) location_9: vec4f, @location(6) location_6: vec4i, @location(4) location_4: vec2f, @location(8) location_8: vec2h, a7: VertexInput8, a8: VertexInput9, @location(7) @interpolate(flat) location_7: vec2u, @location(13) @interpolate(flat) location_13: u32, @location(11) location_11: f32) -> VertexOutput1 {
   var out: VertexOutput1;
   var vf23: f32 = location_4[unconst_u32(1163486805)];
   for (var jj87=0u; jj87<3; jj87++) { vp1[unconst_u32(1229928460)][unconst_u32(698359182)][jj87].fract = f16(select(unconst_u32(509442499), unconst_u32(240136560), unconst_bool(true))); }
@@ -1569,17 +1569,17 @@ fn unconst_i32(v: i32) -> i32 { return v; }
 
 struct VertexOutput2 {
   @location(3) location_3: vec4h,
-  @location(11) @interpolate(flat, centroid) location_11: vec2i,
-  @location(12) @interpolate(flat, centroid) location_12: vec4i,
+  @location(11) @interpolate(flat) location_11: vec2i,
+  @location(12) @interpolate(flat) location_12: vec4i,
   @location(1) @interpolate(perspective) location_1: f32,
   @builtin(position) position: vec4f,
-  @location(13) @interpolate(flat, centroid) location_13: i32,
+  @location(13) @interpolate(flat) location_13: i32,
 }
 
 var<workgroup> vw2: array<array<array<atomic<u32>, 1>, 28>, 1>;
 
 struct VertexInput12 {
-  @location(12) @interpolate(linear, either) location_12: f16,
+  @location(12) @interpolate(linear) location_12: f16,
 }
 
 fn unconst_u32(v: u32) -> u32 { return v; }
@@ -1597,8 +1597,8 @@ struct ComputeInput4 {
 }
 
 struct VertexInput10 {
-  @location(8) @interpolate(flat, center) location_8: u32,
-  @location(11) @interpolate(flat, centroid) location_11: u32,
+  @location(8) @interpolate(flat) location_8: u32,
+  @location(11) @interpolate(flat) location_11: u32,
   @location(3) location_3: vec4u,
   @location(9) @interpolate(flat) location_9: vec2u,
   @location(1) location_1: vec2h,
@@ -2096,11 +2096,11 @@ let shaderModule4 = device0.createShaderModule({
 enable f16;
 
 struct VertexOutput3 {
-  @location(1) location_1: u32,
-  @location(2) location_2: vec4i,
-  @location(6) @interpolate(flat, sample) location_6: vec2i,
+  @location(1) @interpolate(flat) location_1: u32,
+  @location(2) @interpolate(flat) location_2: vec4i,
+  @location(6) @interpolate(flat) location_6: vec2i,
   @builtin(position) position: vec4f,
-  @location(12) @interpolate(flat, centroid) location_12: vec2i,
+  @location(12) @interpolate(flat) location_12: vec2i,
 }
 
 fn unconst_bool(v: bool) -> bool { return v; }
@@ -2188,8 +2188,8 @@ fn fn3() -> array<vec2<bool>, 2> {
 struct VertexInput14 {
   @location(10) location_10: i32,
   @location(4) location_4: vec2i,
-  @location(15) @interpolate(linear, first) location_15: vec4f,
-  @location(11) @interpolate(flat, sample) location_11: vec4u,
+  @location(15) @interpolate(linear) location_15: vec4f,
+  @location(11) @interpolate(flat) location_11: vec4u,
 }
 
 @group(0) @binding(4) var<storage, read_write> buffer42: array<array<array<array<array<f16, 1>, 29>, 1>, 1>>;
@@ -2221,7 +2221,7 @@ fn fn0() -> vec2f {
 
 /* zero global variables used */
 @vertex
-fn vertex3(@location(1) location_1: vec4i, a1: VertexInput13, a2: VertexInput14, a3: VertexInput15, @location(9) @interpolate(flat) location_9: vec2u, a5: VertexInput16, @location(13) @interpolate(flat) location_13: vec2i, @location(3) location_3: vec2f, a8: VertexInput17, @location(6) @interpolate(flat, first) location_6: vec2u, @location(0) location_0: vec4u, @location(12) @interpolate(perspective, either) location_12: vec2h, @builtin(instance_index) instance_index: u32) -> VertexOutput3 {
+fn vertex3(@location(1) location_1: vec4i, a1: VertexInput13, a2: VertexInput14, a3: VertexInput15, @location(9) @interpolate(flat) location_9: vec2u, a5: VertexInput16, @location(13) @interpolate(flat) location_13: vec2i, @location(3) location_3: vec2f, a8: VertexInput17, @location(6) @interpolate(flat) location_6: vec2u, @location(0) location_0: vec4u, @location(12) @interpolate(perspective) location_12: vec2h, @builtin(instance_index) instance_index: u32) -> VertexOutput3 {
   var out: VertexOutput3;
   var vf45: mat3x3f = transpose(mat3x3f(unconst_f32(0.02210), unconst_f32(0.06663e-29), unconst_f32(-0.2306), unconst_f32(0.03241e-40), unconst_f32(0.06883e-43), unconst_f32(0.1397e38), unconst_f32(-0.6149e-41), unconst_f32(0.05078e-13), unconst_f32(0.07371)));
   out.location_1 = bitcast<u32>(cos(unconst_f32(0.1994)));
@@ -2484,9 +2484,9 @@ fn unconst_f16(v: f16) -> f16 { return v; }
 fn unconst_bool(v: bool) -> bool { return v; }
 
 struct FragmentInput17 {
-  @location(13) location_13: vec2i,
+  @location(13) @interpolate(flat) location_13: vec2i,
   @location(12) location_12: vec4f,
-  @location(1) @interpolate(flat, sample) location_1: vec4i,
+  @location(1) @interpolate(flat) location_1: vec4i,
   @location(10) location_10: f32,
 }
 
@@ -2498,18 +2498,18 @@ struct FragmentOutput3 {
 fn unconst_i32(v: i32) -> i32 { return v; }
 
 struct VertexOutput5 {
-  @location(0) location_0: vec2u,
-  @location(8) location_8: vec2u,
-  @location(13) @interpolate(linear, first) location_13: vec4f,
-  @location(6) @interpolate(perspective, center) location_6: vec4f,
+  @location(0) @interpolate(flat) location_0: vec2u,
+  @location(8) @interpolate(flat) location_8: vec2u,
+  @location(13) @interpolate(linear) location_13: vec4f,
+  @location(6) @interpolate(perspective) location_6: vec4f,
   @location(14) location_14: f32,
-  @location(5) @interpolate(linear, either) location_5: f16,
+  @location(5) @interpolate(linear) location_5: f16,
   @builtin(position) position: vec4f,
-  @location(7) location_7: vec4u,
+  @location(7) @interpolate(flat) location_7: vec4u,
   @location(9) location_9: f16,
-  @location(1) @interpolate(flat, centroid) location_1: vec2h,
-  @location(2) location_2: vec2u,
-  @location(4) location_4: i32,
+  @location(1) @interpolate(flat) location_1: vec2h,
+  @location(2) @interpolate(flat) location_2: vec2u,
+  @location(4) @interpolate(flat) location_4: i32,
 }
 
 /* used global variables: buffer57, buffer58 */
@@ -2530,7 +2530,7 @@ fn unconst_f32(v: f32) -> f32 { return v; }
 @group(0) @binding(4) var<storage, read_write> buffer57: array<array<array<array<array<f16, 1>, 29>, 1>, 1>>;
 
 struct FragmentInput19 {
-  @location(8) @interpolate(linear, either) location_8: vec2f,
+  @location(8) @interpolate(linear) location_8: vec2f,
   @location(14) @interpolate(flat) location_14: vec2u,
 }
 
@@ -2543,11 +2543,11 @@ struct ComputeInput6 {
 }
 
 struct FragmentInput18 {
-  @location(9) location_9: vec2i,
+  @location(9) @interpolate(flat) location_9: vec2i,
 }
 
 struct FragmentInput20 {
-  @location(11) @interpolate(perspective, first) location_11: vec4h,
+  @location(11) @interpolate(perspective) location_11: vec4h,
   @location(6) location_6: vec4f,
   @location(0) @interpolate(flat) location_0: vec2i,
 }
@@ -2560,7 +2560,7 @@ struct T1 {
 
 /* used global variables: et8 */
 @vertex
-fn vertex5(@location(2) location_2: f16, @location(7) location_7: vec4f, a2: VertexInput23, @location(8) @interpolate(flat, either) location_8: i32, @location(9) @interpolate(flat, center) location_9: u32) -> VertexOutput5 {
+fn vertex5(@location(2) location_2: f16, @location(7) location_7: vec4f, a2: VertexInput23, @location(8) @interpolate(flat) location_8: i32, @location(9) @interpolate(flat) location_9: u32) -> VertexOutput5 {
   var out: VertexOutput5;
   let vf61: f16 = fma(unconst_f16(29448.0), vec4h(location_7.yyxx.xwyy.yxxx).z, unconst_f16(8773.8));
   out.location_5 -= smoothstep(vec3h(unconst_f16(7086.9), unconst_f16(6882.0), unconst_f16(11010.6)), vec3h(f16(out.location_14)), vec3h(unconst_f16(-9225.2), unconst_f16(14348.4), unconst_f16(1396.3)))[1];
@@ -2570,7 +2570,7 @@ fn vertex5(@location(2) location_2: f16, @location(7) location_7: vec4f, a2: Ver
 
 /* used global variables: buffer59 */
 @fragment
-fn fragment6(@builtin(position) position: vec4f, a1: FragmentInput17, a2: FragmentInput18, a3: FragmentInput19, a4: FragmentInput20, @location(7) @interpolate(linear, sample) location_7: vec2h, @location(15) location_15: vec2i, a7: FragmentInput21, @location(4) location_4: vec4f, a9: FragmentInput22) -> FragmentOutput3 {
+fn fragment6(@builtin(position) position: vec4f, a1: FragmentInput17, a2: FragmentInput18, a3: FragmentInput19, a4: FragmentInput20, @location(7) @interpolate(linear) location_7: vec2h, @location(15) @interpolate(flat) location_15: vec2i, a7: FragmentInput21, @location(4) location_4: vec4f, a9: FragmentInput22) -> FragmentOutput3 {
   var out: FragmentOutput3;
   var vf63: u32 = pack4xU8Clamp(vec4u(unconst_u32(73128350), unconst_u32(1247516492), unconst_u32(1182335425), unconst_u32(421641405)));
   buffer59.location_5 -= vec2f((*&buffer59).location_5[unconst_u32(552354661)]);
@@ -3120,8 +3120,8 @@ struct FragmentOutput4 {
 }
 
 struct FragmentInput23 {
-  @location(3) @interpolate(flat, centroid) location_3: vec2i,
-  @location(6) @interpolate(flat, center) location_6: f16,
+  @location(3) @interpolate(flat) location_3: vec2i,
+  @location(6) @interpolate(flat) location_6: f16,
   @location(11) location_11: vec2f,
 }
 
@@ -3162,23 +3162,23 @@ struct T2 {
 }
 
 struct VertexOutput6 {
-  @location(5) location_5: vec4u,
+  @location(5) @interpolate(flat) location_5: vec4u,
   @builtin(position) position: vec4f,
   @location(0) @interpolate(flat) location_0: vec2u,
   @location(4) location_4: f32,
   @location(11) location_11: vec2f,
-  @location(8) location_8: vec2i,
-  @location(15) @interpolate(flat, centroid) location_15: vec2i,
+  @location(8) @interpolate(flat) location_8: vec2i,
+  @location(15) @interpolate(flat) location_15: vec2i,
   @location(9) @interpolate(flat) location_9: vec4i,
-  @location(2) location_2: vec4i,
-  @location(3) @interpolate(flat, centroid) location_3: vec2i,
-  @location(7) location_7: vec4u,
-  @location(6) @interpolate(flat, center) location_6: f16,
+  @location(2) @interpolate(flat) location_2: vec4i,
+  @location(3) @interpolate(flat) location_3: vec2i,
+  @location(7) @interpolate(flat) location_7: vec4u,
+  @location(6) @interpolate(flat) location_6: f16,
 }
 
 struct VertexInput25 {
   @location(5) location_5: u32,
-  @location(9) @interpolate(flat, either) location_9: vec4f,
+  @location(9) @interpolate(flat) location_9: vec4f,
   @builtin(vertex_index) vertex_index: u32,
 }
 
@@ -3196,18 +3196,18 @@ fn unconst_f32(v: f32) -> f32 { return v; }
 
 struct VertexInput27 {
   @location(1) location_1: vec4u,
-  @location(6) @interpolate(flat, first) location_6: vec2u,
+  @location(6) @interpolate(flat) location_6: vec2u,
 }
 
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 struct VertexInput24 {
   @location(15) location_15: vec2u,
-  @location(13) @interpolate(linear, center) location_13: vec2f,
+  @location(13) @interpolate(linear) location_13: vec2f,
   @location(14) location_14: vec4h,
   @location(8) @interpolate(flat) location_8: vec2i,
   @location(10) location_10: vec4i,
-  @location(4) @interpolate(flat, either) location_4: u32,
+  @location(4) @interpolate(flat) location_4: u32,
 }
 
 fn unconst_i32(v: i32) -> i32 { return v; }
@@ -3221,7 +3221,7 @@ struct T6 {
 
 /* zero global variables used */
 @vertex
-fn vertex6(a0: VertexInput24, a1: VertexInput25, a2: VertexInput26, @location(12) @interpolate(flat, sample) location_12: vec4u, a4: VertexInput27, @location(2) @interpolate(perspective, center) location_2: f16, @builtin(instance_index) instance_index: u32, @location(0) location_0: vec4u, a8: VertexInput28, a9: VertexInput29) -> VertexOutput6 {
+fn vertex6(a0: VertexInput24, a1: VertexInput25, a2: VertexInput26, @location(12) @interpolate(flat) location_12: vec4u, a4: VertexInput27, @location(2) @interpolate(perspective) location_2: f16, @builtin(instance_index) instance_index: u32, @location(0) location_0: vec4u, a8: VertexInput28, a9: VertexInput29) -> VertexOutput6 {
   var out: VertexOutput6;
   out.location_5 <<= bitcast<vec4u>(unpack2x16snorm(unconst_u32(2530682028)).yyyx);
   _ = fn0(&vp14[5].fract, &vp17[unconst_u32(182078122)][0]);
@@ -3694,11 +3694,11 @@ var<workgroup> vw7: atomic<u32>;
 
 struct VertexOutput8 {
   @invariant @builtin(position) position: vec4f,
-  @location(10) location_10: vec2i,
-  @location(11) @interpolate(flat, centroid) location_11: vec4h,
-  @location(14) location_14: vec4i,
-  @location(7) @interpolate(perspective, sample) location_7: vec2h,
-  @location(8) @interpolate(flat, either) location_8: f16,
+  @location(10) @interpolate(flat) location_10: vec2i,
+  @location(11) @interpolate(flat) location_11: vec4h,
+  @location(14) @interpolate(flat) location_14: vec4i,
+  @location(7) @interpolate(perspective) location_7: vec2h,
+  @location(8) @interpolate(flat) location_8: f16,
 }
 
 var<workgroup> vw5: vec4h;
@@ -3714,7 +3714,7 @@ struct VertexInput34 {
 var<workgroup> vw6: array<vec2i, 4>;
 
 struct VertexInput37 {
-  @location(11) @interpolate(perspective, either) location_11: vec2f,
+  @location(11) @interpolate(perspective) location_11: vec2f,
 }
 
 struct VertexInput36 {
@@ -3722,7 +3722,7 @@ struct VertexInput36 {
 }
 
 struct FragmentOutput5 {
-  @location(0) @interpolate(perspective, centroid) location_0: vec4f,
+  @location(0) @interpolate(perspective) location_0: vec4f,
   @location(7) location_7: vec4u,
 }
 
@@ -3759,12 +3759,12 @@ struct T0 {
 }
 
 struct VertexInput35 {
-  @location(10) @interpolate(flat, sample) location_10: u32,
+  @location(10) @interpolate(flat) location_10: u32,
 }
 
 /* zero global variables used */
 @vertex
-fn vertex8(@location(5) location_5: vec2u, @location(2) @interpolate(flat) location_2: u32, @location(4) location_4: f32, a3: VertexInput32, @location(12) location_12: f16, a5: VertexInput33, a6: VertexInput34, a7: VertexInput35, a8: VertexInput36, @location(15) location_15: vec4f, a10: VertexInput37, @location(3) @interpolate(flat, either) location_3: vec4u) -> VertexOutput8 {
+fn vertex8(@location(5) location_5: vec2u, @location(2) @interpolate(flat) location_2: u32, @location(4) location_4: f32, a3: VertexInput32, @location(12) location_12: f16, a5: VertexInput33, a6: VertexInput34, a7: VertexInput35, a8: VertexInput36, @location(15) location_15: vec4f, a10: VertexInput37, @location(3) @interpolate(flat) location_3: vec4u) -> VertexOutput8 {
   var out: VertexOutput8;
   out.location_14 |= firstTrailingBit(vec2i(unconst_i32(821815081), unconst_i32(366373640))).xxyx;
   var vf72: vec4u = unpack4xU8(unconst_u32(186391009));
@@ -3966,13 +3966,13 @@ struct FragmentOutput7 {
 fn unconst_bool(v: bool) -> bool { return v; }
 
 struct FragmentInput33 {
-  @location(3) @interpolate(flat, first) location_3: u32,
+  @location(3) @interpolate(flat) location_3: u32,
 }
 
 struct FragmentInput34 {
   @builtin(position) position: vec4f,
-  @location(11) location_11: vec4i,
-  @location(1) location_1: vec4u,
+  @location(11) @interpolate(flat) location_11: vec4i,
+  @location(1) @interpolate(flat) location_1: vec4u,
 }
 
 fn unconst_i32(v: i32) -> i32 { return v; }
@@ -3982,9 +3982,9 @@ struct T0 {
 }
 
 struct FragmentInput32 {
-  @location(5) @interpolate(perspective, sample) location_5: vec2h,
-  @location(14) @interpolate(perspective, either) location_14: vec2h,
-  @location(7) @interpolate(linear, centroid) location_7: vec2h,
+  @location(5) @interpolate(perspective) location_5: vec2h,
+  @location(14) @interpolate(perspective) location_14: vec2h,
+  @location(7) @interpolate(linear) location_7: vec2h,
 }
 
 /* used global variables: st14, st15 */
@@ -4004,8 +4004,8 @@ fn fn2(a0: array<array<array<array<array<vec2i, 1>, 1>, 4>, 1>, 1>) -> vec2<bool
 override override35: u32 = (167572716 % 103) + 1;
 
 struct FragmentInput30 {
-  @location(4) @interpolate(flat, centroid) location_4: vec2u,
-  @location(0) location_0: vec2i,
+  @location(4) @interpolate(flat) location_4: vec2u,
+  @location(0) @interpolate(flat) location_0: vec2i,
 }
 
 @id(38647) override override36: u32;
@@ -4046,16 +4046,16 @@ struct FragmentInput31 {
 }
 
 struct FragmentInput35 {
-  @location(8) @interpolate(flat, either) location_8: f16,
-  @location(14) location_14: vec4i,
-  @location(10) location_10: vec2i,
+  @location(8) @interpolate(flat) location_8: f16,
+  @location(14) @interpolate(flat) location_14: vec4i,
+  @location(10) @interpolate(flat) location_10: vec2i,
 }
 
 fn unconst_f16(v: f16) -> f16 { return v; }
 
 /* zero global variables used */
 @fragment
-fn fragment10(@location(9) @interpolate(flat, centroid) location_9: i32, a1: FragmentInput30, @location(13) @interpolate(perspective) location_13: vec4f, a3: FragmentInput31, @location(10) @interpolate(flat, centroid) location_10: vec2u, a5: FragmentInput32, a6: FragmentInput33, @location(15) location_15: f16, @location(2) @interpolate(flat, center) location_2: vec4i, a9: FragmentInput34, @location(12) location_12: vec2u, @location(6) location_6: vec4h) -> FragmentOutput6 {
+fn fragment10(@location(9) @interpolate(flat) location_9: i32, a1: FragmentInput30, @location(13) @interpolate(perspective) location_13: vec4f, a3: FragmentInput31, @location(10) @interpolate(flat) location_10: vec2u, a5: FragmentInput32, a6: FragmentInput33, @location(15) location_15: f16, @location(2) @interpolate(flat) location_2: vec4i, a9: FragmentInput34, @location(12) @interpolate(flat) location_12: vec2u, @location(6) location_6: vec4h) -> FragmentOutput6 {
   var out: FragmentOutput6;
   out.sample_mask = a1.location_4[0];
   fn1();
@@ -4065,7 +4065,7 @@ fn fragment10(@location(9) @interpolate(flat, centroid) location_9: i32, a1: Fra
 
 /* used global variables: st14 */
 @fragment
-fn fragment11(a0: FragmentInput35, @location(11) @interpolate(linear, first) location_11: vec4h, @location(7) @interpolate(perspective, either) location_7: vec2h, a3: FragmentInput36) -> FragmentOutput7 {
+fn fragment11(a0: FragmentInput35, @location(11) @interpolate(linear) location_11: vec4h, @location(7) @interpolate(perspective) location_7: vec2h, a3: FragmentInput36) -> FragmentOutput7 {
   var out: FragmentOutput7;
   return out;
   _ = override36;

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
@@ -9,69 +9,9 @@ PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="";sampling=
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="";sampling="perspective"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling=""
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="center" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, center) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="centroid" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, centroid) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="sample" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, sample) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="center"
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="centroid"
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="sample"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="first"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="either"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="flat"
@@ -81,48 +21,8 @@ PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="center"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="sample"
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, first) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, either) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="first"
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="either"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="flat"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="perspective"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="linear"
@@ -130,48 +30,8 @@ PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sam
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="center"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="sample"
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, first) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, either) value : f32,
-    };
-
-    @vertex
-        fn main(in : S) -> @builtin(position) vec4<f32> {
-          return vec4<f32>();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="first"
+PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="either"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="flat"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="perspective"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="linear"
@@ -230,72 +90,9 @@ PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="";sampling
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="";sampling="perspective"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling=""
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="center" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, center) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="centroid" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, centroid) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="sample" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, sample) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="center"
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="centroid"
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="sample"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="first"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="either"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="flat"
@@ -305,50 +102,8 @@ PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspectiv
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="center"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="sample"
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, first) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, either) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="first"
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="either"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="flat"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="perspective"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="linear"
@@ -356,50 +111,8 @@ PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sa
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="center"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="sample"
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, first) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, either) value : f32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="first"
+PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="either"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="flat"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="perspective"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="linear"
@@ -458,69 +171,9 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="";samplin
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling=""
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="center" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, center) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="centroid" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, centroid) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="sample" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, sample) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="center"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="centroid"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="sample"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="first"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="flat"
@@ -530,48 +183,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspecti
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, first) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, either) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="linear"
@@ -579,48 +192,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";s
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, first) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, either) value : f32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="linear"
@@ -679,57 +252,9 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="";sampli
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling=""
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="center" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(flat, center) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="centroid" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(flat, centroid) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="sample" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(flat, sample) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="center"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="centroid"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="sample"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="first"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="flat"
@@ -739,40 +264,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspect
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, first) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, either) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="linear"
@@ -780,40 +273,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, first) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, either) value : f32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="linear"
@@ -872,69 +333,9 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="";sampli
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling=""
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="center" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, center) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="centroid" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, centroid) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="sample" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(flat, sample) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="center"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="centroid"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="sample"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="first"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="flat"
@@ -944,48 +345,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspect
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, first) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, either) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="linear"
@@ -993,48 +354,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, first) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, either) value : f32,
-    };
-
-    @fragment
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="linear"
@@ -1093,57 +414,9 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="";sampl
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling=""
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="center" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(flat, center) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="centroid" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(flat, centroid) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="sample" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(flat, sample) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="center"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="centroid"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="sample"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="first"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="flat"
@@ -1153,40 +426,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspec
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(perspective, first) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(perspective, either) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="linear"
@@ -1194,40 +435,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="center"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="sample"
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="first" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(linear, first) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="either" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main() -> @location(0)@interpolate(linear, either) f32 {
-          return f32();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="first"
+PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="either"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="flat"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="perspective"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="linear"
@@ -1284,207 +493,18 @@ PASS :require_location:stage="fragment";attribute="%40location(0)";use_struct=tr
 PASS :require_location:stage="fragment";attribute="%40location(0)";use_struct=false
 PASS :require_location:stage="fragment";attribute="%40builtin(position)";use_struct=true
 PASS :require_location:stage="fragment";attribute="%40builtin(position)";use_struct=false
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute=""
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : i32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute=""
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(perspective)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20center)"
@@ -1497,207 +517,18 @@ PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40in
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20center)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)"
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute=""
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : u32,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute=""
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(perspective)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20center)"
@@ -1710,207 +541,18 @@ PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40in
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20center)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)"
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute=""
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : vec2<i32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute=""
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"
@@ -1923,207 +565,18 @@ PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attrib
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute=""
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : vec4<u32>,
-      @builtin(position) position : vec4<f32>,
-    };
-
-    @vertex
-        fn main() -> S {
-          return S();
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute=""
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"
@@ -2136,1417 +589,107 @@ PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attrib
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute=""
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : i32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, center) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, centroid) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute=""
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, sample) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, center) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, centroid) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, sample) value : i32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute=""
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : u32,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, center) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, centroid) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute=""
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, sample) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, center) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, centroid) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, sample) value : u32)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute=""
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : vec2<i32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, center) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, centroid) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute=""
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, sample) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, center) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, centroid) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, sample) value : vec2<i32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, center) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, centroid) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute=""
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(perspective, sample) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, center) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, centroid) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    struct S {
-      @location(0)@interpolate(linear, sample) value : vec4<u32>,
-    };
-
-    @fragment
-        fn main(in : S)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, center) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, centroid) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute=""
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat,%20either)"
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(perspective, sample) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, center) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, centroid) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    @fragment
-        fn main(@location(0)@interpolate(linear, sample) value : vec4<u32>)  {
-
-        }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
+PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"
 PASS :duplicate:attr=""
 PASS :duplicate:attr="%40interpolate(flat)"
 PASS :interpolation_validation:attr="valid"
 PASS :interpolation_validation:attr="no_space"
-FAIL :interpolation_validation:attr="trailing_comma_one_arg" assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    2:35: error: Expected a Identifier, but got a )
-
-    ---- shader ----
-
-    @vertex fn main(@interpolate(flat,) @location(0) b: f32) ->
-        @builtin(position) vec4<f32> {
-      return vec4f(0);
-    }
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    2:34: Expected a Identifier, but got a )
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :interpolation_validation:attr="trailing_comma_one_arg"
 PASS :interpolation_validation:attr="trailing_comma_two_arg"
 PASS :interpolation_validation:attr="newline"
 PASS :interpolation_validation:attr="comment"

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1957,8 +1957,9 @@ webkit.org/b/287122 imported/w3c/web-platform-tests/html/capability-delegation/d
 [ arm64 ] fast/webgpu/regression/repro_283595-for.html [ Skip ]
 [ arm64 ] fast/webgpu/regression/repro_283595-loop.html [ Skip ]
 [ arm64 ] fast/webgpu/regression/repro_283595-while.html [ Skip ]
-[ arm64 ] fast/webgpu/nocrash/fuzz-284937.html [ Skip ]
 [ arm64 ] fast/webgpu/nocrash/fuzz-287444.html [ Skip ]
+
+webkit.org/b/309524 fast/webgpu/nocrash/fuzz-284937.html [ Skip ]
 
 webkit.org/b/287865 pdf/two-pages-continuous-to-discrete.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -69,6 +69,7 @@ private:
     void validateBuiltinIO(const SourceSpan&, const Type*, ShaderStage, Builtin, Direction, Builtins&);
     void validateLocationIO(const SourceSpan&, const Type*, ShaderStage, unsigned, Locations&);
     void validateStructIO(ShaderStage, const Types::Struct&, Direction, Builtins&, Locations&);
+    void validateInterpolationIO(const SourceSpan&, ShaderStage, Direction, const Type*, const std::optional<AST::Interpolation>&);
     void validateAlignment(const SourceSpan&, AddressSpace, const Type*);
 
     template<typename T>
@@ -650,6 +651,18 @@ void AttributeValidator::validateInterpolation(const SourceSpan& span, const std
 {
     if (interpolation && !location) [[unlikely]]
         error(span, "@interpolate is only allowed on declarations that have a @location attribute"_s);
+    if (!interpolation)
+        return;
+    auto type = interpolation->type;
+    auto sampling = interpolation->sampling;
+
+    if (type == InterpolationType::Flat) {
+        if (sampling != InterpolationSampling::First && sampling != InterpolationSampling::Either) [[unlikely]]
+            error(span, "flat interpolation attribute must have a sampling parameter of `first` or `either`"_s);
+    } else {
+        if (sampling != InterpolationSampling::Center && sampling != InterpolationSampling::Centroid && sampling != InterpolationSampling::Sample) [[unlikely]]
+            error(span, makeString(toString(type), " interpolation attribute must have a sampling parameter of `center`, `centroid` or `sample`"_s));
+    }
 }
 
 void AttributeValidator::validateInvariant(const SourceSpan& span, const std::optional<Builtin>& builtin, bool invariant)
@@ -713,6 +726,7 @@ std::optional<FailedCheck> AttributeValidator::validateIO()
 
             if (auto location = parameter.location()) {
                 CHECK(validateLocationIO(span, type, entryPoint.stage, *location, locations));
+                CHECK(validateInterpolationIO(span, entryPoint.stage, Direction::Input, type, parameter.interpolation()));
                 continue;
             }
 
@@ -833,6 +847,23 @@ void AttributeValidator::validateLocationIO(const SourceSpan& span, const Type* 
         error(span, "@location("_s, location, ") appears multiple times"_s);
 }
 
+void AttributeValidator::validateInterpolationIO(const SourceSpan& span, ShaderStage stage, Direction direction, const Type* type, const std::optional<AST::Interpolation>& interpolation)
+{
+    if (!(stage == ShaderStage::Vertex && direction == Direction::Output) && !(stage == ShaderStage::Fragment && direction == Direction::Input)) [[unlikely]]
+        return;
+
+    if (!satisfies(type, Constraints::Integer)) {
+        auto* vector = std::get_if<Types::Vector>(type);
+        if (!vector || !satisfies(vector->element, Constraints::Integer)) [[unlikely]]
+            return;
+    }
+
+    if (!interpolation || interpolation->type != InterpolationType::Flat) [[unlikely]] {
+        auto location = stage == ShaderStage::Vertex ? "vertex output"_s : "fragment input"_s;
+        error(span, makeString("integral user-defined "_s, location, " must have a @interpolate(flat) attribute"_s));
+    }
+}
+
 void AttributeValidator::validateStructIO(ShaderStage stage, const Types::Struct& structType, Direction direction, Builtins& builtins, Locations& locations)
 {
     for (auto& member : structType.structure.members()) {
@@ -848,6 +879,9 @@ void AttributeValidator::validateStructIO(ShaderStage stage, const Types::Struct
 
         if (auto location = member.location()) {
             validateLocationIO(span, type, stage, *location, locations);
+            if (hasError()) [[unlikely]]
+                return;
+            validateInterpolationIO(span, stage, direction, type, member.interpolation());
             if (hasError()) [[unlikely]]
                 return;
             continue;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1122,6 +1122,7 @@ static ASCIILiteral convertToSampleMode(InterpolationType type, InterpolationSam
         switch (sampleType) {
         case InterpolationSampling::First:
         case InterpolationSampling::Either:
+            RELEASE_ASSERT_NOT_REACHED();
         case InterpolationSampling::Center:
             return "center_no_perspective"_s;
         case InterpolationSampling::Centroid:
@@ -1133,6 +1134,7 @@ static ASCIILiteral convertToSampleMode(InterpolationType type, InterpolationSam
         switch (sampleType) {
         case InterpolationSampling::First:
         case InterpolationSampling::Either:
+            RELEASE_ASSERT_NOT_REACHED();
         case InterpolationSampling::Center:
             return "center_perspective"_s;
         case InterpolationSampling::Centroid:

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -752,19 +752,30 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
         auto* interpolationType = parseInterpolationType(interpolate);
         if (!interpolationType)
             FAIL("Unknown interpolation type. Expected 'flat', 'linear' or 'perspective'"_s);
-        InterpolationSampling sampleType { InterpolationSampling::Center };
+        std::optional<InterpolationSampling> sampleType;
         if (current().type == TokenType::Comma) {
             consume();
-            PARSE(sampling, Identifier);
-            auto* interpolationSampling = parseInterpolationSampling(sampling);
-            if (!interpolationSampling)
-                FAIL("Unknown interpolation sampling. Expected 'center', 'centroid', 'sample', 'first' or 'either"_s);
-            sampleType = *interpolationSampling;
+
+            if (current().type == TokenType::Identifier) {
+                PARSE(sampling, Identifier);
+                auto* interpolationSampling = parseInterpolationSampling(sampling);
+                if (!interpolationSampling)
+                    FAIL("Unknown interpolation sampling. Expected 'center', 'centroid', 'sample', 'first' or 'either"_s);
+                sampleType = *interpolationSampling;
+                if (current().type == TokenType::Comma)
+                    consume();
+            }
         }
-        if (current().type == TokenType::Comma)
-            consume();
+
+        if (!sampleType) {
+            if (*interpolationType == InterpolationType::Flat)
+                sampleType = InterpolationSampling::First;
+            else
+                sampleType = InterpolationSampling::Center;
+        }
+
         CONSUME_TYPE(ParenRight);
-        RETURN_ARENA_NODE(InterpolateAttribute, *interpolationType, sampleType);
+        RETURN_ARENA_NODE(InterpolateAttribute, *interpolationType, *sampleType);
     }
 
     if (ident.ident == "size"_s) {

--- a/Tools/TestWebKitAPI/Tests/WGSL/shaders/struct.wgsl
+++ b/Tools/TestWebKitAPI/Tests/WGSL/shaders/struct.wgsl
@@ -34,11 +34,11 @@ fn main()
 }
 
 struct S1 {
-@location(0) x: i32,
+@location(0) @interpolate(flat) x: i32,
 }
 
 struct S2 {
-@location(1) x: i32,
+@location(1) @interpolate(flat) x: i32,
 }
 
 @fragment


### PR DESCRIPTION
#### b9692262ea64c2a55f54c6008115d0f565630788
<pre>
[WGSL] webgpu:shader,validation,shader_io,interpolate:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=309023">https://bugs.webkit.org/show_bug.cgi?id=309023</a>
<a href="https://rdar.apple.com/148085740">rdar://148085740</a>

Reviewed by Mike Wyrzykowski.

We were missing validations around which interpolation sampling are allowed for
each interpolation type, as well as missing validation for required interpolation
annotations for integer inputs and outputs.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt:
* Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h:
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::validateInterpolation):
(WGSL::AttributeValidator::validateIO):
(WGSL::AttributeValidator::validateInterpolationIO):
(WGSL::AttributeValidator::validateStructIO):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::convertToSampleMode):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/308968@main">https://commits.webkit.org/308968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08c02feb8e5730ba7d0d998e77404cd36f155308

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102374 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da779241-10d9-47a1-98f4-0e0cab1c82f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21535 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114825 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81762 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d519481a-586b-41c7-ba90-c18e38c20dc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95583 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16123 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5480 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160113 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122877 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33484 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77655 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10156 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84871 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20801 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->