### PR TITLE
XMLDocumentParser should defer inline script execution until pending stylesheets have loaded

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-import-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-import-xhtml-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-FAIL Stylesheet in XHTML HEAD with @import blocking scripts assert_equals: expected "fixed" but got "static"
+PASS Stylesheet in XHTML HEAD with @import blocking scripts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-noimport-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-noimport-xhtml-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-FAIL Stylesheet in XHTML HEAD blocking scripts assert_equals: expected "fixed" but got "static"
+PASS Stylesheet in XHTML HEAD blocking scripts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/150-import-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/150-import-xhtml-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL Stylesheet in XHTML BODY with @import blocking scripts assert_equals: expected "fixed" but got "static"
+PASS Stylesheet in XHTML BODY with @import blocking scripts
 Test

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/150-noimport-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/150-noimport-xhtml-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-FAIL Stylesheet in XHTML BODY blocking scripts assert_equals: expected "fixed" but got "static"
+PASS Stylesheet in XHTML BODY blocking scripts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL xml-stylesheet blocks script execution and rendering assert_equals: XML processing instruction should've blocked script execution and rendering expected "3" but got "auto"
+PASS xml-stylesheet blocks script execution and rendering
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/style-sheet-interfaces-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/style-sheet-interfaces-expected.txt
@@ -4,5 +4,5 @@ PASS sheet_property_updates
 PASS CSSStyleSheet_properties
 PASS CSSStyleSheet_property_values
 PASS StyleSheet_properties
-FAIL StyleSheet_property_values null is not an object (evaluating 'importSheet.ownerNode')
+PASS StyleSheet_property_values
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -180,6 +180,7 @@ bool XMLDocumentParser::updateLeafTextNode()
 
 void XMLDocumentParser::detach()
 {
+    m_scriptWaitingForStylesheets = nullptr;
     clearCurrentNodeStack();
     ScriptableDocumentParser::detach();
 }
@@ -248,6 +249,31 @@ void XMLDocumentParser::notifyFinished(PendingScript& pendingScript)
     pendingScript.clearClient();
 
     pendingScript.element().executePendingScript(pendingScript);
+
+    if (!isDetached() && !m_requestingScript)
+        resumeParsing();
+}
+
+bool XMLDocumentParser::hasScriptsWaitingForStylesheets() const
+{
+    return !!m_scriptWaitingForStylesheets;
+}
+
+void XMLDocumentParser::executeScriptsWaitingForStylesheets()
+{
+    ASSERT(!isDetached());
+
+    RefPtr document = this->document();
+    if (document->styleScope().hasPendingSheets())
+        return;
+
+    ASSERT(m_scriptWaitingForStylesheets);
+
+    RefPtr pendingScript = std::exchange(m_scriptWaitingForStylesheets, nullptr);
+    if (!pendingScript)
+        return;
+
+    pendingScript->element().executePendingScript(*pendingScript);
 
     if (!isDetached() && !m_requestingScript)
         resumeParsing();

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -115,6 +115,9 @@ private:
 
     void notifyFinished(PendingScript&) final;
 
+    bool hasScriptsWaitingForStylesheets() const final;
+    void executeScriptsWaitingForStylesheets() final;
+
     void end();
 
     void pauseParsing();
@@ -181,6 +184,7 @@ private:
     std::unique_ptr<XMLErrors> m_xmlErrors;
 
     RefPtr<PendingScript> m_pendingScript;
+    RefPtr<PendingScript> m_scriptWaitingForStylesheets;
     TextPosition m_scriptStartPosition;
 
     bool m_parsingFragment { false };

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -693,6 +693,8 @@ XMLDocumentParser::~XMLDocumentParser()
     // FIXME: m_pendingScript handling should be moved into XMLDocumentParser.cpp!
     if (RefPtr pendingScript = m_pendingScript)
         pendingScript->clearClient();
+
+    m_scriptWaitingForStylesheets = nullptr;
 }
 
 void XMLDocumentParser::doWrite(const String& parseString)
@@ -960,7 +962,10 @@ void XMLDocumentParser::endElementNs()
     protect(document->eventLoop())->performMicrotaskCheckpoint(document->vm());
     if (scriptElement->prepareScript(m_scriptStartPosition)) {
         if (scriptElement->readyToBeParserExecuted()) {
-            if (scriptElement->scriptType() == ScriptType::Classic)
+            if (!document->haveStylesheetsLoaded()) {
+                m_scriptWaitingForStylesheets = PendingScript::create(*scriptElement, m_scriptStartPosition);
+                pauseParsing();
+            } else if (scriptElement->scriptType() == ScriptType::Classic)
                 scriptElement->executeClassicScript(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(*scriptElement)));
             else
                 scriptElement->registerImportMap(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::ImportMap));


### PR DESCRIPTION
#### f54bd14d678756e6db8225d3be608a577b9878e3
<pre>
XMLDocumentParser should defer inline script execution until pending stylesheets have loaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=268620">https://bugs.webkit.org/show_bug.cgi?id=268620</a>
<a href="https://rdar.apple.com/122574381">rdar://122574381</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The HTMLDocumentParser already defers inline script execution when
stylesheets are still loading (e.g. @import subsheets) via
HTMLScriptRunner::isPendingScriptReady(). The XMLDocumentParser, used
for SVG and XHTML documents, lacked this deferral — it executed inline
&lt;script&gt; elements immediately in endElementNs() regardless of pending
stylesheet loads. This caused scripts to run before @import rules had
been fetched, so CSSOM queries against those sheets would fail.

Adopt the same pattern used by HTMLDocumentParser: when
endElementNs() encounters a ready-to-execute inline script and
Document::haveStylesheetsLoaded() returns false, stash the script in
m_scriptWaitingForStylesheets and pause parsing. The existing
notification chain in ScriptableDocumentParser —
didRemoveAllPendingStylesheet() → executeScriptsWaitingForStylesheetsSoon()
→ executeScriptsWaitingForStylesheets() then fires the deferred script and
resumes parsing once all sheets are loaded.

* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::detach):
(WebCore::XMLDocumentParser::hasScriptsWaitingForStylesheets const):
(WebCore::XMLDocumentParser::executeScriptsWaitingForStylesheets):
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::~XMLDocumentParser):
(WebCore::XMLDocumentParser::endElementNs):
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/style-sheet-interfaces-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-import-xhtml-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-noimport-xhtml-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/150-import-xhtml-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/150-noimport-xhtml-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xml-stylesheet-blocking-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/308980@main">https://commits.webkit.org/308980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3220babacdf5cc086b8260f0ffd2557e67d5f8b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157749 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/245e67e0-42da-44a0-a2ff-c1ec002253f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114919 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40153a38-6ca6-4786-ac14-6f5573f412bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95678 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/470db087-6502-442c-ab82-41449e5597c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14071 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5601 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160231 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122971 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33494 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133497 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77779 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10256 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84988 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20918 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->