### PR TITLE
Support chaining pseudo-elements after ::picker(select)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+body {
+  background: green;
+  color: green;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+body {
+  background: green;
+  color: green;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS ::backdrop pseudo-element on select::picker(select)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#the-picker-pseudo-element">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#backdrop">
+<link rel="match" href="select-picker-pseudo-backdrop-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+/*
+ * Make the select button invisible against the backdrop color so that
+ * the select button being covered by the backdrop (in this test) vs.
+ * being on the green body (in the reference) produces the same visual.
+ */
+body {
+  background: red;
+  color: green;
+}
+
+select::picker(select)::backdrop {
+  background: green;
+}
+</style>
+
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector("select").showPicker();
+  document.documentElement.classList.remove("reftest-wait");
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.before-placeholder {
+  height: 20px;
+  background: lime;
+}
+
+.after-placeholder {
+  height: 20px;
+  background: blue;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <div class="before-placeholder"></div>
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+  <div class="after-placeholder"></div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.before-placeholder {
+  height: 20px;
+  background: lime;
+}
+
+.after-placeholder {
+  height: 20px;
+  background: blue;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <div class="before-placeholder"></div>
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+  <div class="after-placeholder"></div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS ::before and ::after pseudo-elements on select::picker(select)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#the-picker-pseudo-element">
+<link rel="match" href="select-picker-pseudo-before-after-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+select::picker(select)::before {
+  content: "";
+  display: block;
+  height: 20px;
+  background: lime;
+}
+
+select::picker(select)::after {
+  content: "";
+  display: block;
+  height: 20px;
+  background: blue;
+}
+</style>
+
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector("select").showPicker();
+  document.documentElement.classList.remove("reftest-wait");
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.picker-first-letter {
+  color: red;
+  font-size: 20px;
+}
+
+.picker-first-line {
+  color: navy;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <div><span class="picker-first-line"><span class="picker-first-letter">H</span>ello World</span></div>
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.picker-first-letter {
+  color: red;
+  font-size: 20px;
+}
+
+.picker-first-line {
+  color: navy;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <div><span class="picker-first-line"><span class="picker-first-letter">H</span>ello World</span></div>
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS ::first-letter and ::first-line pseudo-elements on select::picker(select)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#the-picker-pseudo-element">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo/#first-line-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo/#first-letter-pseudo">
+<link rel="match" href="select-picker-pseudo-first-letter-first-line-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+select::picker(select)::first-letter {
+  color: red;
+  font-size: 20px;
+}
+
+select::picker(select)::first-line {
+  color: navy;
+}
+</style>
+
+<select>
+  <div>Hello World</div>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector("select").showPicker();
+  document.documentElement.classList.remove("reftest-wait");
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.highlight {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent"></span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <span class="highlight">Hello</span> World
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.highlight {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent"></span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <span class="highlight">Hello</span> World
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS ::highlight() pseudo-element on select::picker(select)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#the-picker-pseudo-element">
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/#custom-highlight-pseudo">
+<link rel="match" href="select-picker-pseudo-highlight-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+select::picker(select)::highlight(example) {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<select>
+  Hello World
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector("select").showPicker();
+
+  const select = document.querySelector("select");
+  const textNode = [...select.childNodes].find(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.includes("Hello"));
+  const start = textNode.nodeValue.indexOf("Hello");
+  const range = new Range();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, start + 5); // "Hello"
+  const highlight = new Highlight(range);
+  CSS.highlights.set("example", highlight);
+
+  document.documentElement.classList.remove("reftest-wait");
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+::selection {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  Hello World
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+
+const popover = document.getElementById("popover");
+const textNode = [...popover.childNodes].find(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.includes("Hello"));
+const start = textNode.nodeValue.indexOf("Hello");
+const range = document.createRange();
+range.setStart(textNode, start);
+range.setEnd(textNode, start + 5); // "Hello"
+window.getSelection().addRange(range);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+::selection {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  Hello World
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+
+const popover = document.getElementById("popover");
+const textNode = [...popover.childNodes].find(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.includes("Hello"));
+const start = textNode.nodeValue.indexOf("Hello");
+const range = document.createRange();
+range.setStart(textNode, start);
+range.setEnd(textNode, start + 5); // "Hello"
+window.getSelection().addRange(range);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS ::selection pseudo-element on select::picker(select)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#the-picker-pseudo-element">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo/#selectordef-selection">
+<link rel="match" href="select-picker-pseudo-selection-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+select::picker(select)::selection {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<select>
+  Hello World
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+(async () => {
+  await test_driver.bless();
+  document.querySelector("select").showPicker();
+
+  const select = document.querySelector("select");
+  const textNode = [...select.childNodes].find(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.includes("Hello"));
+  const start = textNode.nodeValue.indexOf("Hello");
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, start + 5); // "Hello"
+  window.getSelection().addRange(range);
+
+  document.documentElement.classList.remove("reftest-wait");
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.target-text {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <span class="target-text">Hello</span> World
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel=stylesheet href="resources/customizable-select-styles.css">
+
+<style>
+.target-text {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<button class="customizable-select-button" popovertarget="popover" id="button">
+  <span class="customizable-select-selectedcontent">one</span>
+</button>
+<div id="popover" popover="auto" class="customizable-select-popover">
+  <span class="target-text">Hello</span> World
+  <div class="customizable-select-option selected">one</div>
+  <div class="customizable-select-option">two</div>
+</div>
+
+<script>
+document.getElementById("popover").showPopover({ source: button });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS ::target-text pseudo-element on select::picker(select)</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-forms/#the-picker-pseudo-element">
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/#target-text-pseudo">
+<link rel="match" href="select-picker-pseudo-target-text-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+select, select::picker(select) {
+  appearance: base-select;
+}
+
+select::picker(select)::target-text {
+  background-color: green;
+  color: white;
+}
+</style>
+
+<select>
+  Hello World
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+window.location.hash = "#:~:text=Hello";
+
+(async () => {
+  await test_driver.bless();
+  document.querySelector("select").showPicker();
+  await new Promise(requestAnimationFrame);
+  document.documentElement.classList.remove("reftest-wait");
+})();
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5772,6 +5772,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-hr-listbox.html [ ImageOnlyFailure ]
 
 # Newly imported WPT tests that are timing out on iOS.

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -575,7 +575,8 @@ static bool isTreeAbidingPseudoElement(const MutableCSSSelector& simpleSelector)
 
 static bool isSimpleSelectorValidAfterPseudoElement(const MutableCSSSelector& simpleSelector, const MutableCSSSelector& compoundPseudoElement)
 {
-    if (compoundPseudoElement.pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && compoundPseudoElement.value() == UserAgentParts::detailsContent()) {
+    if (compoundPseudoElement.pseudoElement() == CSSSelector::PseudoElement::Picker
+        || (compoundPseudoElement.pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && compoundPseudoElement.value() == UserAgentParts::detailsContent())) {
         if (simpleSelector.match() == CSSSelector::Match::PseudoElement)
             return true;
     }


### PR DESCRIPTION
#### 7361d0c4619659a332a3cddc553a6e32292488c4
<pre>
Support chaining pseudo-elements after ::picker(select)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309052">https://bugs.webkit.org/show_bug.cgi?id=309052</a>
<a href="https://rdar.apple.com/171604109">rdar://171604109</a>

Reviewed by Anne van Kesteren.

This commit starts supporting combinations like:
- ::picker(select)::before
- ::picker(select)::after
- ::picker(select)::backdrop
- ::picker(select)::first-letter
- ::picker(select)::first-line
- ::picker(select)::highlight(...)
- ::picker(select)::target-text
- ::picker(select)::selection
- ::picker(select)::grammar-error
- ::picker(select)::spelling-error

Some demos already use ::before/::after/::backdrop, so these will be fixed with this change.

Tests: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-backdrop.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-before-after.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-first-letter-first-line.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-highlight.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isSimpleSelectorValidAfterPseudoElement):

Canonical link: <a href="https://commits.webkit.org/308556@main">https://commits.webkit.org/308556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1944c16408ffbdde8ca3f80451bf566f6b8be615

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101240 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fab891ab-7516-4d73-8ad6-7595c2140ee5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113964 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81268 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/029de14f-8d66-496a-aeef-0f8e58cc913b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94725 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9813a0fc-4d45-473c-91b3-98638f109054) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13145 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3948 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158843 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121994 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31311 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76442 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9243 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83687 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19654 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->