### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/html

### DIFF
--- a/Source/WebCore/html/Allowlist.h
+++ b/Source/WebCore/html/Allowlist.h
@@ -52,7 +52,7 @@ public:
         : m_origins(WTF::move(origins))
     {
     }
-    const OriginsVariant& origins() const { return m_origins; }
+    const OriginsVariant& origins() const LIFETIME_BOUND { return m_origins; }
 
     // This is simplified version of https://w3c.github.io/webappsec-permissions-policy/#matches.
     bool matches(const SecurityOriginData& origin) const

--- a/Source/WebCore/html/AttachmentAssociatedElement.cpp
+++ b/Source/WebCore/html/AttachmentAssociatedElement.cpp
@@ -45,7 +45,7 @@ void AttachmentAssociatedElement::setAttachmentElement(Ref<HTMLAttachmentElement
     protect(protect(asHTMLElement())->ensureUserAgentShadowRoot())->appendChild(WTF::move(attachment));
 }
 
-RefPtr<HTMLAttachmentElement> AttachmentAssociatedElement::attachmentElement() const
+HTMLAttachmentElement* AttachmentAssociatedElement::attachmentElement() const
 {
     if (RefPtr shadowRoot = protect(asHTMLElement())->userAgentShadowRoot())
         return childrenOfType<HTMLAttachmentElement>(*shadowRoot).first();
@@ -58,7 +58,7 @@ const String& AttachmentAssociatedElement::attachmentIdentifier() const
     if (!m_pendingClonedAttachmentID.isEmpty())
         return m_pendingClonedAttachmentID;
 
-    if (RefPtr attachment = attachmentElement())
+    if (auto* attachment = attachmentElement())
         return attachment->uniqueIdentifier();
 
     return nullAtom();

--- a/Source/WebCore/html/AttachmentAssociatedElement.h
+++ b/Source/WebCore/html/AttachmentAssociatedElement.h
@@ -58,7 +58,7 @@ public:
 
     virtual void setAttachmentElement(Ref<HTMLAttachmentElement>&&);
 
-    RefPtr<HTMLAttachmentElement> attachmentElement() const;
+    HTMLAttachmentElement* attachmentElement() const;
     const String& attachmentIdentifier() const;
     void didUpdateAttachmentIdentifier();
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -71,7 +71,7 @@ public:
 
     virtual unsigned width() const { return m_size.width(); }
     virtual unsigned height() const { return m_size.height(); }
-    const IntSize& size() const { return m_size; }
+    const IntSize& size() const LIFETIME_BOUND { return m_size; }
     virtual void setSizeForControllingContext(IntSize) = 0;
 
     RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
@@ -161,7 +161,7 @@ private:
 WebCoreOpaqueRoot NODELETE root(CanvasBase*);
 
 
-inline const CSSParserContext& CanvasBase::cssParserContext() const
+inline const CSSParserContext& CanvasBase::cssParserContext() const LIFETIME_BOUND
 {
     if (!m_cssParserContext) [[unlikely]]
         m_cssParserContext = createCSSParserContext();

--- a/Source/WebCore/html/DOMFormData.h
+++ b/Source/WebCore/html/DOMFormData.h
@@ -57,8 +57,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const Vector<Item>& items() const { return m_items; }
-    const PAL::TextEncoding& encoding() const { return m_encoding; }
+    const Vector<Item>& items() const LIFETIME_BOUND { return m_items; }
+    const PAL::TextEncoding& encoding() const LIFETIME_BOUND { return m_encoding; }
 
     void append(const String& name, const String& value);
     void append(const String& name, Blob&, const String& filename = { });

--- a/Source/WebCore/html/DOMTokenList.h
+++ b/Source/WebCore/html/DOMTokenList.h
@@ -64,8 +64,8 @@ private:
     void updateTokensFromAttributeValue(const AtomString&);
     void updateAssociatedAttributeFromTokens();
 
-    WEBCORE_EXPORT Vector<AtomString, 1>& tokens();
-    const Vector<AtomString, 1>& tokens() const { return const_cast<DOMTokenList&>(*this).tokens(); }
+    WEBCORE_EXPORT Vector<AtomString, 1>& tokens() LIFETIME_BOUND;
+    const Vector<AtomString, 1>& tokens() const LIFETIME_BOUND { return const_cast<DOMTokenList&>(*this).tokens(); }
 
     static ExceptionOr<void> validateToken(StringView);
     static ExceptionOr<void> validateTokens(std::span<const AtomString> tokens);

--- a/Source/WebCore/html/DOMURL.h
+++ b/Source/WebCore/html/DOMURL.h
@@ -47,12 +47,12 @@ public:
     static RefPtr<DOMURL> parse(const String& url, const String& base);
     static bool canParse(const String& url, const String& base);
 
-    const URL& href() const { return m_url; }
+    const URL& href() const LIFETIME_BOUND { return m_url; }
     ExceptionOr<void> setHref(const String&);
 
     URLSearchParams& searchParams();
 
-    const String& toJSON() const { return m_url.string(); }
+    const String& toJSON() const LIFETIME_BOUND { return m_url.string(); }
 
     static String createObjectURL(ScriptExecutionContext&, Blob&);
     static void revokeObjectURL(ScriptExecutionContext&, const String&);

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -57,7 +57,7 @@ public:
     enum class UpdateDisplayAttributes : bool { No, Yes };
     void setFile(RefPtr<File>&&, UpdateDisplayAttributes = UpdateDisplayAttributes::No);
 
-    const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
+    const String& uniqueIdentifier() const LIFETIME_BOUND { return m_uniqueIdentifier; }
     void setUniqueIdentifier(const String&);
 
     void copyNonAttributePropertiesFromElement(const Element&) final;

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -35,7 +35,7 @@ class CollectionNamedElementCache {
 public:
     inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* findElementsWithId(const AtomString& id) const;
     inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* findElementsWithName(const AtomString& name) const;
-    const Vector<AtomString>& propertyNames() const { return m_propertyNames; }
+    const Vector<AtomString>& propertyNames() const LIFETIME_BOUND { return m_propertyNames; }
     
     inline void appendToIdCache(const AtomString& id, Element&);
     inline void appendToNameCache(const AtomString& name, Element&);

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -126,7 +126,7 @@ inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedEle
     protect(document())->collectionCachedIdNameMap(*this);
 }
 
-inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const
+inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const LIFETIME_BOUND
 {
     ASSERT(!!m_namedElementCache);
     return *m_namedElementCache;

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -38,7 +38,7 @@ public:
 
     bool isOpen() const { return m_isOpen; }
 
-    const String& returnValue() const { return m_returnValue; }
+    const String& returnValue() const LIFETIME_BOUND { return m_returnValue; }
     void setReturnValue(String&& value) { m_returnValue = WTF::move(value); }
 
     ExceptionOr<void> show();

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -109,19 +109,19 @@ public:
     WEBCORE_EXPORT bool checkValidity();
     bool reportValidity();
 
-    RadioButtonGroups& radioButtonGroups() { return m_radioButtonGroups; }
+    RadioButtonGroups& radioButtonGroups() LIFETIME_BOUND { return m_radioButtonGroups; }
 
     WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& NODELETE unsafeListedElements() const;
     WEBCORE_EXPORT Vector<Ref<FormListedElement>> copyListedElementsVector() const;
     Vector<Ref<ValidatedFormListedElement>> copyValidatedListedElementsVector() const;
-    const Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>>& imageElements() const { return m_imageElements; }
+    const Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>>& imageElements() const LIFETIME_BOUND { return m_imageElements; }
 
     StringPairVector textFieldValues() const;
 
     static HTMLFormElement* findClosestFormAncestor(const Element&);
     
     RefPtr<DOMFormData> constructEntryList(RefPtr<HTMLFormControlElement>&&, Ref<DOMFormData>&&, StringPairVector*);
-    const FormSubmission::Attributes& attributes() const { return m_attributes; }
+    const FormSubmission::Attributes& attributes() const LIFETIME_BOUND { return m_attributes; }
     
 private:
     HTMLFormElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -62,7 +62,7 @@ public:
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    const URL& initiatorSourceURL() const { return m_initiatorSourceURL; }
+    const URL& initiatorSourceURL() const LIFETIME_BOUND { return m_initiatorSourceURL; }
     void setInitiatorSourceURL(URL&& url) { m_initiatorSourceURL = WTF::move(url); }
 #endif
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -78,7 +78,7 @@ public:
 
     WEBCORE_EXPORT unsigned naturalWidth() const;
     WEBCORE_EXPORT unsigned naturalHeight() const;
-    const URL& currentURL() const { return m_currentURL; }
+    const URL& currentURL() const LIFETIME_BOUND { return m_currentURL; }
     WEBCORE_EXPORT const AtomString& currentSrc();
 
     bool isServerMap() const;

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -39,7 +39,7 @@ public:
     static Ref<HTMLMapElement> create(const QualifiedName&, Document&);
     virtual ~HTMLMapElement();
 
-    const AtomString& getName() const { return m_name; }
+    const AtomString& getName() const LIFETIME_BOUND { return m_name; }
 
     bool mapMouseEvent(LayoutPoint location, const LayoutSize&, HitTestResult&);
     

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -253,9 +253,9 @@ public:
 // error state
     WEBCORE_EXPORT MediaError* NODELETE error() const;
 
-    const URL& currentSrc() const { return m_currentSrc; }
+    const URL& currentSrc() const LIFETIME_BOUND { return m_currentSrc; }
 
-    const std::optional<MediaProvider>& srcObject() const { return m_mediaProvider; }
+    const std::optional<MediaProvider>& srcObject() const LIFETIME_BOUND { return m_mediaProvider; }
     void setSrcObject(std::optional<MediaProvider>&&);
 
     WEBCORE_EXPORT String crossOrigin() const;

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -80,8 +80,8 @@ public:
 
     virtual void updateWidget(CreatePlugins) = 0;
 
-    const String& serviceType() const { return m_serviceType; }
-    const String& url() const { return m_url; }
+    const String& serviceType() const LIFETIME_BOUND { return m_serviceType; }
+    const String& url() const LIFETIME_BOUND { return m_url; }
 
     bool needsWidgetUpdate() const { return m_needsWidgetUpdate; }
     void setNeedsWidgetUpdate(bool needsWidgetUpdate) { m_needsWidgetUpdate = needsWidgetUpdate; }

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -101,7 +101,7 @@ public:
     void setRecalcListItems();
     void updateListItemSelectedStates(AllowStyleInvalidation = AllowStyleInvalidation::Yes);
 
-    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& listItems() const;
+    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& listItems() const LIFETIME_BOUND;
 
     void accessKeySetSelectedIndex(int);
 

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -45,7 +45,7 @@ public:
     Vector<Ref<Element>> assignedElements(const AssignedNodesOptions&) const;
 
     void assign(FixedVector<ElementOrText>&&);
-    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& manuallyAssignedNodes() const { return m_manuallyAssignedNodes; }
+    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& manuallyAssignedNodes() const LIFETIME_BOUND { return m_manuallyAssignedNodes; }
     void removeManuallyAssignedNode(Node&);
 
     void enqueueSlotChangeEvent();

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -60,11 +60,11 @@ public:
 
     static PredefinedColorSpace NODELETE computeColorSpace(std::optional<ImageDataSettings>, PredefinedColorSpace defaultColorSpace = PredefinedColorSpace::SRGB);
 
-    const IntSize& size() const { return m_size; }
+    const IntSize& size() const LIFETIME_BOUND { return m_size; }
 
     int width() const { return m_size.width(); }
     int height() const { return m_size.height(); }
-    const ImageDataArray& data() const { return m_data; }
+    const ImageDataArray& data() const LIFETIME_BOUND { return m_data; }
     PredefinedColorSpace colorSpace() const { return m_colorSpace; }
     ImageDataPixelFormat pixelFormat() const { return m_data.pixelFormat(); }
 

--- a/Source/WebCore/html/MediaError.h
+++ b/Source/WebCore/html/MediaError.h
@@ -50,7 +50,7 @@ public:
     }
 
     Code code() const { return m_code; }
-    const String& message() const { return m_message; }
+    const String& message() const LIFETIME_BOUND { return m_message; }
 
 private:
     MediaError(Code code, String&& message)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -87,7 +87,7 @@ class DetachedOffscreenCanvas {
 public:
     DetachedOffscreenCanvas(const IntSize&, bool originClean, RefPtr<PlaceholderRenderingContextSource>&&);
     WEBCORE_EXPORT ~DetachedOffscreenCanvas();
-    const IntSize& size() const { return m_size; }
+    const IntSize& size() const LIFETIME_BOUND { return m_size; }
     bool originClean() const { return m_originClean; }
     RefPtr<PlaceholderRenderingContextSource> NODELETE takePlaceholderSource();
 

--- a/Source/WebCore/html/TimeRanges.h
+++ b/Source/WebCore/html/TimeRanges.h
@@ -54,8 +54,8 @@ public:
     WEBCORE_EXPORT double nearest(double time) const;
     double totalDuration() const;
 
-    const PlatformTimeRanges& ranges() const { return m_ranges; }
-    PlatformTimeRanges& ranges() { return m_ranges; }
+    const PlatformTimeRanges& ranges() const LIFETIME_BOUND { return m_ranges; }
+    PlatformTimeRanges& ranges() LIFETIME_BOUND { return m_ranges; }
 
 private:
     WEBCORE_EXPORT TimeRanges();

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -69,7 +69,7 @@ public:
     Iterator createIterator(ScriptExecutionContext*) { return Iterator { *this }; }
 
 private:
-    const Vector<KeyValuePair<String, String>>& pairs() const { return m_pairs; }
+    const Vector<KeyValuePair<String, String>>& pairs() const LIFETIME_BOUND { return m_pairs; }
     URLSearchParams(const String&, DOMURL*);
     URLSearchParams(const Vector<KeyValuePair<String, String>>&);
     void updateURL();

--- a/Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp
+++ b/Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ANGLEInstancedArrays);
 ANGLEInstancedArrays::ANGLEInstancedArrays(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::ANGLEInstancedArrays)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_instanced_arrays);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_instanced_arrays);
 }
 
 ANGLEInstancedArrays::~ANGLEInstancedArrays() = default;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -102,7 +102,7 @@ public:
 
     bool isAccelerated() const;
 
-    const CanvasRenderingContext2DSettings& getContextAttributes() const { return m_settings; }
+    const CanvasRenderingContext2DSettings& getContextAttributes() const LIFETIME_BOUND { return m_settings; }
     using RenderingMode = WebCore::RenderingMode;
     std::optional<RenderingMode> renderingModeForTesting() const final;
     std::optional<RenderingMode> getEffectiveRenderingModeForTesting();
@@ -121,10 +121,10 @@ public:
     double miterLimit() const { return state().miterLimit; }
     void setMiterLimit(double);
 
-    const Vector<double>& getLineDash() const { return state().lineDash; }
+    const Vector<double>& getLineDash() const LIFETIME_BOUND { return state().lineDash; }
     void setLineDash(const Vector<double>&);
 
-    const Vector<double>& webkitLineDash() const { return getLineDash(); }
+    const Vector<double>& webkitLineDash() const LIFETIME_BOUND { return getLineDash(); }
     void setWebkitLineDash(const Vector<double>&);
 
     double lineDashOffset() const { return state().lineDashOffset; }
@@ -265,8 +265,8 @@ public:
 
         bool realized() const { return m_font.fontSelector(); }
         void initialize(FontSelector&, const FontCascade&);
-        const FontMetrics& metricsOfPrimaryFont() const;
-        const FontCascadeDescription& NODELETE fontDescription() const;
+        const FontMetrics& metricsOfPrimaryFont() const LIFETIME_BOUND;
+        const FontCascadeDescription& NODELETE fontDescription() const LIFETIME_BOUND;
         float width(const TextRun&, GlyphOverflow* = 0) const;
         void drawBidiText(GraphicsContext&, const TextRun&, const FloatPoint&, FontCascade::CustomFontNotReadyAction) const;
 
@@ -274,7 +274,7 @@ public:
         bool isPopulated() const { return m_font.fonts(); }
 #endif
 
-        const FontCascade& fontCascade() const { return m_font; }
+        const FontCascade& fontCascade() const LIFETIME_BOUND { return m_font; }
 
         float letterSpacing() const { return m_font.letterSpacing(); }
         void setLetterSpacing(float letterSpacing) { m_font.setLetterSpacing(letterSpacing); }
@@ -335,15 +335,15 @@ public:
         String globalCompositeOperationString() const;
         String shadowColorString() const;
     };
-    const Vector<State, 1>& stateStack();
+    const Vector<State, 1>& stateStack() LIFETIME_BOUND;
 
 protected:
     static const int DefaultFontSize;
     static const ASCIILiteral DefaultFontFamily;
 
-    const State& state() const { return m_stateStack.last(); }
+    const State& state() const LIFETIME_BOUND { return m_stateStack.last(); }
     void realizeSaves();
-    State& modifiableState() { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
+    State& modifiableState() LIFETIME_BOUND { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
 
     GraphicsContext* drawingContext() const;
     GraphicsContext* effectiveDrawingContext() const;

--- a/Source/WebCore/html/canvas/EXTBlendMinMax.cpp
+++ b/Source/WebCore/html/canvas/EXTBlendMinMax.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTBlendMinMax);
 EXTBlendMinMax::EXTBlendMinMax(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTBlendMinMax)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_blend_minmax);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_blend_minmax);
 }
 
 EXTBlendMinMax::~EXTBlendMinMax() = default;

--- a/Source/WebCore/html/canvas/EXTClipControl.cpp
+++ b/Source/WebCore/html/canvas/EXTClipControl.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTClipControl);
 EXTClipControl::EXTClipControl(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTClipControl)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_clip_control);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_clip_control);
 }
 
 EXTClipControl::~EXTClipControl() = default;
@@ -51,7 +51,7 @@ void EXTClipControl::clipControlEXT(GCGLenum origin, GCGLenum depth)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->clipControlEXT(origin, depth);
+    protect(context()->graphicsContextGL())->clipControlEXT(origin, depth);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTColorBufferFloat);
 EXTColorBufferFloat::EXTColorBufferFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTColorBufferFloat)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_color_buffer_float);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_color_buffer_float);
 
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.

--- a/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTColorBufferHalfFloat);
 EXTColorBufferHalfFloat::EXTColorBufferHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTColorBufferHalfFloat)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_color_buffer_half_float);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_color_buffer_half_float);
 }
 
 EXTColorBufferHalfFloat::~EXTColorBufferHalfFloat() = default;

--- a/Source/WebCore/html/canvas/EXTConservativeDepth.cpp
+++ b/Source/WebCore/html/canvas/EXTConservativeDepth.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTConservativeDepth);
 EXTConservativeDepth::EXTConservativeDepth(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTConservativeDepth)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_conservative_depth);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_conservative_depth);
 }
 
 EXTConservativeDepth::~EXTConservativeDepth() = default;

--- a/Source/WebCore/html/canvas/EXTDepthClamp.cpp
+++ b/Source/WebCore/html/canvas/EXTDepthClamp.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTDepthClamp);
 EXTDepthClamp::EXTDepthClamp(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDepthClamp)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_depth_clamp);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_depth_clamp);
 }
 
 EXTDepthClamp::~EXTDepthClamp() = default;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTDisjointTimerQuery);
 EXTDisjointTimerQuery::EXTDisjointTimerQuery(WebGLRenderingContext& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDisjointTimerQuery)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_disjoint_timer_query);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_disjoint_timer_query);
 }
 
 EXTDisjointTimerQuery::~EXTDisjointTimerQuery() = default;
@@ -85,10 +85,10 @@ void EXTDisjointTimerQuery::deleteQueryEXT(WebGLTimerQueryEXT* query)
     if (query == context->m_activeQuery) {
         context->m_activeQuery = nullptr;
         ASSERT(query->target() == GraphicsContextGL::TIME_ELAPSED_EXT);
-        context->graphicsContextGL()->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
+        protect(context->graphicsContextGL())->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
     }
 
-    query->deleteObject(locker, context->graphicsContextGL().get());
+    query->deleteObject(locker, protect(context->graphicsContextGL()));
 }
 
 GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
@@ -187,7 +187,7 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
 
     query.setTarget(target);
 
-    context->graphicsContextGL()->queryCounterEXT(query.object(), target);
+    protect(context->graphicsContextGL())->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context->scriptExecutionContext()->eventLoop().queueMicrotask(context->scriptExecutionContext()->vm(), [&] {

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTDisjointTimerQueryWebGL2);
 EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDisjointTimerQueryWebGL2)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_disjoint_timer_query);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_disjoint_timer_query);
 }
 
 EXTDisjointTimerQueryWebGL2::~EXTDisjointTimerQueryWebGL2() = default;
@@ -74,7 +74,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
 
     query.setTarget(target);
 
-    context->graphicsContextGL()->queryCounterEXT(query.object(), target);
+    protect(context->graphicsContextGL())->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     protect(protect(context->scriptExecutionContext())->eventLoop())->queueMicrotask(protect(context->scriptExecutionContext())->vm(), [&] {

--- a/Source/WebCore/html/canvas/EXTFloatBlend.cpp
+++ b/Source/WebCore/html/canvas/EXTFloatBlend.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTFloatBlend);
 EXTFloatBlend::EXTFloatBlend(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTFloatBlend)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_float_blend);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_float_blend);
 }
 
 EXTFloatBlend::~EXTFloatBlend() = default;

--- a/Source/WebCore/html/canvas/EXTFragDepth.cpp
+++ b/Source/WebCore/html/canvas/EXTFragDepth.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTFragDepth);
 EXTFragDepth::EXTFragDepth(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTFragDepth)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_frag_depth);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_frag_depth);
 }
 
 EXTFragDepth::~EXTFragDepth() = default;

--- a/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp
+++ b/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTPolygonOffsetClamp);
 EXTPolygonOffsetClamp::EXTPolygonOffsetClamp(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTPolygonOffsetClamp)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_polygon_offset_clamp);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_polygon_offset_clamp);
 }
 
 EXTPolygonOffsetClamp::~EXTPolygonOffsetClamp() = default;
@@ -51,7 +51,7 @@ void EXTPolygonOffsetClamp::polygonOffsetClampEXT(GCGLfloat factor, GCGLfloat un
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->polygonOffsetClampEXT(factor, units, clamp);
+    protect(context()->graphicsContextGL())->polygonOffsetClampEXT(factor, units, clamp);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTRenderSnorm.cpp
+++ b/Source/WebCore/html/canvas/EXTRenderSnorm.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTRenderSnorm);
 EXTRenderSnorm::EXTRenderSnorm(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTRenderSnorm)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_render_snorm);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_render_snorm);
 }
 
 EXTRenderSnorm::~EXTRenderSnorm() = default;

--- a/Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp
+++ b/Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTShaderTextureLOD);
 EXTShaderTextureLOD::EXTShaderTextureLOD(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTShaderTextureLOD)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_shader_texture_lod);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_shader_texture_lod);
 }
 
 EXTShaderTextureLOD::~EXTShaderTextureLOD() = default;

--- a/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTTextureCompressionBPTC);
 EXTTextureCompressionBPTC::EXTTextureCompressionBPTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureCompressionBPTC)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_texture_compression_bptc);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_texture_compression_bptc);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGBA_BPTC_UNORM_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT);

--- a/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTTextureCompressionRGTC);
 EXTTextureCompressionRGTC::EXTTextureCompressionRGTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureCompressionRGTC)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_texture_compression_rgtc);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_texture_compression_rgtc);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RED_RGTC1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SIGNED_RED_RGTC1_EXT);

--- a/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTTextureFilterAnisotropic);
 EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureFilterAnisotropic)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_texture_filter_anisotropic);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_texture_filter_anisotropic);
 }
 
 EXTTextureFilterAnisotropic::~EXTTextureFilterAnisotropic() = default;

--- a/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTTextureMirrorClampToEdge);
 EXTTextureMirrorClampToEdge::EXTTextureMirrorClampToEdge(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureMirrorClampToEdge)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_texture_mirror_clamp_to_edge);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_texture_mirror_clamp_to_edge);
 }
 
 EXTTextureMirrorClampToEdge::~EXTTextureMirrorClampToEdge() = default;

--- a/Source/WebCore/html/canvas/EXTTextureNorm16.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureNorm16.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTTextureNorm16);
 EXTTextureNorm16::EXTTextureNorm16(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureNorm16)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_texture_norm16);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_texture_norm16);
 }
 
 EXTTextureNorm16::~EXTTextureNorm16() = default;

--- a/Source/WebCore/html/canvas/EXTsRGB.cpp
+++ b/Source/WebCore/html/canvas/EXTsRGB.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EXTsRGB);
 EXTsRGB::EXTsRGB(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTsRGB)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_sRGB);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_sRGB);
 }
 
 EXTsRGB::~EXTsRGB() = default;

--- a/Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp
+++ b/Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(KHRParallelShaderCompile);
 KHRParallelShaderCompile::KHRParallelShaderCompile(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::KHRParallelShaderCompile)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::KHR_parallel_shader_compile);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::KHR_parallel_shader_compile);
 }
 
 KHRParallelShaderCompile::~KHRParallelShaderCompile() = default;

--- a/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp
+++ b/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NVShaderNoperspectiveInterpolation);
 NVShaderNoperspectiveInterpolation::NVShaderNoperspectiveInterpolation(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::NVShaderNoperspectiveInterpolation)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::NV_shader_noperspective_interpolation);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::NV_shader_noperspective_interpolation);
 }
 
 NVShaderNoperspectiveInterpolation::~NVShaderNoperspectiveInterpolation() = default;

--- a/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
+++ b/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESDrawBuffersIndexed);
 OESDrawBuffersIndexed::OESDrawBuffersIndexed(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESDrawBuffersIndexed)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_draw_buffers_indexed);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_draw_buffers_indexed);
 }
 
 OESDrawBuffersIndexed::~OESDrawBuffersIndexed() = default;
@@ -51,42 +51,42 @@ void OESDrawBuffersIndexed::enableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->enableiOES(target, index);
+    protect(context()->graphicsContextGL())->enableiOES(target, index);
 }
 
 void OESDrawBuffersIndexed::disableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->disableiOES(target, index);
+    protect(context()->graphicsContextGL())->disableiOES(target, index);
 }
 
 void OESDrawBuffersIndexed::blendEquationiOES(GCGLuint buf, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->blendEquationiOES(buf, mode);
+    protect(context()->graphicsContextGL())->blendEquationiOES(buf, mode);
 }
 
 void OESDrawBuffersIndexed::blendEquationSeparateiOES(GCGLuint buf, GCGLenum modeRGB, GCGLenum modeAlpha)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
+    protect(context()->graphicsContextGL())->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
 }
 
 void OESDrawBuffersIndexed::blendFunciOES(GCGLuint buf, GCGLenum src, GCGLenum dst)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->blendFunciOES(buf, src, dst);
+    protect(context()->graphicsContextGL())->blendFunciOES(buf, src, dst);
 }
 
 void OESDrawBuffersIndexed::blendFuncSeparateiOES(GCGLuint buf, GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
+    protect(context()->graphicsContextGL())->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha)
@@ -101,7 +101,7 @@ void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboo
         context->m_colorMask[2] = blue;
         context->m_colorMask[3] = alpha;
     }
-    context->graphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
+    protect(context->graphicsContextGL())->colorMaskiOES(buf, red, green, blue, alpha);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/OESElementIndexUint.cpp
+++ b/Source/WebCore/html/canvas/OESElementIndexUint.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESElementIndexUint);
 OESElementIndexUint::OESElementIndexUint(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESElementIndexUint)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_element_index_uint);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_element_index_uint);
 }
 
 OESElementIndexUint::~OESElementIndexUint() = default;

--- a/Source/WebCore/html/canvas/OESFBORenderMipmap.cpp
+++ b/Source/WebCore/html/canvas/OESFBORenderMipmap.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESFBORenderMipmap);
 OESFBORenderMipmap::OESFBORenderMipmap(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESFBORenderMipmap)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_fbo_render_mipmap);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_fbo_render_mipmap);
 }
 
 OESFBORenderMipmap::~OESFBORenderMipmap() = default;

--- a/Source/WebCore/html/canvas/OESSampleVariables.cpp
+++ b/Source/WebCore/html/canvas/OESSampleVariables.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESSampleVariables);
 OESSampleVariables::OESSampleVariables(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESSampleVariables)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_sample_variables);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_sample_variables);
 }
 
 OESSampleVariables::~OESSampleVariables() = default;

--- a/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp
+++ b/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESShaderMultisampleInterpolation);
 OESShaderMultisampleInterpolation::OESShaderMultisampleInterpolation(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESShaderMultisampleInterpolation)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_shader_multisample_interpolation);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_shader_multisample_interpolation);
 }
 
 OESShaderMultisampleInterpolation::~OESShaderMultisampleInterpolation() = default;

--- a/Source/WebCore/html/canvas/OESStandardDerivatives.cpp
+++ b/Source/WebCore/html/canvas/OESStandardDerivatives.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESStandardDerivatives);
 OESStandardDerivatives::OESStandardDerivatives(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESStandardDerivatives)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_standard_derivatives);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_standard_derivatives);
 }
 
 OESStandardDerivatives::~OESStandardDerivatives() = default;

--- a/Source/WebCore/html/canvas/OESTextureFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESTextureFloat);
 OESTextureFloat::OESTextureFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureFloat)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_texture_float);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_texture_float);
 
     // Spec requires WEBGL_color_buffer_float to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.

--- a/Source/WebCore/html/canvas/OESTextureFloatLinear.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloatLinear.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESTextureFloatLinear);
 OESTextureFloatLinear::OESTextureFloatLinear(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureFloatLinear)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_texture_float_linear);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_texture_float_linear);
 }
 
 OESTextureFloatLinear::~OESTextureFloatLinear() = default;

--- a/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESTextureHalfFloat);
 OESTextureHalfFloat::OESTextureHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureHalfFloat)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_texture_half_float);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_texture_half_float);
 
     // Spec requires EXT_color_buffer_half_float to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.

--- a/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESTextureHalfFloatLinear);
 OESTextureHalfFloatLinear::OESTextureHalfFloatLinear(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureHalfFloatLinear)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_texture_half_float_linear);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_texture_half_float_linear);
 }
 
 OESTextureHalfFloatLinear::~OESTextureHalfFloatLinear() = default;

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OESVertexArrayObject);
 OESVertexArrayObject::OESVertexArrayObject(WebGLRenderingContext& context)
     : WebGLExtension(context, WebGLExtensionName::OESVertexArrayObject)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_vertex_array_object);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_vertex_array_object);
 }
 
 OESVertexArrayObject::~OESVertexArrayObject() = default;
@@ -78,7 +78,7 @@ void OESVertexArrayObject::deleteVertexArrayOES(WebGLVertexArrayObjectOES* array
     if (!arrayObject->isDefaultObject() && arrayObject == context->m_boundVertexArrayObject)
         context->setBoundVertexArrayObject(locker, nullptr);
 
-    arrayObject->deleteObject(locker, context->graphicsContextGL().get());
+    arrayObject->deleteObject(locker, protect(context->graphicsContextGL()));
 }
 
 GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)
@@ -88,7 +88,7 @@ GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* ar
     Ref context = this->context();
     if (!context->validateIsWebGLObject(arrayObject))
         return false;
-    return context->graphicsContextGL()->isVertexArray(arrayObject->object());
+    return protect(context->graphicsContextGL())->isVertexArray(arrayObject->object());
 }
 
 void OESVertexArrayObject::bindVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)

--- a/Source/WebCore/html/canvas/Path2D.h
+++ b/Source/WebCore/html/canvas/Path2D.h
@@ -63,7 +63,7 @@ public:
 
     ExceptionOr<void> addPath(Path2D&, DOMMatrix2DInit&&);
 
-    const Path& path() const { return m_path; }
+    const Path& path() const LIFETIME_BOUND { return m_path; }
 
 private:
     Path2D() = default;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1601,7 +1601,7 @@ void WebGL2RenderingContext::drawRangeElements(GCGLenum mode, GCGLuint start, GC
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
 
-        graphicsContextGL()->drawRangeElements(mode, start, end, count, type, offset);
+        protect(graphicsContextGL())->drawRangeElements(mode, start, end, count, type, offset);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -1639,7 +1639,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
         }
         // Because the backbuffer is simulated on all current WebKit ports, we need to change BACK to COLOR_ATTACHMENT0.
         GCGLenum value[1] { (bufs[0] == GraphicsContextGL::BACK) ? GraphicsContextGL::COLOR_ATTACHMENT0 : GraphicsContextGL::NONE };
-        graphicsContextGL()->drawBuffers(value);
+        protect(graphicsContextGL())->drawBuffers(value);
         setBackDrawBuffer(bufs[0]);
     } else {
         if (n > maxDrawBuffers()) {
@@ -2578,11 +2578,11 @@ void WebGL2RenderingContext::deleteVertexArray(WebGLVertexArrayObject* arrayObje
 
     if (!arrayObject->isDefaultObject() && arrayObject == m_boundVertexArrayObject) {
         // The default VAO was removed in OpenGL 3.3 but not from WebGL 2; bind the default for WebGL to use.
-        graphicsContextGL()->bindVertexArray(m_defaultVertexArrayObject->object());
+        protect(graphicsContextGL())->bindVertexArray(m_defaultVertexArrayObject->object());
         setBoundVertexArrayObject(locker, m_defaultVertexArrayObject.get());
     }
 
-    arrayObject->deleteObject(locker, graphicsContextGL().get());
+    arrayObject->deleteObject(locker, protect(graphicsContextGL()));
 }
 
 GCGLboolean WebGL2RenderingContext::isVertexArray(WebGLVertexArrayObject* arrayObject)
@@ -2591,7 +2591,7 @@ GCGLboolean WebGL2RenderingContext::isVertexArray(WebGLVertexArrayObject* arrayO
         return false;
     if (!validateIsWebGLObject(arrayObject))
         return false;
-    return graphicsContextGL()->isVertexArray(arrayObject->object());
+    return protect(graphicsContextGL())->isVertexArray(arrayObject->object());
 }
 
 void WebGL2RenderingContext::bindVertexArray(WebGLVertexArrayObject* arrayObject)
@@ -2853,13 +2853,13 @@ WebGLAny WebGL2RenderingContext::getFramebufferAttachmentParameter(GCGLenum targ
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING:
-        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return protect(graphicsContextGL())->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE:
         if (attachment == GraphicsContextGL::DEPTH_STENCIL_ATTACHMENT) {
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "component type cannot be queried for DEPTH_STENCIL_ATTACHMENT"_s);
             return nullptr;
         }
-        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return protect(graphicsContextGL())->getFramebufferAttachmentParameteri(target, attachment, pname);
     }
 
     synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name"_s);
@@ -2907,7 +2907,7 @@ bool WebGL2RenderingContext::validateNonDefaultFramebufferAttachment(ASCIILitera
 GCGLint WebGL2RenderingContext::maxDrawBuffers()
 {
     if (!m_maxDrawBuffers)
-        m_maxDrawBuffers = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
+        m_maxDrawBuffers = protect(graphicsContextGL())->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
     return m_maxDrawBuffers;
 }
 
@@ -2915,7 +2915,7 @@ GCGLint WebGL2RenderingContext::maxColorAttachments()
 {
     // DrawBuffers requires MAX_COLOR_ATTACHMENTS == MAX_DRAW_BUFFERS
     if (!m_maxColorAttachments)
-        m_maxColorAttachments = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
+        m_maxColorAttachments = protect(graphicsContextGL())->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
     return m_maxColorAttachments;
 }
 

--- a/Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp
+++ b/Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLBlendFuncExtended);
 WebGLBlendFuncExtended::WebGLBlendFuncExtended(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLBlendFuncExtended)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_blend_func_extended);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_blend_func_extended);
 }
 
 WebGLBlendFuncExtended::~WebGLBlendFuncExtended() = default;

--- a/Source/WebCore/html/canvas/WebGLBuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLBuffer.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 Ref<WebGLBuffer> WebGLBuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createBuffer();
+    auto object = protect(context.graphicsContextGL())->createBuffer();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLBuffer { context, object });

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLClipCullDistance);
 WebGLClipCullDistance::WebGLClipCullDistance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLClipCullDistance)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_clip_cull_distance);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_clip_cull_distance);
 }
 
 WebGLClipCullDistance::~WebGLClipCullDistance() = default;

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp
@@ -36,8 +36,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLCompressedTextureASTC);
 
 WebGLCompressedTextureASTC::WebGLCompressedTextureASTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureASTC)
-    , m_isHDRSupported(context.graphicsContextGL()->supportsExtension(GCGLExtension::KHR_texture_compression_astc_hdr))
-    , m_isLDRSupported(context.graphicsContextGL()->supportsExtension(GCGLExtension::KHR_texture_compression_astc_ldr))
+    , m_isHDRSupported(protect(context.graphicsContextGL())->supportsExtension(GCGLExtension::KHR_texture_compression_astc_hdr))
+    , m_isLDRSupported(protect(context.graphicsContextGL())->supportsExtension(GCGLExtension::KHR_texture_compression_astc_ldr))
 {
     RefPtr graphicsContextGL = context.graphicsContextGL();
     graphicsContextGL->enableExtension(GCGLExtension::KHR_texture_compression_astc_hdr);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLCompressedTextureETC);
 WebGLCompressedTextureETC::WebGLCompressedTextureETC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureETC)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_compressed_texture_etc);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_compressed_texture_etc);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_R11_EAC);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SIGNED_R11_EAC);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLCompressedTextureETC1);
 WebGLCompressedTextureETC1::WebGLCompressedTextureETC1(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureETC1)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_compressed_ETC1_RGB8_texture);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_compressed_ETC1_RGB8_texture);
 
     context.addCompressedTextureFormat(GraphicsContextGL::ETC1_RGB8_OES);
 }

--- a/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLCompressedTexturePVRTC);
 WebGLCompressedTexturePVRTC::WebGLCompressedTexturePVRTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTexturePVRTC)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::IMG_texture_compression_pvrtc);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::IMG_texture_compression_pvrtc);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGB_PVRTC_4BPPV1_IMG);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGB_PVRTC_2BPPV1_IMG);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLCompressedTextureS3TCsRGB);
 WebGLCompressedTextureS3TCsRGB::WebGLCompressedTextureS3TCsRGB(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureS3TCsRGB)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_texture_compression_s3tc_srgb);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_texture_compression_s3tc_srgb);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_S3TC_DXT1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT);

--- a/Source/WebCore/html/canvas/WebGLContextEvent.h
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.h
@@ -49,7 +49,7 @@ public:
     }
     virtual ~WebGLContextEvent();
 
-    const String& statusMessage() const { return m_statusMessage; }
+    const String& statusMessage() const LIFETIME_BOUND { return m_statusMessage; }
 
 private:
     WebGLContextEvent(const AtomString& type, CanBubble, IsCancelable, const String& statusMessage);

--- a/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
+++ b/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLDebugShaders);
 WebGLDebugShaders::WebGLDebugShaders(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDebugShaders)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_translated_shader_source);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_translated_shader_source);
 }
 
 WebGLDebugShaders::~WebGLDebugShaders() = default;
@@ -56,7 +56,7 @@ String WebGLDebugShaders::getTranslatedShaderSource(WebGLShader& shader)
     Ref context = this->context();
     if (!context->validateWebGLObject("getTranslatedShaderSource"_s, shader))
         return emptyString();
-    return String::fromUTF8(context->graphicsContextGL()->getTranslatedShaderSourceANGLE(shader.object()).span());
+    return String::fromUTF8(protect(context->graphicsContextGL())->getTranslatedShaderSourceANGLE(shader.object()).span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -62,7 +62,7 @@ IntSize WebGLDefaultFramebuffer::size() const
 
 void WebGLDefaultFramebuffer::reshape(IntSize size)
 {
-    m_context->graphicsContextGL()->reshape(size.width(), size.height());
+    protect(m_context->graphicsContextGL())->reshape(size.width(), size.height());
 }
 
 void WebGLDefaultFramebuffer::markBuffersClear(GCGLbitfield clearBuffers)

--- a/Source/WebCore/html/canvas/WebGLDepthTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLDepthTexture.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLDepthTexture);
 WebGLDepthTexture::WebGLDepthTexture(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDepthTexture)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::OES_depth_texture);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::OES_depth_texture);
 }
 
 WebGLDepthTexture::~WebGLDepthTexture() = default;

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
@@ -37,14 +37,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLDrawBuffers);
 WebGLDrawBuffers::WebGLDrawBuffers(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDrawBuffers)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::EXT_draw_buffers);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::EXT_draw_buffers);
 }
 
 WebGLDrawBuffers::~WebGLDrawBuffers() = default;
 
 bool WebGLDrawBuffers::supported(WebGLRenderingContextBase& context)
 {
-    return context.graphicsContextGL()->supportsExtension(GCGLExtension::EXT_draw_buffers);
+    return protect(context.graphicsContextGL())->supportsExtension(GCGLExtension::EXT_draw_buffers);
 }
 
 void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
@@ -65,7 +65,7 @@ void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
         }
         // Because the backbuffer is simulated on all current WebKit ports, we need to change BACK to COLOR_ATTACHMENT0.
         GCGLenum value[1] { bufs[0] == GraphicsContextGL::BACK ? GraphicsContextGL::COLOR_ATTACHMENT0 : GraphicsContextGL::NONE };
-        context->graphicsContextGL()->drawBuffersEXT(value);
+        protect(context->graphicsContextGL())->drawBuffersEXT(value);
         context->setBackDrawBuffer(bufs[0]);
     } else {
         if (n > context->maxDrawBuffers()) {

--- a/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLDrawInstancedBaseVertexBaseInstance);
 WebGLDrawInstancedBaseVertexBaseInstance::WebGLDrawInstancedBaseVertexBaseInstance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDrawInstancedBaseVertexBaseInstance)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_base_vertex_base_instance);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_base_vertex_base_instance);
 }
 
 WebGLDrawInstancedBaseVertexBaseInstance::~WebGLDrawInstancedBaseVertexBaseInstance() = default;
@@ -66,7 +66,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWE
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
+        protect(context->graphicsContextGL())->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -89,7 +89,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBa
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
+        protect(context->graphicsContextGL())->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.cpp
@@ -129,7 +129,7 @@ Ref<WebGLFramebuffer> WebGLFramebuffer::createLost()
 
 Ref<WebGLFramebuffer> WebGLFramebuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createFramebuffer();
+    auto object = protect(context.graphicsContextGL())->createFramebuffer();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLFramebuffer { context, object, Type::Plain });
@@ -138,7 +138,7 @@ Ref<WebGLFramebuffer> WebGLFramebuffer::create(WebGLRenderingContextBase& contex
 #if ENABLE(WEBXR)
 RefPtr<WebGLFramebuffer> WebGLFramebuffer::createOpaque(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createFramebuffer();
+    auto object = protect(context.graphicsContextGL())->createFramebuffer();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLFramebuffer { context, object, Type::Opaque });
@@ -236,9 +236,9 @@ void WebGLFramebuffer::drawBuffers(const Vector<GCGLenum>& bufs)
     // so we pass the user-specified buffers directly.
     RefPtr context = this->context();
     if (context->isWebGL2())
-        context->graphicsContextGL()->drawBuffers(m_drawBuffers);
+        protect(context->graphicsContextGL())->drawBuffers(m_drawBuffers);
     else if (context->m_webglDrawBuffers)
-        context->graphicsContextGL()->drawBuffersEXT(m_drawBuffers);
+        protect(context->graphicsContextGL())->drawBuffersEXT(m_drawBuffers);
 }
 
 GCGLenum WebGLFramebuffer::getDrawBuffer(GCGLenum drawBuffer)

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLMultiDraw);
 WebGLMultiDraw::WebGLMultiDraw(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLMultiDraw)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_multi_draw);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_multi_draw);
 
     // Spec requires ANGLE_instanced_arrays to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.
@@ -78,7 +78,7 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List&& firstsList,
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), static_cast<size_t>(drawcount) });
+        protect(context->graphicsContextGL())->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), static_cast<size_t>(drawcount) });
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -108,7 +108,7 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& fi
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) });
+        protect(context->graphicsContextGL())->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) });
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -137,7 +137,7 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsLis
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), static_cast<size_t>(drawcount) }, type);
+        protect(context->graphicsContextGL())->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -167,7 +167,7 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) }, type);
+        protect(context->graphicsContextGL())->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLMultiDrawInstancedBaseVertexBaseInstance);
 WebGLMultiDrawInstancedBaseVertexBaseInstance::WebGLMultiDrawInstancedBaseVertexBaseInstance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLMultiDrawInstancedBaseVertexBaseInstance)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_base_vertex_base_instance);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_base_vertex_base_instance);
 
     // Spec requires WEBGL_multi_draw to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.
@@ -79,7 +79,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBase
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) });
+        protect(context->graphicsContextGL())->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.span().subspan(firstsOffset).data(), countsList.span().subspan(countsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) });
     }
 
     context->markContextChangedAndNotifyCanvasObserver();
@@ -111,7 +111,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBa
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context.get() };
 
-        context->graphicsContextGL()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseVerticesList.span().subspan(baseVerticesOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) }, type);
+        protect(context->graphicsContextGL())->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.span().subspan(countsOffset).data(), offsetsList.span().subspan(offsetsOffset).data(), instanceCountsList.span().subspan(instanceCountsOffset).data(), baseVerticesList.span().subspan(baseVerticesOffset).data(), baseInstancesList.span().subspan(baseInstancesOffset).data(), static_cast<size_t>(drawcount) }, type);
     }
 
     context->markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLObject.cpp
@@ -45,7 +45,7 @@ WebGLObject::WebGLObject(WebGLRenderingContextBase& context, PlatformGLObject ob
 
 WebGLObject::~WebGLObject() = default;
 
-RefPtr<WebGLRenderingContextBase> WebGLObject::context() const
+WebGLRenderingContextBase* WebGLObject::context() const
 {
     return m_context.get();
 }
@@ -57,7 +57,7 @@ Lock& WebGLObject::objectGraphLockForContext()
     return context()->objectGraphLock();
 }
 
-RefPtr<GraphicsContextGL> WebGLObject::graphicsContextGL() const
+GraphicsContextGL* WebGLObject::graphicsContextGL() const
 {
     return m_context ? m_context->graphicsContextGL() : nullptr;
 }

--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -100,8 +100,8 @@ class WebGLObject : public RefCounted<WebGLObject> {
 public:
     virtual ~WebGLObject();
 
-    RefPtr<WebGLRenderingContextBase> NODELETE context() const;
-    RefPtr<GraphicsContextGL> graphicsContextGL() const;
+    WebGLRenderingContextBase* NODELETE context() const;
+    GraphicsContextGL* graphicsContextGL() const;
 
     PlatformGLObject object() const { return m_object; }
 

--- a/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
+++ b/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLPolygonMode);
 WebGLPolygonMode::WebGLPolygonMode(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLPolygonMode)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_polygon_mode);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_polygon_mode);
     context.printToConsole(MessageLevel::Warning, "WebGL: non-portable extension enabled: WEBGL_polygon_mode"_s);
 }
 
@@ -52,7 +52,7 @@ void WebGLPolygonMode::polygonModeWEBGL(GCGLenum face, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->polygonModeANGLE(face, mode);
+    protect(context()->graphicsContextGL())->polygonModeANGLE(face, mode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -62,7 +62,7 @@ Ref<WebGLProgram> WebGLProgram::createLost(WebGLRenderingContextBase& context)
 
 Ref<WebGLProgram> WebGLProgram::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createProgram();
+    auto object = protect(context.graphicsContextGL())->createProgram();
     if (!object)
         return createLost(context);
     return adoptRef(*new WebGLProgram { context, object });

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -68,7 +68,7 @@ public:
     bool linkStatus();
     std::span<const GCGLAttribActiveInfo> activeAttribs() LIFETIME_BOUND;
     const HashMap<String, int>& attribLocations() LIFETIME_BOUND;
-    std::span<const GCGLUniformActiveInfo> activeUniforms();
+    std::span<const GCGLUniformActiveInfo> activeUniforms() LIFETIME_BOUND;
     const HashMap<String, int>& uniformLocations() LIFETIME_BOUND;
     const HashMap<String, unsigned>& uniformIndices() LIFETIME_BOUND;
     int requiredTransformFeedbackBufferCount();

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLProvokingVertex);
 WebGLProvokingVertex::WebGLProvokingVertex(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLProvokingVertex)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_provoking_vertex);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_provoking_vertex);
 }
 
 WebGLProvokingVertex::~WebGLProvokingVertex() = default;
@@ -51,7 +51,7 @@ void WebGLProvokingVertex::provokingVertexWEBGL(GCGLenum provokeMode)
 {
     if (isContextLost())
         return;
-    context()->graphicsContextGL()->provokingVertexANGLE(provokeMode);
+    protect(context()->graphicsContextGL())->provokingVertexANGLE(provokeMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLQuery.cpp
+++ b/Source/WebCore/html/canvas/WebGLQuery.cpp
@@ -41,7 +41,7 @@ Ref<WebGLQuery> WebGLQuery::createLost()
 
 Ref<WebGLQuery> WebGLQuery::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createQuery();
+    auto object = protect(context.graphicsContextGL())->createQuery();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLQuery { context, object });

--- a/Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLRenderSharedExponent);
 WebGLRenderSharedExponent::WebGLRenderSharedExponent(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLRenderSharedExponent)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::QCOM_render_shared_exponent);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::QCOM_render_shared_exponent);
 }
 
 WebGLRenderSharedExponent::~WebGLRenderSharedExponent() = default;

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
@@ -43,7 +43,7 @@ Ref<WebGLRenderbuffer> WebGLRenderbuffer::createLost()
 
 Ref<WebGLRenderbuffer> WebGLRenderbuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createRenderbuffer();
+    auto object = protect(context.graphicsContextGL())->createRenderbuffer();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLRenderbuffer { context, object });

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -300,13 +300,13 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE:
         if (!isTexture)
             break;
-        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return protect(graphicsContextGL())->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT:
         if (!m_extsRGB) {
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name, EXT_sRGB not enabled"_s);
             return nullptr;
         }
-        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return protect(graphicsContextGL())->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT:
         if (!m_extColorBufferHalfFloat && !m_webglColorBufferFloat) {
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name, EXT_color_buffer_half_float or WEBGL_color_buffer_float not enabled"_s);
@@ -316,7 +316,7 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "component type cannot be queried for DEPTH_STENCIL_ATTACHMENT"_s);
             return nullptr;
         }
-        return graphicsContextGL()->getFramebufferAttachmentParameteri(target, attachment, pname);
+        return protect(graphicsContextGL())->getFramebufferAttachmentParameteri(target, attachment, pname);
     }
 
     synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid parameter name"_s);
@@ -325,7 +325,7 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
 
 long long WebGLRenderingContext::getInt64Parameter(GCGLenum pname)
 {
-    return graphicsContextGL()->getInteger64EXT(pname);
+    return protect(graphicsContextGL())->getInteger64EXT(pname);
 }
 
 GCGLint WebGLRenderingContext::maxDrawBuffers()
@@ -346,7 +346,7 @@ GCGLint WebGLRenderingContext::maxColorAttachments()
     if (!supportsDrawBuffers())
         return 0;
     if (!m_maxColorAttachments)
-        m_maxColorAttachments = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
+        m_maxColorAttachments = protect(graphicsContextGL())->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
     return m_maxColorAttachments;
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1146,35 +1146,35 @@ void WebGLRenderingContextBase::blendColor(GCGLfloat red, GCGLfloat green, GCGLf
 {
     if (isContextLost())
         return;
-    graphicsContextGL()->blendColor(red, green, blue, alpha);
+    protect(graphicsContextGL())->blendColor(red, green, blue, alpha);
 }
 
 void WebGLRenderingContextBase::blendEquation(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    graphicsContextGL()->blendEquation(mode);
+    protect(graphicsContextGL())->blendEquation(mode);
 }
 
 void WebGLRenderingContextBase::blendEquationSeparate(GCGLenum modeRGB, GCGLenum modeAlpha)
 {
     if (isContextLost())
         return;
-    graphicsContextGL()->blendEquationSeparate(modeRGB, modeAlpha);
+    protect(graphicsContextGL())->blendEquationSeparate(modeRGB, modeAlpha);
 }
 
 void WebGLRenderingContextBase::blendFunc(GCGLenum sfactor, GCGLenum dfactor)
 {
     if (isContextLost())
         return;
-    graphicsContextGL()->blendFunc(sfactor, dfactor);
+    protect(graphicsContextGL())->blendFunc(sfactor, dfactor);
 }
 
 void WebGLRenderingContextBase::blendFuncSeparate(GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
 {
     if (isContextLost())
         return;
-    graphicsContextGL()->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+    protect(graphicsContextGL())->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void WebGLRenderingContextBase::bufferData(GCGLenum target, long long size, GCGLenum usage)
@@ -1419,7 +1419,7 @@ void WebGLRenderingContextBase::cullFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    graphicsContextGL()->cullFace(mode);
+    protect(graphicsContextGL())->cullFace(mode);
 }
 
 bool WebGLRenderingContextBase::deleteObject(const AbstractLocker& locker, WebGLObject* object)
@@ -1435,7 +1435,7 @@ bool WebGLRenderingContextBase::deleteObject(const AbstractLocker& locker, WebGL
     if (object->object())
         // We need to pass in context here because we want
         // things in this context unbound.
-        object->deleteObject(locker, graphicsContextGL().get());
+        object->deleteObject(locker, protect(graphicsContextGL()));
     return true;
 }
 
@@ -1578,8 +1578,9 @@ void WebGLRenderingContextBase::detachShader(WebGLProgram& program, WebGLShader&
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "detachShader"_s, "shader not attached"_s);
         return;
     }
-    graphicsContextGL()->detachShader(program.object(), shader.object());
-    shader.onDetached(locker, graphicsContextGL().get());
+    RefPtr graphicsContextGL = this->graphicsContextGL();
+    graphicsContextGL->detachShader(program.object(), shader.object());
+    shader.onDetached(locker, graphicsContextGL);
 }
 
 void WebGLRenderingContextBase::disable(GCGLenum cap)
@@ -1590,7 +1591,7 @@ void WebGLRenderingContextBase::disable(GCGLenum cap)
         m_scissorEnabled = false;
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
         m_rasterizerDiscardEnabled = false;
-    graphicsContextGL()->disable(cap);
+    protect(graphicsContextGL())->disable(cap);
 }
 
 void WebGLRenderingContextBase::disableVertexAttribArray(GCGLuint index)
@@ -1628,7 +1629,7 @@ void WebGLRenderingContextBase::drawArrays(GCGLenum mode, GCGLint first, GCGLsiz
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        graphicsContextGL()->drawArrays(mode, first, count);
+        protect(graphicsContextGL())->drawArrays(mode, first, count);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -1648,7 +1649,7 @@ void WebGLRenderingContextBase::drawElements(GCGLenum mode, GCGLsizei count, GCG
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        graphicsContextGL()->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
+        protect(graphicsContextGL())->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
     }
     markContextChangedAndNotifyCanvasObserver();
 }
@@ -1661,7 +1662,7 @@ void WebGLRenderingContextBase::enable(GCGLenum cap)
         m_scissorEnabled = true;
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
         m_rasterizerDiscardEnabled = true;
-    graphicsContextGL()->enable(cap);
+    protect(graphicsContextGL())->enable(cap);
 }
 
 void WebGLRenderingContextBase::enableVertexAttribArray(GCGLuint index)
@@ -2659,7 +2660,8 @@ WebGLAny WebGLRenderingContextBase::getVertexAttrib(GCGLuint index, GCGLenum pna
         return nullptr;
     }
 
-    const WebGLVertexArrayObjectBase::VertexAttribState& state = protect(m_boundVertexArrayObject)->getVertexAttribState(index);
+    RefPtr boundVertexArrayObject = *m_boundVertexArrayObject;
+    const WebGLVertexArrayObjectBase::VertexAttribState& state = boundVertexArrayObject->getVertexAttribState(index);
 
     if ((isWebGL2() || m_angleInstancedArrays) && pname == GraphicsContextGL::VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE)
         return state.divisor;
@@ -4507,10 +4509,11 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
     }
 
     if (m_currentProgram != program) {
+        RefPtr graphicsContextGL = this->graphicsContextGL();
         if (RefPtr currentProgram = m_currentProgram)
-            currentProgram->onDetached(locker, graphicsContextGL().get());
+            currentProgram->onDetached(locker, graphicsContextGL);
         m_currentProgram = program;
-        graphicsContextGL()->useProgram(objectOrZero(program));
+        graphicsContextGL->useProgram(objectOrZero(program));
         if (program)
             program->onAttached();
     }
@@ -4745,12 +4748,12 @@ float WebGLRenderingContextBase::getFloatParameter(GCGLenum pname)
 
 int WebGLRenderingContextBase::getIntParameter(GCGLenum pname)
 {
-    return graphicsContextGL()->getInteger(pname);
+    return protect(graphicsContextGL())->getInteger(pname);
 }
 
 unsigned WebGLRenderingContextBase::getUnsignedIntParameter(GCGLenum pname)
 {
-    return graphicsContextGL()->getInteger(pname);
+    return protect(graphicsContextGL())->getInteger(pname);
 }
 
 RefPtr<Float32Array> WebGLRenderingContextBase::getWebGLFloatArrayParameter(GCGLenum pname)
@@ -5378,7 +5381,7 @@ GCGLint WebGLRenderingContextBase::maxColorAttachments()
     if (!supportsDrawBuffers())
         return 0;
     if (!m_maxColorAttachments)
-        m_maxColorAttachments = graphicsContextGL()->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
+        m_maxColorAttachments = protect(graphicsContextGL())->getInteger(GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT);
     return m_maxColorAttachments;
 }
 
@@ -5420,7 +5423,7 @@ void WebGLRenderingContextBase::drawArraysInstanced(GCGLenum mode, GCGLint first
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        graphicsContextGL()->drawArraysInstanced(mode, first, count, primcount);
+        protect(graphicsContextGL())->drawArraysInstanced(mode, first, count, primcount);
     }
 
     markContextChangedAndNotifyCanvasObserver();
@@ -5441,7 +5444,7 @@ void WebGLRenderingContextBase::drawElementsInstanced(GCGLenum mode, GCGLsizei c
 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
-        graphicsContextGL()->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
+        protect(graphicsContextGL())->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
     }
 
     markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -433,7 +433,7 @@ public:
     using SimulatedEventForTesting = GraphicsContextGL::SimulatedEventForTesting;
     WEBCORE_EXPORT void simulateEventForTesting(SimulatedEventForTesting);
 
-    RefPtr<GraphicsContextGL> graphicsContextGL() const { return m_context; }
+    GraphicsContextGL* graphicsContextGL() const { return m_context; }
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
@@ -479,14 +479,14 @@ public:
     // currently latched into the context - without traversing all of
     // the latched objects to find the current one, which would be
     // prohibitively expensive.
-    Lock& NODELETE objectGraphLock() WTF_RETURNS_LOCK(m_objectGraphLock);
+    Lock& NODELETE objectGraphLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_objectGraphLock);
 
     // Returns the ordinal number of when the context was last active (drew, read pixels).
     uint64_t activeOrdinal() const { return m_activeOrdinal; }
 
     using PixelStoreParameters = GraphicsContextGL::PixelStoreParameters;
-    const PixelStoreParameters& pixelStorePackParameters() const { return m_packParameters; }
-    const PixelStoreParameters& unpackPixelStoreParameters() const { return m_unpackParameters; };
+    const PixelStoreParameters& pixelStorePackParameters() const LIFETIME_BOUND { return m_packParameters; }
+    const PixelStoreParameters& unpackPixelStoreParameters() const LIFETIME_BOUND { return m_unpackParameters; };
 
     bool isOpaque() const final;
 

--- a/Source/WebCore/html/canvas/WebGLSampler.cpp
+++ b/Source/WebCore/html/canvas/WebGLSampler.cpp
@@ -41,7 +41,7 @@ Ref<WebGLSampler> WebGLSampler::createLost()
 
 Ref<WebGLSampler> WebGLSampler::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createSampler();
+    auto object = protect(context.graphicsContextGL())->createSampler();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLSampler { context, object });

--- a/Source/WebCore/html/canvas/WebGLShader.cpp
+++ b/Source/WebCore/html/canvas/WebGLShader.cpp
@@ -42,7 +42,7 @@ Ref<WebGLShader> WebGLShader::createLost(GCGLenum type)
 
 Ref<WebGLShader> WebGLShader::create(WebGLRenderingContextBase& context, GCGLenum type)
 {
-    auto object = context.graphicsContextGL()->createShader(type);
+    auto object = protect(context.graphicsContextGL())->createShader(type);
     if (!object)
         return createLost(type);
     return adoptRef(*new WebGLShader(context, object, type));

--- a/Source/WebCore/html/canvas/WebGLShader.h
+++ b/Source/WebCore/html/canvas/WebGLShader.h
@@ -39,7 +39,7 @@ public:
     virtual ~WebGLShader();
 
     GCGLenum getType() const { return m_type; }
-    const String& getSource() const { return m_source; }
+    const String& getSource() const LIFETIME_BOUND { return m_source; }
 
     void setSource(const String& source) { m_source = source; }
 

--- a/Source/WebCore/html/canvas/WebGLStencilTexturing.cpp
+++ b/Source/WebCore/html/canvas/WebGLStencilTexturing.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGLStencilTexturing);
 WebGLStencilTexturing::WebGLStencilTexturing(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLStencilTexturing)
 {
-    context.graphicsContextGL()->enableExtension(GCGLExtension::ANGLE_stencil_texturing);
+    protect(context.graphicsContextGL())->enableExtension(GCGLExtension::ANGLE_stencil_texturing);
 }
 
 WebGLStencilTexturing::~WebGLStencilTexturing() = default;

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -42,7 +42,7 @@ Ref<WebGLSync> WebGLSync::createLost()
 
 Ref<WebGLSync> WebGLSync::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->fenceSync(GraphicsContextGL::SYNC_GPU_COMMANDS_COMPLETE, 0);
+    auto object = protect(context.graphicsContextGL())->fenceSync(GraphicsContextGL::SYNC_GPU_COMMANDS_COMPLETE, 0);
     if (!object)
         return createLost();
     return adoptRef(*new WebGLSync { context, object });
@@ -79,7 +79,7 @@ void WebGLSync::updateCache(WebGLRenderingContextBase& context)
         return;
 
     m_allowCacheUpdate = false;
-    m_syncStatus = context.graphicsContextGL()->getSynci(m_sync, GraphicsContextGL::SYNC_STATUS);
+    m_syncStatus = protect(context.graphicsContextGL())->getSynci(m_sync, GraphicsContextGL::SYNC_STATUS);
     if (m_syncStatus == GraphicsContextGL::UNSIGNALED)
         scheduleAllowCacheUpdate(context);
 }

--- a/Source/WebCore/html/canvas/WebGLTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLTexture.cpp
@@ -41,7 +41,7 @@ Ref<WebGLTexture> WebGLTexture::createLost()
 
 Ref<WebGLTexture> WebGLTexture::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createTexture();
+    auto object = protect(context.graphicsContextGL())->createTexture();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLTexture { context, object });

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 RefPtr<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createQueryEXT();
+    auto object = protect(context.graphicsContextGL())->createQueryEXT();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTimerQueryEXT { context, object });

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -44,7 +44,7 @@ Ref<WebGLTransformFeedback> WebGLTransformFeedback::createLost()
 
 Ref<WebGLTransformFeedback> WebGLTransformFeedback::create(WebGL2RenderingContext& context)
 {
-    auto object = context.graphicsContextGL()->createTransformFeedback();
+    auto object = protect(context.graphicsContextGL())->createTransformFeedback();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLTransformFeedback { context, object });

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -114,14 +114,14 @@ public:
     {
         if (!m_context)
             return;
-        context.graphicsContextGL()->disable(GraphicsContextGL::RASTERIZER_DISCARD);
+        protect(context.graphicsContextGL())->disable(GraphicsContextGL::RASTERIZER_DISCARD);
     }
 
     ~ScopedDisableRasterizerDiscard()
     {
         if (!m_context)
             return;
-        m_context->graphicsContextGL()->enable(GraphicsContextGL::RASTERIZER_DISCARD);
+        protect(m_context->graphicsContextGL())->enable(GraphicsContextGL::RASTERIZER_DISCARD);
     }
 
 private:
@@ -138,9 +138,9 @@ public:
             return;
         GCGLenum value[1] { GraphicsContextGL::COLOR_ATTACHMENT0 };
         if (context.isWebGL2())
-            context.graphicsContextGL()->drawBuffers(value);
+            protect(context.graphicsContextGL())->drawBuffers(value);
         else
-            context.graphicsContextGL()->drawBuffersEXT(value);
+            protect(context.graphicsContextGL())->drawBuffersEXT(value);
     }
 
     ~ScopedEnableBackbuffer()
@@ -149,9 +149,9 @@ public:
             return;
         GCGLenum value[1] { GraphicsContextGL::NONE };
         if (m_context->isWebGL2())
-            m_context->graphicsContextGL()->drawBuffers(value);
+            protect(m_context->graphicsContextGL())->drawBuffers(value);
         else
-            m_context->graphicsContextGL()->drawBuffersEXT(value);
+            protect(m_context->graphicsContextGL())->drawBuffersEXT(value);
     }
 
 private:
@@ -166,14 +166,14 @@ public:
     {
         if (!m_context)
             return;
-        context.graphicsContextGL()->disable(GraphicsContextGL::SCISSOR_TEST);
+        protect(context.graphicsContextGL())->disable(GraphicsContextGL::SCISSOR_TEST);
     }
 
     ~ScopedDisableScissorTest()
     {
         if (!m_context)
             return;
-        m_context->graphicsContextGL()->enable(GraphicsContextGL::SCISSOR_TEST);
+        protect(m_context->graphicsContextGL())->enable(GraphicsContextGL::SCISSOR_TEST);
     }
 
 private:

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
@@ -42,7 +42,7 @@ Ref<WebGLVertexArrayObject> WebGLVertexArrayObject::createLost()
     
 Ref<WebGLVertexArrayObject> WebGLVertexArrayObject::create(WebGLRenderingContextBase& context, Type type)
 {
-    auto object = context.graphicsContextGL()->createVertexArray();
+    auto object = protect(context.graphicsContextGL())->createVertexArray();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLVertexArrayObject { context, object, type });

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -52,7 +52,7 @@ void WebGLVertexArrayObjectBase::setElementArrayBuffer(const AbstractLocker& loc
     if (buffer)
         buffer->onAttached();
     if (RefPtr boundElementArrayBuffer = m_boundElementArrayBuffer.get())
-        boundElementArrayBuffer->onDetached(locker, graphicsContextGL().get());
+        boundElementArrayBuffer->onDetached(locker, protect(graphicsContextGL()));
     m_boundElementArrayBuffer = buffer;
     
 }
@@ -75,7 +75,7 @@ void WebGLVertexArrayObjectBase::setVertexAttribState(const AbstractLocker& lock
     if (buffer)
         buffer->onAttached();
     if (RefPtr bufferBinding = state.bufferBinding.get())
-        bufferBinding->onDetached(locker, graphicsContextGL().get());
+        bufferBinding->onDetached(locker, protect(graphicsContextGL()));
     state.bufferBinding = buffer;
     if (!state.validateBinding())
         m_allEnabledAttribBuffersBoundCache = false;

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
@@ -74,7 +74,7 @@ public:
     void setElementArrayBuffer(const AbstractLocker&, WebGLBuffer*);
 
     void NODELETE setVertexAttribEnabled(int index, bool flag);
-    const VertexAttribState& getVertexAttribState(int index) { return m_vertexAttribState[index]; }
+    const VertexAttribState& getVertexAttribState(int index) LIFETIME_BOUND { return m_vertexAttribState[index]; }
     void setVertexAttribState(const AbstractLocker&, GCGLuint, GCGLsizei, GCGLint, GCGLenum, GCGLboolean, GCGLsizei, GCGLintptr, bool, WebGLBuffer*);
     bool hasArrayBuffer(WebGLBuffer* buffer) { return m_vertexAttribState.containsIf([&](auto& item) { return item.bufferBinding == buffer; }); }
     void unbindBuffer(const AbstractLocker&, WebGLBuffer&);

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
@@ -45,7 +45,7 @@ Ref<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createDefault(WebGLRen
 
 Ref<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createUser(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createVertexArray();
+    auto object = protect(context.graphicsContextGL())->createVertexArray();
     if (!object)
         return createLost();
     return adoptRef(*new WebGLVertexArrayObjectOES { context, object, Type::User });

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -52,7 +52,7 @@ public:
 
     void setTagName(TagName);
 
-    const AtomString& name() const;
+    const AtomString& name() const LIFETIME_BOUND;
 
     // DOCTYPE.
 
@@ -62,12 +62,12 @@ public:
 
     // StartTag, EndTag.
 
-    Vector<Attribute>& attributes();
+    Vector<Attribute>& attributes() LIFETIME_BOUND;
 
     TagName tagName() const;
     bool selfClosing() const;
     void setSelfClosingToFalse();
-    const Vector<Attribute>& attributes() const;
+    const Vector<Attribute>& attributes() const LIFETIME_BOUND;
 
     // Characters
 
@@ -76,8 +76,8 @@ public:
 
     // Comment
 
-    const String& comment() const;
-    String& comment();
+    const String& comment() const LIFETIME_BOUND;
+    String& comment() LIFETIME_BOUND;
 
     bool hasDuplicateAttribute() const { return m_hasDuplicateAttribute; }
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -157,16 +157,16 @@ public:
     Element& currentElement() const { return m_openElements.top(); }
     ContainerNode& currentNode() const { return m_openElements.topNode(); }
     ElementName currentElementName() const { return m_openElements.topElementName(); }
-    HTMLStackItem& currentStackItem() const { return m_openElements.topStackItem(); }
-    HTMLStackItem* oneBelowTop() const { return m_openElements.oneBelowTop(); }
+    HTMLStackItem& currentStackItem() const LIFETIME_BOUND { return m_openElements.topStackItem(); }
+    HTMLStackItem* oneBelowTop() const LIFETIME_BOUND { return m_openElements.oneBelowTop(); }
     TreeScope& treeScopeForCurrentNode();
     Document& ownerDocumentForCurrentNode();
-    HTMLElementStack& openElements() const { return m_openElements; }
-    HTMLFormattingElementList& activeFormattingElements() const { return m_activeFormattingElements; }
+    HTMLElementStack& openElements() const LIFETIME_BOUND { return m_openElements; }
+    HTMLFormattingElementList& activeFormattingElements() const LIFETIME_BOUND { return m_activeFormattingElements; }
     bool currentIsRootNode() { return &m_openElements.topNode() == &m_openElements.rootNode(); }
 
     Element& head() const { return m_head.element(); }
-    HTMLStackItem& headStackItem() { return m_head; }
+    HTMLStackItem& headStackItem() LIFETIME_BOUND { return m_head; }
 
     void setForm(HTMLFormElement*);
     HTMLFormElement* form() const { return m_form.get(); }

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -69,7 +69,7 @@ public:
     void resumeParsingAfterYield();
 
     // For HTMLTreeBuilder.
-    HTMLTokenizer& tokenizer();
+    HTMLTokenizer& tokenizer() LIFETIME_BOUND;
     TextPosition textPosition() const final;
 
     bool isOnStackOfOpenElements(Element&) const;
@@ -82,7 +82,7 @@ protected:
     void appendSynchronously(RefPtr<StringImpl>&&) override;
     void finish() override;
 
-    HTMLTreeBuilder& treeBuilder() { return m_treeBuilder; }
+    HTMLTreeBuilder& treeBuilder() LIFETIME_BOUND { return m_treeBuilder; }
 
 private:
     HTMLDocumentParser(DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy>, CustomElementRegistry*);
@@ -106,7 +106,7 @@ private:
     // HTMLScriptRunnerHost
     void watchForLoad(PendingScript&) final;
     void stopWatchingForLoad(PendingScript&) final;
-    HTMLInputStream& inputStream() final;
+    HTMLInputStream& inputStream() LIFETIME_BOUND final;
     bool hasPreloadScanner() const final;
     void appendCurrentInputStreamToPreloadScannerAndScan() final;
 

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -57,14 +57,14 @@ public:
         Element& element() const { return m_item.element(); }
         ContainerNode& node() const { return m_item.node(); }
         ElementName elementName() const { return m_item.elementName(); }
-        HTMLStackItem& stackItem() { return m_item; }
-        const HTMLStackItem& stackItem() const { return m_item; }
+        HTMLStackItem& stackItem() LIFETIME_BOUND { return m_item; }
+        const HTMLStackItem& stackItem() const LIFETIME_BOUND { return m_item; }
 
         void replaceElement(HTMLStackItem&&);
 
         bool NODELETE isAbove(ElementRecord&) const;
 
-        ElementRecord* next() const { return m_next.get(); }
+        ElementRecord* next() const LIFETIME_BOUND { return m_next.get(); }
 
     private:
         friend class HTMLElementStack;
@@ -83,13 +83,13 @@ public:
     Element& top() const { return m_top->element(); }
     ContainerNode& topNode() const { return m_top->node(); }
     ElementName topElementName() const { return m_top->elementName(); }
-    HTMLStackItem& topStackItem() const { return m_top->stackItem(); }
+    HTMLStackItem& topStackItem() const LIFETIME_BOUND { return m_top->stackItem(); }
 
-    HTMLStackItem* NODELETE oneBelowTop() const;
-    ElementRecord& NODELETE topRecord() const;
-    ElementRecord* NODELETE find(Element&) const;
-    ElementRecord* NODELETE furthestBlockForFormattingElement(Element&) const;
-    ElementRecord* NODELETE topmost(ElementName) const;
+    HTMLStackItem* NODELETE oneBelowTop() const LIFETIME_BOUND;
+    ElementRecord& NODELETE topRecord() const LIFETIME_BOUND;
+    ElementRecord* NODELETE find(Element&) const LIFETIME_BOUND;
+    ElementRecord* NODELETE furthestBlockForFormattingElement(Element&) const LIFETIME_BOUND;
+    ElementRecord* NODELETE topmost(ElementName) const LIFETIME_BOUND;
 
     bool containsTemplateElement() const { return m_templateElementCount; }
 

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.h
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.h
@@ -58,7 +58,7 @@ public:
 
         bool isMarker() const { return m_item.isNull(); }
 
-        const HTMLStackItem& stackItem() const { return m_item; }
+        const HTMLStackItem& stackItem() const LIFETIME_BOUND { return m_item; }
         Element& element() const
         {
             // Callers should check isMarker() before calling element().
@@ -101,7 +101,7 @@ public:
 
     Element* NODELETE closestElementInScopeWithName(ElementName);
 
-    Entry* find(Element&);
+    Entry* find(Element&) LIFETIME_BOUND;
     bool contains(Element&);
     void append(HTMLStackItem&&);
     void remove(Element&);
@@ -114,15 +114,15 @@ public:
     // clearToLastMarker also clears the marker (per the HTML5 spec).
     void clearToLastMarker();
 
-    const Entry& at(size_t i) const { return m_entries[i]; }
-    Entry& at(size_t i) { return m_entries[i]; }
+    const Entry& at(size_t i) const LIFETIME_BOUND { return m_entries[i]; }
+    Entry& at(size_t i) LIFETIME_BOUND { return m_entries[i]; }
 
 #if ENABLE(TREE_DEBUGGING)
     void show();
 #endif
 
 private:
-    Entry& first() { return at(0); }
+    Entry& first() LIFETIME_BOUND { return at(0); }
 
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#list-of-active-formatting-elements
     // These functions enforce the "Noah's Ark" condition, which removes redundant mis-nested elements.

--- a/Source/WebCore/html/parser/HTMLInputStream.h
+++ b/Source/WebCore/html/parser/HTMLInputStream.h
@@ -87,8 +87,8 @@ public:
         return m_last->isClosed();
     }
 
-    SegmentedString& current() { return m_first; }
-    const SegmentedString& current() const { return m_first; }
+    SegmentedString& current() LIFETIME_BOUND { return m_first; }
+    const SegmentedString& current() const LIFETIME_BOUND { return m_first; }
 
     void splitInto(SegmentedString& next)
     {

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
@@ -45,7 +45,7 @@ public:
     // Returns true if done checking, regardless whether an encoding is found.
     bool checkForMetaCharset(std::span<const uint8_t>);
 
-    const PAL::TextEncoding& encoding() { return m_encoding; }
+    const PAL::TextEncoding& encoding() LIFETIME_BOUND { return m_encoding; }
 
     // The returned encoding might not be valid.
     static PAL::TextEncoding encodingFromMetaAttributes(std::span<const std::pair<StringView, StringView>>);

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -51,8 +51,8 @@ public:
 
     CachedResourceRequest resourceRequest(Document&);
 
-    const String& charset() const { return m_charset; }
-    const String& media() const { return m_mediaAttribute; }
+    const String& charset() const LIFETIME_BOUND { return m_charset; }
+    const String& media() const LIFETIME_BOUND { return m_mediaAttribute; }
     void setCharset(const String& charset) { m_charset = charset.isolatedCopy(); }
     void setCrossOriginMode(const String& mode) { m_crossOriginMode = mode; }
     void setNonce(const String& nonce) { m_nonceAttribute = nonce; }

--- a/Source/WebCore/html/parser/HTMLStackItem.h
+++ b/Source/WebCore/html/parser/HTMLStackItem.h
@@ -55,14 +55,14 @@ public:
     Element& element() const { return downcast<Element>(node()); }
     Element* elementOrNull() const { return downcast<Element>(m_node.get()); }
 
-    const AtomString& localName() const { return isElement() ? element().localName() : nullAtom(); }
-    const AtomString& namespaceURI() const { return isElement() ? element().namespaceURI() : nullAtom(); }
+    const AtomString& localName() const LIFETIME_BOUND { return isElement() ? element().localName() : nullAtom(); }
+    const AtomString& namespaceURI() const LIFETIME_BOUND { return isElement() ? element().namespaceURI() : nullAtom(); }
 
     ElementName elementName() const { return m_elementName; }
     Namespace nodeNamespace() const { return m_namespace; }
 
-    const Vector<Attribute>& attributes() const;
-    const Attribute* findAttribute(const QualifiedName& attributeName) const;
+    const Vector<Attribute>& attributes() const LIFETIME_BOUND;
+    const Attribute* findAttribute(const QualifiedName& attributeName) const LIFETIME_BOUND;
 
     bool matchesHTMLTag(const AtomString&) const;
 

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -74,7 +74,7 @@ public:
 
     // StartTag, EndTag, DOCTYPE.
 
-    const DataVector& name() const;
+    const DataVector& name() const LIFETIME_BOUND;
 
     void appendToName(char16_t);
 
@@ -96,7 +96,7 @@ public:
     // StartTag, EndTag.
 
     bool selfClosing() const;
-    const AttributeList& attributes() const;
+    const AttributeList& attributes() const LIFETIME_BOUND;
 
     void beginStartTag(Latin1Character);
 
@@ -118,7 +118,7 @@ public:
     // other types of tokens because we want to save a per-character branch.
     // There is no beginCharacters, and appending a character sets the type.
 
-    const DataVector& characters() const;
+    const DataVector& characters() const LIFETIME_BOUND;
     bool charactersIsAll8BitData() const;
 
     void appendToCharacter(Latin1Character);
@@ -128,7 +128,7 @@ public:
 
     // Comment.
 
-    const DataVector& comment() const;
+    const DataVector& comment() const LIFETIME_BOUND;
     bool commentIsAll8BitData() const;
 
     void beginComment();

--- a/Source/WebCore/html/parser/HTMLTokenizer.h
+++ b/Source/WebCore/html/parser/HTMLTokenizer.h
@@ -222,8 +222,8 @@ public:
 
     operator bool() const;
 
-    HTMLToken& operator*() const;
-    HTMLToken* operator->() const;
+    HTMLToken& operator*() const LIFETIME_BOUND;
+    HTMLToken* operator->() const LIFETIME_BOUND;
 
 private:
     friend class HTMLTokenizer;

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -172,7 +172,7 @@ private:
     bool shouldProcessTokenInForeignContent(const AtomHTMLToken&);
     void processTokenInForeignContent(AtomHTMLToken&&);
 
-    HTMLStackItem& adjustedCurrentStackItem();
+    HTMLStackItem& adjustedCurrentStackItem() LIFETIME_BOUND;
 
     void callTheAdoptionAgency(AtomHTMLToken&);
 
@@ -197,7 +197,7 @@ private:
 
         DocumentFragment* fragment() const;
         Element& NODELETE contextElement();
-        HTMLStackItem& NODELETE contextElementStackItem();
+        HTMLStackItem& NODELETE contextElementStackItem() LIFETIME_BOUND;
 
     private:
         WeakPtr<DocumentFragment, WeakPtrImplWithEventTargetData> m_fragment;

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -68,7 +68,7 @@ public:
     void updateSizes(ForceUpdate force = ForceUpdate::No);
     void updateDisplay();
 
-    TextTrackRepresentation* textTrackRepresentation() const { return m_textTrackRepresentation.get(); }
+    TextTrackRepresentation* textTrackRepresentation() const LIFETIME_BOUND { return m_textTrackRepresentation.get(); }
     void updateTextTrackRepresentationImageIfNeeded();
     void requiresTextTrackRepresentationChanged();
 

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
@@ -82,7 +82,8 @@ std::optional<Style::UnadjustedStyle> SelectFallbackButtonElement::resolveCustom
     style->setTextAlign(hostStyle->writingMode().isBidiLTR() ? Style::TextAlign::Left : Style::TextAlign::Right);
 
     // Apply direction and unicodeBidi from the selected option for proper bidirectional text rendering.
-    for (auto& item : protect(selectElement())->listItems()) {
+    Ref selectElement = this->selectElement();
+    for (auto& item : selectElement->listItems()) {
         RefPtr option = dynamicDowncast<HTMLOptionElement>(item.get());
         if (!option || !option->selected())
             continue;

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -136,7 +136,7 @@ public:
 
     virtual MediaTime startTimeVariance() const { return MediaTime::zeroTime(); }
 
-    const std::optional<Vector<String>>& styleSheets() const { return m_styleSheets; }
+    const std::optional<Vector<String>>& styleSheets() const LIFETIME_BOUND { return m_styleSheets; }
 
     virtual bool shouldPurgeCuesFromUnbufferedRanges() const { return false; }
     virtual void removeCuesNotInTimeRanges(const PlatformTimeRanges&);

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -81,7 +81,7 @@ public:
     TextTrack* NODELETE track() const;
     void setTrack(TextTrack*);
 
-    const AtomString& id() const { return m_id; }
+    const AtomString& id() const LIFETIME_BOUND { return m_id; }
     void setId(const AtomString&);
 
     double startTime() const { return startMediaTime().toDouble(); }

--- a/Source/WebCore/html/track/TextTrackCueGeneric.h
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.h
@@ -49,16 +49,16 @@ public:
     double fontSizeMultiplier() const { return m_fontSizeMultiplier; }
     void setFontSizeMultiplier(double);
 
-    const String& fontName() const { return m_fontName; }
+    const String& fontName() const LIFETIME_BOUND { return m_fontName; }
     void setFontName(const String& name) { m_fontName = name; }
 
-    const Color& foregroundColor() const { return m_foregroundColor; }
+    const Color& foregroundColor() const LIFETIME_BOUND { return m_foregroundColor; }
     void setForegroundColor(const Color& color) { m_foregroundColor = color; }
-    
-    const Color& backgroundColor() const { return m_backgroundColor; }
+
+    const Color& backgroundColor() const LIFETIME_BOUND { return m_backgroundColor; }
     void setBackgroundColor(const Color& color) { m_backgroundColor = color; }
-    
-    const Color& highlightColor() const { return m_highlightColor; }
+
+    const Color& highlightColor() const LIFETIME_BOUND { return m_highlightColor; }
     void setHighlightColor(const Color& color) { m_highlightColor = color; }
 
 private:

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -61,7 +61,7 @@ public:
     void remove(TrackBase&, bool scheduleEvent = true) final;
 
     void setDuration(MediaTime duration) { m_duration = duration; }
-    const MediaTime& duration() const { return m_duration; }
+    const MediaTime& duration() const LIFETIME_BOUND { return m_duration; }
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final;

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -126,7 +126,7 @@ private:
 class MediaTrackBase : public TrackBase {
     WTF_MAKE_TZONE_ALLOCATED(MediaTrackBase);
 public:
-    const AtomString& kind() const { return m_kind; }
+    const AtomString& kind() const LIFETIME_BOUND { return m_kind; }
     virtual void setKind(const AtomString&);
 
 protected:

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -161,10 +161,10 @@ public:
     AlignSetting align() const { return m_cueAlignment; }
     void setAlign(AlignSetting);
 
-    const String& text() const final { return m_content; }
+    const String& text() const LIFETIME_BOUND final { return m_content; }
     void setText(const String&);
 
-    const String& cueSettings() const { return m_settings; }
+    const String& cueSettings() const LIFETIME_BOUND { return m_settings; }
     void setCueSettings(const String&);
 
     RefPtr<DocumentFragment> getCueAsHTML() final;
@@ -175,7 +175,7 @@ public:
     VTTRegion* NODELETE region();
     void setRegion(VTTRegion*);
 
-    const String& NODELETE regionId();
+    const String& NODELETE regionId() LIFETIME_BOUND;
 
     void setIsActive(bool) override;
 
@@ -192,7 +192,7 @@ public:
     std::pair<double, double> getPositionCoordinates() const;
 
     using DisplayPosition = std::pair<std::optional<double>, std::optional<double>>;
-    const DisplayPosition& getCSSPosition() const { return m_displayPosition; };
+    const DisplayPosition& getCSSPosition() const LIFETIME_BOUND { return m_displayPosition; };
 
     CSSValueID NODELETE getCSSAlignment() const;
     int NODELETE getCSSSize() const;
@@ -217,10 +217,10 @@ public:
     SpeechSynthesisUtterance* speechUtterance() const { return m_speechUtterance.get(); }
 #endif
 
-    const LineAndPositionSetting& left() const { return m_left; }
-    const LineAndPositionSetting& top() const { return m_top; }
-    const LineAndPositionSetting& width() const { return m_width; }
-    const LineAndPositionSetting& height() const { return m_height; }
+    const LineAndPositionSetting& left() const LIFETIME_BOUND { return m_left; }
+    const LineAndPositionSetting& top() const LIFETIME_BOUND { return m_top; }
+    const LineAndPositionSetting& width() const LIFETIME_BOUND { return m_width; }
+    const LineAndPositionSetting& height() const LIFETIME_BOUND { return m_height; }
 
 protected:
     VTTCue(Document&, const MediaTime& start, const MediaTime& end, String&& content);

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -58,7 +58,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const String& id() const { return m_id; }
+    const String& id() const LIFETIME_BOUND { return m_id; }
     void setId(const String&);
 
     double width() const { return m_width; }
@@ -85,7 +85,7 @@ public:
 
     void NODELETE updateParametersFromRegion(const VTTRegion&);
 
-    const String& regionSettings() const { return m_settings; }
+    const String& regionSettings() const LIFETIME_BOUND { return m_settings; }
     void setRegionSettings(const String&);
 
     HTMLDivElement& getDisplayTree();

--- a/Source/WebCore/html/track/WebVTTToken.h
+++ b/Source/WebCore/html/track/WebVTTToken.h
@@ -77,10 +77,10 @@ public:
     }
 
     Type::Type type() const { return m_type; }
-    const String& name() const { return m_data; }
-    const String& characters() const { return m_data; }
-    const AtomString& classes() const { return m_classes; }
-    const AtomString& annotation() const { return m_annotation; }
+    const String& name() const LIFETIME_BOUND { return m_data; }
+    const String& characters() const LIFETIME_BOUND { return m_data; }
+    const AtomString& classes() const LIFETIME_BOUND { return m_classes; }
+    const AtomString& annotation() const LIFETIME_BOUND { return m_annotation; }
 
 private:
     WebVTTToken(Type::Type type, const String& data)


### PR DESCRIPTION
#### 8761bda2522be9321ce58e438f83c759194e5796
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=309032">https://bugs.webkit.org/show_bug.cgi?id=309032</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/html/Allowlist.h:
(WebCore::Allowlist::origins const): Deleted.
* Source/WebCore/html/AttachmentAssociatedElement.cpp:
(WebCore::AttachmentAssociatedElement::attachmentElement const):
(WebCore::AttachmentAssociatedElement::attachmentIdentifier const):
* Source/WebCore/html/AttachmentAssociatedElement.h:
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::size const): Deleted.
(WebCore::CanvasBase::cssParserContext const): Deleted.
* Source/WebCore/html/DOMFormData.h:
(WebCore::DOMFormData::items const): Deleted.
(WebCore::DOMFormData::encoding const): Deleted.
* Source/WebCore/html/DOMTokenList.h:
* Source/WebCore/html/DOMURL.h:
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLCollection.h:
(WebCore::CollectionNamedElementCache::propertyNames const): Deleted.
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::namedItemCaches const): Deleted.
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/HTMLImageElement.h:
(WebCore::HTMLImageElement::currentURL const): Deleted.
* Source/WebCore/html/HTMLMapElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::currentSrc const): Deleted.
(WebCore::HTMLMediaElement::srcObject const): Deleted.
* Source/WebCore/html/HTMLPlugInElement.h:
(WebCore::HTMLPlugInElement::serviceType const): Deleted.
(WebCore::HTMLPlugInElement::url const): Deleted.
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/HTMLSlotElement.h:
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::size const): Deleted.
(WebCore::ImageData::data const): Deleted.
* Source/WebCore/html/MediaError.h:
(WebCore::MediaError::message const): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
(WebCore::DetachedOffscreenCanvas::size const): Deleted.
* Source/WebCore/html/TimeRanges.h:
(WebCore::TimeRanges::ranges const): Deleted.
(WebCore::TimeRanges::ranges): Deleted.
* Source/WebCore/html/URLSearchParams.h:
(WebCore::URLSearchParams::pairs const): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::getContextAttributes const): Deleted.
(WebCore::CanvasRenderingContext2DBase::getLineDash const): Deleted.
(WebCore::CanvasRenderingContext2DBase::webkitLineDash const): Deleted.
(WebCore::CanvasRenderingContext2DBase::state const): Deleted.
(WebCore::CanvasRenderingContext2DBase::modifiableState): Deleted.
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::deleteQueryEXT):
* Source/WebCore/html/canvas/OESVertexArrayObject.cpp:
(WebCore::OESVertexArrayObject::deleteVertexArrayOES):
* Source/WebCore/html/canvas/Path2D.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::deleteVertexArray):
* Source/WebCore/html/canvas/WebGLContextEvent.h:
* Source/WebCore/html/canvas/WebGLObject.cpp:
(WebCore::WebGLObject::context const):
(WebCore::WebGLObject::graphicsContextGL const):
* Source/WebCore/html/canvas/WebGLObject.h:
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::cullFace):
(WebCore::WebGLRenderingContextBase::deleteObject):
(WebCore::WebGLRenderingContextBase::detachShader):
(WebCore::WebGLRenderingContextBase::disable):
(WebCore::WebGLRenderingContextBase::getVertexAttrib):
(WebCore::WebGLRenderingContextBase::useProgram):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::graphicsContextGL const):
(WebCore::WebGLRenderingContextBase::pixelStorePackParameters const): Deleted.
(WebCore::WebGLRenderingContextBase::unpackPixelStoreParameters const): Deleted.
* Source/WebCore/html/canvas/WebGLShader.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::setElementArrayBuffer):
(WebCore::WebGLVertexArrayObjectBase::setVertexAttribState):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h:
(WebCore::WebGLVertexArrayObjectBase::getVertexAttribState): Deleted.
* Source/WebCore/html/parser/AtomHTMLToken.h:
* Source/WebCore/html/parser/HTMLConstructionSite.h:
(WebCore::HTMLConstructionSite::currentStackItem const): Deleted.
(WebCore::HTMLConstructionSite::oneBelowTop const): Deleted.
(WebCore::HTMLConstructionSite::openElements const): Deleted.
(WebCore::HTMLConstructionSite::activeFormattingElements const): Deleted.
(WebCore::HTMLConstructionSite::headStackItem): Deleted.
* Source/WebCore/html/parser/HTMLDocumentParser.h:
(WebCore::HTMLDocumentParser::treeBuilder): Deleted.
* Source/WebCore/html/parser/HTMLElementStack.h:
(WebCore::HTMLElementStack::ElementRecord::stackItem): Deleted.
(WebCore::HTMLElementStack::ElementRecord::stackItem const): Deleted.
(WebCore::HTMLElementStack::ElementRecord::next const): Deleted.
(WebCore::HTMLElementStack::topStackItem const): Deleted.
* Source/WebCore/html/parser/HTMLFormattingElementList.h:
(WebCore::HTMLFormattingElementList::Entry::stackItem const): Deleted.
(WebCore::HTMLFormattingElementList::at const): Deleted.
(WebCore::HTMLFormattingElementList::at): Deleted.
(WebCore::HTMLFormattingElementList::first): Deleted.
* Source/WebCore/html/parser/HTMLInputStream.h:
(WebCore::HTMLInputStream::current): Deleted.
(WebCore::HTMLInputStream::current const): Deleted.
* Source/WebCore/html/parser/HTMLMetaCharsetParser.h:
(WebCore::HTMLMetaCharsetParser::encoding): Deleted.
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::PreloadRequest::charset const): Deleted.
(WebCore::PreloadRequest::media const): Deleted.
* Source/WebCore/html/parser/HTMLStackItem.h:
(WebCore::HTMLStackItem::localName const): Deleted.
(WebCore::HTMLStackItem::namespaceURI const): Deleted.
* Source/WebCore/html/parser/HTMLToken.h:
* Source/WebCore/html/parser/HTMLTokenizer.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/html/track/TextTrack.h:
(WebCore::TextTrack::styleSheets const): Deleted.
* Source/WebCore/html/track/TextTrackCue.h:
(WebCore::TextTrackCue::id const): Deleted.
* Source/WebCore/html/track/TextTrackCueGeneric.h:
* Source/WebCore/html/track/TextTrackList.h:
* Source/WebCore/html/track/TrackBase.h:
(WebCore::MediaTrackBase::kind const): Deleted.
* Source/WebCore/html/track/VTTCue.h:
(WebCore::VTTCue::cueSettings const): Deleted.
(WebCore::VTTCue::getCSSPosition const): Deleted.
(WebCore::VTTCue::left const): Deleted.
(WebCore::VTTCue::top const): Deleted.
(WebCore::VTTCue::width const): Deleted.
(WebCore::VTTCue::height const): Deleted.
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/html/track/WebVTTToken.h:
(WebCore::WebVTTToken::name const): Deleted.
(WebCore::WebVTTToken::characters const): Deleted.
(WebCore::WebVTTToken::classes const): Deleted.
(WebCore::WebVTTToken::annotation const): Deleted.

Canonical link: <a href="https://commits.webkit.org/308581@main">https://commits.webkit.org/308581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01dd3c63ab046776802ca9c0df9ca990d3648aee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147777 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101192 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4974c00f-8d00-4480-b05b-f1dc347e6017) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81241 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9837e50e-3c77-4cf8-939a-2b92f52a4a13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94687 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91fa5346-ac06-458a-92d6-f7e29d0c75ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13108 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3900 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158795 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121956 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122158 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31333 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76387 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9198 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83639 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->