### PR TITLE
[YARR] MultiPatternSIMD scalar loop should not fall into the body with index past end-of-input

### DIFF
--- a/JSTests/stress/regexp-multipattern-simd-scalar-bounds.js
+++ b/JSTests/stress/regexp-multipattern-simd-scalar-bounds.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected, name) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(name + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+{
+    let parent = "ZabcX";
+    let input = parent.slice(0, 4);
+    shouldBe(/abcX|wxyz/.exec(input), null, "scalar-failed must not enter body (4-byte pattern)");
+}
+
+{
+    let parent = "Z".repeat(4000) + "abcdSeCrEtDaTa";
+    let input = parent.slice(0, 4004);
+    shouldBe(/abcdSeCrEtDaTa|wxyzABCDEF1234/.exec(input), null, "scalar-matched must not OOB (14-byte pattern, slice)");
+}
+
+{
+    let parent = "Z".repeat(17) + "abcdEFGH";
+    let input = parent.slice(0, 21);
+    shouldBe(/abcdEFGH|wxyz1234/.exec(input), null, "scalar-matched must not OOB (8-byte pattern, scalar tail)");
+}
+
+{
+    let parent = "Z".repeat(100) + "abcdEFGHIJ";
+    let input = parent.slice(0, 104);
+    shouldBe(/abcdEFGHIJ|wxyz/.exec(input), null, "scalar-matched must not OOB (asymmetric alt lengths)");
+}
+
+shouldBe(/abcd|wxyz/.exec("ZZZZabcd")[0], "abcd", "in-bounds alt1 at end");
+shouldBe(/abcd|wxyz/.exec("ZZZZwxyz")[0], "wxyz", "in-bounds alt2 at end");
+shouldBe(/abcd|wxyz/.exec("abcd")[0], "abcd", "length == patternLength");
+shouldBe(/abcd|wxyz/.exec("Z".repeat(17) + "abcd")[0], "abcd", "scalar tail range, in-bounds");
+shouldBe(/abcdefgh|wxyz1234/.exec("Z".repeat(4000) + "abcdefgh")[0], "abcdefgh", "SIMD loop range, long pattern, in-bounds");
+shouldBe(/abcd|wxyz/i.exec("ZZZZABCD")[0], "ABCD", "ignoreCase (masked path)");
+shouldBe("abcdZwxyzZabcd".match(/abcd|wxyz/g), ["abcd", "wxyz", "abcd"], "global, multiple matches");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3497,20 +3497,30 @@ class YarrGenerator final : public YarrJITInfo {
                     if (simdResult) {
                         m_usesSIMD = true;
                         op.m_reentry = simdResult->backtrackTarget;
+
+                        // Scalar loop fell through (out of input). Do not enter the
+                        // body; index would be past length and the body would OOB.
+                        if (!m_pattern.m_body->m_hasFixedSize) {
+                            if (alternative->m_minimumSize) {
+                                m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize), m_regs.regT0);
+                                setMatchStart(m_regs.regT0);
+                            } else
+                                setMatchStart(m_regs.index);
+                        }
+                        op.m_jumps.append(m_jit.jump());
+
+                        matched.link(&m_jit);
+                        if (!m_pattern.m_body->m_hasFixedSize) {
+                            if (alternative->m_minimumSize) {
+                                m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize), m_regs.regT0);
+                                setMatchStart(m_regs.regT0);
+                            } else
+                                setMatchStart(m_regs.index);
+                        }
+                        break;
                     }
 
-                    // When SIMD can't run (not enough chars), fall through to pattern matching.
-                    // When SIMD finds a potential match, also continue to pattern matching.
-                    matched.link(&m_jit);
-
-                    // If the pattern size is not fixed, store the start index for use if we match.
-                    if (!m_pattern.m_body->m_hasFixedSize) {
-                        if (alternative->m_minimumSize) {
-                            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize), m_regs.regT0);
-                            setMatchStart(m_regs.regT0);
-                        } else
-                            setMatchStart(m_regs.index);
-                    }
+                    ASSERT(matched.empty());
                     break;
                 }
 #endif
@@ -6075,16 +6085,12 @@ class YarrGenerator final : public YarrJITInfo {
         auto scalarLoopHead = m_jit.label();
         MacroAssembler::JumpList failed;
 
-        // Bounds check: need at least (minPatternLength - 1) more characters after current position
-        // Since we load 4 bytes, we need index + baseOffset + 4 <= length (upper bound)
-        // AND index >= -baseOffset (lower bound) when baseOffset is negative
-        int32_t scalarBoundsOffset = 4 + baseOffset;
-        m_jit.add32(MacroAssembler::TrustedImm32(scalarBoundsOffset), m_regs.index, m_regs.regT0);
-        failed.append(m_jit.branch32(MacroAssembler::Above, m_regs.regT0, m_regs.length));
-
-        // Also check lower bound when baseOffset is negative
-        if (baseOffset < 0)
-            failed.append(m_jit.branch32(MacroAssembler::Below, m_regs.index, MacroAssembler::TrustedImm32(-baseOffset)));
+        // Bounds: index <= length keeps the body in range, and also covers
+        // the 4-byte load below since MaskedAlternativeInfo::create guarantees
+        // checkedOffset >= 4. baseOffset (= -checkedOffset) is therefore < 0.
+        ASSERT(baseOffset < 0);
+        failed.append(m_jit.branch32(MacroAssembler::Above, m_regs.index, m_regs.length));
+        failed.append(m_jit.branch32(MacroAssembler::Below, m_regs.index, MacroAssembler::TrustedImm32(-baseOffset)));
 
         // Calculate load address: input + index
         // We incorporate baseOffset into the load address below to save an instruction.
@@ -6113,7 +6119,7 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
         m_jit.jump().linkTo(scalarLoopHead, &m_jit);
 
-        // Not enough characters for scalar pre-filter - fall through to standard regex matching
+        // Scalar loop exhausted. Caller routes this to op.m_jumps.
         failed.link(&m_jit);
 
         // Return both labels:


### PR DESCRIPTION
#### 9a6fa47cdbf34c32d1a53e7e27d123eedbe68cbe
<pre>
[YARR] MultiPatternSIMD scalar loop should not fall into the body with index past end-of-input
<a href="https://bugs.webkit.org/show_bug.cgi?id=309049">https://bugs.webkit.org/show_bug.cgi?id=309049</a>

Reviewed by Yusuke Suzuki.

generateMultiPatternSIMDSearch&apos;s scalar tail loop had two issues:

1. The caller linked both the scalar-exhausted fallthrough and the
   `matched` jump list to the same place, so exhaustion fell into the
   regex body instead of the failure chain. BitInTableSIMD and the
   scalar BM path already route exhaustion to op.m_jumps; do the same
   here.

2. The scalar bounds check only covered the 4-byte prefix load, not
   the full checkedOffset bytes the body reads at that index. Tighten
   the upper bound to index &lt;= length. MaskedAlternativeInfo::create
   guarantees checkedOffset &gt;= 4, so this also covers the load and
   drops an add32.

Test: JSTests/stress/regexp-multipattern-simd-scalar-bounds.js

* JSTests/stress/regexp-multipattern-simd-scalar-bounds.js: Added.
(shouldBe):
(shouldBe.new.RegExp.string_appeared_here.exec):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/308538@main">https://commits.webkit.org/308538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/508e873a773122c6d7b43ca2df1bf0bc9725145e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101222 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113950 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15345 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3930 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139777 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158825 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8595 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121979 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31297 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76417 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9226 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179229 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83669 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45922 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->