### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in svg and xml

### DIFF
--- a/Source/WebCore/bindings/js/JSSVGViewSpecCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSVGViewSpecCustom.cpp
@@ -34,8 +34,8 @@ namespace WebCore {
 template<typename Visitor>
 void JSSVGViewSpec::visitAdditionalChildren(Visitor& visitor)
 {
-    ASSERT(wrapped().contextElementConcurrently().get());
-    addWebCoreOpaqueRoot(visitor, wrapped().contextElementConcurrently().get());
+    ASSERT(wrapped().contextElementConcurrently());
+    addWebCoreOpaqueRoot(visitor, wrapped().contextElementConcurrently());
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSSVGViewSpec);

--- a/Source/WebCore/svg/GradientAttributes.h
+++ b/Source/WebCore/svg/GradientAttributes.h
@@ -36,8 +36,8 @@ struct GradientAttributes {
 
     SVGSpreadMethodType spreadMethod() const { return static_cast<SVGSpreadMethodType>(m_spreadMethod); }
     SVGUnitTypes::SVGUnitType gradientUnits() const { return static_cast<SVGUnitTypes::SVGUnitType>(m_gradientUnits); }
-    const AffineTransform& gradientTransform() const { return m_gradientTransform; }
-    const GradientColorStops& stops() const { return m_stops; }
+    const AffineTransform& gradientTransform() const LIFETIME_BOUND { return m_gradientTransform; }
+    const GradientColorStops& stops() const LIFETIME_BOUND { return m_stops; }
 
     void setSpreadMethod(SVGSpreadMethodType value)
     {

--- a/Source/WebCore/svg/PatternAttributes.h
+++ b/Source/WebCore/svg/PatternAttributes.h
@@ -40,7 +40,7 @@ struct PatternAttributes {
     SVGPreserveAspectRatioValue preserveAspectRatio() const { return m_preserveAspectRatio; }
     SVGUnitTypes::SVGUnitType patternUnits() const { return m_patternUnits; }
     SVGUnitTypes::SVGUnitType patternContentUnits() const { return m_patternContentUnits; }
-    const AffineTransform& patternTransform() const { return m_patternTransform; }
+    const AffineTransform& patternTransform() const LIFETIME_BOUND { return m_patternTransform; }
     const SVGPatternElement* patternContentElement() const { return m_patternContentElement.get(); }
 
     void setX(SVGLengthValue value)

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -33,9 +33,9 @@ class SVGCircleElement final : public SVGGeometryElement {
 public:
     static Ref<SVGCircleElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& cx() const { return m_cx->currentValue(); }
-    const SVGLengthValue& cy() const { return m_cy->currentValue(); }
-    const SVGLengthValue& r() const { return m_r->currentValue(); }
+    const SVGLengthValue& cx() const LIFETIME_BOUND { return m_cx->currentValue(); }
+    const SVGLengthValue& cy() const LIFETIME_BOUND { return m_cy->currentValue(); }
+    const SVGLengthValue& r() const LIFETIME_BOUND { return m_r->currentValue(); }
 
     SVGAnimatedLength& cxAnimated() { return m_cx; }
     SVGAnimatedLength& cyAnimated() { return m_cy; }

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -77,7 +77,7 @@ public:
     ComponentTransferFunction transferFunction() const;
 
     ComponentTransferType type() const { return m_type->currentValue<ComponentTransferType>(); }
-    const SVGNumberList& tableValues() const { return m_tableValues->currentValue(); }
+    const SVGNumberList& tableValues() const LIFETIME_BOUND { return m_tableValues->currentValue(); }
     float slope() const { return m_slope->currentValue(); }
     float intercept() const { return m_intercept->currentValue(); }
     float amplitude() const { return m_amplitude->currentValue(); }

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -43,8 +43,8 @@ public:
     void addClient(Style::CursorImage&);
     void removeClient(Style::CursorImage&);
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -60,7 +60,7 @@ public:
     void reportWarning(const String&);
     void reportError(const String&);
 
-    SVGResourcesCache& resourcesCache() { return m_resourcesCache; }
+    SVGResourcesCache& resourcesCache() LIFETIME_BOUND { return m_resourcesCache; }
 
     void addElementToRebuild(SVGElement&);
     void removeElementToRebuild(SVGElement&);
@@ -68,7 +68,7 @@ public:
     void clearTargetDependencies(SVGElement&);
     void rebuildAllElementReferencesForTarget(SVGElement&);
 
-    const WeakHashSet<SVGFontFaceElement, WeakPtrImplWithEventTargetData>& svgFontFaceElements() const { return m_svgFontFaceElements; }
+    const WeakHashSet<SVGFontFaceElement, WeakPtrImplWithEventTargetData>& svgFontFaceElements() const LIFETIME_BOUND { return m_svgFontFaceElements; }
     void registerSVGFontFaceElement(SVGFontFaceElement&);
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -157,7 +157,7 @@ public:
     class InstanceInvalidationGuard;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGElement>;
-    const SVGPropertyRegistry& propertyRegistry() const { return m_propertyRegistry.get(); }
+    const SVGPropertyRegistry& propertyRegistry() const LIFETIME_BOUND { return m_propertyRegistry.get(); }
     inline void detachAllProperties(); // Defined in SVGElementInlines.h
 
     bool isAnimatedPropertyAttribute(const QualifiedName&) const;
@@ -171,7 +171,7 @@ public:
     void commitPropertyChange(SVGAnimatedPropertyBase&);
 
     const SVGElement* attributeContextElement() const override { return this; }
-    SVGPropertyAnimatorFactory& propertyAnimatorFactory() { return m_propertyAnimatorFactory; }
+    SVGPropertyAnimatorFactory& propertyAnimatorFactory() LIFETIME_BOUND { return m_propertyAnimatorFactory; }
     RefPtr<SVGAttributeAnimator> createAnimator(const QualifiedName&, AnimationMode, CalcMode, bool isAccumulated, bool isAdditive);
     void animatorWillBeDeleted(const QualifiedName&);
 

--- a/Source/WebCore/svg/SVGElementRareData.h
+++ b/Source/WebCore/svg/SVGElementRareData.h
@@ -47,21 +47,21 @@ public:
 
     void addInstance(SVGElement& element) { m_instances.add(element); }
     void removeInstance(SVGElement& element) { m_instances.remove(element); }
-    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& instances() const { return m_instances; }
+    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& instances() const LIFETIME_BOUND { return m_instances; }
 
     bool instanceUpdatesBlocked() const { return m_instancesUpdatesBlocked; }
     void setInstanceUpdatesBlocked(bool value) { m_instancesUpdatesBlocked = value; }
 
     void addReferencingElement(SVGElement& element) { m_referencingElements.add(element); }
     void removeReferencingElement(SVGElement& element) { m_referencingElements.remove(element); }
-    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& referencingElements() const { return m_referencingElements; }
+    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& referencingElements() const LIFETIME_BOUND { return m_referencingElements; }
     WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> takeReferencingElements() { return std::exchange(m_referencingElements, { }); }
     SVGElement* referenceTarget() const { return m_referenceTarget.get(); }
     void setReferenceTarget(WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>&& element) { m_referenceTarget = WTF::move(element); }
 
     void addReferencingCSSClient(SVGResourceElementClient& client) { m_referencingCSSClients.add(client); }
     void removeReferencingCSSClient(SVGResourceElementClient& client) { m_referencingCSSClients.remove(client); }
-    const WeakHashSet<SVGResourceElementClient>& referencingCSSClients() const { return m_referencingCSSClients; }
+    const WeakHashSet<SVGResourceElementClient>& referencingCSSClients() const LIFETIME_BOUND { return m_referencingCSSClients; }
 
     SVGElement* correspondingElement() { return m_correspondingElement.get(); }
     void setCorrespondingElement(SVGElement* correspondingElement) { m_correspondingElement = correspondingElement; }
@@ -80,8 +80,8 @@ public:
     void setUseOverrideComputedStyle(bool value) { m_useOverrideComputedStyle = value; }
     void setNeedsOverrideComputedStyleUpdate() { m_needsOverrideComputedStyleUpdate = true; }
 
-    SVGConditionalProcessingAttributes* conditionalProcessingAttributesIfExists() const { return m_conditionalProcessingAttributes.get(); }
-    SVGConditionalProcessingAttributes& conditionalProcessingAttributes(SVGElement& contextElement)
+    SVGConditionalProcessingAttributes* conditionalProcessingAttributesIfExists() const LIFETIME_BOUND { return m_conditionalProcessingAttributes.get(); }
+    SVGConditionalProcessingAttributes& conditionalProcessingAttributes(SVGElement& contextElement) LIFETIME_BOUND
     {
         if (!m_conditionalProcessingAttributes)
             m_conditionalProcessingAttributes = makeUnique<SVGConditionalProcessingAttributes>(contextElement);

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -33,10 +33,10 @@ class SVGEllipseElement final : public SVGGeometryElement {
 public:
     static Ref<SVGEllipseElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& cx() const { return m_cx->currentValue(); }
-    const SVGLengthValue& cy() const { return m_cy->currentValue(); }
-    const SVGLengthValue& rx() const { return m_rx->currentValue(); }
-    const SVGLengthValue& ry() const { return m_ry->currentValue(); }
+    const SVGLengthValue& cx() const LIFETIME_BOUND { return m_cx->currentValue(); }
+    const SVGLengthValue& cy() const LIFETIME_BOUND { return m_cy->currentValue(); }
+    const SVGLengthValue& rx() const LIFETIME_BOUND { return m_rx->currentValue(); }
+    const SVGLengthValue& ry() const LIFETIME_BOUND { return m_ry->currentValue(); }
 
     SVGAnimatedLength& cxAnimated() { return m_cx; }
     SVGAnimatedLength& cyAnimated() { return m_cy; }

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -72,7 +72,7 @@ public:
 
     String in1() const { return m_in1->currentValue(); }
     ColorMatrixType type() const { return m_type->currentValue<ColorMatrixType>(); }
-    const SVGNumberList& values() const { return m_values->currentValue(); }
+    const SVGNumberList& values() const LIFETIME_BOUND { return m_values->currentValue(); }
 
     SVGAnimatedString& in1Animated() { return m_in1; }
     SVGAnimatedEnumeration& typeAnimated() { return m_type; }

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -73,7 +73,7 @@ public:
     String in1() const { return m_in1->currentValue(); }
     int orderX() const { return m_orderX->currentValue(); }
     int orderY() const { return m_orderY->currentValue(); }
-    const SVGNumberList& kernelMatrix() const { return m_kernelMatrix->currentValue(); }
+    const SVGNumberList& kernelMatrix() const LIFETIME_BOUND { return m_kernelMatrix->currentValue(); }
     float divisor() const { return m_divisor->currentValue(); }
     float bias() const { return m_bias->currentValue(); }
     int targetX() const { return m_targetX->currentValue(); }

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -43,7 +43,7 @@ public:
 
     bool renderingTaintsOrigin() const;
 
-    const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
+    const SVGPreserveAspectRatioValue& preserveAspectRatio() const LIFETIME_BOUND { return m_preserveAspectRatio->currentValue(); }
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -38,10 +38,10 @@ public:
 
     SVGUnitTypes::SVGUnitType filterUnits() const { return m_filterUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGUnitTypes::SVGUnitType primitiveUnits() const { return m_primitiveUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
 
     SVGAnimatedEnumeration& filterUnitsAnimated() { return m_filterUnits; }
     SVGAnimatedEnumeration& primitiveUnitsAnimated() { return m_primitiveUnits; }

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -41,10 +41,10 @@ class SVGFilterPrimitiveStandardAttributes : public SVGElement {
 public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterPrimitiveStandardAttributes, SVGElement>;
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
     String result() const { return m_result->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }

--- a/Source/WebCore/svg/SVGFitToViewBox.h
+++ b/Source/WebCore/svg/SVGFitToViewBox.h
@@ -41,8 +41,8 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFitToViewBox>;
 
-    const FloatRect& viewBox() const { return m_viewBox->currentValue(); }
-    const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
+    const FloatRect& viewBox() const LIFETIME_BOUND { return m_viewBox->currentValue(); }
+    const SVGPreserveAspectRatioValue& preserveAspectRatio() const LIFETIME_BOUND { return m_preserveAspectRatio->currentValue(); }
 
     SVGAnimatedRect& viewBoxAnimated() { return m_viewBox; }
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -32,10 +32,10 @@ class SVGForeignObjectElement final : public SVGGraphicsElement {
 public:
     static Ref<SVGForeignObjectElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -87,7 +87,7 @@ public:
 
     SVGSpreadMethodType spreadMethod() const { return m_spreadMethod->currentValue<SVGSpreadMethodType>(); }
     SVGUnitTypes::SVGUnitType gradientUnits() const { return m_gradientUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
-    const SVGTransformList& gradientTransform() const { return m_gradientTransform->currentValue(); }
+    const SVGTransformList& gradientTransform() const LIFETIME_BOUND { return m_gradientTransform->currentValue(); }
 
     SVGAnimatedEnumeration& spreadMethodAnimated() { return m_spreadMethod; }
     SVGAnimatedEnumeration& gradientUnitsAnimated() { return m_gradientUnits; }

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -68,7 +68,7 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGraphicsElement, SVGElement, SVGTests>;
 
-    const SVGTransformList& transform() const { return m_transform->currentValue(); }
+    const SVGTransformList& transform() const LIFETIME_BOUND { return m_transform->currentValue(); }
     SVGAnimatedTransformList& transformAnimated() { return m_transform; }
 
 protected:

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -38,11 +38,11 @@ public:
     bool renderingTaintsOrigin() const;
     const AtomString& imageSourceURL() const final;
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
-    const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
+    const SVGPreserveAspectRatioValue& preserveAspectRatio() const LIFETIME_BOUND { return m_preserveAspectRatio->currentValue(); }
 
     void setCrossOrigin(const AtomString&);
     String crossOrigin() const;

--- a/Source/WebCore/svg/SVGLineElement.h
+++ b/Source/WebCore/svg/SVGLineElement.h
@@ -33,10 +33,10 @@ class SVGLineElement final : public SVGGeometryElement {
 public:
     static Ref<SVGLineElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& x1() const { return m_x1->currentValue(); }
-    const SVGLengthValue& y1() const { return m_y1->currentValue(); }
-    const SVGLengthValue& x2() const { return m_x2->currentValue(); }
-    const SVGLengthValue& y2() const { return m_y2->currentValue(); }
+    const SVGLengthValue& x1() const LIFETIME_BOUND { return m_x1->currentValue(); }
+    const SVGLengthValue& y1() const LIFETIME_BOUND { return m_y1->currentValue(); }
+    const SVGLengthValue& x2() const LIFETIME_BOUND { return m_x2->currentValue(); }
+    const SVGLengthValue& y2() const LIFETIME_BOUND { return m_y2->currentValue(); }
 
     SVGAnimatedLength& x1Animated() { return m_x1; }
     SVGAnimatedLength& y1Animated() { return m_y1; }

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -37,10 +37,10 @@ public:
 
     bool collectGradientAttributes(LinearGradientAttributes&);
 
-    const SVGLengthValue& x1() const { return m_x1->currentValue(); }
-    const SVGLengthValue& y1() const { return m_y1->currentValue(); }
-    const SVGLengthValue& x2() const { return m_x2->currentValue(); }
-    const SVGLengthValue& y2() const { return m_y2->currentValue(); }
+    const SVGLengthValue& x1() const LIFETIME_BOUND { return m_x1->currentValue(); }
+    const SVGLengthValue& y1() const LIFETIME_BOUND { return m_y1->currentValue(); }
+    const SVGLengthValue& x2() const LIFETIME_BOUND { return m_x2->currentValue(); }
+    const SVGLengthValue& y2() const LIFETIME_BOUND { return m_y2->currentValue(); }
 
     SVGAnimatedLength& x1Animated() { return m_x1; }
     SVGAnimatedLength& y1Animated() { return m_y1; }

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -50,12 +50,12 @@ public:
 
     AffineTransform viewBoxToViewTransform(float viewWidth, float viewHeight) const;
 
-    const SVGLengthValue& refX() const { return m_refX->currentValue(); }
-    const SVGLengthValue& refY() const { return m_refY->currentValue(); }
-    const SVGLengthValue& markerWidth() const { return m_markerWidth->currentValue(); }
-    const SVGLengthValue& markerHeight() const { return m_markerHeight->currentValue(); }
+    const SVGLengthValue& refX() const LIFETIME_BOUND { return m_refX->currentValue(); }
+    const SVGLengthValue& refY() const LIFETIME_BOUND { return m_refY->currentValue(); }
+    const SVGLengthValue& markerWidth() const LIFETIME_BOUND { return m_markerWidth->currentValue(); }
+    const SVGLengthValue& markerHeight() const LIFETIME_BOUND { return m_markerHeight->currentValue(); }
     SVGMarkerUnitsType markerUnits() const { return m_markerUnits->currentValue<SVGMarkerUnitsType>(); }
-    const SVGAngleValue& orientAngle() const { return m_orientAngle->currentValue(); }
+    const SVGAngleValue& orientAngle() const LIFETIME_BOUND { return m_orientAngle->currentValue(); }
     SVGMarkerOrientType orientType() const { return m_orientType->currentValue<SVGMarkerOrientType>(); }
 
     SVGAnimatedLength& refXAnimated() { return m_refX; }

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -37,10 +37,10 @@ class SVGMaskElement final : public SVGElement, public SVGTests {
 public:
     static Ref<SVGMaskElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
     SVGUnitTypes::SVGUnitType maskUnits() const { return m_maskUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGUnitTypes::SVGUnitType maskContentUnits() const { return m_maskContentUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
 

--- a/Source/WebCore/svg/SVGPathSegList.h
+++ b/Source/WebCore/svg/SVGPathSegList.h
@@ -136,10 +136,10 @@ public:
         m_pathByteStream.clear();
     }
 
-    const SVGPathByteStream& existingPathByteStream() const { return m_pathByteStream; }
+    const SVGPathByteStream& existingPathByteStream() const LIFETIME_BOUND { return m_pathByteStream; }
 
-    const SVGPathByteStream& pathByteStream() const { return const_cast<SVGPathSegList*>(this)->pathByteStream(); }
-    SVGPathByteStream& pathByteStream()
+    const SVGPathByteStream& pathByteStream() const LIFETIME_BOUND { return const_cast<SVGPathSegList*>(this)->pathByteStream(); }
+    SVGPathByteStream& pathByteStream() LIFETIME_BOUND
     {
         ensurePathByteStream();
         return m_pathByteStream;

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -43,13 +43,13 @@ public:
 
     AffineTransform localCoordinateSpaceTransform(CTMScope) const final;
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
     SVGUnitTypes::SVGUnitType patternUnits() const { return m_patternUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGUnitTypes::SVGUnitType patternContentUnits() const { return m_patternContentUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
-    const SVGTransformList& patternTransform() const { return m_patternTransform->currentValue(); }
+    const SVGTransformList& patternTransform() const LIFETIME_BOUND { return m_patternTransform->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -37,12 +37,12 @@ public:
 
     bool collectGradientAttributes(RadialGradientAttributes&);
 
-    const SVGLengthValue& cx() const { return m_cx->currentValue(); }
-    const SVGLengthValue& cy() const { return m_cy->currentValue(); }
-    const SVGLengthValue& r() const { return m_r->currentValue(); }
-    const SVGLengthValue& fx() const { return m_fx->currentValue(); }
-    const SVGLengthValue& fy() const { return m_fy->currentValue(); }
-    const SVGLengthValue& fr() const { return m_fr->currentValue(); }
+    const SVGLengthValue& cx() const LIFETIME_BOUND { return m_cx->currentValue(); }
+    const SVGLengthValue& cy() const LIFETIME_BOUND { return m_cy->currentValue(); }
+    const SVGLengthValue& r() const LIFETIME_BOUND { return m_r->currentValue(); }
+    const SVGLengthValue& fx() const LIFETIME_BOUND { return m_fx->currentValue(); }
+    const SVGLengthValue& fy() const LIFETIME_BOUND { return m_fy->currentValue(); }
+    const SVGLengthValue& fr() const LIFETIME_BOUND { return m_fr->currentValue(); }
 
     SVGAnimatedLength& cxAnimated() { return m_cx; }
     SVGAnimatedLength& cyAnimated() { return m_cy; }

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -33,12 +33,12 @@ class SVGRectElement final : public SVGGeometryElement {
 public:
     static Ref<SVGRectElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
-    const SVGLengthValue& rx() const { return m_rx->currentValue(); }
-    const SVGLengthValue& ry() const { return m_ry->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
+    const SVGLengthValue& rx() const LIFETIME_BOUND { return m_rx->currentValue(); }
+    const SVGLengthValue& ry() const LIFETIME_BOUND { return m_ry->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -113,10 +113,10 @@ public:
     AffineTransform viewBoxToViewTransform(float viewWidth, float viewHeight) const;
     bool hasTransformRelatedAttributes() const final;
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -86,8 +86,8 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextContentElement, SVGGraphicsElement>;
 
-    const SVGLengthValue& specifiedTextLength() const { return m_specifiedTextLength; }
-    const SVGLengthValue& textLength() const { return m_textLength->currentValue(); }
+    const SVGLengthValue& specifiedTextLength() const LIFETIME_BOUND { return m_specifiedTextLength; }
+    const SVGLengthValue& textLength() const LIFETIME_BOUND { return m_textLength->currentValue(); }
     SVGLengthAdjustType lengthAdjust() const { return m_lengthAdjust->currentValue<SVGLengthAdjustType>(); }
 
     SVGAnimatedLength& textLengthAnimated();

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -114,7 +114,7 @@ public:
 
     static Ref<SVGTextPathElement> create(const QualifiedName&, Document&);
 
-    const SVGLengthValue& startOffset() const { return m_startOffset->currentValue(); }
+    const SVGLengthValue& startOffset() const LIFETIME_BOUND { return m_startOffset->currentValue(); }
     SVGTextPathMethodType method() const { return m_method->currentValue<SVGTextPathMethodType>(); }
     SVGTextPathSpacingType spacing() const { return m_spacing->currentValue<SVGTextPathSpacingType>(); }
 

--- a/Source/WebCore/svg/SVGTextPositioningElement.h
+++ b/Source/WebCore/svg/SVGTextPositioningElement.h
@@ -34,11 +34,11 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPositioningElement, SVGTextContentElement>;
 
-    const SVGLengthList& x() const { return m_x->currentValue(); }
-    const SVGLengthList& y() const { return m_y->currentValue(); }
-    const SVGLengthList& dx() const { return m_dx->currentValue(); }
-    const SVGLengthList& dy() const { return m_dy->currentValue(); }
-    const SVGNumberList& rotate() const { return m_rotate->currentValue(); }
+    const SVGLengthList& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthList& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthList& dx() const LIFETIME_BOUND { return m_dx->currentValue(); }
+    const SVGLengthList& dy() const LIFETIME_BOUND { return m_dy->currentValue(); }
+    const SVGNumberList& rotate() const LIFETIME_BOUND { return m_rotate->currentValue(); }
 
     SVGAnimatedLengthList& xAnimated() { return m_x; }
     SVGAnimatedLengthList& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -51,10 +51,10 @@ public:
 
     SVGGraphicsElement* visibleTargetGraphicsElement() const;
 
-    const SVGLengthValue& x() const { return m_x->currentValue(); }
-    const SVGLengthValue& y() const { return m_y->currentValue(); }
-    const SVGLengthValue& width() const { return m_width->currentValue(); }
-    const SVGLengthValue& height() const { return m_height->currentValue(); }
+    const SVGLengthValue& x() const LIFETIME_BOUND { return m_x->currentValue(); }
+    const SVGLengthValue& y() const LIFETIME_BOUND { return m_y->currentValue(); }
+    const SVGLengthValue& width() const LIFETIME_BOUND { return m_width->currentValue(); }
+    const SVGLengthValue& height() const LIFETIME_BOUND { return m_height->currentValue(); }
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -44,12 +44,12 @@ public:
     void resetContextElement() { m_contextElement = nullptr; }
 
     RefPtr<SVGElement> viewTarget() const;
-    const String& viewTargetString() const { return m_viewTargetString; }
+    const String& viewTargetString() const LIFETIME_BOUND { return m_viewTargetString; }
 
     String transformString() const { return m_transform->valueAsString(); }
     Ref<SVGTransformList>& transform() { return m_transform; }
 
-    const WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>& contextElementConcurrently() const { return m_contextElement; }
+    SVGElement* contextElementConcurrently() const { return m_contextElement; }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewSpec, SVGFitToViewBox>;
 

--- a/Source/WebCore/svg/animation/SMILTime.h
+++ b/Source/WebCore/svg/animation/SMILTime.h
@@ -73,7 +73,7 @@ public:
     {
     }
 
-    const SMILTime& time() const { return m_time; }
+    const SMILTime& time() const LIFETIME_BOUND { return m_time; }
     bool originIsScript() const { return m_origin == ScriptOrigin; }
 
 private:

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -60,7 +60,7 @@ public:
     SMILTimeContainer* timeContainer() { return m_timeContainer; }
 
     SVGElement* targetElement() const { return m_targetElement; }
-    const QualifiedName& attributeName() const { return m_attributeName; }
+    const QualifiedName& attributeName() const LIFETIME_BOUND { return m_attributeName; }
 
     void beginByLinkActivation();
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
@@ -57,7 +57,7 @@ public:
 
     // Used by SVGElement::parseAttribute().
     void setBaseValInternal(const PropertyType& baseVal) { m_baseVal->setValue(baseVal); }
-    const PropertyType& baseVal() const { return m_baseVal->value(); }
+    const PropertyType& baseVal() const LIFETIME_BOUND { return m_baseVal->value(); }
 
     // Used by SVGAttributeAnimator::progress.
     void setAnimVal(const PropertyType& animVal)
@@ -94,7 +94,7 @@ public:
     std::optional<String> synchronize() override { return m_baseVal->synchronize(); }
 
     // Used by RenderSVGElements and DumpRenderTree.
-    const PropertyType& currentValue() const
+    const PropertyType& currentValue() const LIFETIME_BOUND
     {
         ASSERT_IMPLIES(this->isAnimating(), m_animVal);
         return this->isAnimating() ? m_animVal->value() : m_baseVal->value();

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -74,7 +74,7 @@ public:
     std::optional<String> synchronize() override { return m_baseVal->synchronize(); }
 
     // Used by RenderSVGElements and DumpRenderTree.
-    const ListType& currentValue() const
+    const ListType& currentValue() const LIFETIME_BOUND
     {
         ASSERT_IMPLIES(this->isAnimating(), m_animVal);
         return this->isAnimating() ? *m_animVal : m_baseVal.get();

--- a/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
@@ -90,7 +90,7 @@ public:
     std::optional<String> synchronize() override { return m_baseVal->synchronize(); }
 
     // Used by RenderSVGElements and DumpRenderTree.
-    const ValueType& currentValue() const
+    const ValueType& currentValue() const LIFETIME_BOUND
     {
         ASSERT_IMPLIES(this->isAnimating(), m_animVal);
         return (this->isAnimating() ? *m_animVal : m_baseVal.get()).value();

--- a/Source/WebCore/svg/properties/SVGList.h
+++ b/Source/WebCore/svg/properties/SVGList.h
@@ -140,8 +140,8 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_items.size(); }
 
     // Parsers and animators need to have a direct access to the items.
-    Vector<ItemType>& items() { return m_items; }
-    const Vector<ItemType>& items() const { return m_items; }
+    Vector<ItemType>& items() LIFETIME_BOUND { return m_items; }
+    const Vector<ItemType>& items() const LIFETIME_BOUND { return m_items; }
     size_t size() const { return m_items.size(); }
     bool isEmpty() const { return m_items.isEmpty(); }
 

--- a/Source/WebCore/svg/properties/SVGSharedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGSharedPrimitiveProperty.h
@@ -41,8 +41,8 @@ public:
     }
 
     // Getter/Setter for the value.
-    const PropertyType& value() const { return m_value; }
-    PropertyType& value() { return m_value; }
+    const PropertyType& value() const LIFETIME_BOUND { return m_value; }
+    PropertyType& value() LIFETIME_BOUND { return m_value; }
     void setValue(const PropertyType& value) { m_value = value; }
 
     String valueAsString() const override

--- a/Source/WebCore/svg/properties/SVGValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGValueProperty.h
@@ -40,11 +40,11 @@ public:
     }
 
     // Getter/Setter for the value.
-    const PropertyType& value() const { return m_value; }
+    const PropertyType& value() const LIFETIME_BOUND { return m_value; }
     void setValue(const PropertyType& value) { m_value = value; }
 
     // Used by the SVGAnimatedPropertyAnimator to pass m_value to SVGAnimationFunction.
-    PropertyType& value() { return m_value; }
+    PropertyType& value() LIFETIME_BOUND { return m_value; }
 
 protected:
     // Create an initialized property, e.g creating an item to be appended in an SVGList.

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -83,7 +83,7 @@ public:
 
     using SendTypes = Variant<Ref<Document>, Ref<Blob>, Ref<JSC::ArrayBufferView>, Ref<JSC::ArrayBuffer>, Ref<DOMFormData>, String, Ref<URLSearchParams>>;
 
-    const URL& url() const { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     String statusText() const;
     int status() const;
     State readyState() const { return static_cast<State>(m_readyState); }
@@ -133,7 +133,7 @@ public:
     XMLHttpRequestUpload& upload();
     XMLHttpRequestUpload* optionalUpload() const { return m_upload.get(); }
 
-    const ResourceResponse& resourceResponse() const { return m_response; }
+    const ResourceResponse& resourceResponse() const LIFETIME_BOUND { return m_response; }
 
     size_t memoryCost() const;
 

--- a/Source/WebCore/xml/XPathResult.h
+++ b/Source/WebCore/xml/XPathResult.h
@@ -64,7 +64,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Node*> iterateNext();
     WEBCORE_EXPORT ExceptionOr<Node*> snapshotItem(unsigned index);
 
-    const XPath::Value& value() const { return m_value; }
+    const XPath::Value& value() const LIFETIME_BOUND { return m_value; }
 
 private:
     XPathResult(Document&, const XPath::Value&);

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -39,7 +39,7 @@ public:
     static Ref<XSLImportRule> create(XSLStyleSheet& parentSheet, const String& href);
     virtual ~XSLImportRule();
     
-    const String& href() const { return m_strHref; }
+    const String& href() const LIFETIME_BOUND { return m_strHref; }
     XSLStyleSheet* styleSheet() const { return m_styleSheet.get(); }
 
     XSLStyleSheet* parentStyleSheet() const { return m_parentStyleSheet.get(); }

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -66,7 +66,7 @@ public:
     
     void checkLoaded();
     
-    const URL& finalURL() const { return m_finalURL; }
+    const URL& finalURL() const LIFETIME_BOUND { return m_finalURL; }
 
     void loadChildSheets();
     void loadChildSheet(const String& href);

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -53,7 +53,7 @@ public:
     static Ref<XMLParserContext> createStringParser(xmlSAXHandlerPtr, void* userData);
     XMLParserContext() = delete;
     ~XMLParserContext();
-    xmlParserCtxtPtr context() const { return m_context; }
+    xmlParserCtxtPtr context() const LIFETIME_BOUND { return m_context; }
 
 private:
     XMLParserContext(xmlParserCtxtPtr context)


### PR DESCRIPTION
#### d52eff68175e9cd134b15aa09de4ae959418c4dc
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in svg and xml
<a href="https://bugs.webkit.org/show_bug.cgi?id=309034">https://bugs.webkit.org/show_bug.cgi?id=309034</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/bindings/js/JSSVGViewSpecCustom.cpp:
(WebCore::JSSVGViewSpec::visitAdditionalChildren):
* Source/WebCore/svg/GradientAttributes.h:
(WebCore::GradientAttributes::gradientTransform const): Deleted.
(WebCore::GradientAttributes::stops const): Deleted.
* Source/WebCore/svg/PatternAttributes.h:
(WebCore::PatternAttributes::patternTransform const): Deleted.
* Source/WebCore/svg/SVGCircleElement.h:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
(WebCore::SVGComponentTransferFunctionElement::tableValues const): Deleted.
* Source/WebCore/svg/SVGCursorElement.h:
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::propertyRegistry const): Deleted.
(WebCore::SVGElement::propertyAnimatorFactory): Deleted.
* Source/WebCore/svg/SVGElementRareData.h:
(WebCore::SVGElementRareData::instances const): Deleted.
(WebCore::SVGElementRareData::referencingElements const): Deleted.
(WebCore::SVGElementRareData::referencingCSSClients const): Deleted.
(WebCore::SVGElementRareData::conditionalProcessingAttributesIfExists const): Deleted.
(WebCore::SVGElementRareData::conditionalProcessingAttributes): Deleted.
* Source/WebCore/svg/SVGEllipseElement.h:
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFilterElement.h:
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
(WebCore::SVGFilterPrimitiveStandardAttributes::x const): Deleted.
(WebCore::SVGFilterPrimitiveStandardAttributes::y const): Deleted.
(WebCore::SVGFilterPrimitiveStandardAttributes::width const): Deleted.
(WebCore::SVGFilterPrimitiveStandardAttributes::height const): Deleted.
* Source/WebCore/svg/SVGFitToViewBox.h:
(WebCore::SVGFitToViewBox::viewBox const): Deleted.
(WebCore::SVGFitToViewBox::preserveAspectRatio const): Deleted.
* Source/WebCore/svg/SVGForeignObjectElement.h:
* Source/WebCore/svg/SVGGradientElement.h:
(WebCore::SVGGradientElement::gradientTransform const): Deleted.
* Source/WebCore/svg/SVGGraphicsElement.h:
(WebCore::SVGGraphicsElement::transform const): Deleted.
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGLineElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.h:
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGPathSegList.h:
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.h:
* Source/WebCore/svg/SVGRectElement.h:
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGTextContentElement.h:
(WebCore::SVGTextContentElement::specifiedTextLength const): Deleted.
(WebCore::SVGTextContentElement::textLength const): Deleted.
* Source/WebCore/svg/SVGTextPathElement.h:
* Source/WebCore/svg/SVGTextPositioningElement.h:
(WebCore::SVGTextPositioningElement::x const): Deleted.
(WebCore::SVGTextPositioningElement::y const): Deleted.
(WebCore::SVGTextPositioningElement::dx const): Deleted.
(WebCore::SVGTextPositioningElement::dy const): Deleted.
(WebCore::SVGTextPositioningElement::rotate const): Deleted.
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/SVGViewSpec.h:
* Source/WebCore/svg/animation/SMILTime.h:
(WebCore::SMILTimeWithOrigin::time const): Deleted.
* Source/WebCore/svg/animation/SVGSMILElement.h:
(WebCore::SVGSMILElement::attributeName const): Deleted.
* Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h:
(WebCore::SVGAnimatedPrimitiveProperty::baseVal const): Deleted.
(WebCore::SVGAnimatedPrimitiveProperty::currentValue const): Deleted.
* Source/WebCore/svg/properties/SVGAnimatedPropertyList.h:
(WebCore::SVGAnimatedPropertyList::currentValue const): Deleted.
* Source/WebCore/svg/properties/SVGAnimatedValueProperty.h:
(WebCore::SVGAnimatedValueProperty::currentValue const): Deleted.
* Source/WebCore/svg/properties/SVGList.h:
(WebCore::SVGList::items): Deleted.
(WebCore::SVGList::items const): Deleted.
* Source/WebCore/svg/properties/SVGSharedPrimitiveProperty.h:
(WebCore::SVGSharedPrimitiveProperty::value const): Deleted.
(WebCore::SVGSharedPrimitiveProperty::value): Deleted.
* Source/WebCore/svg/properties/SVGValueProperty.h:
(WebCore::SVGValueProperty::value const): Deleted.
(WebCore::SVGValueProperty::value): Deleted.
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XPathResult.h:
(WebCore::XPathResult::value const): Deleted.
* Source/WebCore/xml/XSLImportRule.h:
(WebCore::XSLImportRule::href const): Deleted.
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
(WebCore::XMLParserContext::context const): Deleted.

Canonical link: <a href="https://commits.webkit.org/308580@main">https://commits.webkit.org/308580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ff4cba1beca7fa026b67bf7d30e32c1f23eecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101189 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e0eabc6-f661-4e02-99c0-2d19f0423817) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81239 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94681 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9faf0f6-634a-40d9-bc7c-e082d0dd62b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15319 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13106 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3897 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158792 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1926 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121950 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9196 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83636 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19661 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->