### PR TITLE
[webkitscmpy] Add a diff viewer

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -34,6 +34,7 @@ from .clone import Clone
 from .command import Command
 from .commit import Commit
 from .conflict import Conflict
+from .diff import Diff
 from .squash import Squash
 from .checkout import Checkout
 from .classify import Classify
@@ -94,7 +95,7 @@ def main(
 
     programs = [
         Blame, Branch, Canonicalize, Checkout,
-        Clean, Clone, Conflict, Find, Info, Land, Log, Pull,
+        Clean, Clone, Conflict, Diff, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
         Pickable, CherryPick, Trace, Track, Show, Publish,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/__init__.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from webkitcorepy import arguments, Terminal, Timeout
+from webkitscmpy import local
+
+from .diff import DiffBase
+from .terminal_diff import TerminalDiff
+from .editor_diff import SublimeDiff, VSDiff
+from .html_diff import HTMLDiff
+
+from ..command import Command
+
+
+class Diff(Command):
+    DEFAULT_VIEWER = HTMLDiff
+
+    name = 'diff'
+    help = "Filter 'git diff' output through the user's prefered diff viewer"
+    _formats = {}
+
+    @classmethod
+    def viewers(cls):
+        if not cls._formats:
+            cls._formats = {
+                viewer.name: viewer for viewer in [
+                    TerminalDiff,
+                    SublimeDiff,
+                    VSDiff,
+                    HTMLDiff,
+                ] if getattr(viewer, 'editor', True)
+            }
+        return cls._formats
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            '-b', '--block', '--no-block',
+            dest='block', default=None,
+            help='Wait for user to stop viewing diff before continuing',
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
+            '--include-commit-message', '--no-commit-message',
+            dest='commit_message', default=True,
+            help='Include (or exclude) commit messages in the provided diff',
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
+            '-d', '--viewer',
+            dest='viewer', default=None,
+            help='Choose a specific diff viewer ({})'.format(', '.join(sorted(cls.viewers().keys()))),
+            type=lambda arg: cls.viewers()[arg],
+            choices=cls.viewers().values(),
+        )
+        parser.add_argument(
+            'argument', nargs='?',
+            type=str, default=None,
+            help='String representation of commit (12345@main, a6a3d713e48e) or range of commits (a6a3d713e48e..cd1f220a274e) to display diff of',
+        )
+
+    @classmethod
+    def default_viewer(cls, repository):
+        viewer = repository.config().get('webkitscmpy.diff-viewer', None)
+        if viewer not in cls.viewers():
+            if viewer:
+                print(f"'{viewer}' is not a recognized diff viewer on this machine, falling back to '{cls.DEFAULT_VIEWER.name}'")
+            return cls.DEFAULT_VIEWER
+        return cls.viewers()[viewer]
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not args.viewer:
+            args.viewer = cls.default_viewer(repository)
+        if args.block and Terminal.isatty(sys.stdout):
+            print('Cannot block when not run with an interactive terminal', file=sys.stderr)
+            args.block = False
+
+        if not args.argument:
+            # Check if the user is providing a diff to stdin
+            try:
+                with Timeout(.1):
+                    line = sys.stdin.readline()
+
+                if args.block:
+                    print('Cannot block when receiving diff from stdin', file=sys.stderr)
+
+                with args.viewer(block=False, repository=repository) as diff_viewer:
+                    diff_viewer.add_line(line)
+                    diff_viewer.add_file(sys.stdin)
+                return 0
+            except Timeout.Exception:
+                pass
+
+            if not isinstance(repository, local.Git):
+                print('Cannot infer local diff. Please provide a commit one the command line, pipe in an existing diff, or run this command in a git repository.', file=sys.stderr)
+                return 1
+
+            branch_point = repository.branch_point()
+            with args.viewer(block=args.block, repository=repository) as diff_viewer:
+                diff_viewer.add_lines(repository.diff(
+                    head='HEAD',
+                    base=branch_point.hash if branch_point else 'HEAD',
+                    include_log=args.commit_message,
+                ))
+            return 0
+
+        head = args.argument
+        base = None
+        if '..' in args.argument:
+            if '...' in args.argument:
+                print("'diff' sub-command only supports '..' notation", file=sys.stderr)
+                return 1
+            references = args.argument.split('..')
+            if len(references) > 2:
+                print('Can only include two references in a range', file=sys.stderr)
+                return 1
+            commit_a = repository.find(references[0])
+            commit_b = repository.find(references[1])
+            head = commit_a.hash if commit_a > commit_b else commit_b.hash
+            base = commit_b.hash if commit_a > commit_b else commit_a.hash
+
+        with args.viewer(block=args.block, repository=repository) as diff_viewer:
+            diff_viewer.add_lines(repository.diff(head=head, base=base, include_log=args.commit_message))
+
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/diff.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/diff.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+
+from email.header import decode_header
+
+from webkitscmpy import Commit
+
+
+class DiffMeta(type):
+    def __str__(cls):
+        return cls.name
+
+
+class DiffBase(object, metaclass=DiffMeta):
+    FROM_COMMIT_RE = re.compile(r'^From\s+([a-f0-9A-F]+)')
+    FROM_AUTHOR_RE = re.compile(r'^From:\s+(.+)$')
+    SUBJECT_LINE_RE = re.compile(r'Subject:\s+\[PATCH(\s+\d+/\d+)?\] (.+)')
+    URL_RE = re.compile(r'^\S+://\S+$')
+    ADD_SUB_RE = re.compile(r'[^|]+\s+\|\s+(\d+)\s+(\+*)(\-*)$')
+
+    def __init__(self, block=None, repository=None):
+        self.block = block
+        self.repository = repository
+
+    def add_line(self, line):
+        line = '\n' if line is None else line
+        line = line + '\n' if not line or line[0] != '\n' else line
+
+        commit_match = self.FROM_COMMIT_RE.match(line)
+        if commit_match and self.repository:
+            commit = self.repository.commit(hash=commit_match.group(1), include_log=False)
+            return 'From {} ({})\n'.format(commit, commit_match.group(1)[:Commit.HASH_LABEL_SIZE])
+        author_match = self.FROM_AUTHOR_RE.match(line)
+        if author_match:
+            result = 'From: '
+            for part in decode_header(author_match.group(1)):
+                result += part[0] if isinstance(part[0], str) else part[0].decode()
+            return result
+        return line
+
+    def add_lines(self, lines):
+        subject_lines = []
+        for line in lines:
+            stripped_line = line.strip()
+            if not stripped_line:
+                for s_line in subject_lines:
+                    self.add_line(s_line + '\n')
+                subject_lines = []
+            elif subject_lines:
+                if self.URL_RE.match(stripped_line):
+                    subject_lines.append(stripped_line)
+                else:
+                    subject_lines[-1] += line.rstrip()
+                continue
+
+            subject_match = self.SUBJECT_LINE_RE.match(line)
+            if subject_match:
+                subject_lines.append(subject_match.group(2))
+                continue
+            self.add_line(line)
+
+    def add_file(self, file):
+        self.add_lines(file.readlines())

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/editor_diff.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/editor_diff.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import tempfile
+
+from webkitcorepy import Editor
+
+from .diff import DiffBase
+
+
+class EditorDiff(DiffBase):
+    editor = None
+
+    def __init__(self, **kwargs):
+        super(EditorDiff, self).__init__(**kwargs)
+
+        if self.block is None:
+            self.block = False
+
+        self._file_handle = None
+        self.file = os.path.join(tempfile.gettempdir(), 'patch.diff')
+
+    def add_line(self, line):
+        line = super(EditorDiff, self).add_line(line)
+        if not self._file_handle:
+            raise ValueError('EditorDiff context has not been initialized')
+        self._file_handle.write(line)
+        return line
+
+    def __enter__(self):
+        if self.editor is None:
+            raise ValueError('Undefined editor')
+        if not self.editor:
+            raise ValueError('{} cannot be found'.format(self.editor.name))
+
+        self._file_handle = open(self.file, 'w')
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        if not self._file_handle:
+            return
+        self._file_handle.close()
+        self._file_handle = None
+        self.editor.open(self.file, block=self.block)
+
+
+class SublimeDiff(EditorDiff):
+    editor = Editor.sublime()
+    name = editor.name.lower()
+
+
+class VSDiff(EditorDiff):
+    editor = Editor.vscode()
+    name = editor.name.lower()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/html_diff.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/html_diff.py
@@ -1,0 +1,523 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import re
+import sys
+import tempfile
+import threading
+
+if sys.version_info >= (3, 2):
+    from html import escape
+else:
+    from cgi import escape
+
+if sys.version_info >= (3, 0):
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+else:
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+
+from .diff import DiffBase
+
+from webkitcorepy import Terminal
+
+
+class HTMLDiff(DiffBase):
+    HEAD = '''<html>
+<head>
+<meta charset='utf-8'>
+<style>
+:root {
+    color-scheme: light dark;
+    --border-color: #d0d7de;
+    --background-color: #f6f8fa;
+    --border-bottom-color: #d0d7de;
+    --text-color: #1f2328;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --border-color: #30363d;
+        --background-color: #0d1117;
+        --border-bottom-color: #21262d;
+        --text-color: #e6edf3;
+    }
+    body {
+        background-color: var(--background-color);
+        color: var(--text-color);
+    }
+}
+
+.file {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace;
+    font-size: 12px;
+    margin: 1em 0;
+    overflow-x: auto;
+    position: relative;
+}
+@media (prefers-color-scheme: dark) {
+    .file {
+        background-color: #161b22;
+    }
+}
+
+h1 {
+    color: var(--text-color);
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 1.1em;
+    font-weight: 600;
+    margin-left: 0.5em;
+    display: inline;
+    width: 100%;
+    padding: 0.5em;
+}
+
+.section {
+    background-color: var(--background-color);
+    border: solid var(--border-color);
+    border-width: 1px 0px;
+    display: block;
+    min-width: 100%;
+    width: max-content;
+}
+
+.line, .section-header {
+    display: flex;
+    white-space: nowrap;
+    width: 100%;
+}
+
+.original, .edited {
+    border-bottom: 1px solid var(--border-bottom-color);
+    border-right: 1px solid var(--border-color);
+    color: #57606a;
+    display: block;
+    flex-shrink: 0;
+    padding: 1px 10px 0px 0px;
+    text-align: right;
+    width: 3em;
+    background-color: #f6f8fa;
+    user-select: none;
+    position: sticky;
+    left: 0;
+    z-index: 1;
+}
+.original::before {
+    content: attr(data-line);
+}
+.edited::before {
+    content: attr(data-line);
+}
+.edited {
+    left: 3em;
+}
+@media (prefers-color-scheme: dark) {
+    .original, .edited {
+        color: #848d97;
+        background-color: #161b22;
+        border-right-color: #21262d;
+    }
+}
+
+pre, .text {
+    padding-left: 5px;
+}
+
+.text {
+    white-space: pre;
+    text-decoration: none;
+    flex: 1;
+}
+.add {
+    background-color: #d1f0d8;
+}
+.remove {
+    background-color: #f8d0d0;
+}
+@media (prefers-color-scheme: dark) {
+    .add {
+        background-color: #1a4d2e;
+    }
+    .remove {
+        background-color: #5a1e1e;
+    }
+}
+
+.context {
+    border-right: none;
+    color: #57606a;
+    background-color: #eaeef2;
+    border-bottom: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    .context {
+        color: #848d97;
+        background-color: #1c2128;
+    }
+}
+
+.conflict {
+    background-color: #fff3cd;
+    font-weight: bold;
+}
+.conflict-ours {
+    background-color: #fde0c0;
+}
+.conflict-theirs {
+    background-color: #ede0f5;
+}
+@media (prefers-color-scheme: dark) {
+    .conflict {
+        background-color: #3d2e00;
+    }
+    .conflict-ours {
+        background-color: #5a2d00;
+    }
+    .conflict-theirs {
+        background-color: #3d1f6e;
+    }
+}
+</style>
+</head>
+<body>
+'''
+    TAIL = '</body>\n</html>\n'
+    INDENT = 4 * ' '
+    FILES_CHANGED_RE = re.compile(r'^ (\d+ files? changed)?(create mode\s+)?')
+    name = 'html'
+
+    class Type(object):
+        DELETED = 0
+        MODIFIED = 1
+        CREATED = 2
+        MOVED = 3
+
+    class Section(object):
+        SECTION_RE = re.compile(r'@@\s+-(\d+),\d+\s+\+(\d+),\d+\s+@@\s+(.*)')
+        ORIGINAL = 1
+        EDITED = 2
+        CONFLICT = 3
+        CONFLICT_OURS = 4
+        CONFLICT_THEIRS = 5
+
+        @classmethod
+        def from_header(cls, string):
+            match = cls.SECTION_RE.match(string)
+            if not match:
+                return None
+            return cls(
+                title=match.group(3),
+                original_position=match.group(1),
+                edited_position=match.group(2),
+            )
+
+        def __init__(self, title, original_position, edited_position):
+            self.title = title
+            self.original_position = int(original_position)
+            self.edited_position = int(edited_position)
+
+        def header(self):
+            return [
+                '<div class="section-header context">',
+                '    <span class="original context">@</span>',
+                '    <span class="edited context">@</span>',
+                '    <span class="section-title">{}</span>'.format(escape(self.title)),
+                '</div>',
+            ]
+
+        def line(self, line, type=None):
+            type_class = {
+                self.EDITED: ' add',
+                self.ORIGINAL: ' remove',
+                self.CONFLICT: ' conflict',
+                self.CONFLICT_OURS: ' conflict-ours',
+                self.CONFLICT_THEIRS: ' conflict-theirs',
+            }.get(type, '')
+            line_class = {
+                self.CONFLICT: ' context',
+            }.get(type, '')
+
+            orig = self.original_position if type in (None, self.ORIGINAL, self.CONFLICT_OURS) else None
+            edit = self.edited_position if type in (None, self.EDITED, self.CONFLICT_THEIRS) else None
+            result = [
+                '<div class="line{}">'.format(type_class),
+                '    <span class="original{}"{}></span>'.format(line_class, ' data-line="{}"'.format(orig) if orig is not None else ''),
+                '    <span class="edited{}"{}></span>'.format(line_class, ' data-line="{}"'.format(edit) if edit is not None else ''),
+                '    <span class="text{}">{}</span>'.format(type_class, escape(line)),
+                '</div>',
+            ]
+            if type is not self.EDITED and type is not self.CONFLICT_THEIRS:
+                self.original_position += 1
+            if type is not self.ORIGINAL and type is not self.CONFLICT_OURS:
+                self.edited_position += 1
+            return result
+
+    @classmethod
+    def title_for(cls, *files):
+        files = list(files)
+        prefix = ['a/', 'b/']
+        for index in range(len(prefix)):
+            if not files or len(files) <= index:
+                break
+            if files[index].startswith(prefix[index]):
+                files[index] = files[index][len(prefix[index]):]
+
+        for empty in ['/dev/null']:
+            while empty in files or []:
+                files.remove(empty)
+
+        if not files:
+            return None
+        if len(files) == 1:
+            return files[0]
+
+        if files[0] == files[1]:
+            return files[0]
+        return '{} -> {}'.format(*files)
+
+    def commit_message_line(self, line, context=None):
+        if context:
+            return [
+                '<div class="section-header context">',
+                '    <span class="original context">{}</span>'.format(escape(context)),
+                '    <span class="section-title">{}</span>'.format(escape(line.rstrip())),
+                '</div>',
+            ]
+        result = [
+            '<div class="line">',
+            '    <span class="original" data-line="{}"></span>'.format(self._position),
+            '    <span class="text">{}</span>'.format(escape(line.rstrip())),
+            '</div>',
+        ]
+        self._position += 1
+        return result
+
+    def __init__(self, **kwargs):
+        super(HTMLDiff, self).__init__(**kwargs)
+
+        if self.block is None:
+            self.block = False
+
+        self._file_handle = None
+        self._div = []
+        self._section = None
+        self._current_title = None
+        self._files = []
+        self._conflict_side = None
+        self._in_commit_message = False
+        self._position = 1
+
+        self.file = os.path.join(tempfile.gettempdir(), 'diff.html')
+
+    def _start_div(self, klass=None):
+        self._file_handle.write("{}<div class='{}'>\n".format(len(self._div) * self.INDENT, klass))
+        self._div.append(klass)
+
+    def _end_div(self, klass=None):
+        if not self._div or self._div[-1] != klass:
+            return
+        self._div.pop()
+        self._file_handle.write("{}</div>\n".format(len(self._div) * self.INDENT))
+
+    def add_line(self, line):
+        line = super(HTMLDiff, self).add_line(line)
+        splitline = line.rstrip().split(maxsplit=1)
+        if len(splitline) == 2 and splitline[0] in ('rename', 'new', 'deleted'):
+            splitline = line.rstrip().split(maxsplit=2)
+            splitline[0] = '{} {}'.format(splitline[0], splitline.pop(1))
+        word = splitline[0] if splitline else None
+
+        if word == '---' and self._in_commit_message:
+            self._end_div(klass='file')
+            self._in_commit_message = False
+            return line
+
+        if self._in_commit_message:
+            if word == 'From:' and len(splitline) > 1:
+                output_lines = self.commit_message_line(splitline[1], context='By')
+            elif word == 'Date:' and len(splitline) > 1:
+                output_lines = self.commit_message_line(splitline[1], context='Date')
+            else:
+                output_lines = self.commit_message_line(line or ' ')
+            for output_line in output_lines:
+                self._file_handle.write('{}{}\n'.format(len(self._div) * self.INDENT, output_line))
+            return line
+
+        if word == 'From':
+            self._in_commit_message = True
+            self._end_div(klass='section')
+            self._end_div(klass='file')
+            self._start_div(klass='file')
+            self._file_handle.write('{}<h1>{}</h1>\n'.format(len(self._div) * self.INDENT, splitline[1] if len(splitline) > 1 else '?'))
+            self._start_div(klass='section')
+            self._position = 1
+            self._section = None
+            return line
+
+        if word in ('diff', 'index', 'deleted', 'new file', 'deleted file'):
+            self._files = []
+            self._end_div(klass='section')
+            return line
+
+        if word in ('similarity',):
+            return line
+
+        if not self._files and word in ('---', 'rename from') and len(splitline) > 1:
+            self._files = [splitline[1]]
+            return line
+        if len(self._files) == 1 and word in ('+++', 'rename to'):
+            self._files.append(splitline[1])
+            title = self.title_for(*self._files)
+
+            if title != self._current_title:
+                self._end_div(klass='file')
+                self._start_div(klass='file')
+                self._file_handle.write('{}<h1>{}</h1>\n'.format(len(self._div) * self.INDENT, title))
+            self._current_title = title
+            return line
+
+        new_section = self.Section.from_header(line)
+        if new_section:
+            if self._section:
+                self._end_div(klass='section')
+                self._file_handle.write('{}<br>\n'.format(len(self._div) * self.INDENT))
+            self._start_div(klass='section')
+            self._conflict_side = None
+            self._section = new_section
+            for header_line in self._section.header():
+                self._file_handle.write('{}{}\n'.format(len(self._div) * self.INDENT, header_line))
+            return line
+
+        if not self._section:
+            stripped_line = line.rstrip()
+            if not stripped_line:
+                return line
+            if self.ADD_SUB_RE.match(stripped_line):
+                return line
+            if self.FILES_CHANGED_RE.match(stripped_line):
+                return line
+
+            sys.stderr.write('Unrecognized diff format, excluding:\n')
+            sys.stderr.write(line)
+            return line
+
+        typ = None
+        if line.startswith('+<<<'):
+            self._conflict_side = 'ours'
+            typ = self._section.CONFLICT
+        elif line.startswith('+==='):
+            self._conflict_side = 'theirs'
+            typ = self._section.CONFLICT
+        elif line.startswith('+>>>'):
+            self._conflict_side = None
+            typ = self._section.CONFLICT
+        elif self._conflict_side == 'ours':
+            typ = self._section.CONFLICT_OURS
+        elif self._conflict_side == 'theirs':
+            typ = self._section.CONFLICT_THEIRS
+        elif line[0] == '-':
+            typ = self._section.ORIGINAL
+        elif line[0] == '+':
+            typ = self._section.EDITED
+
+        for output_line in self._section.line(line[1:-1], type=typ):
+            self._file_handle.write('{}{}\n'.format(len(self._div) * self.INDENT, output_line))
+
+        return line
+
+    def __enter__(self):
+        self._file_handle = open(self.file, 'w')
+        self._div = []
+        self._section = None
+        self._current_title = None
+        self._files = []
+
+        self._file_handle.write(self.HEAD)
+
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        if not self._file_handle:
+            return
+
+        while self._div:
+            self._end_div(klass=self._div[-1])
+        self._file_handle.write(self.TAIL)
+
+        self._file_handle.close()
+        self._file_handle = None
+
+        if self.block:
+            finished = threading.Event()
+            diff_file = self.file
+
+            class _Handler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    try:
+                        with open(diff_file, 'rb') as f:
+                            content = f.read()
+                        script = (
+                            b'<script>window.addEventListener("beforeunload",function(){'
+                            b'try{navigator.sendBeacon("/done")}catch(e){}});</script>'
+                        )
+                        content = content.replace(b'</body>', script + b'</body>', 1)
+                        self.send_response(200)
+                        self.send_header('Content-Type', 'text/html; charset=utf-8')
+                        self.send_header('Content-Length', str(len(content)))
+                        self.end_headers()
+                        self.wfile.write(content)
+                    except Exception:
+                        self.send_error(500)
+
+                def do_POST(self):
+                    self.send_response(204)
+                    self.end_headers()
+                    if self.path == '/done':
+                        finished.set()
+
+                def log_message(self, *args, **kwargs):
+                    pass
+
+            server = HTTPServer(('127.0.0.1', 0), _Handler)
+            port = server.server_address[1]
+            server_thread = threading.Thread(target=server.serve_forever)
+            server_thread.daemon = True
+            server_thread.start()
+
+            def _wait_for_enter():
+                try:
+                    sys.stdin.readline()
+                finally:
+                    finished.set()
+
+            enter_thread = threading.Thread(target=_wait_for_enter)
+            enter_thread.daemon = True
+            enter_thread.start()
+
+            Terminal.open_url('http://127.0.0.1:{}/'.format(port))
+            finished.wait()
+            server.shutdown()
+        else:
+            Terminal.open_url('file://{}'.format(self.file))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/terminal_diff.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/terminal_diff.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+import shutil
+import subprocess
+import sys
+
+from webkitcorepy import NullContext, Terminal
+
+from .diff import DiffBase
+
+
+class TerminalDiff(DiffBase):
+    name = 'terminal'
+
+    def __init__(self, **kwargs):
+        super(TerminalDiff, self).__init__(**kwargs)
+
+        if self.block is None:
+            self.block = True
+
+        self._is_conflicting = False
+        self._pager = None
+        self._out = None
+
+    def __enter__(self):
+        if self.block and Terminal.isatty(sys.stdout) and shutil.which('less'):
+            self._pager = subprocess.Popen(
+                ['less', '-R'],
+                stdin=subprocess.PIPE,
+                encoding='utf-8',
+                errors='replace',
+            )
+            self._out = self._pager.stdin
+            Terminal._atty_overrides[self._out.fileno()] = True
+        else:
+            self._out = sys.stdout
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        if self._pager:
+            Terminal._atty_overrides.pop(self._pager.stdin.fileno(), None)
+            self._pager.stdin.close()
+            self._pager.wait()
+            self._pager = None
+        self._out = None
+
+    def add_line(self, line):
+        line = super(TerminalDiff, self).add_line(line)
+        if not Terminal.isatty(sys.stdout):
+            print(line.rstrip())
+            return
+
+        add_sub_match = self.ADD_SUB_RE.match(line)
+        if add_sub_match:
+            parsed_line, _ = line.split(' | ', 1)
+            self._out.write('{} | {} '.format(parsed_line, add_sub_match.group(1)))
+            if add_sub_match.group(2):
+                with Terminal.Style(color=Terminal.Text.green).apply(self._out):
+                    self._out.write(add_sub_match.group(2))
+            if add_sub_match.group(3):
+                with Terminal.Style(color=Terminal.Text.red).apply(self._out):
+                    self._out.write(add_sub_match.group(3))
+            self._out.write('\n')
+            return line
+
+        style = None
+        if line.startswith('+<<<'):
+            style = Terminal.Style(color=Terminal.Text.magenta)
+            self._is_conflicting = True
+        elif line.startswith('+===') or line.startswith('+>>>'):
+            style = Terminal.Style(color=Terminal.Text.magenta)
+            self._is_conflicting = False
+        elif line.startswith('diff') or line.startswith('index') or line.startswith('new file') or line.startswith('From') or line.startswith('Date'):
+            style = Terminal.Style(color=Terminal.Text.blue)
+            self._is_conflicting = False
+        elif line.startswith('@@') or line.startswith('---') or line.startswith('+++'):
+            style = Terminal.Style(color=Terminal.Text.cyan)
+            self._is_conflicting = False
+        elif line.startswith('+'):
+            style = Terminal.Style(color=Terminal.Text.green)
+        elif line.startswith('-') or self._is_conflicting:
+            style = Terminal.Style(color=Terminal.Text.red)
+
+        with style.apply(self._out) if style else NullContext():
+            self._out.write(line.rstrip())
+        self._out.write('\n')
+        return line

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -539,7 +539,6 @@ CommitDate: {time_c}
             )
 
     def test_diff_with_commit_message(self):
-        self.maxDiff = None
         with mocks.local.Git(self.path), OutputCapture():
             repo = local.Git(self.path)
             self.assertEqual(


### PR DESCRIPTION
#### ab64ba1375a213ba5f233654164843ee7b7e59ed
<pre>
[webkitscmpy] Add a diff viewer
<a href="https://bugs.webkit.org/show_bug.cgi?id=309038">https://bugs.webkit.org/show_bug.cgi?id=309038</a>
<a href="https://rdar.apple.com/171589298">rdar://171589298</a>

Reviewed by Brianna Fan.

Add a diff viewer, inspired by pretty-diff originally used to locally inspect Subversion
patches before uploading them.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add &apos;diff&apos; sub-program.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/__init__.py: Added.
(Diff.viewers): Return all viewers available in the current program.
(Diff.parser): Parse command line arguments to the &apos;diff&apos; sub-command.
(Diff.default_viewer): Return the default diff viewer for a given repository.
(Diff.main): Display a formatted diff for the provided arguments.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/diff.py: Added.
(DiffMeta): Meta class allowing the transparent printing of Diff classes.
(DiffBase): Base-class for all diff viewers.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/editor_diff.py: Added.
(EditorDiff): Diff viewer based on an existing webkitcorepy editor. Note that not all editors
make good diff viewers.
(SublimeDiff):
(VSDiff):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/html_diff.py: Added.
(HTMLDiff): Build a self-contained webpage containing a diff.
(Type): Track different file-modification modes.
(Section): Edits for a file.
(title_for): Return a section title for a given set of files.
(commit_message_line): Format commit messages in a diff.
(__init__):
(_start_div): Enter a new div.
(_end_div): Close the most recent div.
(add_line): Add line from diff.
(__enter__): Start writing to the generated HTML file.
(__exit__): Open html diff file, either from a local webserver in blocking mode or directly
from a file. If in blocking mode, await either terminal input or a becon message as the user
navigates away from the generated webpage.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/diff/terminal_diff.py: Added.
(TerminalDiff): View a paged color-coded diff within the terminal
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/308932@main">https://commits.webkit.org/308932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43395ac52ca23dc2ef67e6cd2802e141880a2865

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101967 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecb5c0eb-c955-48e9-a34f-e4bd31045b65) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81550 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a468c4a3-b315-498e-85ba-a0abd9529a29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95283 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/773d80b6-4298-43ac-afa7-a377a863585a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147858 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13664 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159556 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122562 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/147935 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122783 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77189 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20638 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20370 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20424 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->