### PR TITLE
[JSC] GetByStatus::computeFor has race condition around swapped object's structure checks

### DIFF
--- a/JSTests/stress/dfg-miscompiles-new-regexp.js
+++ b/JSTests/stress/dfg-miscompiles-new-regexp.js
@@ -1,0 +1,16 @@
+function opt(regExp) {
+    return new RegExp(regExp, undefined);
+}
+
+function main() {
+    const regExp = /a/;
+
+    for (let i = 0; i < testLoopCount; i++) {
+        if (opt(regExp) === regExp) {
+            throw new Error(`Bug triggered at ${i}`);
+            break;
+        }
+    }
+}
+
+main();

--- a/JSTests/stress/dfg-proto-fold-invalidate3.js
+++ b/JSTests/stress/dfg-proto-fold-invalidate3.js
@@ -1,0 +1,93 @@
+//@ runDefault
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function opt(objectA, exitEarly) {
+    if (exitEarly) {
+        return;
+    }
+
+    objectA.tag;
+
+    const arr = objectA.callee;
+
+    arr[0] = 2.3023e-320;
+}
+
+function watchCalleeProperty(objectA) {
+    return objectA.callee;
+}
+
+async function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createObjectX(objectD) {
+    const x = new Function();
+    Reflect.setPrototypeOf(x, objectD);
+
+    return x;
+}
+
+function createClonedArguments() {
+    return createClonedArguments.arguments;
+}
+
+function p(value) {
+    print(value);
+    return String(value);
+}
+noInline(p);
+
+async function main() {
+    createClonedArguments[0] = {};
+
+    const objectE = {};
+    const objectD = Object.create(objectE);
+    const objectC = Object.create(objectD);
+    const objectB = Object.create(objectC);
+    const objectA = Object.create(objectB);
+
+    const objectX = createClonedArguments();
+    Object.setPrototypeOf(objectX, objectD);
+
+    objectA.tag = 1;
+
+    objectE.callee = {
+        0: 1.1
+    };
+
+    for (let i = 0; i < 50; i++) {
+        opt(objectA, /* exitEarly */ false);
+    }
+
+    for (let i = 0; i < 1000; i++) {
+        watchCalleeProperty(objectE);
+    }
+
+    await sleep(1000);
+    Reflect.setPrototypeOf(objectD, null);
+
+    for (let i = 0; i < 1000; i++) {
+        opt(objectA, /* exitEarly */ true);
+    }
+
+    await sleep(500);
+
+    // Before: A -> B -> C -> D -> E
+    // After:  A -> B -> X -> D -> E
+    Reflect.setPrototypeOf(objectD, objectE);
+    Reflect.setPrototypeOf(objectB, objectX);
+
+    await sleep(1000);
+
+    opt(objectA, /* exitEarly */ false);
+
+    shouldBe(createClonedArguments[0], 2.3023e-320);
+}
+
+main().catch($vm.abort);

--- a/JSTests/stress/object-assign-inline-storage.js
+++ b/JSTests/stress/object-assign-inline-storage.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+class C extends Object {
+    constructor() {
+        super();
+    }
+}
+
+const a = new C();
+const b = new C();
+a.f = 42;
+const c = Object["assign"](a, a, b);
+
+shouldBe(a.f, 42);
+shouldBe(b.f, undefined);
+shouldBe(c.f, 42);

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -526,6 +526,17 @@ GetByStatus GetByStatus::computeFor(JSGlobalObject* globalObject, const Structur
                     size_t i = 0;
                     size_t totalSize = conditionSet.size();
                     for (auto& condition : conditionSet) {
+                        auto* object = condition.object();
+                        if (!object)
+                            return std::nullopt;
+
+                        auto* currentStructure = object->structure();
+                        if (currentStructure->typeInfo().overridesGetOwnPropertySlot())
+                            return std::nullopt;
+
+                        if (!currentStructure->propertyAccessesAreCacheable())
+                            return std::nullopt;
+
                         if ((i + 1) == totalSize) {
                             // The last condition
                             if (condition.kind() != PropertyCondition::Presence)
@@ -541,6 +552,9 @@ GetByStatus GetByStatus::computeFor(JSGlobalObject* globalObject, const Structur
 
                             return result;
                         }
+
+                        if (currentStructure->hasPolyProto())
+                            return std::nullopt;
 
                         if (condition.kind() != PropertyCondition::Absence)
                             return std::nullopt;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3004,7 +3004,8 @@ JSC_DEFINE_JIT_OPERATION(operationNewRegExpUntyped, JSObject*, (JSGlobalObject* 
     };
 
     JSGlobalObject* regExpGlobalObject = structure->globalObject();
-    OPERATION_RETURN(scope, constructRegExp(regExpGlobalObject, ArgList { args, 2 }, regExpGlobalObject->regExpConstructor()));
+    JSObject* regExpConstructor = regExpGlobalObject->regExpConstructor();
+    OPERATION_RETURN(scope, constructRegExp(regExpGlobalObject, ArgList { args, 2 }, regExpConstructor, regExpConstructor));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewRegExpString, JSObject*, (JSGlobalObject* globalObject, Structure* structure, JSString* content, JSString* flags))

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -65,7 +65,7 @@ ALWAYS_INLINE void objectAssignIndexedPropertiesFast(JSGlobalObject* globalObjec
     RETURN_IF_EXCEPTION(scope, void());
 }
 
-ALWAYS_INLINE bool checkStrucureForClone(Structure* structure)
+ALWAYS_INLINE bool checkStructureForClone(Structure* structure)
 {
     static constexpr bool verbose = false;
 
@@ -152,7 +152,7 @@ ALWAYS_INLINE bool objectCloneFast(VM& vm, JSFinalObject* target, JSObject* sour
         return false;
     }
 
-    if (!checkStrucureForClone(targetStructure))
+    if (!checkStructureForClone(targetStructure))
         return false;
 
     if (targetStructure->transitionWatchpointSetIsStillValid()) {
@@ -180,7 +180,7 @@ ALWAYS_INLINE bool objectCloneFast(VM& vm, JSFinalObject* target, JSObject* sour
         }
     }
 
-    if (!checkStrucureForClone(sourceStructure))
+    if (!checkStructureForClone(sourceStructure))
         return false;
 
     if (!sourceStructure->didTransition()) {
@@ -205,14 +205,17 @@ ALWAYS_INLINE bool objectCloneFast(VM& vm, JSFinalObject* target, JSObject* sour
 
     dataLogLnIf(verbose, "Use fast cloning!");
 
+    bool canCopyInlineStorage = source->hasInlineStorage();
+
     unsigned propertyCapacity = sourceStructure->outOfLineCapacity();
     if (propertyCapacity) {
         Butterfly* newButterfly = Butterfly::createUninitialized(vm, target, 0, propertyCapacity, /* hasIndexingHeader */ false, 0);
         // memcpy is fine since newButterfly is not tied to any object yet.
         memcpy(newButterfly->propertyStorage() - propertyCapacity, source->butterfly()->propertyStorage() - propertyCapacity, propertyCapacity * sizeof(EncodedJSValue));
-        gcSafeMemcpy(target->inlineStorage(), source->inlineStorage(), sourceStructure->inlineCapacity() * sizeof(EncodedJSValue));
+        if (canCopyInlineStorage)
+            gcSafeMemcpy(target->inlineStorage(), source->inlineStorage(), sourceStructure->inlineCapacity() * sizeof(EncodedJSValue));
         target->nukeStructureAndSetButterfly(vm, targetStructure->id(), newButterfly);
-    } else
+    } else if (canCopyInlineStorage)
         gcSafeMemcpy(target->inlineStorage(), source->inlineStorage(), sourceStructure->inlineCapacity() * sizeof(EncodedJSValue));
     target->setStructure(vm, sourceStructure);
 
@@ -244,7 +247,7 @@ ALWAYS_INLINE JSObject* tryCreateObjectViaCloning(VM& vm, JSGlobalObject* global
         }
     }
 
-    if (!checkStrucureForClone(sourceStructure))
+    if (!checkStructureForClone(sourceStructure))
         return nullptr;
 
     if (!sourceStructure->didTransition()) {

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -75,7 +75,7 @@ bool Highlight::removeFromSetLike(const AbstractRange& range)
 
 void Highlight::clearFromSetLike()
 {
-    for (auto& highlightRange : m_highlightRanges)
+    for (auto& highlightRange : std::exchange(m_highlightRanges, { }))
         repaintRange(highlightRange->range());
     m_highlightRanges.clear();
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8610,7 +8610,7 @@ header: <WebCore/ShareableBitmap.h>
     bool m_isOpaque;
     [Validator='*bitsPerComponent >= 1 && *bitsPerComponent <= 16'] unsigned bitsPerComponent();
     [Validator='*bytesPerPixel >= 1 && *bytesPerPixel <= 8'] unsigned bytesPerPixel();
-    [Validator='*bytesPerRow >= m_size->width() * *bytesPerPixel'] unsigned bytesPerRow();
+    [Validator='[&]() { std::remove_cvref_t<decltype(*bytesPerRow)> bytesForWidth; return WTF::safeMultiply(m_size->width(), *bytesPerPixel, bytesForWidth) && *bytesPerRow >= bytesForWidth; }()'] unsigned bytesPerRow();
 #if USE(CG)
     CGBitmapInfo m_bitmapInfo;
 #endif


### PR DESCRIPTION
#### 3330a93a8523304755eb9603f3ff52ea8eb1e648
<pre>
[JSC] GetByStatus::computeFor has race condition around swapped object&apos;s structure checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=305521">https://bugs.webkit.org/show_bug.cgi?id=305521</a>
<a href="https://rdar.apple.com/155413221">rdar://155413221</a>

Reviewed by Yijia Huang.

Now ObjectPropertyCondition is propertly created. But it is possible
that this finally registered ObjectPropertyCondition&apos;s structures are
not having a proper condition we would like. We are obtainining objects
from the condition and checking structure&apos;s characteristics.

Test: JSTests/stress/dfg-proto-fold-invalidate3.js

* JSTests/stress/dfg-proto-fold-invalidate3.js: Added.
(shouldBe):
(opt):
(watchCalleeProperty):
(async sleep):
(createClonedArguments):
(p):
(async main):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFor):

Originally-landed-as: 305413.33@safari-7624-branch (744106342146). <a href="https://rdar.apple.com/170270523">rdar://170270523</a>
Canonical link: <a href="https://commits.webkit.org/308720@main">https://commits.webkit.org/308720@main</a>
</pre>
----------------------------------------------------------------------
#### 13d284abcfcb276e9340d5e338ee479ab7927522
<pre>
[WebKit][Main] [76d1bb47f067ac21] ASAN_SEGV | WebCore::Highlight::clearFromSetLike; WebCore::HighlightRegistry::clear; WebCore::Document::commonTeardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=304176">https://bugs.webkit.org/show_bug.cgi?id=304176</a>
<a href="https://rdar.apple.com/166163089">rdar://166163089</a>

Reviewed by Chris Dumez.

Follow-up after 302196.10@webkit-2025.11-embargoed to improve the bug fix.

Covered by existing test.

* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::Highlight::clearFromSetLike):

Originally-landed-as: 302196.11@webkit-2025.11-embargoed (51b8db6618a3). <a href="https://rdar.apple.com/170272051">rdar://170272051</a>
Canonical link: <a href="https://commits.webkit.org/308719@main">https://commits.webkit.org/308719@main</a>
</pre>
----------------------------------------------------------------------
#### 3d2be34257ec9aa21c645e4c0eac25b8117240c6
<pre>
Catch multiplication overflow in bytesPerRow() validator
<a href="https://bugs.webkit.org/show_bug.cgi?id=305033">https://bugs.webkit.org/show_bug.cgi?id=305033</a>
<a href="https://rdar.apple.com/167621238">rdar://167621238</a>

Reviewed by Dan Glastonbury.

The multiplication `m_size-&gt;width() * *bytesPerPixel` could overflow
into a negative number, allowing the validation to pass for very large
widths.
Fixed by using `WTF::safeMultiply`, which checks for overflows relative
to the result type.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Originally-landed-as: 301765.416@safari-7623-branch (7c8da3f7f913). <a href="https://rdar.apple.com/171555967">rdar://171555967</a>
Canonical link: <a href="https://commits.webkit.org/308718@main">https://commits.webkit.org/308718@main</a>
</pre>
----------------------------------------------------------------------
#### 47b17ca50c7b3c8bb070f9c8ecf551cf3615a5a2
<pre>
operationNewRegExpUntyped should call constructRegExp with a newTarget
<a href="https://bugs.webkit.org/show_bug.cgi?id=305161">https://bugs.webkit.org/show_bug.cgi?id=305161</a>
<a href="https://rdar.apple.com/167199047">rdar://167199047</a>

Reviewed by Mark Lam.

If the RegExp constructor is invoked using &quot;new&quot; then it must have a
valid newTarget, but not if it is invoked as a function call
(&quot;RegExp(...)&quot; vs. &quot;new RegExp(...)&quot;). This patch updates DFG to
follow the specification correctly, since previously the code did not
pass in a newTarget to the RegExp constructor.

operationNewRegExpUntyped() is only called for the NewRegExpUntyped DFG node.
NewRegExpUntyped is only emitted by the bytecode parser if newTargetNode != callTargetNode.
Hence, the newTarget value that should be passes is the callTargetNode i.e. the RegExp constructor.

See <a href="https://262.ecma-international.org/#sec-regexp-pattern-flags">https://262.ecma-international.org/#sec-regexp-pattern-flags</a>
specifying what should be passed in newTarget.

```
2. If NewTarget is undefined, then
  a. Let newTarget be the active function object.
```

Test: JSTests/stress/dfg-miscompiles-new-regexp.js

* JSTests/stress/dfg-miscompiles-new-regexp.js: Added.
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Originally-landed-as: 301765.415@safari-7623-branch (4175b9cec24d). <a href="https://rdar.apple.com/167199047">rdar://167199047</a>
Canonical link: <a href="https://commits.webkit.org/308717@main">https://commits.webkit.org/308717@main</a>
</pre>
----------------------------------------------------------------------
#### 0c60c77c0c3d01dcfb95c0c1e0bd40d9fb6562c6
<pre>
Don&apos;t attempt to copy nonexistent inline storage in fast object cloning
<a href="https://rdar.apple.com/167110652">rdar://167110652</a>

Reviewed by Yusuke Suzuki.

This prevents an attempt to access inline storage in Object.assign when
there is no inline storage to copy.

Added a test that crashed with an assertion failure in debug mode
before these changes.

* JSTests/stress/object-assign-inline-storage.js: Added.
(shouldBe):
(C):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::checkStructureForClone): Renamed from checkStrucureForClone.
(JSC::objectCloneFast): Add a check for inline storage presence.
(JSC::tryCreateObjectViaCloning): Updated an invocation name.
(JSC::checkStrucureForClone): Renamed to checkStructureForClone.

Originally-landed-as: 301765.401@safari-7623-branch (dabdca54351d). <a href="https://rdar.apple.com/171556071">rdar://171556071</a>
Canonical link: <a href="https://commits.webkit.org/308716@main">https://commits.webkit.org/308716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a05329c989a6ac84b2a29452708248a8b74db5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101598 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34e55475-aac0-4848-a14b-17b06324e6ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81447 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c70158f-7403-484a-b7ba-245ed77c08f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95005 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8a13b6f-b199-4d71-b3cc-4f579f5afccd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15606 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13409 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4305 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140152 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159201 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8972 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122268 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122487 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33319 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76829 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9523 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179605 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84069 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45985 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20017 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->