### PR TITLE
REGRESSION(306825@main): [Cocoa] HLS videos stutter when toggling muted

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1701,7 +1701,6 @@ void MediaPlayerPrivateAVFoundationObjC::setPlayerRate(double rate, std::optiona
     } else
         [m_avPlayer setRate:rate];
 
-    m_cachedTimeControlStatus = [m_avPlayer timeControlStatus];
     setShouldObserveTimeControlStatus(true);
 
     m_wallClockAtCachedCurrentTime = std::nullopt;
@@ -2295,6 +2294,16 @@ void MediaPlayerPrivateAVFoundationObjC::updateIsAudible()
 {
     bool isAudible = hasAudio() && !m_muted && m_volume;
     if (m_isAudible == isAudible)
+        return;
+
+    // Only change the state of suppressesAudioRendering and
+    // participatesInAudioSession when playback is paused, to
+    // avoid the reconfiguring of video playback that AVFoundation
+    // performs when these properties are changed. However,
+    // ignore this check if becoming audible to ensure audio
+    // rendering starts immediately. This method will be called
+    // again by timeControlStatusDidChange().
+    if (!isAudible && m_cachedTimeControlStatus == AVPlayerTimeControlStatusPlaying)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, isAudible);
@@ -3924,6 +3933,7 @@ void MediaPlayerPrivateAVFoundationObjC::timeControlStatusDidChange(int timeCont
 
     m_cachedTimeControlStatus = timeControlStatus;
     rateChanged();
+    updateIsAudible();
     m_wallClockAtCachedCurrentTime = std::nullopt;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
@@ -80,6 +80,24 @@ public:
         EXPECT_GE(mediaPlayer->readyState(), readyState);
     }
 
+    void waitForCurrentTimeGreaterThan(MediaTime time)
+    {
+        Util::waitFor([&] { return mediaPlayer->currentTime() > time; });
+        EXPECT_GE(mediaPlayer->currentTime(), time);
+    }
+
+    void waitForEffectiveRateGreaterThan(double rate)
+    {
+        Util::waitFor([&] { return mediaPlayer->effectiveRate() > rate; });
+        EXPECT_GE(mediaPlayer->effectiveRate(), rate);
+    }
+
+    void waitForEffectiveRateEqualTo(double rate)
+    {
+        Util::waitFor([&] { return mediaPlayer->effectiveRate() == rate; });
+        EXPECT_EQ(mediaPlayer->effectiveRate(), rate);
+    }
+
     RefPtr<WebCore::MediaPlayer> mediaPlayer;
 };
 
@@ -155,5 +173,46 @@ TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleSilentVideo)
     EXPECT_EQ(playerPrivate->isAudible(), false);
 }
 
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleWhilePlaying)
+{
+    mediaPlayer->load(videoWithAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveNothing);
+
+    RefPtr playerPrivate = this->playerPrivate();
+    ASSERT_NE(playerPrivate.get(), nullptr);
+
+    // Reduce the possibility of this test flaking when the underlying
+    // media reaches the end by reducing the playback rate to 1/10000.
+    // Calling setPreservesPitch(false) also has the effect of shifting
+    // all generated frequencies to nearly inaudible ranges.
+    mediaPlayer->setRate(0.0001);
+    mediaPlayer->setPreservesPitch(false);
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+
+    mediaPlayer->play();
+    waitForEffectiveRateGreaterThan(0);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    // isAudible() should not become false during playback
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    // isAudible() should subsequently become false once playback stops
+    mediaPlayer->pause();
+    waitForEffectiveRateEqualTo(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->play();
+    waitForEffectiveRateGreaterThan(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    // isAudible() should become true during playback
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+}
 
 }


### PR DESCRIPTION
#### 851a40d30f33e8a89df17c100fd7ce49e40ee01e
<pre>
REGRESSION(306825@main): [Cocoa] HLS videos stutter when toggling muted
<a href="https://rdar.apple.com/171093593">rdar://171093593</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309043">https://bugs.webkit.org/show_bug.cgi?id=309043</a>

Reviewed by Jean-Yves Avenard.

Toggling the value of AVPlayer.suppressesAudioRendering causes AVFoundation to perturb
the timebase driving the video rendering. Previously, we would only set that property
to true during initialization, and we would set it back to false the first time the
video was unmuted. In 306825@main, we started toggling that property whenever the volume
or muted values changed, which caused video to stutter.

Restore the previous behavior, to an extent, by only updating isAudible when a) the video
is paused or b) when moving from not audible to audible.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPlayerRate):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateIsAudible):
(WebCore::MediaPlayerPrivateAVFoundationObjC::timeControlStatusDidChange):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm:
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::waitForCurrentTimeGreaterThan):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::waitForEffectiveRateGreaterThan):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::waitForEffectiveRateEqualTo):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleWhilePlaying)):

Canonical link: <a href="https://commits.webkit.org/308572@main">https://commits.webkit.org/308572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d10f283114a77e825e1391080fcbee2b9ea90fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147797 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156480 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101212 "Failed to checkout and rebase branch from PR 59779") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113939 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/101212 "Failed to checkout and rebase branch from PR 59779") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94699 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9ca064c-1cd1-476e-840b-eb07842969fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15335 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3920 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158815 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1949 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122169 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31325 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76407 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9216 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83659 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19626 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19777 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->