### PR TITLE
PreconnectTask should cancel its NetworkLoad on timeout.

### DIFF
--- a/Source/WebKit/NetworkProcess/PreconnectTask.cpp
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.cpp
@@ -115,6 +115,7 @@ void PreconnectTask::didFailLoading(const ResourceError& error)
 void PreconnectTask::didTimeout()
 {
     RELEASE_LOG_ERROR(Network, "%p - PreconnectTask::didTimeout", this);
+    m_networkLoad->cancel();
     m_completionHandler(ResourceError { String(), 0, m_networkLoad->parameters().request.url(), "Preconnection timed out"_s, ResourceError::Type::Timeout }, { }); // Deletes this.
 }
 


### PR DESCRIPTION
#### d3fa2f1daabafbeaa4c33062a889028746d99daf
<pre>
PreconnectTask should cancel its NetworkLoad on timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309026">https://bugs.webkit.org/show_bug.cgi?id=309026</a>
<a href="https://rdar.apple.com/171339073">rdar://171339073</a>

Reviewed by Per Arne Vollan.

When PreconnectTask times out, it fires the completion handler and destroys itself, but
does not cancel the　underlying NetworkLoad. This leaves the NSURLSessionTask running,
which can result in wasted TLS handshakes and misleading SSL error logs (e.g., trust
evaluation failure / -1202) after the preconnect has already timed out.

The fix is to call m_networkLoad-&gt;cancel() in didTimeout() before invoking the completion
handler, so the underlying network task is immediately cancelled on timeout.

Manually verified with logs that the underlying network task is cancelled immediately
after PreconnectTask::didTimeout fires, with no confusing error logs.

* Source/WebKit/NetworkProcess/PreconnectTask.cpp:
(WebKit::PreconnectTask::didTimeout):

Canonical link: <a href="https://commits.webkit.org/308565@main">https://commits.webkit.org/308565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d88dd24bfb766f17cbfba128af38bfaabd47d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101173 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f224753-7b78-439e-9e9d-b07808b4610b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113907 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81233 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a71fdcf5-7384-4e37-8133-ba8bcedce8dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16152 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132705 "Found 1 new API test failure: TestWebKitAPI.ScrollingCoordinatorTests.ScrollingTreeAfterDetachReattach (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94667 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44671a4b-90d1-478d-9243-d108ff5ad0ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15312 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3881 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124909 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158776 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121935 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31321 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76368 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9178 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19858 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83620 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19587 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19645 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->