### PR TITLE
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/css/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -75,7 +75,6 @@ css/MediaQueryList.cpp
 css/MediaQueryMatcher.cpp
 css/SelectorChecker.cpp
 css/SelectorCheckerTestFunctions.h
-css/SelectorFilter.cpp
 css/StyleAttributeMutationScope.h
 css/parser/SizesAttributeParser.cpp
 css/typedom/InlineStylePropertyMap.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -161,7 +161,6 @@ css/CSSKeyframesRule.cpp
 css/CSSNestedDeclarations.cpp
 css/CSSPageRule.cpp
 css/CSSProperty.h
-css/CSSPropertyRule.cpp
 css/CSSRuleList.h
 css/CSSSelector.cpp
 css/CSSStyleProperties.cpp
@@ -169,18 +168,14 @@ css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
 css/CSSStyleSheetObservableArray.cpp
 css/CSSValueList.cpp
-css/DOMMatrixReadOnly.cpp
 css/DeprecatedCSSOMPrimitiveValue.h
 css/DeprecatedCSSOMRGBColor.h
 css/FontFace.cpp
 css/FontFaceSet.cpp
-css/ImmutableStyleProperties.cpp
 css/MediaQueryList.cpp
 css/MediaQueryMatcher.cpp
-css/MutableStyleProperties.cpp
 css/SelectorChecker.cpp
 css/SelectorCheckerTestFunctions.h
-css/SelectorFilter.cpp
 css/ShorthandSerializer.cpp
 css/StyleAttributeMutationScope.h
 css/StyleProperties.cpp

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -67,7 +67,7 @@ String CSSPropertyRule::initialValue() const
     if (!m_propertyRule->descriptor().initialValue)
         return nullString();
 
-    return m_propertyRule->descriptor().initialValue->serialize();
+    return protect(m_propertyRule->descriptor().initialValue)->serialize();
 }
 
 String CSSPropertyRule::cssText() const

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -244,7 +244,7 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
 
     AbstractMatrix matrix;
     for (auto& function : *transform) {
-        function->apply(matrix.matrix, { 0, 0 });
+        protect(function.function())->apply(matrix.matrix, { 0, 0 });
         if (function->is3DOperation())
             matrix.is2D = false;
     }

--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -77,7 +77,7 @@ Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(std:
         Hasher hasher;
         add(hasher, mode);
         for (auto& property : properties) {
-            if (!property.value()->addHash(hasher))
+            if (!protect(property.value())->addHash(hasher))
                 return 0u;
             add(hasher, property.id(), property.isImportant());
         }

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -112,7 +112,7 @@ bool MutableStyleProperties::removePropertyAtIndex(int index, String* returnText
 
     if (returnText) {
         auto property = propertyAt(index);
-        *returnText = WebCore::serializeLonghandValue(CSS::defaultSerializationContext(), property.id(), *property.value());
+        *returnText = WebCore::serializeLonghandValue(CSS::defaultSerializationContext(), property.id(), protect(*property.value()));
     }
 
     // A more efficient removal strategy would involve marking entries as empty

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -85,7 +85,7 @@ void SelectorFilter::initializeParentStack(Element& parent)
         ancestors.append(ancestor.get());
     m_parentStack.reserveCapacity(m_parentStack.capacity() + ancestors.size());
     for (unsigned i = ancestors.size(); i--;)
-        pushParent(ancestors[i]);
+        pushParent(protect(ancestors[i]));
 }
 
 void SelectorFilter::pushParent(Element* parent)


### PR DESCRIPTION
#### 5161d8a605523a56a6c4c73c9dfe2fe5217b7472
<pre>
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/css/
<a href="https://bugs.webkit.org/show_bug.cgi?id=309037">https://bugs.webkit.org/show_bug.cgi?id=309037</a>
<a href="https://rdar.apple.com/171588901">rdar://171588901</a>

Reviewed by Ryosuke Niwa.

As dictated by the SaferCPP bot.

No new tests since no change in behavior.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::initialValue const):
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(WebCore::DOMMatrixReadOnly::parseStringIntoAbstractMatrix):
* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::ImmutableStyleProperties::createDeduplicating):
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::removePropertyAtIndex):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::initializeParentStack):

Canonical link: <a href="https://commits.webkit.org/309293@main">https://commits.webkit.org/309293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60bd62092e968adf98e3ac02184f093f613eaee1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101194 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bff3a24b-5ce1-49cd-a7fe-1808a878e4f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113925 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81246 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45342f6d-98be-435c-bd6d-628c499ff329) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94685 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f30128a5-740d-4d89-ab1e-7b882b9c89af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13109 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3902 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158797 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1931 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121954 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33691 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76389 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9201 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83641 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19608 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->