### PR TITLE
[Cocoa] Add IsAudible test for 308503@main

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -184,14 +184,6 @@ private:
     explicit NullMediaPlayerPrivate(MediaPlayer&) { }
 };
 
-#if !RELEASE_LOG_DISABLED
-static RefPtr<Logger>& nullLogger()
-{
-    static NeverDestroyed<RefPtr<Logger>> logger;
-    return logger;
-}
-#endif
-
 static const Vector<WebCore::ContentType>& nullContentTypeVector()
 {
     static NeverDestroyed<Vector<WebCore::ContentType>> vector;
@@ -210,6 +202,58 @@ static const std::optional<Vector<FourCC>>& nullOptionalFourCCVector()
     return vector;
 }
 
+const Vector<ContentType>& MediaPlayerClient::mediaContentTypesRequiringHardwareSupport() const
+{
+    return nullContentTypeVector();
+}
+
+const std::optional<Vector<String>>& MediaPlayerClient::allowedMediaContainerTypes() const
+{
+    return nullOptionalStringVector();
+}
+
+const std::optional<Vector<String>>& MediaPlayerClient::allowedMediaCodecTypes() const
+{
+    return nullOptionalStringVector();
+}
+
+const std::optional<Vector<FourCC>>& MediaPlayerClient::allowedMediaVideoCodecIDs() const
+{
+    return nullOptionalFourCCVector();
+}
+
+const std::optional<Vector<FourCC>>& MediaPlayerClient::allowedMediaAudioCodecIDs() const
+{
+    return nullOptionalFourCCVector();
+}
+
+const std::optional<Vector<FourCC>>& MediaPlayerClient::allowedMediaCaptionFormatTypes() const
+{
+    return nullOptionalFourCCVector();
+}
+
+class NullMediaResourceLoader final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NullMediaResourceLoader>
+    , public PlatformMediaResourceLoader {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(NullMediaResourceLoader);
+public:
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock(); }
+    uint32_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); }
+private:
+    void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler) final
+    {
+        completionHandler(makeUnexpected(ResourceError { }));
+    }
+    RefPtr<PlatformMediaResource> requestResource(ResourceRequest&&, LoadOptions) final { return nullptr; }
+};
+
+Ref<PlatformMediaResourceLoader> MediaPlayerClient::mediaPlayerCreateResourceLoader()
+{
+    return *new NullMediaResourceLoader;
+}
+
 class NullMediaPlayerClient final
     : public MediaPlayerClient
     , public RefCounted<NullMediaPlayerClient>
@@ -225,66 +269,8 @@ public:
 
 private:
     NullMediaPlayerClient() = default;
-
-#if !RELEASE_LOG_DISABLED
-    const Logger& mediaPlayerLogger() final
-    {
-        if (!nullLogger().get()) {
-            nullLogger() = Logger::create(this);
-            nullLogger()->setEnabled(this, false);
-        }
-
-        return *nullLogger().get();
-    }
-#endif
-
-    const Vector<WebCore::ContentType>& mediaContentTypesRequiringHardwareSupport() const final { return nullContentTypeVector(); }
-
-    Ref<PlatformMediaResourceLoader> mediaPlayerCreateResourceLoader() final
-    {
-        ASSERT_NOT_REACHED();
-        return adoptRef(*new NullMediaResourceLoader());
-    }
-
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const final { return nullptr; }
-#endif
-
-    const std::optional<Vector<String>>& allowedMediaContainerTypes() const final { return nullOptionalStringVector(); }
-    const std::optional<Vector<String>>& allowedMediaCodecTypes() const final { return nullOptionalStringVector(); }
-    const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const final { return nullOptionalFourCCVector(); }
-    const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const final { return nullOptionalFourCCVector(); }
-    const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const final { return nullOptionalFourCCVector(); }
-
     MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const final { return identifier(); }
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    MediaPlaybackTargetType playbackTargetType() const final { return MediaPlaybackTargetType::None; }
-#endif
-
-    class NullMediaResourceLoader final
-        : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NullMediaResourceLoader>
-        , public PlatformMediaResourceLoader {
-        WTF_MAKE_TZONE_ALLOCATED_INLINE(NullMediaResourceLoader);
-    public:
-        void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-        void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
-        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock(); }
-        uint32_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); }
-    private:
-        void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler) final
-        {
-            completionHandler(makeUnexpected(ResourceError { }));
-        }
-        RefPtr<PlatformMediaResource> requestResource(ResourceRequest&&, LoadOptions) final { return nullptr; }
-    };
 };
-
-const Vector<ContentType>& MediaPlayerClient::mediaContentTypesRequiringHardwareSupport() const
-{
-    static NeverDestroyed<Vector<ContentType>> contentTypes;
-    return contentTypes;
-}
 
 static MediaPlayerClient& nullMediaPlayerClient()
 {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -182,7 +182,7 @@ struct MediaPlayerLoadOptions {
     VideoRendererPreferences videoRendererPreferences { };
 };
 
-class MediaPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaPlayerClient> {
+class WEBCORE_EXPORT MediaPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaPlayerClient> {
 public:
     virtual ~MediaPlayerClient() = default;
 
@@ -216,7 +216,7 @@ public:
     // The MediaPlayer could not discover an engine which supports the requested resource.
     virtual void mediaPlayerResourceNotSupported() { }
 
-// Presentation-related methods
+    // Presentation-related methods
     // a new frame of video is available
     virtual void mediaPlayerRepaint() { }
 
@@ -245,7 +245,7 @@ public:
     virtual void mediaPlayerActiveSourceBuffersChanged() { }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    virtual RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const = 0;
+    virtual RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const { return nullptr; }
     virtual void mediaPlayerKeyNeeded(const SharedBuffer&) { }
 #endif
 
@@ -275,7 +275,7 @@ public:
     virtual bool mediaPlayerPlatformVolumeConfigurationRequired() const { return false; }
     virtual bool mediaPlayerIsLooping() const { return false; }
     virtual CachedResourceLoader* mediaPlayerCachedResourceLoader() const { return nullptr; }
-    virtual Ref<PlatformMediaResourceLoader> mediaPlayerCreateResourceLoader() = 0;
+    virtual Ref<PlatformMediaResourceLoader> mediaPlayerCreateResourceLoader();
     virtual bool doesHaveAttribute(const AtomString&, AtomString* = nullptr) const { return false; }
     virtual bool mediaPlayerShouldUsePersistentCache() const { return true; }
     virtual String mediaPlayerMediaCacheDirectory() const { return emptyString(); }
@@ -313,14 +313,14 @@ public:
     virtual Vector<String> mediaPlayerPreferredAudioCharacteristics() const { return Vector<String>(); }
 
     virtual bool mediaPlayerShouldDisableSleep() const { return false; }
-    virtual const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const = 0;
+    virtual const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const;
     virtual bool mediaPlayerShouldCheckHardwareSupport() const { return false; }
 
-    virtual const std::optional<Vector<String>>& allowedMediaContainerTypes() const = 0;
-    virtual const std::optional<Vector<String>>& allowedMediaCodecTypes() const = 0;
-    virtual const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const = 0;
-    virtual const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const = 0;
-    virtual const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const = 0;
+    virtual const std::optional<Vector<String>>& allowedMediaContainerTypes() const;
+    virtual const std::optional<Vector<String>>& allowedMediaCodecTypes() const;
+    virtual const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const;
+    virtual const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const;
+    virtual const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const;
 
     virtual void mediaPlayerBufferedTimeRangesChanged() { }
     virtual void mediaPlayerSeekableTimeRangesChanged() { }
@@ -351,7 +351,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual uint64_t mediaPlayerLogIdentifier() { return 0; }
-    virtual const Logger& mediaPlayerLogger() = 0;
+    virtual const Logger& mediaPlayerLogger() { return emptyLogger(); }
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -359,7 +359,7 @@ public:
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    virtual MediaPlaybackTargetType playbackTargetType() const = 0;
+    virtual MediaPlaybackTargetType playbackTargetType() const { return MediaPlaybackTargetType::None; }
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -342,11 +342,13 @@ void MediaPlayerPrivateAVFoundation::setHasVideo(bool b)
 
 void MediaPlayerPrivateAVFoundation::setHasAudio(bool b)
 {
-    if (m_cachedHasAudio != b) {
-        m_cachedHasAudio = b;
-        characteristicsChanged();
-        updateIsAudible();
-    }
+    if (m_cachedHasAudio == b)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, b);
+    m_cachedHasAudio = b;
+    characteristicsChanged();
+    updateIsAudible();
 }
 
 void MediaPlayerPrivateAVFoundation::setHasClosedCaptions(bool b)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -78,7 +78,7 @@ class VideoLayerManagerObjC;
 class VideoTrackPrivateAVFObjC;
 class WebCoreAVFResourceLoader;
 
-class MediaPlayerPrivateAVFoundationObjC final : public MediaPlayerPrivateAVFoundation {
+class WEBCORE_EXPORT MediaPlayerPrivateAVFoundationObjC final : public MediaPlayerPrivateAVFoundation {
 public:
     explicit MediaPlayerPrivateAVFoundationObjC(MediaPlayer&);
     virtual ~MediaPlayerPrivateAVFoundationObjC();
@@ -135,6 +135,8 @@ public:
     void processChapterTracks();
 
     Ref<WebCoreAVFResourceLoader> ensureAVFResourceLoader(AVAssetResourceLoadingRequest *);
+
+    bool isAudible() const { return m_isAudible; }
 
 private:
 #if ENABLE(ENCRYPTED_MEDIA)
@@ -550,5 +552,9 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaPlayerPrivateAVFoundationObjC)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::AVFObjC; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1347,6 +1347,7 @@
 		C54237F116B8957D00E638FC /* PasteboardNotifications_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C54237ED16B8955800E638FC /* PasteboardNotifications_Bundle.cpp */; };
 		C9E6DD351EA97D0800DD78AA /* FirstResponderSuppression.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E6DD311EA972D800DD78AA /* FirstResponderSuppression.mm */; };
 		CD0BD0A61F79924D001AB2CF /* ContextMenuImgWithVideo.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */; };
+		CD21458A2F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */; };
 		CD27A1C123C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */; };
 		CD48A87324C8A66F00F5800C /* Observer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD48A87224C8A66F00F5800C /* Observer.cpp */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
@@ -4041,6 +4042,7 @@
 		CD0370E224A44B7A00BA3CAE /* MediaLoading.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaLoading.mm; sourceTree = "<group>"; };
 		CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuImgWithVideo.mm; sourceTree = "<group>"; };
 		CD0BD0A71F7997C2001AB2CF /* ContextMenuImgWithVideo.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ContextMenuImgWithVideo.html; sourceTree = "<group>"; };
+		CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaPlayerPrivateAVFoundationObjCTests.mm; sourceTree = "<group>"; };
 		CD225C071C45A69200140761 /* ParsedContentRange.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParsedContentRange.cpp; sourceTree = "<group>"; };
 		CD227E43211A4D5D00D285AF /* PreferredAudioBufferSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PreferredAudioBufferSize.mm; sourceTree = "<group>"; };
 		CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewPausePlayingAudioTests.mm; sourceTree = "<group>"; };
@@ -7016,6 +7018,7 @@
 				751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */,
 				41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */,
 				7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */,
+				CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */,
 				57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */,
 				EB1F62962D19E07E000B3A04 /* ResourceMonitor.mm */,
 				1AF86FBF2CD5526B00AD337C /* ScrollbarWidthCrash.mm */,
@@ -8051,6 +8054,7 @@
 				CE1866491F72E8F100A0CAB6 /* MarkedText.cpp in Sources */,
 				A17C57EB2C9A5383009DD0B5 /* MediaLoading.mm in Sources */,
 				CDA315981ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm in Sources */,
+				CD21458A2F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm in Sources */,
 				518C1C532E2149EE00083695 /* MediaReorderQueue.cpp in Sources */,
 				075A9CF526177218006DFA3A /* MediaSessionCoordinatorTest.mm in Sources */,
 				CDC9442E1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "PlatformUtilities.h"
+#include "TestNSBundleExtras.h"
+#include "WebCoreTestSupport.h"
+#include <WebCore/MediaPlayerPrivateAVFoundationObjC.h>
+#include <wtf/Identified.h>
+
+namespace TestWebKitAPI {
+
+class MediaPlayerPrivateAVFoundationObjCTest
+    : public testing::Test
+    , public WebCore::MediaPlayerClient
+    , public Identified<WebCore::MediaPlayerClientIdentifier> {
+public:
+    // Pretend to be reference counted:
+    void ref() const final { }
+    void deref() const final { }
+
+    // MediaPlayerPrivateInterface:
+    WebCore::MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const { return identifier(); }
+
+    // testing::Test:
+    void SetUp() final
+    {
+        mediaPlayer = WebCore::MediaPlayer::create(*this, WebCore::MediaPlayerMediaEngineIdentifier::AVFoundation);
+    }
+
+    void TearDown() final
+    {
+        mediaPlayer = nullptr;
+    }
+
+    // Utility methods:
+    RefPtr<WebCore::MediaPlayerPrivateAVFoundationObjC> playerPrivate() const
+    {
+        if (mediaPlayer)
+            return dynamicDowncast<WebCore::MediaPlayerPrivateAVFoundationObjC>(mediaPlayer->playerPrivate());
+        return nullptr;
+    }
+
+    URL videoWithAudioURL() const
+    {
+        return [NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"mp4"];
+    }
+
+    URL videoWithoutAudioURL() const
+    {
+        return [NSBundle.test_resourcesBundle URLForResource:@"video-without-audio" withExtension:@"mp4"];
+    }
+
+    void waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState readyState)
+    {
+        Util::waitFor([&] { return mediaPlayer->readyState() > readyState; });
+        EXPECT_GE(mediaPlayer->readyState(), readyState);
+    }
+
+    RefPtr<WebCore::MediaPlayer> mediaPlayer;
+};
+
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, Basic)
+{
+    mediaPlayer->load(videoWithAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveCurrentData);
+}
+
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudible)
+{
+    mediaPlayer->load(videoWithAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveNothing);
+
+    RefPtr playerPrivate = this->playerPrivate();
+    ASSERT_NE(playerPrivate.get(), nullptr);
+
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(false);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setMuted(true);
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setVolume(0);
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(1);
+    mediaPlayer->setMuted(false);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+}
+
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleSilentVideo)
+{
+    mediaPlayer->load(videoWithoutAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveNothing);
+
+    RefPtr playerPrivate = this->playerPrivate();
+    ASSERT_NE(playerPrivate.get(), nullptr);
+
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(false);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+}
+
+
+}


### PR DESCRIPTION
#### c01deccd0d0d7bcd8f7c4b2060bd3d8044bb20bb
<pre>
[Cocoa] Add IsAudible test for 308503@main
<a href="https://rdar.apple.com/171583006">rdar://171583006</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309033">https://bugs.webkit.org/show_bug.cgi?id=309033</a>

Reviewed by Jean-Yves Avenard.

Add a test for the behavior fixed by 308503@main, where depending upon the order in which
setMuted() and setVolume() were called, the MediaPlayer PrivateAVFoundationObjC object would not
update whether it was audible.

To do so, give default implementations to (nearly) all the methods in MediaPlayerClient, which makes
writing unit tests for MediaPlayer very simple. Additionally, add a type traits macro to
MediaPlayerPrivateAVFoundationObjC to enable the test code to safely cast to that type from
MediaPlayerPrivateInterface.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
(isType):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm: Added.
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::mediaPlayerClientIdentifier const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::playerPrivate const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::videoWithAudioURL const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::videoWithoutAudioURL const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::waitForReadyStateGreaterThan):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, Basic)):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudible)):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleSilentVideo)):

Canonical link: <a href="https://commits.webkit.org/308520@main">https://commits.webkit.org/308520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26d3d9fff5c742099baa1f565eac073cfb96208f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147772 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156455 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c8e690e-3864-465f-b9ef-bcbf58a85dc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113920 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c74edc0-73bf-45e2-9480-1b40dd2e68ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94680 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15317 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3895 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158790 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1924 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121949 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31286 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76382 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9194 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83634 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->