### PR TITLE
URLPattern.exec() crashes with nested capturing group

### DIFF
--- a/LayoutTests/fast/url/url-pattern-exec-with-nested-capturing-group-expected.txt
+++ b/LayoutTests/fast/url/url-pattern-exec-with-nested-capturing-group-expected.txt
@@ -1,0 +1,12 @@
+Tests that URLPattern.exec() does not crash when the pattern contains a named capturing group inside a parenthesized regex.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is non-null.
+PASS result.pathname.input is "/a"
+PASS result.pathname.groups.foo is "a"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/url/url-pattern-exec-with-nested-capturing-group.html
+++ b/LayoutTests/fast/url/url-pattern-exec-with-nested-capturing-group.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that URLPattern.exec() does not crash when the pattern contains a named capturing group inside a parenthesized regex.");
+
+result = new URLPattern({ pathname: "/:foo((?<x>a))" }).exec({ pathname: "/a" });
+shouldBeNonNull("result");
+shouldBeEqualToString("result.pathname.input", "/a");
+shouldBeEqualToString("result.pathname.groups.foo", "a");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -114,8 +114,7 @@ URLPatternComponentResult URLPatternComponent::createComponentMatchResult(JSC::J
 
     Ref vm = globalObject->vm();
 
-    auto length = execResult.get(globalObject, vm->propertyNames->length).toIntegerOrInfinity(globalObject);
-    ASSERT(length >= 0 && std::isfinite(length));
+    auto length = std::min<unsigned>(execResult.get(globalObject, vm->propertyNames->length).toIntegerOrInfinity(globalObject), m_groupNameList.size() + 1);
 
     for (unsigned index = 1; index < length; ++index) {
         auto match = execResult.get(globalObject, index);


### PR DESCRIPTION
#### e3f20183b0c443859c3e27510893a1c4ea617494
<pre>
URLPattern.exec() crashes with nested capturing group
<a href="https://bugs.webkit.org/show_bug.cgi?id=309048">https://bugs.webkit.org/show_bug.cgi?id=309048</a>
<a href="https://rdar.apple.com/171543463">rdar://171543463</a>

Reviewed by Youenn Fablet.

The pattern `/:foo((?&lt;x&gt;a))`` produces a part list with a single entry
named `foo`, so `m_groupNameList` has one element. However, the
generated regex wraps the user-provided regex in a capturing group:
`((?&lt;x&gt;a))`, resulting in two capturing groups total. In
`createComponentMatchResult`, the loop iterated based on the regex exec
result length, causing an out-of-bounds access into `m_groupNameList`
when it tried to find a name for the second capturing group.

The fix clamps the loop bound to `m_groupNameList.size() + 1` so only
the top-level capturing groups (one per part) are processed, and any
extra inner capturing groups from user-provided regex patterns are
skipped.

Test: fast/url/url-pattern-exec-with-nested-capturing-group.html

* LayoutTests/fast/url/url-pattern-exec-with-nested-capturing-group-expected.txt: Added.
* LayoutTests/fast/url/url-pattern-exec-with-nested-capturing-group.html: Added.
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::createComponentMatchResult const):

Canonical link: <a href="https://commits.webkit.org/308534@main">https://commits.webkit.org/308534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00efee3441e77641c12194f3d9d88d4a595ac7c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156484 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113946 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94706 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15339 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3924 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158819 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121974 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31294 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76411 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9219 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83663 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19630 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19781 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19688 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->