### PR TITLE
[GameController] Fix crash in GameControllerGamepad callback blocks

### DIFF
--- a/JSTests/stress/ftl-valuerepreduction-double-undefined.js
+++ b/JSTests/stress/ftl-valuerepreduction-double-undefined.js
@@ -1,0 +1,12 @@
+for (let v0 = 0; v0 < 100; v0++) {
+    const v1 = {a: v0};
+    for (let v2 = 0; v2 < 5; v2++) {
+        v1.length += v0;
+        v0[1] = v2;
+        v2.constructor;
+    }
+    for (let v4 = 0; v4 < 50; v4++) {
+        function f5() { return v1;}
+        for (let v8 = 0; v8 < 100; v8++) {}
+    }
+}

--- a/JSTests/wasm/function-references/nullability.js
+++ b/JSTests/wasm/function-references/nullability.js
@@ -1,0 +1,40 @@
+import * as assert from '../assert.js';
+import { instantiate } from "../wabt-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+async function nullability() {
+  /*
+  (module
+    (type $sig (func))
+    (import "env" "getFunc" (func $getFunc (result (ref func))))
+    (func (export "callGetFunc") (result i32)
+          (call $getFunc)
+          (ref.test (ref $sig)))
+  )
+  */
+  let instance = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x0d\x03\x60\x00\x01\x64\x70\x60\x00\x01\x7f\x60\x00\x00\x02\x0f\x01\x03\x65\x6e\x76\x07\x67\x65\x74\x46\x75\x6e\x63\x00\x00\x03\x02\x01\x01\x07\x0f\x01\x0b\x63\x61\x6c\x6c\x47\x65\x74\x46\x75\x6e\x63\x00\x01\x0a\x09\x01\x07\x00\x10\x00\xfb\x14\x02\x0b"), {
+    env: {
+      getFunc: () => null
+    }
+  });
+
+  assert.throws(
+    () => {
+      for (let i = 0; i < 1000; i++) {
+        instance.exports.callGetFunc();
+      }
+    },
+    TypeError,
+    "Host function incorrectly returned null for a nonnullable reference type"
+  )
+}
+
+await assert.asyncTest(nullability());

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data-expected.txt
@@ -1,0 +1,10 @@
+Test importing a PKCS8 RSA-OAEP key where headerSize equals keyData.size()
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data.html
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a PKCS8 RSA-OAEP key where headerSize equals keyData.size()");
+
+// This test verifies that importing a malformed PKCS8 key where the computed
+// headerSize exactly equals the buffer size is rejected gracefully.
+// After stripping the header, there would be zero bytes left for the key data.
+//
+// Key structure (22 bytes):
+// - Offset 0: 0x30 (SequenceMark)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2-20: 19 placeholder bytes (Version + RSAOIDHeader + OctetStringMark)
+// - Offset 21: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+//
+// headerSize computation:
+// 1. headerSize = 1
+// 2. Check: 22 >= 2 (pass)
+// 3. headerSize = 1 + 1 + 3 + 15 + 1 = 21
+// 4. Check: 22 >= 22 (pass)
+// 5. headerSize = 21 + 1 = 22
+// 6. headerSize == keyData.size(), subspan(22) returns empty span
+// 7. CCRSACryptorImport fails with 0 bytes of key data
+
+var extractable = true;
+
+// 22 bytes: 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+var emptyKeyDataPkcs8 = hexStringToUint8Array("30000000000000000000000000000000000000000000");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"])');
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length-expected.txt
@@ -1,0 +1,10 @@
+Test importing a PKCS8 RSA-OAEP key with invalid length byte causing buffer overread
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length.html
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a PKCS8 RSA-OAEP key with invalid length byte causing buffer overread");
+
+// This test verifies that importing a malformed PKCS8 key where the final
+// length byte has a large value (0xFF) is rejected gracefully.
+// Without proper bounds checking, this would cause subspan() to attempt
+// accessing memory far beyond the buffer.
+//
+// Key structure (22 bytes):
+// - Offset 0: 0x30 (SequenceMark)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2-20: 19 placeholder bytes (Version + RSAOIDHeader + OctetStringMark)
+// - Offset 21: 0x83 (length byte indicating 3 more bytes encode the length)
+//
+// headerSize computation:
+// 1. headerSize = 1
+// 2. Check: 22 >= 2 (pass)
+// 3. headerSize = 1 + 1 + 3 + 15 + 1 = 21
+// 4. Check: 22 >= 22 (pass)
+// 5. bytesUsedToEncodedLength(0x83) = 131 - 128 + 1 = 4
+//    headerSize = 21 + 4 = 25
+// 6. subspan(25) on 22-byte buffer -> buffer overread without bounds check
+
+var extractable = true;
+
+// 22 bytes: 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 83
+var invalidLengthPkcs8Key = hexStringToUint8Array("30000000000000000000000000000000000000000083");
+
+// Should reject with DataError, not crash or read beyond buffer
+shouldReject('crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"])');
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key-expected.txt
@@ -1,0 +1,10 @@
+Test importing a truncated PKCS8 RSA-OAEP key that triggers bounds check failure
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key.html
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a truncated PKCS8 RSA-OAEP key that triggers bounds check failure");
+
+// This test verifies that importing a malformed PKCS8 key with a truncated
+// ASN.1 structure is rejected gracefully rather than crashing.
+//
+// The malformed key is crafted so that:
+// 1. The first two size checks in importPkcs8() pass
+// 2. But the final computed headerSize exceeds the buffer size
+// 3. Without the fix, keyData.subspan(headerSize) crashes
+//
+// Key structure (22 bytes):
+// - Offset 0: 0x30 (SequenceMark)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2-20: 19 placeholder bytes (Version + RSAOIDHeader + OctetStringMark)
+// - Offset 21: 0x82 (length byte, bytesUsedToEncodedLength returns 3)
+//
+// headerSize computation:
+// 1. headerSize = 1
+// 2. Check: 22 >= 2 (pass)
+// 3. headerSize = 1 + 1 + 3 + 15 + 1 = 21
+// 4. Check: 22 >= 22 (pass)
+// 5. headerSize = 21 + 3 = 24
+// 6. subspan(24) on 22-byte buffer -> CRASH (before fix)
+
+var extractable = true;
+
+// 22 bytes: 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 82
+var truncatedPkcs8Key = hexStringToUint8Array("30000000000000000000000000000000000000000082");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"])');
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data-expected.txt
@@ -1,0 +1,10 @@
+Test importing a SPKI RSA-OAEP key where headerSize equals keyData.size()
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data.html
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a SPKI RSA-OAEP key where headerSize equals keyData.size()");
+
+// This test verifies that importing a malformed SPKI key where the computed
+// headerSize exactly equals the buffer size is rejected gracefully.
+// After stripping the header, there would be zero bytes left for the key data.
+//
+// Key structure (20 bytes):
+// - Offset 0: 0x30 (SequenceMark)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2-18: 17 placeholder bytes
+// - Offset 19: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+//
+// headerSize computation:
+// 1. headerSize = 1
+// 2. Check: 20 >= 2 (pass)
+// 3. headerSize = 1 + 1 + 15 + 1 = 18
+// 4. Check: 20 >= 19 (pass)
+// 5. headerSize = 18 + 1 + 1 = 20
+// 6. headerSize == keyData.size(), subspan(20) returns empty span
+// 7. CCRSACryptorImport fails with 0 bytes of key data
+
+var extractable = true;
+
+// 20 bytes: 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+var emptyKeyDataSpki = hexStringToUint8Array("3000000000000000000000000000000000000000");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"])');
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length-expected.txt
@@ -1,0 +1,10 @@
+Test importing a SPKI RSA-OAEP key with invalid length byte causing buffer overread
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length.html
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a SPKI RSA-OAEP key with invalid length byte causing buffer overread");
+
+// This test verifies that importing a malformed SPKI key where the final
+// length byte has a large value (0xFF) is rejected gracefully.
+// Without proper bounds checking, this would cause subspan() to attempt
+// accessing memory far beyond the buffer.
+//
+// Key structure (19 bytes):
+// - Offset 0: 0x30 (SequenceMark)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2-17: 16 placeholder bytes
+// - Offset 18: 0x83 (length byte indicating 3 more bytes encode the length)
+//
+// headerSize computation:
+// 1. headerSize = 1
+// 2. Check: 19 >= 2 (pass)
+// 3. headerSize = 1 + 1 + 15 + 1 = 18
+// 4. Check: 19 >= 19 (pass)
+// 5. bytesUsedToEncodedLength(0x83) = 131 - 128 + 1 = 4
+//    headerSize = 18 + 4 + 1 = 23
+// 6. subspan(23) on 19-byte buffer -> buffer overread without bounds check
+
+var extractable = true;
+
+// 19 bytes: 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 83
+var invalidLengthSpkiKey = hexStringToUint8Array("30000000000000000000000000000000000083");
+
+// Should reject with DataError, not crash or read beyond buffer
+shouldReject('crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"])');
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key-expected.txt
@@ -1,0 +1,10 @@
+Test importing a truncated SPKI RSA-OAEP key that triggers bounds check failure
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key.html
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a truncated SPKI RSA-OAEP key that triggers bounds check failure");
+
+// This test verifies that importing a malformed SPKI key with a truncated
+// ASN.1 structure is rejected gracefully rather than crashing.
+//
+// The malformed key is crafted so that:
+// 1. The first two size checks in importSpki() pass
+// 2. But the final computed headerSize exceeds the buffer size
+// 3. Without the fix, keyData.subspan(headerSize) crashes
+//
+// Key structure (19 bytes):
+// - Offset 0: 0x30 (SequenceMark)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2-17: 16 placeholder bytes
+// - Offset 18: 0x82 (length byte, bytesUsedToEncodedLength returns 3)
+//
+// headerSize computation:
+// 1. headerSize = 1
+// 2. Check: 19 >= 2 (pass)
+// 3. headerSize = 1 + 1 + 15 + 1 = 18
+// 4. Check: 19 >= 19 (pass)
+// 5. headerSize = 18 + 3 + 1 = 22
+// 6. subspan(22) on 19-byte buffer -> CRASH (before fix)
+
+var extractable = true;
+
+// 19 bytes: 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 82
+var truncatedSpkiKey = hexStringToUint8Array("30000000000000000000000000000000000082");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"])');
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGMultiGetByOffsetData.h
+++ b/Source/JavaScriptCore/dfg/DFGMultiGetByOffsetData.h
@@ -98,7 +98,13 @@ public:
         ASSERT(kind() == Load || kind() == LoadFromPrototype);
         return u.load.offset;
     }
-    
+
+    void setConstantValue(FrozenValue* value)
+    {
+        ASSERT(kind() == Constant);
+        u.constant = value;
+    }
+
     void dumpInContext(PrintStream&, DumpContext*) const;
     void dump(PrintStream&) const;
     
@@ -127,6 +133,7 @@ public:
     
     RegisteredStructureSet& set() { return m_set; }
     const RegisteredStructureSet& set() const { return m_set; }
+    GetByOffsetMethod& method() { return m_method; }
     const GetByOffsetMethod& method() const { return m_method; }
     
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -598,10 +598,24 @@ private:
             case GetClosureVar:
             case GetGlobalVar:
             case GetGlobalLexicalVariable:
-            case MultiGetByOffset:
             case GetByOffset: {
                 candidate->setResult(NodeResultDouble);
                 candidate->mergeFlags(NodeMustGenerate); // Absorbs speculation check from the using edge
+                resultNode = candidate;
+                break;
+            }
+
+            case MultiGetByOffset: {
+                MultiGetByOffsetData& data = candidate->multiGetByOffsetData();
+                for (unsigned i = 0; i < data.cases.size(); ++i) {
+                    GetByOffsetMethod& method = data.cases[i].method();
+                    if (method.kind() == GetByOffsetMethod::Constant) {
+                        // It's possible there are non-Number constants that still predict NumberUse, e.g. undefined.
+                        std::optional<double> doubleConstant = method.constant()->value().toNumberFromPrimitive();
+                        method.setConstantValue(m_graph.freeze(jsDoubleNumber(*doubleConstant)));
+                    }
+                }
+                candidate->setResult(NodeResultDouble);
                 resultNode = candidate;
                 break;
             }

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -67,6 +67,7 @@ namespace Wasm {
     macro(NullArrayInitData, "array.init_data to a null reference"_s) \
     macro(TypeErrorInvalidValueUse, "an exported wasm function cannot contain an invalid parameter or return value"_s) \
     macro(TypeErrorV128TagAccessInJS, "a v128 parameter of a tag may not be accessed from JS"_s) \
+    macro(TypeErrorUnexpectedNullReference, "Host function incorrectly returned null for a nonnullable reference type"_s) \
     macro(NullRefAsNonNull, "ref.as_non_null to a null reference"_s) \
     macro(CastFailure, "ref.cast failed to cast reference to target heap type"_s) \
     macro(OutOfBoundsDataSegmentAccess, "Offset + array length would exceed the size of a data segment"_s) \
@@ -141,6 +142,7 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::InvalidGCTypeUse:
     case ExceptionType::TypeErrorInvalidValueUse:
     case ExceptionType::TypeErrorV128TagAccessInJS:
+    case ExceptionType::TypeErrorUnexpectedNullReference:
         return true;
     }
     return false;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -560,11 +560,16 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
         }
         default:  {
             if (Wasm::isRefType(returnType)) {
+                JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(returned));
+                if (value.isNull() && !returnType.isNullable()) [[unlikely]] {
+                    throwTypeError(globalObject, scope, "Host function incorrectly returned null for a nonnullable reference type"_s);
+                    OPERATION_RETURN(scope);
+                }
+
                 if (Wasm::isExternref(returnType)) {
                     // Do nothing.
                 } else if (Wasm::isFuncref(returnType)) {
                     // operationConvertToFuncref
-                    JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(returned));
                     WebAssemblyFunction* wasmFunction = nullptr;
                     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
                     if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull()) [[unlikely]] {
@@ -583,7 +588,6 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                     // Validation only: value not modified so write back not needed.
                 } else {
                     // operationConvertToAnyref
-                    JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(returned));
                     value = Wasm::internalizeExternref(value);
                     if (!Wasm::TypeInformation::isReferenceValueAssignable(value, returnType.isNullable(), returnType.index)) [[unlikely]] {
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
@@ -646,6 +650,11 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
             break;
         default: {
             if (Wasm::isRefType(returnType)) {
+                if (value.isNull() && !returnType.isNullable()) [[unlikely]] {
+                    throwTypeError(globalObject, scope, "Host function incorrectly returned null for a nonnullable reference type"_s);
+                    OPERATION_RETURN(scope);
+                }
+
                 if (isExternref(returnType)) {
                     // Do nothing.
                 } else if (isFuncref(returnType)) {
@@ -1421,6 +1430,11 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyInstance* 
             break;
         default: {
             if (Wasm::isRefType(returnType)) {
+                if (value.isNull() && !returnType.isNullable()) [[unlikely]] {
+                    throwTypeError(globalObject, scope, "Host function incorrectly returned null for a nonnullable reference type"_s);
+                    OPERATION_RETURN(scope);
+                }
+
                 if (isExternref(returnType)) {
                     // Do nothing.
                 } else if (isFuncref(returnType)) {

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -449,6 +449,13 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
         }
         default:  {
             if (Wasm::isRefType(returnType)) {
+                if (!returnType.isNullable()) {
+                    auto isNotNull = jit.branchIfNotNull(JSRInfo::returnValueJSR);
+                    jit.move(GPRInfo::wasmContextInstancePointer, GPRInfo::argumentGPR0);
+                    emitThrowWasmToJSException(jit, GPRInfo::argumentGPR0, ExceptionType::TypeErrorUnexpectedNullReference);
+                    isNotNull.link(&jit);
+                }
+
                 if (Wasm::isExternref(returnType)) {
                     // Do nothing.
                 } else if (Wasm::isFuncref(returnType)) {

--- a/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -323,6 +323,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifi
     if (keyData.size() < headerSize + 1)
         return nullptr;
     headerSize += bytesUsedToEncodedLength(keyData[headerSize]) + sizeof(InitialOctet);
+    if (keyData.size() < headerSize)
+        return nullptr;
 
     CCRSACryptorRef ccPublicKey = nullptr;
     auto dataAfterHeader = keyData.subspan(headerSize);
@@ -381,6 +383,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importPkcs8(CryptoAlgorithmIdentifier identif
     if (keyData.size() < headerSize + 1)
         return nullptr;
     headerSize += bytesUsedToEncodedLength(keyData[headerSize]);
+    if (keyData.size() < headerSize)
+        return nullptr;
 
     CCRSACryptorRef ccPrivateKey = nullptr;
     auto dataAfterHeader = keyData.subspan(headerSize);

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,10 @@ OBJC_CLASS GCControllerButtonInput;
 OBJC_CLASS GCControllerElement;
 
 namespace WebCore {
+class GameControllerGamepad;
+}
+
+namespace WebCore {
 
 class GameControllerHapticEngines;
 
@@ -47,6 +51,7 @@ class GameControllerGamepad final : public PlatformGamepad {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GameControllerGamepad);
 public:
     GameControllerGamepad(GCController *, unsigned index);
+    ~GameControllerGamepad();
 
     const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
     const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
@@ -59,6 +64,7 @@ public:
 
 private:
     void setupElements();
+    void teardownElements();
 
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     GameControllerHapticEngines& ensureHapticEngines();

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,6 +51,11 @@ GameControllerGamepad::GameControllerGamepad(GCController *controller, unsigned 
     setupElements();
 }
 
+GameControllerGamepad::~GameControllerGamepad()
+{
+    teardownElements();
+}
+
 static void disableDefaultSystemAction(GCControllerButtonInput *button)
 {
     if ([button respondsToSelector:@selector(preferredSystemGestureState)])
@@ -60,13 +65,16 @@ static void disableDefaultSystemAction(GCControllerButtonInput *button)
 void GameControllerGamepad::setupElements()
 {
     RetainPtr<GCPhysicalInputProfile> profile = m_gcController.get().physicalInputProfile;
+    WeakPtr weakThis { *this };
 
     // The user can expose an already-connected game controller to a web page by expressing explicit intent.
     // Examples include pressing a button, or wiggling the joystick with intent.
     if ([profile respondsToSelector:@selector(setThumbstickUserIntentHandler:)]) {
         [profile setThumbstickUserIntentHandler:^(__kindof GCPhysicalInputProfile*, GCControllerElement*) {
-            m_lastUpdateTime = MonotonicTime::now();
-            GameControllerGamepadProvider::singleton().gamepadHadInput(*this, true);
+            if (!weakThis)
+                return;
+            weakThis->m_lastUpdateTime = MonotonicTime::now();
+            GameControllerGamepadProvider::singleton().gamepadHadInput(*weakThis, true);
         }];
     }
 
@@ -104,9 +112,11 @@ void GameControllerGamepad::setupElements()
             // Ignoring them is preferable to surfacing NaN to javascript.
             if (std::isnan(value))
                 return;
-            m_buttonValues[(size_t)index].setValue(value);
-            m_lastUpdateTime = MonotonicTime::now();
-            GameControllerGamepadProvider::singleton().gamepadHadInput(*this, pressed);
+            if (!weakThis)
+                return;
+            weakThis->m_buttonValues[(size_t)index].setValue(value);
+            weakThis->m_lastUpdateTime = MonotonicTime::now();
+            GameControllerGamepadProvider::singleton().gamepadHadInput(*weakThis, pressed);
         };
     };
 
@@ -151,25 +161,54 @@ void GameControllerGamepad::setupElements()
     m_axisValues[3].setValue(-profile.get().dpads[GCInputRightThumbstick].yAxis.value);
 
     profile.get().dpads[GCInputLeftThumbstick].xAxis.valueChangedHandler = ^(GCControllerAxisInput *, float value) {
-        m_axisValues[0].setValue(value);
-        m_lastUpdateTime = MonotonicTime::now();
+        if (!weakThis)
+            return;
+        weakThis->m_axisValues[0].setValue(value);
+        weakThis->m_lastUpdateTime = MonotonicTime::now();
         GameControllerGamepadProvider::singleton().gamepadHadInput(*this, false);
     };
     profile.get().dpads[GCInputLeftThumbstick].yAxis.valueChangedHandler = ^(GCControllerAxisInput *, float value) {
-        m_axisValues[1].setValue(-value);
-        m_lastUpdateTime = MonotonicTime::now();
+        if (!weakThis)
+            return;
+        weakThis->m_axisValues[1].setValue(-value);
+        weakThis->m_lastUpdateTime = MonotonicTime::now();
         GameControllerGamepadProvider::singleton().gamepadHadInput(*this, false);
     };
     profile.get().dpads[GCInputRightThumbstick].xAxis.valueChangedHandler = ^(GCControllerAxisInput *, float value) {
-        m_axisValues[2].setValue(value);
-        m_lastUpdateTime = MonotonicTime::now();
+        if (!weakThis)
+            return;
+        weakThis->m_axisValues[2].setValue(value);
+        weakThis->m_lastUpdateTime = MonotonicTime::now();
         GameControllerGamepadProvider::singleton().gamepadHadInput(*this, false);
     };
     profile.get().dpads[GCInputRightThumbstick].yAxis.valueChangedHandler = ^(GCControllerAxisInput *, float value) {
-        m_axisValues[3].setValue(-value);
-        m_lastUpdateTime = MonotonicTime::now();
+        if (!weakThis)
+            return;
+        weakThis->m_axisValues[3].setValue(-value);
+        weakThis->m_lastUpdateTime = MonotonicTime::now();
         GameControllerGamepadProvider::singleton().gamepadHadInput(*this, false);
     };
+}
+
+void GameControllerGamepad::teardownElements()
+{
+    auto profile = RetainPtr { m_gcController.get().physicalInputProfile };
+    if (!profile)
+        return;
+
+    // Clear thumbstick user intent handler.
+    if ([profile respondsToSelector:@selector(setThumbstickUserIntentHandler:)])
+        [profile setThumbstickUserIntentHandler:nil];
+
+    // Clear all button handlers.
+    for (GCControllerButtonInput *button in [profile allButtons])
+        button.valueChangedHandler = nil;
+
+    // Clear axis handlers for thumbsticks.
+    profile.get().dpads[GCInputLeftThumbstick].xAxis.valueChangedHandler = nil;
+    profile.get().dpads[GCInputLeftThumbstick].yAxis.valueChangedHandler = nil;
+    profile.get().dpads[GCInputRightThumbstick].xAxis.valueChangedHandler = nil;
+    profile.get().dpads[GCInputRightThumbstick].yAxis.valueChangedHandler = nil;
 }
 
 #if HAVE(WIDE_GAMECONTROLLER_SUPPORT)

--- a/Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -719,6 +719,71 @@ TEST(Gamepad, FullInfoAfterConnection)
     done = false;
 }
 
+TEST(Gamepad, DisconnectDuringInput)
+{
+    // Tests that handler blocks don't crash when invoked after GameControllerGamepad destruction.
+    [WebCore::getGCControllerClassSingleton() setShouldMonitorBackgroundEvents:YES];
+
+    auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
+
+    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
+
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
+        [task didFinish];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    keyWindowForTesting = [webView window];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
+
+    [[webView window] makeFirstResponder:webView.get()];
+
+    // Resigning/reinstating the key window state triggers the "key window did change" notification.
+    [[webView window] resignKeyWindow];
+    [[webView window] makeKeyWindow];
+
+    // Connect a gamepad.
+    auto gamepad = makeUnique<VirtualGamepad>(VirtualGamepad::steelSeriesNimbusMapping());
+    while (![webView.get().configuration.processPool _numberOfConnectedGamepadsForTesting])
+        Util::runFor(0.01_s);
+
+    // Make gamepad visible by pressing button.
+    gamepad->setButtonValue(0, 1.0);
+    gamepad->publishReport();
+    Util::run(&didReceiveMessage);
+    didReceiveMessage = false;
+
+    EXPECT_EQ(messageHandler.get().messages.size(), 1u);
+
+    // Fire off rapid publishes. Handlers will be queued asynchronously.
+    for (int i = 0; i < 100; ++i) {
+        gamepad->setAxisValue(0, (float)i / 100.0);
+        gamepad->setAxisValue(1, (float)(100 - i) / 100.0);
+        gamepad->publishReport();
+    }
+
+    // This destroys VirtualGamepad, which triggers controllerDidDisconnect,
+    // which destroys GameControllerGamepad.
+    gamepad = nullptr;
+
+    // Wait for disconnect message.
+    Util::run(&didReceiveMessage);
+    didReceiveMessage = false;
+
+    EXPECT_EQ(messageHandler.get().messages.size(), 2u);
+
+    NSString *expectedName = @"\"Virtual Nimbus Extended Gamepad\"";
+    NSString *expectedDisconnect = [NSString stringWithFormat:@"Disconnect: %@", expectedName];
+    EXPECT_TRUE([messageHandler.get().messages[1] isEqualToString:expectedDisconnect]);
+}
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 101c8550132390bf6427713872bd85c5c5eab928
<pre>
[GameController] Fix crash in GameControllerGamepad callback blocks
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305094">https://bugs.webkit.org/show_bug.cgi?id=305094</a>&gt;
&lt;<a href="https://rdar.apple.com/165613031">rdar://165613031</a>&gt;

Reviewed by Chris Dumez.

This fixes a crash that occurred when GameController framework callbacks
continued executing after GameControllerGamepad objects were destroyed.

The fix uses WeakPtr to safely capture the GameControllerGamepad object
in callback blocks and adds null checks before accessing object members.
A new destructor calls teardownElements() to clear all registered
handlers when the object is destroyed, preventing callbacks from
executing after deallocation.

Test: Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm

* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
(WTF::IsDeprecatedWeakRefSmartPointerException&lt;WebCore::GameControllerGamepad&gt;): Add.
- Suppress static assert for using a WeakPtr without also implementing
  CheckedPtr or RefPtr.  This is only needed for the branch since
  WebCore::PlatformGamepad implements CheckedPtr on main.
(WebCore::GameControllerGamepad::~GameControllerGamepad): Add declaration.
(WebCore::GameControllerGamepad::teardownElements): Add declaration.
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::~GameControllerGamepad): Add.
- Calls teardownElements().
(WebCore::GameControllerGamepad::setupElements):
- Use WeakPtr for handler blocks instead of this.
(WebCore::GameControllerGamepad::teardownElements): Add.
- Unregister all the handlers configured in setupElements().
* Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm:
(TestWebKitAPI::(Gamepad, DisconnectDuringInput)): Add.
- Add test. Reproduces rarely since this is a race condition.

Originally-landed-as: 301765.400@safari-7623-branch (a0cedddb8c35). <a href="https://rdar.apple.com/171556229">rdar://171556229</a>
Canonical link: <a href="https://commits.webkit.org/308708@main">https://commits.webkit.org/308708@main</a>
</pre>
----------------------------------------------------------------------
#### f2c5bf80637acde3b9a869f7e42e85c78af4b2a6
<pre>
[JSC] Convert MultiGetByOffsetMethod constants to double if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=305064">https://bugs.webkit.org/show_bug.cgi?id=305064</a>
<a href="https://rdar.apple.com/167109771">rdar://167109771</a>

Reviewed by Keith Miller and Yusuke Suzuki.

FTL&apos;s ValueRep reduction phase can convert MultiGetByOffset nodes to
NodeResultDouble with non-Number constant values in its cases. These constants
are non-Cells and should be converted to Numbers.

Test: JSTests/stress/ftl-valuerepreduction-double-undefined.js

Originally-landed-as: 301765.399@safari-7623-branch (d32d4c76087a). <a href="https://rdar.apple.com/171556424">rdar://171556424</a>
Canonical link: <a href="https://commits.webkit.org/308707@main">https://commits.webkit.org/308707@main</a>
</pre>
----------------------------------------------------------------------
#### bbec6de6445ff9480e343c7fdc7deb17bac37ed2
<pre>
Crash under WebCore::SubtleCrypto::importKey() when using invalid keys
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305035">https://bugs.webkit.org/show_bug.cgi?id=305035</a>&gt;
&lt;<a href="https://rdar.apple.com/167471255">rdar://167471255</a>&gt;

Reviewed by Pascoe.

CryptoKeyRSA::importSpki() and CryptoKeyRSA::importPkcs8() compute a
headerSize incrementally based on ASN.1 length encoding bytes, but
failed to verify that the final headerSize does not exceed the buffer
size before calling keyData.subspan(headerSize).

When importing malformed RSA keys with truncated or invalid ASN.1
length encoding, the computed headerSize could exceed the actual key
data size, causing std::span::subspan() to trigger a bounds check
failure (EXC_BREAKPOINT SIGTRAP) in builds with the hardened C++
runtime enabled.

Add a final bounds check after computing headerSize to reject keys
where keyData.size() &lt; headerSize before attempting to create the
subspan.

Tests: crypto/subtle/rsa-import-pkcs8-empty-key-data.html
       crypto/subtle/rsa-import-pkcs8-invalid-length.html
       crypto/subtle/rsa-import-pkcs8-truncated-key.html
       crypto/subtle/rsa-import-spki-empty-key-data.html
       crypto/subtle/rsa-import-spki-invalid-length.html
       crypto/subtle/rsa-import-spki-truncated-key.html

* LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data-expected.txt: Add.
* LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data.html: Add.
* LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length-expected.txt: Add.
* LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length.html: Add.
* LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key-expected.txt: Add.
* LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key.html: Add.
* LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data-expected.txt: Add.
* LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data.html: Add.
* LayoutTests/crypto/subtle/rsa-import-spki-invalid-length-expected.txt: Add.
* LayoutTests/crypto/subtle/rsa-import-spki-invalid-length.html: Add.
* LayoutTests/crypto/subtle/rsa-import-spki-truncated-key-expected.txt: Add.
* LayoutTests/crypto/subtle/rsa-import-spki-truncated-key.html: Add.
* Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp:
(WebCore::CryptoKeyRSA::importSpki):
(WebCore::CryptoKeyRSA::importPkcs8):
- Add bounds check after final headerSize computation.

Originally-landed-as: 301765.398@safari-7623-branch (314f967eebf3). <a href="https://rdar.apple.com/171556687">rdar://171556687</a>
Canonical link: <a href="https://commits.webkit.org/308706@main">https://commits.webkit.org/308706@main</a>
</pre>
----------------------------------------------------------------------
#### 2d64f53d2e4766fa2ff899a03e3db9a3741d0f83
<pre>
[WASM] Return-from-JS conversions should check the nullability
<a href="https://rdar.apple.com/159086936">rdar://159086936</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304356">https://bugs.webkit.org/show_bug.cgi?id=304356</a>

Reviewed by Yusuke Suzuki.

Adds a null check when returning from JS to Wasm and the expected
return type is a nonnullable reference type.

Test: JSTests/wasm/function-references/nullability.js

* JSTests/wasm/function-references/nullability.js: Added.
(module):
(async nullability): Tests whether the null check occurs
* Source/JavaScriptCore/wasm/WasmExceptionType.h: Added ExceptionType::TypeErrorUnexpectedNullReference
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmOperations.cpp: Added null checks
(JSC::Wasm::operationWasmToJSExitMarshalReturnValues):
(JSC::Wasm::operationWasmToJSExitIterateResults):
(JSC::Wasm::operationIterateResults):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp: Added null check
(JSC::Wasm::wasmToJS): JIT now emits a null check when needed

Originally-landed-as: 301765.394@safari-7623-branch (f5681488766e). <a href="https://rdar.apple.com/171556806">rdar://171556806</a>
Canonical link: <a href="https://commits.webkit.org/308705@main">https://commits.webkit.org/308705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b496116a8f027f7588b924197e9cbadfd9e677f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101596 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6c732d0-2978-49c0-8390-3809be34b847) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81445 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bff10d1-6e7e-4848-b505-15939adc4aee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95008 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6c8be53-0670-4955-bddc-a87ea5e093a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15604 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13411 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4303 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159199 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8970 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2333 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122271 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33315 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76827 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9531 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179603 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84062 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45983 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20015 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->