### PR TITLE
Top color sampling occasionally fails on page reload when JavaScript is injected

### DIFF
--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -191,8 +191,10 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
             else
                 LOG_ONCE(SiteIsolation, "Unable to properly construct UserGestureIndicator::UserGestureIndicator() without access to the main frame document ");
         }
-        if (RefPtr page = document->page())
+        if (RefPtr page = document->page()) {
             page->setUserDidInteractWithPage(true);
+            page->setUserDidInteractWithPageExcludingForcedUserGestures(processInteractionStyle != ProcessInteractionStyle::Never);
+        }
         if (RefPtr frame = document->frame(); frame && !frame->hasHadUserInteraction()) {
             for (RefPtr<Frame> ancestor = WTF::move(frame); ancestor; ancestor = ancestor->tree().parent()) {
                 if (RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor)) {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1842,6 +1842,7 @@ void Page::didCommitLoad()
 
     m_hasEverSetVisibilityAdjustment = false;
     m_userHasInteractedSinceLastPageLoad = false;
+    m_userHasInteractedSinceLastPageLoadExcludingForcedUserGestures = false;
 
     m_mainFrameURLFragment = { };
 
@@ -5379,7 +5380,7 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
         auto maximumOffset = frameView->maximumScrollOffset();
 
         bool canSampleTopEdge = settings().topContentInsetBackgroundCanChangeAfterScrolling()
-            || (!frameView->wasEverScrolledExplicitlyByUser() && !m_userHasInteractedSinceLastPageLoad)
+            || (!frameView->wasEverScrolledExplicitlyByUser() && !m_userHasInteractedSinceLastPageLoadExcludingForcedUserGestures)
             || document->parsing();
 
         if (scrollOffset.y() < minimumOffset.y() || !canSampleTopEdge)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -435,6 +435,7 @@ public:
 #endif
     void setUserDidInteractWithPage(bool);
     bool NODELETE userDidInteractWithPage() const;
+    void NODELETE setUserDidInteractWithPageExcludingForcedUserGestures(bool didInteract) { m_userHasInteractedSinceLastPageLoadExcludingForcedUserGestures = didInteract; }
     void setAutofocusProcessed();
     bool NODELETE autofocusProcessed() const;
     bool NODELETE topDocumentHasDocumentClass(DocumentClass) const;
@@ -1755,6 +1756,7 @@ private:
     std::optional<Color> m_sampledPageTopColor;
     std::pair<UniqueRef<FixedContainerEdges>, WeakElementEdges> m_fixedContainerEdgesAndElements;
     bool m_userHasInteractedSinceLastPageLoad { false };
+    bool m_userHasInteractedSinceLastPageLoadExcludingForcedUserGestures { false };
 
     const bool m_httpsUpgradeEnabled { true };
     mutable Markable<MediaSessionGroupIdentifier> m_mediaSessionGroupIdentifier;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
@@ -27,6 +27,7 @@
 
 #import "TestCocoa.h"
 #import "TestWKWebView.h"
+#import "UserInterfaceSwizzler.h"
 #import "Utilities.h"
 #import <WebCore/Color.h>
 #import <WebKit/WKPreferencesPrivate.h>
@@ -37,6 +38,10 @@
 #import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/text/StringBuilder.h>
+
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
+#import "IOSMouseEventTestHarness.h"
+#endif
 
 #define EXPECT_IN_RANGE(actual, min, max) \
     EXPECT_GE(actual, min); \
@@ -81,6 +86,8 @@
 }
 
 @end
+
+namespace TestWebKitAPI {
 
 static RetainPtr<TestWKWebView> createWebViewWithSampledPageTopColorMaxDifference(double sampledPageTopColorMaxDifference, double sampledPageTopColorMinHeight = 0)
 {
@@ -512,3 +519,86 @@ TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)
 }
 
 #endif // PLATFORM(IOS_FAMILY) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL) && (PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION))
+
+TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeSampling)
+{
+#if PLATFORM(IOS_FAMILY)
+    IPadUserInterfaceSwizzler iPadUserInterface;
+#endif
+    RetainPtr webView = createWebViewWithSampledPageTopColorMaxDifference(5);
+
+#if PLATFORM(IOS_FAMILY)
+    auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
+    auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
+    [webView _setObscuredInsets:insets];
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
+#else
+    [webView _setTopContentInset:75];
+#endif
+
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    {
+        auto components = CGColorGetComponents([webView _sampledTopFixedPositionContentColor].CGColor);
+        EXPECT_IN_RANGE(components[0], 0.99, 1.01);
+        EXPECT_IN_RANGE(components[1], 0.38, 0.39);
+        EXPECT_IN_RANGE(components[2], 0.27, 0.28);
+        EXPECT_EQ(components[3], 1);
+    }
+
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"'injected'"];
+
+    bool done = false;
+    RetainPtr topColorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView.get() keyPath:@"_sampledTopFixedPositionContentColor" callback:[&] {
+        done = true;
+    }]);
+
+    [webView objectByEvaluatingJavaScript:@"document.querySelector('header').style.backgroundColor = 'blue'"];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_TRUE([webView _fixedContainerEdges] & _WKRectEdgeTop);
+
+    {
+        auto components = CGColorGetComponents([webView _sampledTopFixedPositionContentColor].CGColor);
+        EXPECT_IN_RANGE(components[0], -0.01, 0.01);
+        EXPECT_IN_RANGE(components[1], -0.01, 0.01);
+        EXPECT_IN_RANGE(components[2], 0.99, 1.01);
+        EXPECT_EQ(components[3], 1);
+    }
+
+    // Now make sure actual user interaction *does* prevent top edge sampling still.
+    [webView objectByEvaluatingJavaScript:@"var btn = document.createElement('button'); btn.id = 'changeColor'; btn.textContent = 'Change'; btn.style.cssText = 'position: absolute; top: 200px; left: 50px'; btn.onclick = function() { document.querySelector('header').style.backgroundColor = 'yellow'; }; document.body.appendChild(btn); void(0)"];
+    [webView waitForNextPresentationUpdate];
+
+    id buttonRect = [webView objectByEvaluatingJavaScript:@"var r = document.getElementById('changeColor').getBoundingClientRect(); ({left: r.left, top: r.top, width: r.width, height: r.height})"];
+    CGFloat buttonX = [buttonRect[@"left"] floatValue] + [buttonRect[@"width"] floatValue] / 2;
+    CGFloat buttonY = [buttonRect[@"top"] floatValue] + [buttonRect[@"height"] floatValue] / 2;
+#if PLATFORM(IOS_FAMILY)
+    {
+        TestWebKitAPI::MouseEventTestHarness testHarness { webView.get() };
+        testHarness.mouseMove(buttonX, buttonY);
+        testHarness.mouseDown();
+        testHarness.mouseUp();
+    }
+#else
+    [webView sendClickAtPoint:NSMakePoint(buttonX, [webView frame].size.height - buttonY)];
+#endif
+    [webView waitForNextPresentationUpdate];
+
+    {
+        auto components = CGColorGetComponents([webView _sampledTopFixedPositionContentColor].CGColor);
+        EXPECT_IN_RANGE(components[0], -0.01, 0.01);
+        EXPECT_IN_RANGE(components[1], -0.01, 0.01);
+        EXPECT_IN_RANGE(components[2], 0.99, 1.01);
+        EXPECT_EQ(components[3], 1);
+    }
+}
+
+#endif
+
+}


### PR DESCRIPTION
#### 479b03fb2a417346275e62737274a8632c2feabf
<pre>
Top color sampling occasionally fails on page reload when JavaScript is injected
<a href="https://bugs.webkit.org/show_bug.cgi?id=309024#">https://bugs.webkit.org/show_bug.cgi?id=309024#</a>
<a href="https://rdar.apple.com/171571987">rdar://171571987</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

To prevent rapid changes in the sampled top color, we stop updating it after
user interaction. However, WebKit APIs used for JS injections often force
user gestures, and we sometimes stop updating before sampling the proper
color as a result.

To fix this, we only stop updating after user interaction if the user gesture
did not originate from JS injection. If the process interaction style is
ProcessInteractionStyle::Never, then we know it originated from JS injection
from `ScriptController::executeScriptInWorld`.

* Source/WebCore/dom/UserGestureIndicator.cpp:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::updateFixedContainerEdges):
* Source/WebCore/page/Page.h:
(WebCore::Page::setUserDidInteractWithPageExcludingForcedUserGestures):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm:
(TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeSampling)):

Canonical link: <a href="https://commits.webkit.org/308684@main">https://commits.webkit.org/308684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8141b34f5ecee8aa0d2d76ca4c2f9a7951ed35b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156898 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3fa396b-6381-4802-bb2a-f55fea2509bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114265 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef399259-0101-413f-9269-17023b4cb4cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95036 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c168bb80-7204-41e6-94ba-ada92a5add49) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13435 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4335 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159231 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122300 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122519 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76859 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22841 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9556 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20316 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20047 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20193 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->