### PR TITLE
Do not give JIT-related entitlement to com.apple.WebKit.WebContent.CaptivePortal

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -298,7 +298,7 @@ function mac_process_webcontent_shared_entitlements()
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
         then
-            if [[ "${PRODUCT_NAME}" != com.apple.WebKit.WebContent.EnhancedSecurity ]]
+            if [[ "${PRODUCT_NAME}" != com.apple.WebKit.WebContent.EnhancedSecurity && "${PRODUCT_NAME}" != com.apple.WebKit.WebContent.CaptivePortal ]]
             then
                 plistbuddy Add :com.apple.private.verified-jit bool YES
                 plistbuddy Add :com.apple.security.cs.single-jit bool YES


### PR DESCRIPTION
#### 8715ab263cf3008f2d94d7d828415bd5c7a4b047
<pre>
Do not give JIT-related entitlement to com.apple.WebKit.WebContent.CaptivePortal
<a href="https://bugs.webkit.org/show_bug.cgi?id=309057">https://bugs.webkit.org/show_bug.cgi?id=309057</a>
<a href="https://rdar.apple.com/170485418">rdar://170485418</a>

Reviewed by Per Arne Vollan.

Do not give JIT-related entitlement to com.apple.WebKit.WebContent.CaptivePortal
on macOS since there should be no JIT in lockdown mode.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/308582@main">https://commits.webkit.org/308582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a963716a779e7cbe855f132e89a5edfb62388b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101235 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ded23f6c-e152-487b-803f-6435dd003ce3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113959 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81264 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c2e7f36-b5f4-4017-9c72-ed92eb9a27e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16202 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa7cb3e4-aea2-4db0-8a8c-413017934c91) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147142 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15352 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13139 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3943 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124955 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158838 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1972 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121988 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31334 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132466 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76436 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17693 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83682 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19649 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->