### PR TITLE
Fix TextIndicator for -webkit-user-select: none ranges during find in page

### DIFF
--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -107,7 +107,7 @@ RefPtr<TextIndicator> TextIndicator::createWithRange(const SimpleRange& range, O
     auto rangeIndicatesCurrentSelection = [document](const SimpleRange& range) {
         auto selectionRange = document->selection().selection().toNormalizedRange();
         auto normalizedRange = VisibleSelection(range).toNormalizedRange();
-        return selectionRange && selectionRange == normalizedRange;
+        return selectionRange && !selectionRange->collapsed() && selectionRange == normalizedRange;
     };
 
     bool indicatesCurrentSelection = rangeIndicatesCurrentSelection(rangeToUse);

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -312,12 +312,6 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
         idOfFrameContainingString = frameID;
         foundRange = range;
         found = idOfFrameContainingString.has_value();
-
-        RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get());
-        if (foundRange && selectedFrame) {
-            m_lastFoundRange = foundRange;
-            m_lastSelection = protect(selectedFrame->selection())->selection().toNormalizedRange();
-        }
     }
 
     if (found && !options.contains(FindOptions::DoNotSetSelection)) {
@@ -422,9 +416,6 @@ void FindController::hideFindUI()
     hideFindIndicator();
     resetMatchIndex();
 
-    m_lastFoundRange = std::nullopt;
-    m_lastSelection = std::nullopt;
-
 #if ENABLE(IMAGE_ANALYSIS)
     if (RefPtr imageAnalysisQueue = m_webPage->corePage()->imageAnalysisQueueIfExists())
         imageAnalysisQueue->clearDidBecomeEmptyCallback();
@@ -446,13 +437,16 @@ bool FindController::updateFindIndicator(bool isShowingOverlay, bool shouldAnima
 #endif
         if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get())) {
             auto selectedRange = protect(selectedFrame->selection())->selection().toNormalizedRange();
-            if (selectedRange && ImageOverlay::isInsideOverlay(*selectedRange))
+            if (!selectedRange)
+                return { };
+
+            if (ImageOverlay::isInsideOverlay(*selectedRange))
                 textIndicatorOptions.add({ TextIndicatorOption::PaintAllContent, TextIndicatorOption::PaintBackgrounds });
 
-            if (selectedRange && selectedRange->collapsed() && selectedRange == m_lastSelection)
-                return { selectedFrame, TextIndicator::createWithRange(*m_lastFoundRange, textIndicatorOptions, presentationTransition) };
+            if (selectedRange->collapsed())
+                selectedRange = protect(selectedFrame->selection())->selection().range();
 
-            return { selectedFrame, TextIndicator::createWithSelectionInFrame(*selectedFrame, textIndicatorOptions, presentationTransition) };
+            return { selectedFrame, TextIndicator::createWithRange(*selectedRange, textIndicatorOptions, presentationTransition) };
         }
 
         return { };

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -126,10 +126,6 @@ private:
     // Index value is -1 if not found or if number of matches exceeds provided maximum.
     int m_foundStringMatchIndex { -1 };
 
-    // For instances where the normalized selection range is collapsed.
-    std::optional<WebCore::SimpleRange> m_lastFoundRange;
-    std::optional<WebCore::VisibleSelection> m_lastSelection;
-
 #if PLATFORM(IOS_FAMILY)
     RefPtr<WebCore::PageOverlay> m_findIndicatorOverlay;
     std::unique_ptr<FindIndicatorOverlayClientIOS> m_findIndicatorOverlayClient;


### PR DESCRIPTION
#### e24a99cde1a5b4e31f09e5e91f823f14a180f8ad
<pre>
Fix TextIndicator for -webkit-user-select: none ranges during find in page
<a href="https://bugs.webkit.org/show_bug.cgi?id=309040">https://bugs.webkit.org/show_bug.cgi?id=309040</a>
<a href="https://rdar.apple.com/171590205">rdar://171590205</a>

Reviewed by Megan Gardner.

When text indicators are shown for user-select: none matches, only a solid
yellow box is rendered. Users cannot see any of the underlying text. This
is because it tries to use the selection to render, but user-select: none
matches cannot have selections.

To fix this issue, I check if the range is collapsed, and switch the text
indicator options to PaintAllContent. This allows the text to show, but
the background does not match the yellow indicator.

In the future, there needs to be a larger refactor of the TextIndicator
code to decouple it from selections.

* Source/WebCore/page/TextIndicator.cpp:
(WebCore::TextIndicator::createWithSelectionInFrame):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):
(WebKit::FindController::hideFindUI):
(WebKit::FindController::updateFindIndicator):
* Source/WebKit/WebProcess/WebPage/FindController.h:
* selection.html: Added.

Canonical link: <a href="https://commits.webkit.org/308667@main">https://commits.webkit.org/308667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb7c223dae1ee3745f90e0a720a51e011fa12d8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dec598d-41d9-4f2f-98f4-99c5535e7e18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114075 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81348 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc8aebcd-4044-4202-9f35-8bd0b40dc689) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94838 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08938104-b3ec-4642-a129-4d76f83da4ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15470 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13264 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4098 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158994 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122108 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76613 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17793 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9384 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83838 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19808 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19956 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->