### PR TITLE
Fixed bar briefly shows up in middle of the page after rotation to portrait (apple.com, cnn.com, etc.)

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3002,12 +3002,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
 
             // Reposition fixed/sticky layers even though the full update to WebContent is throttled.
             // Without taking this step, fixed or sticky elements will freeze in position and then visibly jump when WebContent updates.
-            [self _updateScrollViewContentInsetsIfNecessary];
-            if (auto info = [self _createVisibleContentRectUpdate]) {
-                _page->updateVisibleContentRectsLocally(*info);
-                auto layoutViewport = _page->unconstrainedLayoutViewportRect();
-                _page->adjustLayersForLayoutViewport(_page->unobscuredContentRect().location(), layoutViewport, _page->displayedContentScale());
-            }
+            [self _updateViewportRelativeLayersOutOfBand];
             return;
         }
     }
@@ -3043,6 +3038,17 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
     _timeOfLastVisibleContentRectUpdate = timeNow;
     if (!_timeOfFirstVisibleContentRectUpdateWithPendingCommit)
         _timeOfFirstVisibleContentRectUpdateWithPendingCommit = timeNow;
+}
+
+- (void)_updateViewportRelativeLayersOutOfBand
+{
+    // Reposition fixed/sticky layers even when visible content rect updates are deferred.
+    [self _updateScrollViewContentInsetsIfNecessary];
+    if (auto info = [self _createVisibleContentRectUpdate]) {
+        _page->updateVisibleContentRectsLocally(*info);
+        auto layoutViewport = _page->unconstrainedLayoutViewportRect();
+        _page->adjustLayersForLayoutViewport(_page->unobscuredContentRect().location(), layoutViewport, _page->displayedContentScale());
+    }
 }
 
 - (void)_didStartProvisionalLoadForMainFrame
@@ -4567,6 +4573,8 @@ static bool isLockdownModeWarningNeeded()
 #if HAVE(LIQUID_GLASS)
     [self _updateFixedColorExtensionViewFrames];
 #endif
+
+    [self _updateViewportRelativeLayersOutOfBand];
 }
 
 - (void)_endAnimatedResize

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -737,4 +737,56 @@ TEST(AnimatedResize, ScaleDuringAnimatedResizeDoesNotMoveContentViewFrameOrigin)
     EXPECT_EQ(frameOrigin.y, 0);
 }
 
+TEST(AnimatedResize, AnimatedResizeDoesNotFreezeFixedElements)
+{
+    auto webView = createAnimatedResizeWebView();
+    [webView setFrame:CGRectMake(0, 0, 500, 200)];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='initial-scale=1'>"
+        "<style>"
+        "body { margin: 0; height: 10000px; }"
+        "#footer { position: fixed; top: 0; left: 0; width: 320px; height: 47px; background: blue; }"
+        "</style>"
+        "<div id='footer'>text</div>"];
+    [[webView scrollView] setContentOffset:CGPointMake(0, 5000)];
+    [webView waitForNextPresentationUpdate];
+
+    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 500, 500)]);
+    [window addSubview:webView.get()];
+    [window setHidden:NO];
+
+    auto footerIsPinned = ^{
+        __block CALayer *footerLayer = nil;
+
+        [webView forEachCALayer:^(CALayer *layer) {
+            if (CGSizeEqualToSize(layer.bounds.size, CGSizeMake(320, 47))) {
+                footerLayer = layer;
+                return IterationStatus::Done;
+            }
+
+            return IterationStatus::Continue;
+        }];
+
+        auto rect = [footerLayer convertRect:footerLayer.bounds toLayer:[webView layer]];
+        return !CGRectGetMinY(rect);
+    };
+
+    EXPECT_TRUE(footerIsPinned());
+
+    [webView _beginAnimatedResizeWithUpdates:^{
+        [webView setFrame:CGRectMake(0, 0, 500, 400)];
+    }];
+
+    EXPECT_TRUE(footerIsPinned());
+
+    dispatch_async(mainDispatchQueueSingleton(), ^{
+        [webView _endAnimatedResize];
+    });
+
+    TestWebKitAPI::Util::run(&didEndAnimatedResize);
+    didEndAnimatedResize = false;
+
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE(footerIsPinned());
+}
+
 #endif


### PR DESCRIPTION
#### a71323b7d6371c5f2fd7b244c5f2638aded9cd8a
<pre>
Fixed bar briefly shows up in middle of the page after rotation to portrait (apple.com, cnn.com, etc.)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309030">https://bugs.webkit.org/show_bug.cgi?id=309030</a>
<a href="https://rdar.apple.com/21719346">rdar://21719346</a>

Reviewed by Ryan Reno.

Similar to 308209@main, use 306156@main&apos;s newly-introduced mechanism to make
out-of-band visible content rect updates, and update viewport-relative layers
during animated resize, updating the layers *after* we apply the resize update block.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateVisibleContentRects]):
(-[WKWebView _updateViewportRelativeLayersOutOfBand]):
Factor _updateViewportRelativeLayersOutOfBand out of _updateVisibleContentRects.

(-[WKWebView _beginAnimatedResizeWithUpdates:]):
Update viewport relative layers when we start an animated resize.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST(AnimatedResize, AnimatedResizeDoesNotFreezeFixedElements)):
Add a test.

Canonical link: <a href="https://commits.webkit.org/308558@main">https://commits.webkit.org/308558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10b896346c540f263932c6134d71a5239df51967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101217 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b28d9184-7efc-4b11-af16-3af781308e32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113945 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81253 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7637372-a76c-4ade-ac42-30ed787a14ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94705 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37ff5ddd-5784-4733-afdd-3a6e85d97e64) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13128 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3925 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158820 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1954 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121975 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31314 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76412 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9220 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83664 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19631 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19782 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19689 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->