### PR TITLE
Add address field to wasm memory descriptor

### DIFF
--- a/JSTests/wasm/js-api/memory64-js-api.js
+++ b/JSTests/wasm/js-api/memory64-js-api.js
@@ -1,0 +1,185 @@
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
+import * as assert from '../assert.js';
+
+const pageSize = 64 * 1024;
+
+// Constructor: basic creation with address: "i64" and BigInt initial
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, address: "i64" });
+    assert.eq(memory.buffer.byteLength, 1 * pageSize);
+}
+
+// Constructor: "minimum" is accepted as an alias for "initial"
+{
+    const memory = new WebAssembly.Memory({ minimum: 2n, address: "i64" });
+    assert.eq(memory.buffer.byteLength, 2 * pageSize);
+}
+
+// Constructor: specifying both "initial" and "minimum" throws
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 1n, minimum: 1n, address: "i64" }),
+        TypeError,
+        "WebAssembly.Memory 'initial' and 'minimum' options are specified at the same time"
+    );
+}
+
+// Constructor: initial > maximum throws
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 10n, maximum: 5n, address: "i64" }),
+        RangeError,
+        "'maximum' page count must be than greater than or equal to the 'initial' page count"
+    );
+}
+
+// Constructor: passing a number (not BigInt) for initial in memory64 throws
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 1, address: "i64" }),
+        TypeError,
+        "Invalid argument type in ToBigInt operation"
+    );
+}
+
+// Constructor: passing a number for maximum in memory64 throws
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 1n, maximum: 5, address: "i64" }),
+        TypeError,
+        "Invalid argument type in ToBigInt operation"
+    );
+}
+
+// Constructor: initial page count too large throws
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 65537n, address: "i64" }),
+        RangeError,
+        "WebAssembly.Memory 'initial' page count is too large"
+    );
+}
+
+// Constructor: maximum page count too large throws
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 1n, maximum: 65537n, address: "i64" }),
+        RangeError,
+        "WebAssembly.Memory 'maximum' page count is too large"
+    );
+}
+
+// Constructor: passing invalid address
+{
+    assert.throws(
+        () => new WebAssembly.Memory({ initial: 1n, maximum: 5n, address: "not a number" }),
+        Error,
+        "WebAssembly.Memory 'address' must be a string of value 'i32' or 'i64'"
+    );
+}
+
+// Constructor: passing toString address
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, maximum: 5n, address: { toString() { return "i64"; }} });
+    assert.eq(memory.type().address, "i64");
+}
+
+// type(): shape without maximum has 3 keys: minimum, shared, address
+{
+    const memory = new WebAssembly.Memory({ initial: 3n, address: "i64" });
+    const t = memory.type();
+    assert.eq(Object.keys(t).length, 3);
+    assert.eq(typeof t.minimum, "bigint");
+    assert.eq(t.minimum, 3n);
+    assert.eq(t.shared, false);
+    assert.eq(t.address, "i64");
+}
+
+// type(): shape with maximum has 4 keys: minimum, maximum, shared, address
+{
+    const memory = new WebAssembly.Memory({ initial: 2n, maximum: 10n, address: "i64" });
+    const t = memory.type();
+    assert.eq(Object.keys(t).length, 4);
+    assert.eq(typeof t.minimum, "bigint");
+    assert.eq(typeof t.maximum, "bigint");
+    assert.eq(t.minimum, 2n);
+    assert.eq(t.maximum, 10n);
+    assert.eq(t.shared, false);
+    assert.eq(t.address, "i64");
+}
+
+// type(): shared memory has shared: true
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, maximum: 4n, shared: true, address: "i64" });
+    const t = memory.type();
+    assert.eq(t.shared, true);
+    assert.eq(t.address, "i64");
+}
+
+// type(): round-trip — descriptor from type() can be passed back to the constructor
+{
+    const memory = new WebAssembly.Memory({ initial: 5n, maximum: 20n, address: "i64" });
+    const memory2 = new WebAssembly.Memory(memory.type());
+    const t = memory2.type();
+    assert.eq(t.minimum, memory.type().minimum);
+    assert.eq(t.maximum, memory.type().maximum);
+    assert.eq(t.shared, memory.type().shared);
+    assert.eq(t.address, memory.type().address);
+}
+
+// type(): memory32 minimum and maximum are numbers, not BigInts
+{
+    const memory = new WebAssembly.Memory({ initial: 2, maximum: 10 });
+    const t = memory.type();
+    assert.eq(typeof t.minimum, "number");
+    assert.eq(typeof t.maximum, "number");
+    assert.eq(t.minimum, 2);
+    assert.eq(t.maximum, 10);
+}
+
+// grow(): returns previous page count as a BigInt for memory64
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, maximum: 5n, address: "i64" });
+    const prev = memory.grow(2n);
+    assert.eq(typeof prev, "bigint");
+    assert.eq(prev, 1n);
+    assert.eq(memory.buffer.byteLength, 3 * pageSize);
+}
+
+// grow(): successive grows track page count correctly
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, maximum: 4n, address: "i64" });
+    assert.eq(memory.grow(1n), 1n);
+    assert.eq(memory.grow(1n), 2n);
+    assert.eq(memory.grow(1n), 3n);
+    assert.eq(memory.buffer.byteLength, 4 * pageSize);
+}
+
+// grow(): exceeding maximum throws
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, maximum: 3n, address: "i64" });
+    assert.throws(
+        () => memory.grow(10n),
+        RangeError,
+        "WebAssembly.Memory.grow would exceed the memory's declared maximum size"
+    );
+    assert.eq(memory.buffer.byteLength, 1 * pageSize);
+}
+
+// grow(): passing a number (not BigInt) as delta for memory64 throws
+{
+    const memory = new WebAssembly.Memory({ initial: 1n, maximum: 5n, address: "i64" });
+    assert.throws(
+        () => memory.grow(1),
+        TypeError,
+        "Invalid argument type in ToBigInt operation"
+    );
+}
+
+// grow(): memory32 grow still returns a number
+{
+    const memory = new WebAssembly.Memory({ initial: 1, maximum: 5 });
+    const prev = memory.grow(1);
+    assert.eq(typeof prev, "number");
+    assert.eq(prev, 1);
+}

--- a/JSTests/wasm/js-api/test_memory.js
+++ b/JSTests/wasm/js-api/test_memory.js
@@ -407,25 +407,30 @@ test(function() {
     }, TypeError, "WebAssembly.Memory.prototype.buffer getter called with non WebAssembly.Memory |this| value");
 
     const memory = new WebAssembly.Memory({initial: 20});
-    assert.eq(Object.keys(memory.type()).length, 2);
+    assert.eq(Object.keys(memory.type()).length, 3);
     assert.eq(memory.type().minimum, 20);
     assert.eq(memory.type().shared, false);
+    assert.eq(memory.type().address, "i32");
 
     const memory2 = new WebAssembly.Memory({minimum:40, maximum: 100});
-    assert.eq(Object.keys(memory2.type()).length, 3);
+    assert.eq(Object.keys(memory2.type()).length, 4);
     assert.eq(memory2.type().minimum, 40);
     assert.eq(memory2.type().maximum, 100);
-    assert.eq(memory.type().shared, false);
+    assert.eq(memory2.type().shared, false);
+    assert.eq(memory2.type().address, "i32");
 
     const memory3 = new WebAssembly.Memory(memory2.type());
     assert.eq(Object.keys(memory2.type()).length, Object.keys(memory3.type()).length);
-    assert.eq(memory2.type().minimum, memory3.type().minimum);
-    assert.eq(memory2.type().maximum, memory3.type().maximum);
-    assert.eq(memory.type().shared, false);
+    assert.eq(memory3.type().minimum, memory2.type().minimum);
+    assert.eq(memory3.type().maximum, memory2.type().maximum);
+    assert.eq(memory3.type().shared, memory2.type().shared);
+    assert.eq(memory3.type().address, memory2.type().address);
 
     const memory4 = new WebAssembly.Memory({minimum: 10, maximum: 20, shared:true});
-    assert.eq(Object.keys(memory4.type()).length, 3);
+    assert.eq(Object.keys(memory4.type()).length, 4);
     assert.eq(memory4.type().minimum, 10);
     assert.eq(memory4.type().maximum, 20);
     assert.eq(memory4.type().shared, true);
+    assert.eq(memory4.type().address, "i32");
+
 })

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/bufferdata-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/bufferdata-16gb-wasm-memory-expected.txt
@@ -1,7 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/bufferdata-16gb-wasm-memory.html?webglVersion=2
-
-[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
-[ 1: PASS ] successfullyParsed is true
-[ FAIL ] 1 failures reported
+[ PASS ] All tests passed

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/buffersubdata-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/buffersubdata-16gb-wasm-memory-expected.txt
@@ -1,7 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/buffersubdata-16gb-wasm-memory.html?webglVersion=2
-
-[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
-[ 1: PASS ] successfullyParsed is true
-[ FAIL ] 1 failures reported
+[ PASS ] All tests passed

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/getbuffersubdata-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/getbuffersubdata-16gb-wasm-memory-expected.txt
@@ -1,7 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html?webglVersion=2
-
-[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
-[ 1: PASS ] successfullyParsed is true
-[ FAIL ] 1 failures reported
+[ PASS ] All tests passed

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/readpixels-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/readpixels-16gb-wasm-memory-expected.txt
@@ -1,7 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/readpixels-16gb-wasm-memory.html?webglVersion=2
-
-[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
-[ 1: PASS ] successfullyParsed is true
-[ FAIL ] 1 failures reported
+[ PASS ] All tests passed

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/teximage2d-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/teximage2d-16gb-wasm-memory-expected.txt
@@ -1,7 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/teximage2d-16gb-wasm-memory.html?webglVersion=2
-
-[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
-[ 1: PASS ] successfullyParsed is true
-[ FAIL ] 1 failures reported
+[ PASS ] All tests passed

--- a/LayoutTests/webgl/2.0.y/conformance2/wasm/texsubimage2d-16gb-wasm-memory-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/wasm/texsubimage2d-16gb-wasm-memory-expected.txt
@@ -1,7 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../resources/webgl_test_files/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html?webglVersion=2
-
-[ 0: FAIL ] Allocating 17179869184 threw: TypeError: Conversion from 'BigInt' to 'number' is not allowed.
-[ 1: PASS ] successfullyParsed is true
-[ FAIL ] 1 failures reported
+[ PASS ] All tests passed

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -53,16 +53,16 @@ public:
         static_assert(maxPageCount < UINT_MAX, "We rely on this here.");
     }
 
-    PageCount(uint32_t pageCount)
+    PageCount(uint64_t pageCount)
         : m_pageCount(pageCount)
     { }
 
     void dump(WTF::PrintStream&) const;
 
-    uint64_t bytes() const { return static_cast<uint64_t>(m_pageCount) * static_cast<uint64_t>(pageSize); }
-    uint32_t pageCount() const { return m_pageCount; }
+    uint64_t bytes() const { return m_pageCount * static_cast<uint64_t>(pageSize); }
+    uint64_t pageCount() const { return m_pageCount; }
 
-    static bool isValid(uint32_t pageCount)
+    static bool isValid(uint64_t pageCount)
     {
         return pageCount <= maxPageCount;
     }
@@ -99,9 +99,9 @@ public:
 
     PageCount operator+(const PageCount& other) const
     {
-        if (sumOverflows<uint32_t>(m_pageCount, other.m_pageCount))
+        if (sumOverflows<uint64_t>(m_pageCount, other.m_pageCount))
             return PageCount();
-        uint32_t newCount = m_pageCount + other.m_pageCount;
+        uint64_t newCount = m_pageCount + other.m_pageCount;
         if (!PageCount::isValid(newCount))
             return PageCount();
         return PageCount(newCount);
@@ -116,7 +116,7 @@ private:
     // be able to parse such a memory and instantiate it with a smaller initial size.
     static constexpr uint32_t maxPageCount = std::max<uint32_t>(64*1024, MAX_ARRAY_BUFFER_SIZE / static_cast<uint64_t>(pageSize));
 
-    uint32_t m_pageCount;
+    uint64_t m_pageCount;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include <limits>
 #include "Error.h"
 #include "JSArrayBuffer.h"
 #include "JSArrayBufferViewInlines.h"
@@ -35,6 +36,7 @@
 #include "JSSourceCode.h"
 #include "JSWebAssemblyException.h"
 #include "JSWebAssemblyRuntimeError.h"
+#include "WasmAddressType.h"
 #include "WasmFormat.h"
 #include "WasmTypeDefinition.h"
 #include "WebAssemblyFunction.h"
@@ -67,6 +69,35 @@ ALWAYS_INLINE uint32_t toNonWrappingUint32(JSGlobalObject* globalObject, JSValue
     else
         throwTypeError(globalObject, throwScope, message);
     return { };
+}
+
+ALWAYS_INLINE uint64_t toNonWrappingUint64(JSGlobalObject* globalObject, JSValue value, ErrorType errorType = ErrorType::TypeError)
+{
+    VM& vm = getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue bigInt = value.toBigInt(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    auto lo = JSBigInt::compare(bigInt, static_cast<uint64_t>(0));
+    auto high = JSBigInt::compare(bigInt, std::numeric_limits<uint64_t>::max());
+    bool validRange = lo != JSBigInt::ComparisonResult::LessThan && high != JSBigInt::ComparisonResult::GreaterThan;
+    if (validRange && bigInt)
+        RELEASE_AND_RETURN(throwScope, bigInt.toBigUInt64(globalObject));
+
+    constexpr auto message = "Expect an integer argument in the range: [0, 2^64 - 1]"_s;
+    if (errorType == ErrorType::RangeError)
+        throwRangeError(globalObject, throwScope, message);
+    else
+        throwTypeError(globalObject, throwScope, message);
+    return { };
+}
+
+ALWAYS_INLINE uint64_t addressValueToUint64(JSGlobalObject* globalObject, JSValue value, Wasm::AddressType addressType, ErrorType errorType = ErrorType::TypeError)
+{
+    if (addressType.is64Bit())
+        return toNonWrappingUint64(globalObject, value, errorType);
+    return static_cast<uint64_t>(toNonWrappingUint32(globalObject, value, errorType));
 }
 
 ALWAYS_INLINE std::span<const uint8_t> getWasmBufferFromValue(JSGlobalObject* globalObject, JSValue value, const SourceProviderBufferGuard&)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -226,7 +226,7 @@ JSArrayBuffer* JSWebAssemblyMemory::toResizableBuffer(JSGlobalObject* globalObje
     return m_bufferWrapper.get();
 }
 
-PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, uint32_t delta)
+PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, uint64_t delta)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -258,19 +258,33 @@ PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, uint32
 JSObject* JSWebAssemblyMemory::type(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     PageCount minimum = m_memory->initial();
     PageCount maximum = m_memory->maximum();
 
+    auto pageCountValue = [&](PageCount count) -> JSValue {
+        if (m_memory->addressType().is64Bit())
+            return JSBigInt::createFrom(globalObject, count.pageCount());
+        return jsNumber(count.pageCount());
+    };
+
     JSObject* result;
     if (maximum.isValid()) {
         result = constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);
-        result->putDirect(vm, Identifier::fromString(vm, "maximum"_s), jsNumber(maximum.pageCount()));
+        JSValue maxValue = pageCountValue(maximum);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+        result->putDirect(vm, Identifier::fromString(vm, "maximum"_s), maxValue);
     } else
         result = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
 
-    result->putDirect(vm, Identifier::fromString(vm, "minimum"_s), jsNumber(minimum.pageCount()));
+    JSValue minValue = pageCountValue(minimum);
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
+    result->putDirect(vm, Identifier::fromString(vm, "minimum"_s), minValue);
     result->putDirect(vm, Identifier::fromString(vm, "shared"_s), jsBoolean(m_memory->sharingMode() == MemorySharingMode::Shared));
+
+    JSString* address = m_memory->addressType().is64Bit() ? jsNontrivialString(vm, "i64"_s) : jsNontrivialString(vm, "i32"_s);
+    result->putDirect(vm, Identifier::fromString(vm, "address"_s), address);
 
     return result;
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -64,7 +64,7 @@ public:
     JSArrayBuffer* buffer(JSGlobalObject*);
     JSArrayBuffer* toFixedLengthBuffer(JSGlobalObject*);
     JSArrayBuffer* toResizableBuffer(JSGlobalObject*);
-    PageCount grow(VM&, JSGlobalObject*, uint32_t delta);
+    PageCount grow(VM&, JSGlobalObject*, uint64_t delta);
     JS_EXPORT_PRIVATE void growSuccessCallback(VM&, PageCount oldPageCount, PageCount newPageCount);
 
     JSObject* type(JSGlobalObject*);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -35,6 +35,7 @@
 #include "JSWebAssemblyMemory.h"
 #include "PageCount.h"
 #include "StructureInlines.h"
+#include "WasmAddressType.h"
 #include "WasmMemory.h"
 #include "WebAssemblyMemoryPrototype.h"
 
@@ -49,6 +50,24 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
 {
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    Wasm::AddressType addressType; // default i32
+    {
+        Identifier address = Identifier::fromString(vm, "address"_s);
+        JSValue addressTypeValue = memoryDescriptor->get(globalObject, address);
+        RETURN_IF_EXCEPTION(throwScope, { });
+        if (!addressTypeValue.isUndefined()) {
+            String addressTypeString = addressTypeValue.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, { });
+
+            if (addressTypeString == "i64")
+                addressType = Wasm::AddressType { Wasm::AddressType::I64 };
+            else if (addressTypeString != "i32") {
+                throwException(globalObject, throwScope, createError(globalObject, "WebAssembly.Memory 'address' must be a string of value 'i32' or 'i64'"_s));
+                return { };
+            }
+        }
+    }
 
     PageCount initialPageCount;
     {
@@ -66,7 +85,7 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
         if (!initSizeValue.isUndefined())
             minSizeValue = initSizeValue;
 
-        uint32_t size = toNonWrappingUint32(globalObject, minSizeValue);
+        uint64_t size = addressValueToUint64(globalObject, minSizeValue, addressType);
         RETURN_IF_EXCEPTION(throwScope, { });
         if (!PageCount::isValid(size)) {
             throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory 'initial' page count is too large"_s));
@@ -87,7 +106,7 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
         JSValue maxSizeValue = memoryDescriptor->get(globalObject, maximum);
         RETURN_IF_EXCEPTION(throwScope, { });
         if (!maxSizeValue.isUndefined()) {
-            uint32_t size = toNonWrappingUint32(globalObject, maxSizeValue);
+            uint64_t size = addressValueToUint64(globalObject, maxSizeValue, addressType);
             RETURN_IF_EXCEPTION(throwScope, { });
             if (!PageCount::isValid(size)) {
                 throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory 'maximum' page count is too large"_s));
@@ -122,7 +141,7 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
 
     auto* jsMemory = JSWebAssemblyMemory::create(vm, webAssemblyMemoryStructure);
 
-    RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, Wasm::AddressType { }, desiredMemoryMode,
+    RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, addressType, desiredMemoryMode,
         [&vm, jsMemory] (Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); });
     if (!memory) {
         throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
@@ -82,12 +82,17 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyMemoryProtoFuncGrow, (JSGlobalObject* global
     JSWebAssemblyMemory* memory = getMemory(globalObject, vm, callFrame->thisValue()); 
     RETURN_IF_EXCEPTION(throwScope, { });
     
-    uint32_t delta = toNonWrappingUint32(globalObject, callFrame->argument(0));
+    uint64_t delta = addressValueToUint64(globalObject, callFrame->argument(0), memory->memory().addressType());
     RETURN_IF_EXCEPTION(throwScope, { });
 
     PageCount result = memory->grow(vm, globalObject, delta);
     RETURN_IF_EXCEPTION(throwScope, { });
 
+    if (memory->memory().addressType().is64Bit()) {
+        JSValue bigInt = JSBigInt::createFrom(globalObject, result.pageCount());
+        RETURN_IF_EXCEPTION(throwScope, { });
+        return JSValue::encode(bigInt);
+    }
     return JSValue::encode(jsNumber(result.pageCount()));
 }
 


### PR DESCRIPTION
#### c7a099ccc93537a555e9bdfc625675bf93734e84
<pre>
Add address field to wasm memory descriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=309045">https://bugs.webkit.org/show_bug.cgi?id=309045</a>
<a href="https://rdar.apple.com/171596390">rdar://171596390</a>

Reviewed by Keith Miller.

Add the address field to the memory descriptor.

* JSTests/wasm/js-api/memory64-js-api.js: Added.
(assert.eq):
(assert.throws):
* JSTests/wasm/js-api/test_memory.js:
* LayoutTests/webgl/2.0.y/conformance2/wasm/bufferdata-16gb-wasm-memory-expected.txt:
* LayoutTests/webgl/2.0.y/conformance2/wasm/buffersubdata-16gb-wasm-memory-expected.txt:
* LayoutTests/webgl/2.0.y/conformance2/wasm/getbuffersubdata-16gb-wasm-memory-expected.txt:
* LayoutTests/webgl/2.0.y/conformance2/wasm/readpixels-16gb-wasm-memory-expected.txt:
* LayoutTests/webgl/2.0.y/conformance2/wasm/teximage2d-16gb-wasm-memory-expected.txt:
* LayoutTests/webgl/2.0.y/conformance2/wasm/texsubimage2d-16gb-wasm-memory-expected.txt:
* Source/JavaScriptCore/runtime/PageCount.h:
(JSC::PageCount::PageCount):
(JSC::PageCount::bytes const):
(JSC::PageCount::pageCount const):
(JSC::PageCount::isValid):
(JSC::PageCount::operator+ const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::toNonWrappingUint64):
(JSC::addressValueToUint64):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::grow):
(JSC::JSWebAssemblyMemory::type):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::WebAssemblyMemoryConstructor::createMemoryFromDescriptor):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/308869@main">https://commits.webkit.org/308869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4608ee4691f70065d7794fadf2cc078568ce8f92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102020 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c133b468-13b1-492a-aac5-812f3bbd8dc4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114546 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81565 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d312ecc2-f076-4b8d-8387-2965add8802d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4710 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140557 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159609 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9482 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122599 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33421 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77242 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9859 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180018 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84517 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46076 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20447 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20503 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->