### PR TITLE
Clipboard copy serialization does not preserve background-color for multi-paragraph selections

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color-expected.txt
@@ -1,0 +1,18 @@
+Pasted content should have background-color on inline spans, not on block elements.
+
+Pasted multi-paragraph content:
+| <p>
+|   style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+|   <span>
+|     style="background-color: rgb(30, 30, 30)"
+|     "First paragraph"
+| <p>
+|   style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+|   <span>
+|     style="background-color: rgb(30, 30, 30)"
+|     "Second paragraph"
+| <p>
+|   style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+|   <span>
+|     style="background-color: rgb(30, 30, 30)"
+|     "Third paragraph<#selection-caret>"

--- a/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color.html
+++ b/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test verifies that copying multiple paragraphs from a container with a background-color
+preserves the background-color on inline spans in the pasted content, consistent with single-paragraph copy behavior.</p>
+<p>To manually test, select all three paragraphs in the dark box, copy, and paste into the editable area below.</p>
+<div id="source" style="background-color: rgb(30, 30, 30); color: rgb(255, 255, 255);">
+<p>First paragraph</p>
+<p>Second paragraph</p>
+<p>Third paragraph</p>
+</div>
+<div id="destination" style="border: solid 1px black; padding: 20px;" contenteditable></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+if (window.testRunner) {
+    var source = document.getElementById('source');
+    window.getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
+    document.execCommand('Copy');
+
+    window.getSelection().setPosition(document.getElementById('destination'), 0);
+    document.execCommand('Paste');
+
+    Markup.description('Pasted content should have background-color on inline spans, not on block elements.');
+    Markup.dump('destination', 'Pasted multi-paragraph content');
+} else
+    Markup.noAutoDump();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010, 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -863,9 +863,9 @@ void EditingStyle::removeStyleConflictingWithStyleOfNode(Node& node)
     if (!node.parentNode() || !m_mutableStyle)
         return;
 
-    auto parentStyle = copyPropertiesFromComputedStyle(protect(node.parentNode()).get(), PropertiesToInclude::EditingPropertiesInEffect);
+    auto parentStyle = EditingStyle::create(node.parentNode(), PropertiesToInclude::EditingPropertiesInEffect);
     auto nodeStyle = EditingStyle::create(&node, PropertiesToInclude::EditingPropertiesInEffect);
-    nodeStyle->removeEquivalentProperties(parentStyle.get());
+    nodeStyle->removeEquivalentProperties(*parentStyle->style());
 
     RefPtr mutableStyle = style();
     for (auto property : *nodeStyle->style())
@@ -1355,7 +1355,7 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
 
         // Call collapseTextDecorationProperties first or otherwise it'll copy the value over from in-effect to text-decorations.
         wrappingStyle->collapseTextDecorationProperties();
-        
+
         return wrappingStyle;
     }
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009, 2010, 2011 Google Inc. All rights reserved.
  * Copyright (C) 2011 Igalia S.L.
  * Copyright (C) 2011 Motorola Mobility. All rights reserved.
@@ -620,6 +620,15 @@ void StyledMarkupAccumulator::appendText(StringBuilder& out, const Text& text)
         }());
     }
 
+    bool wrappingBackgroundColorSpan = false;
+    if (!wrappingSpan && !parentIsTextarea && m_wrappingStyle && m_wrappingStyle->style()) {
+        auto backgroundColor = m_wrappingStyle->style()->getPropertyValue(CSSPropertyBackgroundColor);
+        if (!backgroundColor.isEmpty() && backgroundColor != "transparent"_s) {
+            out.append("<span style=\"background-color: "_s, backgroundColor, "\">"_s);
+            wrappingBackgroundColorSpan = true;
+        }
+    }
+
     if (!shouldAnnotate() || parentIsTextarea) {
         auto content = textContentRespectingRange(text);
         appendCharactersReplacingEntities(out, content, entityMaskForText(text));
@@ -630,6 +639,9 @@ void StyledMarkupAccumulator::appendText(StringBuilder& out, const Text& text)
         appendCharactersReplacingEntities(buffer, content, EntityMaskInPCDATA);
         out.append(convertHTMLTextToInterchangeFormat(buffer.toString(), &text));
     }
+
+    if (wrappingBackgroundColorSpan)
+        out.append("</span>"_s);
 
     if (wrappingSpan)
         out.append(styleNodeCloseTag());
@@ -757,6 +769,8 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
             newInlineStyle = m_wrappingStyle->copy();
             newInlineStyle->removePropertiesInElementDefaultStyle(*const_cast<Element*>(&element));
             newInlineStyle->removeStyleConflictingWithStyleOfNode(*const_cast<Element*>(&element));
+            if (isBlock(element) && newInlineStyle->style())
+                newInlineStyle->style()->removeProperty(CSSPropertyBackgroundColor);
         } else
             newInlineStyle = EditingStyle::create();
 


### PR DESCRIPTION
#### 9e47ed2c32bc614c63c2b600963c9d59c1b62239
<pre>
Clipboard copy serialization does not preserve background-color for multi-paragraph selections
<a href="https://bugs.webkit.org/show_bug.cgi?id=308854">https://bugs.webkit.org/show_bug.cgi?id=308854</a>
<a href="https://rdar.apple.com/171391621">rdar://171391621</a>

Reviewed by NOBODY (OOPS!).

When copying multi-paragraph content from a dark-mode page, background-color<br>was stripped because removeStyleConflictingWithStyleOfNode computed the<br>parent&apos;s and node&apos;s styles using different methods. The parent used<br>copyPropertiesFromComputedStyle which got raw background-color: transparent,<br>while the node used EditingStyle::create which walked up the ancestor chain<br>via backgroundColorInEffect and found the actual visible background color.<br>The mismatch caused background-color to be treated as a conflict and thus<br>stripped from the wrapping style. The fix makes both sides use<br>EditingStyle::create, so both walk the ancestor chain and find the same<br>inherited background color. Since they match, background-color is no longer<br>treated as a conflict and is preserved in the wrapping style. It&apos;s then<br>moved from the block-level &lt;p&gt; elements (which render full-width backgrounds)<br>onto inline &lt;span&gt; wrappers around the text content.

* LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color.html: Added.
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::removeStyleConflictingWithStyleOfNode):
(WebCore::EditingStyle::wrappingStyleForSerialization):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::appendText):
(WebCore::StyledMarkupAccumulator::appendStartTag):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e47ed2c32bc614c63c2b600963c9d59c1b62239

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20362 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113919 "Found 1 new test failure: fast/events/input-events-paste-rich-datatransfer.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81238 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150735 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16162 "Found 4 new test failures: editing/pasteboard/4641033.html editing/pasteboard/4944770-1.html editing/pasteboard/copy-element-with-conflicting-background-color-from-rule.html fast/events/input-events-paste-rich-datatransfer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15318 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124916 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10633 "Found 1 new test failure: editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158791 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1925 "Found 3 new failures in editing/EditingStyle.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12116 "Found 6 new test failures: editing/pasteboard/4641033.html editing/pasteboard/4944770-1.html editing/pasteboard/4944770-2.html editing/pasteboard/copy-element-with-conflicting-background-color-from-rule.html editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html fast/events/input-events-paste-rich-datatransfer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121948 "Found 4 new test failures: editing/pasteboard/4641033.html editing/pasteboard/4944770-1.html editing/pasteboard/select-element-1.html fast/events/input-events-paste-rich-datatransfer.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20257 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17021 "Found 7 new test failures: editing/pasteboard/4641033.html editing/pasteboard/4944770-1.html editing/pasteboard/4944770-2.html editing/pasteboard/copy-element-with-conflicting-background-color-from-rule.html editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html editing/pasteboard/select-element-1.html fast/events/input-events-paste-rich-datatransfer.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132425 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76383 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17652 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9195 "Found 6 new test failures: editing/pasteboard/4641033.html editing/pasteboard/4944770-1.html editing/pasteboard/4944770-2.html editing/pasteboard/copy-element-with-conflicting-background-color-from-rule.html editing/pasteboard/data-transfer-get-data-on-drop-rich-text.html fast/events/input-events-paste-rich-datatransfer.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19873 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83635 "Found 3 new failures in editing/EditingStyle.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->