### PR TITLE
UI process may crash due to WebPageProxy null deref under -[WKPrintingView _adjustPrintingMarginsForHeaderAndFooter]

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -163,9 +163,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     CGFloat scale = [info scalingFactor];
     Ref webFrame = *_webFrame;
-    RefPtr page = webFrame->page();
-    [info setTopMargin:originalTopMargin + page->headerHeightForPrinting(webFrame) * scale];
-    [info setBottomMargin:originalBottomMargin + page->footerHeightForPrinting(webFrame) * scale];
+    if (RefPtr page = webFrame->page()) {
+        [info setTopMargin:originalTopMargin + page->headerHeightForPrinting(webFrame) * scale];
+        [info setBottomMargin:originalBottomMargin + page->footerHeightForPrinting(webFrame) * scale];
+    }
 }
 
 - (BOOL)_isPrintingPreview


### PR DESCRIPTION
#### 52c5546da56a8bef8e28997ce8c14bb6e15ebde6
<pre>
UI process may crash due to WebPageProxy null deref under -[WKPrintingView _adjustPrintingMarginsForHeaderAndFooter]
<a href="https://bugs.webkit.org/show_bug.cgi?id=309020">https://bugs.webkit.org/show_bug.cgi?id=309020</a>
<a href="https://rdar.apple.com/165531670">rdar://165531670</a>

Reviewed by Lily Spiniolas.

We have observed crashes under -_adjustPrintingMarginsForHeaderAndFooter
where we make an invalid address read at 0x78. This corresponds to the
m_uiClient member in WebPageProxy, which we dereference in header/footer
height computation methods, implying we perform a null dereference on
the WebPageProxy instance from WKPrintingView.

In this patch, we avoid this crash by doing a null check first.

* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _adjustPrintingMarginsForHeaderAndFooter]):

Canonical link: <a href="https://commits.webkit.org/308577@main">https://commits.webkit.org/308577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da9ddd40e7a75d1bbaaa36452db6987b6ac0e159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101243 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9d85f46-6f4e-4eed-bee0-e8f44117d026) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113967 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81272 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecc98772-daa2-46e6-a82e-c5d5aea1084d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94728 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3951 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124964 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158846 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1980 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121996 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122197 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31328 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76448 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9244 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83690 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19657 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->