### PR TITLE
Remove logging unsafety

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -884,14 +884,14 @@ WebCore::BackForwardItemIdentifier generateBackForwardItemIdentifier()
 }
 
 // rdar://168139823 is the task of doing a productionized version of WebKit Swift logging
-void doLog(const char* WTF_NONNULL msg)
+void doLog(const WTF::String& msg)
 {
-    LOG(BackForward, "%s", msg);
+    LOG(BackForward, "%s", msg.utf8().data());
 }
 
-void doLoadingReleaseLog(const char* WTF_NONNULL msg)
+void doLoadingReleaseLog(const WTF::String& msg)
 {
-    RELEASE_LOG(Loading, "%s", msg);
+    RELEASE_LOG(Loading, "%s", msg.utf8().data());
 }
 // rdar://168139740 is the task of doing a productionized Swift MESSAGE_CHECK
 void messageCheckFailed(Ref<WebKit::WebProcessProxy> process)

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -74,29 +74,11 @@ extension WebKit.WebBackForwardListItem {
 private func backForwardLog(_ msgCreator: @autoclosure () -> String) {
     // rdar://133777029 likely will allow us to avoid the performance penalty
     // of creating the string if logging is disabled.
-    let msg = msgCreator()
-
-    let span = msg.utf8CString.span
-    // Safety: the buffer pointer is guaranteed to be
-    // valid and null-terminated during the call to
-    // doLog
-    unsafe span.withUnsafeBufferPointer { ptr in
-        // swift-format-ignore: NeverForceUnwrap
-        unsafe doLog(ptr.baseAddress!)
-    }
+    doLog(WTF.String(msgCreator()))
 }
 
 private func loadingReleaseLog(_ msgCreator: @autoclosure () -> String) {
-    let msg = msgCreator()
-
-    let span = msg.utf8CString.span
-    // Safety: the buffer pointer is guaranteed to be
-    // valid and null-terminated during the call to
-    // doLoadingReleaseLog
-    unsafe span.withUnsafeBufferPointer { ptr in
-        // swift-format-ignore: NeverForceUnwrap
-        unsafe doLoadingReleaseLog(ptr.baseAddress!)
-    }
+    doLoadingReleaseLog(WTF.String(msgCreator()))
 }
 
 // Temporary partial MESSAGE_CHECK_BASE support from Swift

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -45,8 +45,8 @@
 using SpanConstChar = std::span<const char>;
 
 // These can't be inline due to rdar://162531519
-void doLog(const char* WTF_NONNULL msg); // rdar://168139823
-void doLoadingReleaseLog(const char* WTF_NONNULL msg); // rdar://168139823
+void doLog(const WTF::String& msg); // rdar://168139823
+void doLoadingReleaseLog(const WTF::String& msg); // rdar://168139823
 void messageCheckFailed(Ref<WebKit::WebProcessProxy>); // rdar://168139740
 
 // Workaround for rdar://162357139


### PR DESCRIPTION
#### e6430715b6087de24d64c7714e63ba08c54cb12d
<pre>
Remove logging unsafety
<a href="https://bugs.webkit.org/show_bug.cgi?id=309051">https://bugs.webkit.org/show_bug.cgi?id=309051</a>
<a href="https://rdar.apple.com/171603997">rdar://171603997</a>

Reviewed by Richard Robinson.

This removes some use of the Swift &apos;unsafe&apos; keyword, at a possible small
performance cost when we do logging. We can revisit this when we implement
production-grade WTF logging in Swift within <a href="https://rdar.apple.com/168139823">rdar://168139823</a>.

Canonical link: <a href="https://commits.webkit.org/308617@main">https://commits.webkit.org/308617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83d2a395c4c7ebd63599d66e8db71ab53f4adc3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101226 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3ed08f7-1b36-453f-bc0c-ec6bf9b175c0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113953 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81260 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b96af5d0-7f23-452d-a75c-ce367989d801) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94714 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e01ba43-cd13-4a8d-a5db-fc966bfba9cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13134 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124949 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158829 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121983 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31359 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76421 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17684 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9232 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83673 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19640 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->