### PR TITLE
SVG elements inside hidden containers should not be focusable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/focus-inside-hidden-svg-containers-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/focus-inside-hidden-svg-containers-01-expected.txt
@@ -2,5 +2,5 @@ start
 middle
 end
 
-FAIL Hidden SVG Tab focus test assert_equals: End element should be focused after pressing Tab expected Element node <text tabindex="3" id="end" x="50" y="10">end</text> but got Element node <text tabindex="2" id="middle" x="30" y="10">middle</text>
+PASS Hidden SVG Tab focus test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/focus-inside-hidden-svg-containers-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/focus-inside-hidden-svg-containers-03-expected.txt
@@ -2,5 +2,5 @@ start
 middle
 end
 
-FAIL Hidden SVG Tab focus test assert_equals: End element should be focused after pressing Tab expected Element node <text tabindex="3" id="end" x="50" y="10">end</text> but got Element node <text tabindex="2" id="middle" x="30" y="10">middle</text>
+PASS Hidden SVG Tab focus test
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -923,6 +923,15 @@ bool Element::isFocusable() const
             return false;
     }
 
+    // SVG elements inside hidden containers (e.g. <defs>, <g display="none">)
+    // are never rendered and should not be focusable per the SVG spec.
+    if (renderer()) {
+        for (CheckedPtr ancestor = renderer()->parent(); ancestor; ancestor = ancestor->parent()) {
+            if (ancestor->isRenderSVGHiddenContainer() || ancestor->isLegacyRenderSVGHiddenContainer())
+                return false;
+        }
+    }
+
     return hasFocusableStyle();
 }
 


### PR DESCRIPTION
#### c9407dda7cf28347f0f605625d550f11c80d9cde
<pre>
SVG elements inside hidden containers should not be focusable
<a href="https://bugs.webkit.org/show_bug.cgi?id=309041">https://bugs.webkit.org/show_bug.cgi?id=309041</a>
<a href="https://rdar.apple.com/171590890">rdar://171590890</a>

Reviewed by NOBODY (OOPS!).

According to the specification [1], a non-rendered element can never receive
focus, regardless of the value of the `tabindex` attribute.
If a script programmatically assigns focus to a non-rendered or
otherwise un-focusable element, the focusing call is aborted.

Since elements inside non-rendered containers are also never
rendered, they should not be focusable either.

Add a check in Element::isFocusable() that walks up the render tree
ancestors and returns false if any ancestor is a RenderSVGHiddenContainer
or LegacyRenderSVGHiddenContainer (e.g. &lt;defs&gt;, &lt;g style=&quot;display:none&quot;&gt;).

[1] <a href="https://svgwg.org/svg2-draft/single-page.html#interact-Focus">https://svgwg.org/svg2-draft/single-page.html#interact-Focus</a>

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isFocusable const):
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/focus-inside-hidden-svg-containers-01-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/focus-inside-hidden-svg-containers-03-expected.txt: Ditto
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9407dda7cf28347f0f605625d550f11c80d9cde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101199 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bc7420e-740a-4161-8372-8c095d9ffb70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113929 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81243 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8f73e6e-7400-4eb7-86d8-e5916af006cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/404a12c6-7977-4180-b7fe-c63d45c2b762) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15329 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13112 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3907 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158802 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121958 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122160 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76394 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17667 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9206 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83646 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19764 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19671 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->