### PR TITLE
Font Picker: Style selection becomes unusable after changing fonts (when editing multiple lines of text)

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -138,6 +138,7 @@
 #include "TextCheckingHelper.h"
 #include "TextEvent.h"
 #include "TextIterator.h"
+#include "TextNodeTraversal.h"
 #include "TextPlaceholderElement.h"
 #include "TypingCommand.h"
 #include "UserTypingGestureIndicator.h"
@@ -5030,6 +5031,9 @@ RefPtr<Font> Editor::fontForSelection(bool& hasMultipleFonts)
     for (Ref node : intersectingNodes(*range)) {
         CheckedPtr renderer = node->renderer();
         if (!renderer)
+            continue;
+        // The font of intermediate nodes that don't affect the rendering of text are not necessary to report, so limit to only such nodes.
+        if (!node->isTextNode() && !renderer->isBR() && !TextNodeTraversal::firstChild(node))
             continue;
         Ref primaryFont = renderer->style().fontCascade().primaryFont();
         if (!font)

--- a/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
@@ -595,7 +595,45 @@ TEST(FontManagerTests, ObservingFontPanelShouldNotCrashWhenUnparentingViewTwice)
     EXPECT_WK_STREQ("700", [webView stylePropertyAtSelectionStart:@"font-weight"]);
     EXPECT_WK_STREQ("700", [webView stylePropertyAtSelectionEnd:@"font-weight"]);
     EXPECT_WK_STREQ("Times-Bold", [fontManager selectedFont].fontName);
+}
 
+TEST(FontManagerTests, SelectionSpanningEmptyElementDoesNotReportMultipleFonts)
+{
+    NSFontManager *fontManager = NSFontManager.sharedFontManager;
+
+    auto webView = webViewForFontManagerTesting(NSFontManager.sharedFontManager, @"<body contenteditable><font face=Helvetica>First</font><div><font face=Helvetica> Second</font></div></body>");
+    [webView selectAll:nil];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ([[fontManager selectedFont] fontName], "Helvetica");
+    EXPECT_FALSE([fontManager isMultiple]);
+}
+
+TEST(FontManagerTests, SelectionSpanningTwoFontsDoesReportMultipleFonts)
+{
+    NSFontManager *fontManager = NSFontManager.sharedFontManager;
+
+    auto webView = webViewForFontManagerTesting(NSFontManager.sharedFontManager, @"<body contenteditable><font face=Helvetica>First</font><br/><font face=Arial> Second</font></body>");
+    [webView selectAll:nil];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ([[fontManager selectedFont] fontName], "Helvetica");
+    EXPECT_TRUE([fontManager isMultiple]);
+}
+
+TEST(FontManagerTests, SelectionSpanningBRDoesReportMultipleFonts)
+{
+    NSFontManager *fontManager = NSFontManager.sharedFontManager;
+
+    auto webView = webViewForFontManagerTesting(NSFontManager.sharedFontManager, @"<body contenteditable><font face=Helvetica>First</font><br/><font face=Helvetica> Second</font></body>");
+    [webView selectAll:nil];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ([[fontManager selectedFont] fontName], "Helvetica");
+    EXPECT_TRUE([fontManager isMultiple]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 55c2f6469ac3478b019f93af970bd4ebc1117589
<pre>
Font Picker: Style selection becomes unusable after changing fonts (when editing multiple lines of text)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309056">https://bugs.webkit.org/show_bug.cgi?id=309056</a>
<a href="https://rdar.apple.com/110651645">rdar://110651645</a>

Reviewed by Wenson Hsieh.

Various editing operations result in a document structure in which font changes are applied
at the deepest point in the tree, leaving intermediate unstyled elements. For example, using
the font panel to set a font on this structure:

    First
    &lt;div&gt;Second&lt;/div&gt;

results in this:

    &lt;font face=...&gt;First&lt;/font&gt;
    &lt;div&gt;&lt;font face=...&gt;Second&lt;/font&gt;&lt;/div&gt;

Making a selection that spans the two words intersects the second line&apos;s &lt;div&gt;, which is unstyled.
The existing code in Editor::fontForSelection takes *every* element&apos;s font into account when deciding
whether to indicate multiple selection in the font panel. This results in a failure to round-trip the
font selection (because it comes back as &quot;multiple&quot;), and an unusable panel.

Fix this by only taking the font of elements with immediate text node children into account.

Test: Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::fontForSelection):
* Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST(FontManagerTests, SelectionSpanningEmptyElementDoesNotReportMultipleFonts)):
(TestWebKitAPI::TEST(FontManagerTests, SelectionSpanningTwoFontsDoesReportMultipleFonts)):
(TestWebKitAPI::TEST(FontManagerTests, SelectionSpanningBRDoesReportMultipleFonts)):

Canonical link: <a href="https://commits.webkit.org/308562@main">https://commits.webkit.org/308562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7251126cd99ac68dbbe95ff4ca879403da114176

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20553 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156551 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf3cf2be-dc85-4011-9e5d-761bb546c50e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20457 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/113996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9e6ebdd-8a1b-4d7e-afca-ab2a3fbaf71f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150830 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94758 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3991 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158886 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2020 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31315 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83730 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19697 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->