### PR TITLE
Fix runGoBackAfterNavigatingSameSiteIframe test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -982,6 +982,9 @@ static void runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache shouldE
     }).get();
 
     // After initial loading, page has a main frame and a same-site iframe.
+    didCommitLoadForAllFrames = false;
+    expectedCommittedFrameSize = 2;
+    committedFrames.clear();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
     TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
     EXPECT_TRUE([committedFrames[0] isMainFrame]);
@@ -1072,6 +1075,9 @@ static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache should
     }).get();
 
     // After initial loading, page has a main frame and a same-site iframe.
+    didCommitLoadForAllFrames = false;
+    expectedCommittedFrameSize = 2;
+    committedFrames.clear();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
     TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
     EXPECT_TRUE([committedFrames[0] isMainFrame]);


### PR DESCRIPTION
#### 63755030ab7efdb81dd4252e3bf16edebf3e9b48
<pre>
Fix runGoBackAfterNavigatingSameSiteIframe test
<a href="https://bugs.webkit.org/show_bug.cgi?id=309050">https://bugs.webkit.org/show_bug.cgi?id=309050</a>
<a href="https://rdar.apple.com/171602890">rdar://171602890</a>

Reviewed by Sihui Liu.

This resets variables which may have had stale values from prior
invocations of the function.

Canonical link: <a href="https://commits.webkit.org/308579@main">https://commits.webkit.org/308579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2822a27593d06a03b09d864569f12ad4a1f7f945

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101225 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/675cd360-0970-4e26-81b4-5bfbb0c0838b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113952 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81259 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c88c37f1-22a7-440e-8877-b1b2a4ced602) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94713 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f9cea70-01be-4f1a-8ed5-287b6f5db65a) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13137 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3933 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158828 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121982 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31329 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132462 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76420 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9231 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19910 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19639 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->