### PR TITLE
[flex] Fix widths for flex items with percentage-height descendants

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-basis-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-basis-013-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL .container 1 assert_equals:
-<div class="container row"><div data-expected-height="50" data-expected-width="50" class="item" style="flex-basis: auto;"><canvas height="5" width="5"></canvas></div></div>
-width expected 50 but got 5
-FAIL .container 2 assert_equals:
-<div class="container row"><div data-expected-height="50" data-expected-width="50" class="item" style="flex-basis: content;"><canvas height="5" width="5"></canvas></div></div>
-width expected 50 but got 5
+PASS .container 1
+PASS .container 2
 FAIL .container 3 assert_equals:
 <div class="container row"><div data-expected-height="50" data-expected-width="50" class="item" style="flex-basis: min-content;"><canvas height="5" width="5"></canvas></div></div>
 width expected 50 but got 5

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-percentage-height-img-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-percentage-height-img-001-expected.txt
@@ -1,0 +1,4 @@
+
+PASS .flex-item 1
+PASS .flex-item 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-percentage-height-img-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-percentage-height-img-001.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: flex item width with percentage-height replaced element</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-main-item">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=296562">
+<meta name="assert" content="Flex items containing a percentage-height replaced
+  element should resolve their intrinsic width correctly using the container's
+  definite cross size for aspect ratio calculations.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+.flex-container {
+    display: flex;
+    height: 100%;
+}
+.flex-item {
+    border: 5px solid yellow;
+}
+canvas {
+    height: 100%;
+}
+</style>
+<div style="height: 200px">
+    <div class="flex-container">
+        <div class="flex-item" style="flex-basis: 0" data-expected-width="200" data-expected-height="200">
+            <canvas width="400" height="400" data-expected-width="190" data-expected-height="190"></canvas>
+        </div>
+    </div>
+</div>
+<div style="height: 200px">
+    <div class="flex-container">
+        <div class="flex-item" style="flex-basis: auto" data-expected-width="200" data-expected-height="200">
+            <canvas width="400" height="400" data-expected-width="190" data-expected-height="190"></canvas>
+        </div>
+    </div>
+</div>
+<script>
+checkLayout(".flex-item");
+</script>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -273,6 +273,53 @@ private:
     std::optional<LayoutUnit> m_previousOverridingBorderBoxLogicalHeight;
 };
 
+// Sets m_inFlexItemIntrinsicWidthComputation and applies the container's definite
+// cross size as the flex item's cross-axis override when applicable. Clears all
+// overrides otherwise.
+//
+// When setNeedsPreferredWidthsUpdate is true, the flex item's preferred widths are
+// invalidated so that min/maxPreferredLogicalWidth() will recompute them with the
+// cross-axis override in place. The destructor ASSERTs the dirty flag was consumed.
+enum class InvalidatePreferredWidths : bool { No, Yes };
+
+class ScopedCrossAxisOverrideForFlexItem {
+public:
+    ScopedCrossAxisOverrideForFlexItem(const RenderFlexibleBox& flexBox, RenderBox& flexItem, InvalidatePreferredWidths invalidatePreferredWidths)
+        : m_intrinsicWidthComputation(flexBox.m_inFlexItemIntrinsicWidthComputation, true)
+#if ASSERT_ENABLED
+        , m_flexItem(flexItem)
+#endif
+    {
+        if (flexBox.flexItemCrossSizeShouldUseContainerCrossSize(flexItem) && !flexBox.isFlexItem()) {
+            auto axis = flexBox.mainAxisIsFlexItemInlineAxis(flexItem) ? OverridingSizesScope::Axis::Block : OverridingSizesScope::Axis::Inline;
+            m_overridingScope.emplace(flexItem, axis, flexBox.computeCrossSizeForFlexItemUsingContainerCrossSize(flexItem));
+            if (invalidatePreferredWidths == InvalidatePreferredWidths::Yes) {
+                flexItem.setNeedsPreferredWidthsUpdate(MarkOnlyThis);
+#if ASSERT_ENABLED
+                m_didDirtyPreferredWidths = true;
+#endif
+            }
+        } else
+            m_overridingScope.emplace(flexItem, OverridingSizesScope::Axis::Both);
+    }
+
+    ~ScopedCrossAxisOverrideForFlexItem()
+    {
+#if ASSERT_ENABLED
+        if (m_didDirtyPreferredWidths)
+            ASSERT(!m_flexItem.needsPreferredLogicalWidthsUpdate());
+#endif
+    }
+
+private:
+    SetForScope<bool> m_intrinsicWidthComputation;
+    std::optional<OverridingSizesScope> m_overridingScope;
+#if ASSERT_ENABLED
+    RenderBox& m_flexItem;
+    bool m_didDirtyPreferredWidths { false };
+#endif
+};
+
 static void updateFlexItemDirtyBitsBeforeLayout(bool relayoutFlexItem, RenderBox& flexItem)
 {
     if (flexItem.isOutOfFlowPositioned())
@@ -289,18 +336,8 @@ void RenderFlexibleBox::computeChildIntrinsicLogicalWidths(RenderBox& flexBoxChi
     // Children excluded from normal layout are handled here too (e.g. legend when fieldset is set to flex).
     ASSERT(flexBoxChild.isFlexItem() || (flexBoxChild.parent() == this && flexBoxChild.isExcludedFromNormalLayout()));
 
-    // If the item cross size should use the definite container cross size then set the overriding size now so
-    // the intrinsic sizes are properly computed in the presence of aspect ratios. The only exception is when
-    // we are both a flex item&container, because our parent might have already set our overriding size.
-    auto flexItemIntrinsicSizeComputation = SetForScope(m_inFlexItemIntrinsicWidthComputation, true);
-    if (flexItemCrossSizeShouldUseContainerCrossSize(flexBoxChild) && !isFlexItem()) {
-        auto axis = mainAxisIsFlexItemInlineAxis(flexBoxChild) ? OverridingSizesScope::Axis::Block : OverridingSizesScope::Axis::Inline;
-        OverridingSizesScope overridingSizeScope(flexBoxChild, axis, computeCrossSizeForFlexItemUsingContainerCrossSize(flexBoxChild));
-        RenderBlock::computeChildIntrinsicLogicalWidths(flexBoxChild, minPreferredLogicalWidth, maxPreferredLogicalWidth);
-        return;
-    }
-
-    OverridingSizesScope cleanOverridingSizesScope(flexBoxChild, OverridingSizesScope::Axis::Both);
+    // Compute preferred widths of the child with the correct cross-axis size.
+    ScopedCrossAxisOverrideForFlexItem scopedCrossAxisOverride(*this, flexBoxChild, InvalidatePreferredWidths::Yes);
     RenderBlock::computeChildIntrinsicLogicalWidths(flexBoxChild, minPreferredLogicalWidth, maxPreferredLogicalWidth);
 }
 
@@ -1274,7 +1311,7 @@ bool RenderFlexibleBox::flexItemCrossSizeShouldUseContainerCrossSize(const Rende
             return true;
         // This must be kept in sync with computeMainSizeFromAspectRatioUsing().
         auto& crossSize = isHorizontalFlow() ? style().height() : style().width();
-        return crossSize.isFixed() || (crossSize.isPercent() && availableLogicalHeightForPercentageComputation());  
+        return crossSize.isFixed() || (crossSize.isPercent() && availableLogicalHeightForPercentageComputation());
     }
     return false;
 }
@@ -1397,6 +1434,7 @@ LayoutUnit RenderFlexibleBox::computeFlexBaseSizeForFlexItem(RenderBox& flexItem
     } else {
         // We don't need to add scrollbarLogicalWidth here because the preferred
         // width includes the scrollbar, even for overflow: auto.
+        ScopedCrossAxisOverrideForFlexItem crossSizeScope(*this, flexItem, InvalidatePreferredWidths::Yes);
         mainAxisExtent = flexItem.maxPreferredLogicalWidth();
     }
     return mainAxisExtent - mainAxisBorderAndPadding;
@@ -1738,20 +1776,33 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
 {
     auto max = maxMainSizeLengthForFlexItem(flexItem);
     std::optional<LayoutUnit> maxExtent = std::nullopt;
-    if (max.isSpecified() || max.isIntrinsicOrStretch())
+    if (max.isSpecified()) {
         maxExtent = computeMainAxisExtentForFlexItem(flexItem, max);
+    } else if (max.isIntrinsicOrStretch()) {
+        ScopedCrossAxisOverrideForFlexItem scopedCrossAxisOverride(*this, flexItem, InvalidatePreferredWidths::No);
+        maxExtent = computeMainAxisExtentForFlexItem(flexItem, max);
+    }
 
     auto min = minMainSizeLengthForFlexItem(flexItem);
     // Intrinsic sizes in child's block axis are handled by the min-size:auto code path,
     // but stretch always resolves to a definite value and should be computed directly.
     if (min.isSpecified() || min.isStretch() || (min.isIntrinsic() && mainAxisIsFlexItemInlineAxis(flexItem))) {
-        auto minExtent = computeMainAxisExtentForFlexItem(flexItem, min).value_or(0_lu);
+        auto computeMinExtent = [&] {
+            if (min.isIntrinsicOrStretch()) {
+                ScopedCrossAxisOverrideForFlexItem scopedCrossAxisOverride(*this, flexItem, InvalidatePreferredWidths::No);
+                return computeMainAxisExtentForFlexItem(flexItem, min).value_or(0_lu);
+            }
+            return computeMainAxisExtentForFlexItem(flexItem, min).value_or(0_lu);
+        };
+        auto minExtent = computeMinExtent();
         // We must never return a min size smaller than the min preferred size for tables.
-        if (flexItem.isRenderTable() && mainAxisIsFlexItemInlineAxis(flexItem))
+        if (flexItem.isRenderTable() && mainAxisIsFlexItemInlineAxis(flexItem)) {
+            ScopedCrossAxisOverrideForFlexItem scopedCrossAxisOverride(*this, flexItem, InvalidatePreferredWidths::Yes);
             minExtent = std::max(minExtent, flexItem.minPreferredLogicalWidth());
+        }
         return { minExtent, maxExtent.value_or(LayoutUnit::max()) };
     }
-    
+
     if (shouldApplyMinSizeAutoForFlexItem(flexItem)) {
         // FIXME: If the min value is expected to be valid here, we need to come up with a non optional version of computeMainAxisExtentForFlexItem and
         // ensure it's valid through the virtual calls of computeSizingKeywordLogicalContentHeightUsing.
@@ -1762,8 +1813,10 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
 
         if (canComputeSizeThroughAspectRatio)
             contentSize = computeMainSizeFromAspectRatioUsing(flexItem, flexItemCrossSizeLength);
-        else
+        else {
+            ScopedCrossAxisOverrideForFlexItem scopedCrossAxisOverride(*this, flexItem, InvalidatePreferredWidths::No);
             contentSize = computeMainAxisExtentForFlexItem(flexItem, Style::MinimumSize { CSS::Keyword::MinContent { } }).value_or(0_lu);
+        }
 
         if (flexItemHasAspectRatio(flexItem))
             contentSize = adjustFlexItemSizeForAspectRatioCrossAxisMinAndMax(flexItem, contentSize);
@@ -1909,7 +1962,7 @@ RenderFlexibleBox::FlexLayoutItem RenderFlexibleBox::constructFlexLayoutItem(Ren
 
     if (everHadLayout && flexItem.hasTrimmedMargin(std::optional<Style::MarginTrimSide> { }))
         flexItem.clearTrimmedMarginsMarkings();
-    
+
     if (flexItem.shouldInvalidatePreferredWidths())
         flexItem.setNeedsPreferredWidthsUpdate(MarkOnlyThis);
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -112,6 +112,8 @@ protected:
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
 
 private:
+    friend class ScopedCrossAxisOverrideForFlexItem;
+
     class FlexLayoutItem {
     public:
         FlexLayoutItem(RenderBox&, LayoutUnit, LayoutUnit, LayoutUnit, std::pair<LayoutUnit, LayoutUnit>, bool);


### PR DESCRIPTION
#### eb13205ab9fc826ace4794b51d3ac1c0fe96bd6e
<pre>
[flex] Fix widths for flex items with percentage-height descendants
<a href="https://bugs.webkit.org/show_bug.cgi?id=296562">https://bugs.webkit.org/show_bug.cgi?id=296562</a>
&lt;<a href="https://rdar.apple.com/156902823">rdar://156902823</a>&gt;

Reviewed by Sammy Gill.

Some flex items should use the container&apos;s definite cross size when
computing geometries so aspect ratios and percentage heights resolve
correctly. Previously, this override was only used in
computeChildIntrinsicLogicalWidths.

This PR extracts that logic into a ScopedCrossAxisOverrideForFlexItem class
and adds it to computeFlexBaseSizeForFlexItem and computeFlexItemMinMaxSizes.

The scoped object takes a InvalidatePreferredWidths parameter to conditionally invalidate
the flex item&apos;s preferred width. We assert in the destructor that this dirty flag is consumed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-basis-013-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-percentage-height-img-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-percentage-height-img-001.html: Added.
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::ScopedCrossAxisOverrideForFlexItem::ScopedCrossAxisOverrideForFlexItem):
(WebCore::ScopedCrossAxisOverrideForFlexItem::~ScopedCrossAxisOverrideForFlexItem):
(WebCore::RenderFlexibleBox::computeChildIntrinsicLogicalWidths const):
(WebCore::RenderFlexibleBox::flexItemCrossSizeShouldUseContainerCrossSize const):
(WebCore::RenderFlexibleBox::computeFlexBaseSizeForFlexItem):
(WebCore::RenderFlexibleBox::computeFlexItemMinMaxSizes):
(WebCore::RenderFlexibleBox::constructFlexLayoutItem):
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/309544@main">https://commits.webkit.org/309544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed822801c00a3bdbc1abbb8dc7d9230236a5c263

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104429 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116567 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82746 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97288 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebb1baf4-423f-41f1-98fd-fcf2e6bee5af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17776 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15730 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7567 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162194 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124575 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124762 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33853 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79956 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11952 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87413 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->