### PR TITLE
fast/shadow-dom/touch-event-ios.html fails on iOS 26

### DIFF
--- a/LayoutTests/fast/shadow-dom/touch-event-ios-expected.txt
+++ b/LayoutTests/fast/shadow-dom/touch-event-ios-expected.txt
@@ -42,40 +42,16 @@ touchmove at document with
     targetTouches: [0: left-host]
     changedTouches: [0: left-host]
 
-touchstart at document with
-    target: bottom-target
-    touches: [0: left-host, 1: right-target, 2: bottom-target]
-    targetTouches: [0: bottom-target]
-    changedTouches: [0: bottom-target]
-
-touchmove at right-lower-shadow with
-    target: right-target
-    touches: [0: left-host, 1: right-target, 2: bottom-target]
-    targetTouches: [0: right-target]
-    changedTouches: [0: right-target]
-
-touchmove at right-upper-shadow with
-    target: right-target
-    touches: [0: left-host, 1: right-target, 2: bottom-target]
-    targetTouches: [0: right-target]
-    changedTouches: [0: right-target]
-
-touchmove at document with
-    target: right-target
-    touches: [0: left-host, 1: right-target, 2: bottom-target]
-    targetTouches: [0: right-target]
-    changedTouches: [0: right-target]
-
-touchmove at left-shadow with
+touchend at left-shadow with
     target: left-shadow-target
-    touches: [0: left-shadow-target, 1: right-target, 2: bottom-target]
-    targetTouches: [0: left-shadow-target]
+    touches: []
+    targetTouches: []
     changedTouches: [0: left-shadow-target]
 
-touchmove at document with
+touchend at document with
     target: left-host
-    touches: [0: left-host, 1: right-target, 2: bottom-target]
-    targetTouches: [0: left-host]
+    touches: []
+    targetTouches: []
     changedTouches: [0: left-host]
 
 touchend at right-lower-shadow with
@@ -96,22 +72,16 @@ touchend at document with
     targetTouches: []
     changedTouches: [0: right-target]
 
+touchstart at document with
+    target: bottom-target
+    touches: [0: bottom-target, 1: bottom-target, 2: bottom-target]
+    targetTouches: [0: bottom-target, 1: bottom-target, 2: bottom-target]
+    changedTouches: [0: bottom-target, 1: bottom-target, 2: bottom-target]
+
 touchend at document with
     target: bottom-target
     touches: []
     targetTouches: []
-    changedTouches: [0: bottom-target]
-
-touchend at left-shadow with
-    target: left-shadow-target
-    touches: []
-    targetTouches: []
-    changedTouches: [0: left-shadow-target]
-
-touchend at document with
-    target: left-host
-    touches: []
-    targetTouches: []
-    changedTouches: [0: left-host]
+    changedTouches: [0: bottom-target, 1: bottom-target, 2: bottom-target]
 
 

--- a/LayoutTests/fast/shadow-dom/touch-event-ios.html
+++ b/LayoutTests/fast/shadow-dom/touch-event-ios.html
@@ -75,30 +75,29 @@ var bottomTarget = elementWithStyle('bottom-target', block(100, 100, '#666'));
 
 document.body.appendChild(elementWithStyle('host-parent', block(500, 500, '#eee'), [leftHost, rightUpperHost, bottomTarget]));
 
-function getUIScript()
-{
-    function xCenter(element) { return element.offsetLeft + element.offsetWidth / 2; }
-    function yCenter(element) { return element.offsetTop + element.offsetHeight / 2; }
-
-    return `
-    (function() {
-        uiController.touchDownAtPoint(${xCenter(leftTarget)}, ${yCenter(leftTarget)}, 1, function() {
-            uiController.touchDownAtPoint(${xCenter(rightTarget)}, ${yCenter(rightTarget)}, 2, function() {
-                uiController.touchDownAtPoint(${xCenter(bottomTarget)}, ${yCenter(bottomTarget)}, 3, function() {
-                    uiController.liftUpAtPoint(${xCenter(leftTarget)}, ${yCenter(leftTarget)}, 2, function () {
-                        uiController.liftUpAtPoint(${xCenter(rightTarget)}, ${yCenter(rightTarget)}, 1, function () {
-                            uiController.liftUpAtPoint(${xCenter(bottomTarget)}, ${yCenter(bottomTarget)}, 0, function () {
-                                uiController.uiScriptComplete("Done");
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    })();`
+function issueTouchDownAt(x, y, identifier) {
+    return new Promise((resolve) => {
+        testRunner.runUIScript(`
+            uiController.touchDownAtPoint(${x}, ${y}, ${identifier}, function() {
+                uiController.uiScriptComplete("Done");
+            });`, resolve);
+    });
 }
 
-window.onload = function runTest()
+function issueTouchUpAt(x, y, identifier) {
+    return new Promise((resolve) => {
+        testRunner.runUIScript(`
+            uiController.liftUpAtPoint(${x}, ${y}, ${identifier}, function() {
+                uiController.uiScriptComplete("Done");
+            });`, resolve);
+    });
+}
+
+function timeout(milliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+window.onload = async function runTest()
 {
     if (window.testRunner)
         testRunner.dumpAsText();
@@ -140,12 +139,24 @@ window.onload = function runTest()
 
     if (window.testRunner && testRunner.runUIScript) {
         testRunner.waitUntilDone();
-        testRunner.runUIScript(getUIScript(), function(result) {
-            var pre = document.createElement('pre');
-            pre.textContent = output;
-            document.body.appendChild(pre);
-            testRunner.notifyDone();
-        });
+
+        function xCenter(element) { return element.offsetLeft + element.offsetWidth / 2; }
+        function yCenter(element) { return -document.documentElement.scrollTop + element.offsetTop + element.offsetHeight / 2; }
+
+        await issueTouchDownAt(xCenter(leftTarget), yCenter(leftTarget), 1);
+        await issueTouchDownAt(xCenter(rightTarget), yCenter(rightTarget), 2);
+        await issueTouchUpAt(xCenter(leftTarget), yCenter(leftTarget), 2);
+        await issueTouchUpAt(xCenter(rightTarget), yCenter(rightTarget), 1);
+
+        await timeout(2000);
+
+        await issueTouchDownAt(xCenter(bottomTarget), yCenter(bottomTarget), 3);
+        await issueTouchUpAt(xCenter(bottomTarget), yCenter(bottomTarget), 3);
+
+        var pre = document.createElement('pre');
+        pre.textContent = output;
+        document.body.appendChild(pre);
+        testRunner.notifyDone();
     }
 }
 


### PR DESCRIPTION
#### 5d0754638b1beeaf9a6fd9cf7a1a5526ca85dddb
<pre>
fast/shadow-dom/touch-event-ios.html fails on iOS 26
<a href="https://bugs.webkit.org/show_bug.cgi?id=309031">https://bugs.webkit.org/show_bug.cgi?id=309031</a>
<a href="https://rdar.apple.com/168817806">rdar://168817806</a>

Reviewed by Wenson Hsieh.

Rewrite the test to avoid issuing 3 touch points as that doesn&apos;t work well in WebKitTestRunner.

I tried working around the issue with various timeouts but that end up causing other issues like
triggering random gesture recognizers so I rewrote the test to test up to two points at once.

Manual testing shows that 3+ point are functioning just fine on iOS 26.

* LayoutTests/fast/shadow-dom/touch-event-ios-expected.txt:
* LayoutTests/fast/shadow-dom/touch-event-ios.html:

Canonical link: <a href="https://commits.webkit.org/308510@main">https://commits.webkit.org/308510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d02672fc35d123a53f533aee38d909f3c49a5f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74d68dd0-7b06-4287-9866-0582c185c782) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9eaa9ce-3863-4310-8a0b-6621b1d9efbc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94675 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfe51509-c6ac-468a-b487-81426b644ae4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158786 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121945 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122146 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76378 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9189 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19868 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19655 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->