### PR TITLE
REGRESSION (301944@main): WebGL uniform block variables get uniform location objects

### DIFF
--- a/LayoutTests/webgl/unused-uniform-location-expected.txt
+++ b/LayoutTests/webgl/unused-uniform-location-expected.txt
@@ -1,0 +1,28 @@
+Unused uniform locations should return null, uniform block variables should not have location
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 19 PASS, 0 FAIL
+
+PASS gl.getUniformLocation(program, "c") is non-null.
+PASS gl.getUniformLocation(program, "u0") is null
+PASS gl.getUniformLocation(program, "u1") is null
+PASS gl.getUniformLocation(program, "u1[0]") is null
+PASS gl.getUniformLocation(program, "u2") is null
+PASS gl.getUniformLocation(program, "u3[0]") is null
+PASS gl.getUniformLocation(program, "u3[1]") is null
+PASS gl.getUniformLocation(program, "u4[0]") is null
+PASS gl.getUniformLocation(program, "u4[1]") is null
+PASS gl.getUniformLocation(program, "u4[2]") is null
+PASS gl.getUniformLocation(program, "u5[0]") is non-null.
+PASS gl.getUniformLocation(program, "u5[1]") is non-null.
+PASS gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS) is 5
+PASS gl.getActiveUniform(program, 0).name is "u5[0]"
+PASS gl.getActiveUniform(program, 1).name is "c"
+PASS gl.getActiveUniform(program, 2).name is "u2"
+PASS gl.getActiveUniform(program, 3).name is "u3[0]"
+PASS gl.getActiveUniform(program, 4).name is "u4[0]"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/unused-uniform-location.html
+++ b/LayoutTests/webgl/unused-uniform-location.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL test checking that unused uniforms are null</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="256" height="256"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Unused uniform locations should return null, uniform block variables should not have location");
+var wtu = WebGLTestUtils;
+var vs = `#version 300 es
+precision highp float;
+in vec4 vPosition;
+uniform vec4 u0;
+uniform vec4 u1[2];
+uniform U {
+	vec4 u2;
+    vec4 u3[2];
+    vec4 u4[3];
+};
+uniform vec4 u5[3];
+void main() {
+    gl_Position = vPosition + u4[1] + u5[1];
+}`;
+var fs = `#version 300 es
+precision highp float;
+uniform vec4 c;
+out vec4 color;
+void main() {
+    color = c;
+}`;
+var gl;
+var program;
+function test() {
+    var canvas = document.getElementById("canvas");
+    gl = wtu.create3DContext(canvas, undefined, 2);
+    if (!gl) {
+        testFailed("no context");
+        finishTest();
+        return;
+    }
+
+    program = wtu.setupProgram(gl, [vs, fs], ["vPosition"]);
+    if (!program) {
+        testFailed("Failed to create program");
+        finishTest();
+        return;
+    }
+    shouldBeNonNull('gl.getUniformLocation(program, "c")');
+    shouldBeNull('gl.getUniformLocation(program, "u0")');
+    shouldBeNull('gl.getUniformLocation(program, "u1")');
+    shouldBeNull('gl.getUniformLocation(program, "u1[0]")');
+    shouldBeNull('gl.getUniformLocation(program, "u2")');
+    shouldBeNull('gl.getUniformLocation(program, "u3[0]")');
+    shouldBeNull('gl.getUniformLocation(program, "u3[1]")');
+    shouldBeNull('gl.getUniformLocation(program, "u4[0]")');
+    shouldBeNull('gl.getUniformLocation(program, "u4[1]")');
+    shouldBeNull('gl.getUniformLocation(program, "u4[2]")');
+    shouldBeNonNull('gl.getUniformLocation(program, "u5[0]")');
+    shouldBeNonNull('gl.getUniformLocation(program, "u5[1]")');
+    shouldBe('gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS)', '5');
+    shouldBe('gl.getActiveUniform(program, 0).name', '"u5[0]"');
+    shouldBe('gl.getActiveUniform(program, 1).name', '"c"');
+    shouldBe('gl.getActiveUniform(program, 2).name', '"u2"');
+    shouldBe('gl.getActiveUniform(program, 3).name', '"u3[0]"');
+    shouldBe('gl.getActiveUniform(program, 4).name', '"u4[0]"');
+    finishTest();
+};
+test();
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2462,7 +2462,7 @@ WebGLAny WebGL2RenderingContext::getActiveUniforms(WebGLProgram& program, const 
     }
     case GraphicsContextGL::UNIFORM_SIZE: {
         return uniformIndices.map([&](GCGLuint index) -> GCGLuint {
-            return activeUniforms[index].locations.size();
+            return activeUniforms[index].size;
         });
     }
     case GraphicsContextGL::UNIFORM_BLOCK_INDEX:

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -176,11 +176,15 @@ const HashMap<String, int>& WebGLProgram::uniformLocations() LIFETIME_BOUND
     if (!m_state.uniformLocations) {
         auto& locations = m_state.uniformLocations.emplace();
         for (auto& activeUniform : activeUniforms()) {
+            if (activeUniform.blockIndex != -1)
+                continue;
             auto name = String::fromUTF8(activeUniform.name.data());
-            locations.add(name, activeUniform.locations[0]);
+            if (activeUniform.locations[0] != -1)
+                locations.add(name, activeUniform.locations[0]);
             if (name.endsWith("[0]"_s)) {
                 auto baseName = name.left(name.length() - 3);
-                locations.add(baseName, activeUniform.locations[0]);
+                if (activeUniform.locations[0] != -1)
+                    locations.add(baseName, activeUniform.locations[0]);
                 for (size_t i = 1; i < activeUniform.locations.size(); ++i) {
                     if (activeUniform.locations[i] != -1)
                         locations.add(makeString(baseName, '[', i, ']'), activeUniform.locations[i]);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1796,7 +1796,7 @@ RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveUniform(WebGLProgram
         return nullptr;
     }
     auto& info = activeUniforms[index];
-    return WebGLActiveInfo::create(String::fromUTF8(info.name.span()), info.type, info.locations.size());
+    return WebGLActiveInfo::create(String::fromUTF8(info.name.span()), info.type, info.size);
 }
 
 std::optional<Vector<Ref<WebGLShader>>> WebGLRenderingContextBase::getAttachedShaders(WebGLProgram& program)

--- a/Source/WebCore/platform/graphics/GraphicsContextGLActiveInfo.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLActiveInfo.h
@@ -37,13 +37,15 @@ class GCGLUniformActiveInfo {
 public:
     CString name;
     GCGLenum type { 0 };
-    Vector<int> locations;
+    int size { -1 };
     // WebGL2 properties.
     int blockIndex { -1 };
     int offset { -1 };
     int arrayStride { -1 };
     int matrixStride { -1 };
     int isRowMajor { -1 };
+    // For default block uniforms.
+    Vector<int> locations;
 };
 
 class GCGLAttribActiveInfo {

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -1443,15 +1443,13 @@ Vector<GCGLUniformActiveInfo> GraphicsContextGLANGLE::activeUniforms(PlatformGLO
         name.resize(maxLength); // GL_ACTIVE_UNIFORM_MAX_LENGTH includes nul termination.
         GCGLUniformActiveInfo info;
         GLsizei length = 0;
-        GLint size = 0;
-        GL_GetActiveUniform(program, index, maxLength, &length, &size, &info.type, name.data());
-        if (length < 1 || size < 1) {
+        GL_GetActiveUniform(program, index, maxLength, &length, &info.size, &info.type, name.data());
+        if (length < 1 || info.size < 1) {
             ASSERT_NOT_REACHED();
             return { };
         }
         name.resize(length);
         info.name = name;
-        info.locations.append(GL_GetUniformLocation(program, name.data()));
         if (m_isForWebGL2) {
             GL_GetActiveUniformsiv(program, 1, &index, GL_UNIFORM_BLOCK_INDEX, &info.blockIndex);
             GL_GetActiveUniformsiv(program, 1, &index, GL_UNIFORM_OFFSET, &info.offset);
@@ -1459,15 +1457,18 @@ Vector<GCGLUniformActiveInfo> GraphicsContextGLANGLE::activeUniforms(PlatformGLO
             GL_GetActiveUniformsiv(program, 1, &index, GL_UNIFORM_MATRIX_STRIDE, &info.matrixStride);
             GL_GetActiveUniformsiv(program, 1, &index, GL_UNIFORM_IS_ROW_MAJOR, &info.isRowMajor);
         }
-        if (size > 1) {
-            if (!name.ends_with("[0]")) {
-                ASSERT_NOT_REACHED();
-                return { };
-            }
-            name.resize(name.length() - 3);
-            for (GLint arrayIndex = 1; arrayIndex < size; ++arrayIndex) {
-                auto elementName = (std::ostringstream() << name << '[' << arrayIndex << ']').str();
-                info.locations.append(GL_GetUniformLocation(program, elementName.data()));
+        if (info.blockIndex == -1) {
+            info.locations.append(GL_GetUniformLocation(program, name.data()));
+            if (info.size > 1) {
+                if (!name.ends_with("[0]")) {
+                    ASSERT_NOT_REACHED();
+                    return { };
+                }
+                name.resize(name.length() - 3);
+                for (GLint arrayIndex = 1; arrayIndex < info.size; ++arrayIndex) {
+                    auto elementName = (std::ostringstream() << name << '[' << arrayIndex << ']').str();
+                    info.locations.append(GL_GetUniformLocation(program, elementName.data()));
+                }
             }
         }
         result.append(WTF::move(info));

--- a/Source/WebKit/Shared/WebGL.serialization.in
+++ b/Source/WebKit/Shared/WebGL.serialization.in
@@ -165,12 +165,13 @@ header: <WebCore/GraphicsContextGLActiveInfo.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::GCGLUniformActiveInfo {
     CString name;
     GCGLenum type;
-    Vector<int> locations;
+    int size;
     int blockIndex;
     int offset;
     int arrayStride;
     int matrixStride;
     int isRowMajor;
+    Vector<int> locations;
 };
 header: <WebCore/GraphicsContextGLActiveInfo.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::GCGLAttribActiveInfo {


### PR DESCRIPTION
#### e7c1f6f9f7324a8344e46935d407b777876d5004
<pre>
REGRESSION (301944@main): WebGL uniform block variables get uniform location objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=309018">https://bugs.webkit.org/show_bug.cgi?id=309018</a>
<a href="https://rdar.apple.com/171569214">rdar://171569214</a>

Reviewed by Dan Glastonbury.

Default uniform block variables (&quot;regular uniforms&quot;) are the ones that
get location.
Uniform block variables get block index. WebKit would return
WebGLUniformLocation object referring to -1 location when uniform block
name would be queried for getUniformLocation().

Fix by filtering active uniforms that have block index != -1 when
constructing the default uniform block location map.

Test: webgl/unused-uniform-location.html

* LayoutTests/webgl/unused-uniform-location-expected.txt: Added.
* LayoutTests/webgl/unused-uniform-location.html: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getActiveUniforms):
* Source/WebCore/html/canvas/WebGLProgram.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getActiveUniform):
* Source/WebCore/platform/graphics/GraphicsContextGLActiveInfo.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::activeUniforms):
* Source/WebKit/Shared/WebGL.serialization.in:

Canonical link: <a href="https://commits.webkit.org/308507@main">https://commits.webkit.org/308507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/808d475a198d41d494a2bae69199d22b806ac72a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156442 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b6fe21f-f031-4129-82ec-59209c04248e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113908 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f3b6e7b-b76a-4df9-93e9-f6f3e6f72ced) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94668 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c302d87-083a-402e-8895-9fc9c409392d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3882 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158777 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1911 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121937 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122138 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31281 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76369 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9181 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83621 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19739 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->