### PR TITLE
[GLIB] Reduce unsafe buffer usage in JSC API

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
@@ -89,7 +89,6 @@ JSCCallbackFunction::JSCCallbackFunction(VM& vm, Structure* structure, Type type
         g_closure_set_marshal(m_closure.get(), g_cclosure_marshal_generic);
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
 JSValueRef JSCCallbackFunction::call(JSContextRef callerContext, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     JSLockHolder locker(toJS(callerContext));
@@ -118,25 +117,26 @@ JSValueRef JSCCallbackFunction::call(JSContextRef callerContext, JSObjectRef thi
     auto parameterCount = m_parameters ? m_parameters->size() : 1;
     if (addInstance)
         parameterCount++;
-    auto* values = static_cast<GValue*>(g_alloca(sizeof(GValue) * parameterCount));
-    memset(values, 0, sizeof(GValue) * parameterCount);
+    auto values = unsafeMakeSpan(static_cast<GValue*>(g_alloca(sizeof(GValue) * parameterCount)), parameterCount);
+    zeroSpan(values);
 
     size_t firstParameter = 0;
     if (addInstance) {
-        g_value_init(&values[0], G_TYPE_POINTER);
-        g_value_set_pointer(&values[0], instance);
+        g_value_init(values.data(), G_TYPE_POINTER);
+        g_value_set_pointer(values.data(), instance);
         firstParameter = 1;
     }
     if (m_parameters) {
+        auto argumentsSpan = unsafeMakeSpan(arguments, argumentCount);
         for (size_t i = firstParameter; i < parameterCount && !*exception; ++i) {
             auto argumentIndex = i - firstParameter;
-            jscContextJSValueToGValue(context.get(), argumentIndex < argumentCount ? arguments[argumentIndex] : JSValueMakeUndefined(jsContext),
+            jscContextJSValueToGValue(context.get(), argumentIndex < argumentCount ? argumentsSpan[argumentIndex] : JSValueMakeUndefined(jsContext),
                 m_parameters.value()[argumentIndex], &values[i], exception);
         }
     } else {
         auto* parameters = g_ptr_array_new_full(argumentCount, g_object_unref);
-        for (size_t i = 0; i < argumentCount; ++i)
-            g_ptr_array_add(parameters, jscContextGetOrCreateValue(context.get(), arguments[i]).leakRef());
+        for (auto argument : unsafeMakeSpan(arguments, argumentCount))
+            g_ptr_array_add(parameters, jscContextGetOrCreateValue(context.get(), argument).leakRef());
         g_value_init(&values[firstParameter], G_TYPE_PTR_ARRAY);
         g_value_take_boxed(&values[firstParameter], parameters);
     }
@@ -146,7 +146,7 @@ JSValueRef JSCCallbackFunction::call(JSContextRef callerContext, JSObjectRef thi
         g_value_init(&returnValue, m_returnType);
 
     if (!*exception)
-        g_closure_invoke(m_closure.get(), m_returnType != G_TYPE_NONE ? &returnValue : nullptr, parameterCount, values, nullptr);
+        g_closure_invoke(m_closure.get(), m_returnType != G_TYPE_NONE ? &returnValue : nullptr, parameterCount, values.data(), nullptr);
 
     for (size_t i = 0; i < parameterCount; ++i)
         g_value_unset(&values[i]);
@@ -188,22 +188,23 @@ JSObjectRef JSCCallbackFunction::construct(JSContextRef callerContext, size_t ar
         g_value_unset(&dummyValue);
     } else {
         auto parameterCount = m_parameters ? m_parameters->size() : 1;
-        auto* values = static_cast<GValue*>(g_alloca(sizeof(GValue) * parameterCount));
-        memset(values, 0, sizeof(GValue) * parameterCount);
+        auto values = unsafeMakeSpan(static_cast<GValue*>(g_alloca(sizeof(GValue) * parameterCount)), parameterCount);
+        zeroSpan(values);
 
         if (m_parameters) {
+            auto argumentsSpan = unsafeMakeSpan(arguments, parameterCount);
             for (size_t i = 0; i < parameterCount && !*exception; ++i)
-                jscContextJSValueToGValue(context.get(), i < argumentCount ? arguments[i] : JSValueMakeUndefined(jsContext), m_parameters.value()[i], &values[i], exception);
+                jscContextJSValueToGValue(context.get(), i < argumentCount ? argumentsSpan[i] : JSValueMakeUndefined(jsContext), m_parameters.value()[i], &values[i], exception);
         } else {
             auto* parameters = g_ptr_array_new_full(argumentCount, g_object_unref);
-            for (size_t i = 0; i < argumentCount; ++i)
-                g_ptr_array_add(parameters, jscContextGetOrCreateValue(context.get(), arguments[i]).leakRef());
-            g_value_init(&values[0], G_TYPE_PTR_ARRAY);
-            g_value_take_boxed(&values[0], parameters);
+            for (auto& argument : unsafeMakeSpan(arguments, argumentCount))
+                g_ptr_array_add(parameters, jscContextGetOrCreateValue(context.get(), argument).leakRef());
+            g_value_init(values.data(), G_TYPE_PTR_ARRAY);
+            g_value_take_boxed(values.data(), parameters);
         }
 
         if (!*exception)
-            g_closure_invoke(m_closure.get(), &returnValue, parameterCount, values, nullptr);
+            g_closure_invoke(m_closure.get(), &returnValue, parameterCount, values.data(), nullptr);
 
         for (size_t i = 0; i < parameterCount; ++i)
             g_value_unset(&values[i]);
@@ -234,7 +235,6 @@ JSObjectRef JSCCallbackFunction::construct(JSContextRef callerContext, size_t ar
     g_value_unset(&returnValue);
     return nullptr;
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void JSCCallbackFunction::destroy(JSCell* cell)
 {

--- a/Source/JavaScriptCore/API/glib/JSCClass.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCClass.cpp
@@ -31,6 +31,7 @@
 #include "JSCValuePrivate.h"
 #include "JSCallbackObject.h"
 #include "JSRetainPtr.h"
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -260,13 +261,10 @@ static void getPropertyNames(JSContextRef callerContext, JSObjectRef object, JSP
         if (auto* enumeratePropertiesFunction = jscClass->priv->vtable->enumerate_properties) {
             GUniquePtr<char*> properties(enumeratePropertiesFunction(jscClass, context.get(), instance));
             if (properties) {
-                unsigned i = 0;
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-                while (const auto* name = properties.get()[i++]) {
+                for (auto* name : span(properties)) {
                     JSRetainPtr<JSStringRef> propertyName(Adopt, JSStringCreateWithUTF8CString(name));
                     JSPropertyNameAccumulatorAddName(propertyNames, propertyName.get());
                 }
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             }
         }
     }
@@ -647,10 +645,8 @@ JSCValue* jsc_class_add_constructorv(JSCClass* jscClass, const char* name, GCall
     if (!name)
         name = priv->name.data();
 
-    Vector<GType> parameters(parametersCount, [&](size_t i) -> GType {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    Vector<GType> parameters(parametersCount, [parameterTypes = unsafeMakeSpan(parameterTypes, parametersCount)](size_t i) -> GType {
         return parameterTypes[i];
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     });
 
     return jscClassCreateConstructor(jscClass, name ? name : priv->name.data(), callback, userData, destroyNotify, returnType, WTF::move(parameters)).leakRef();
@@ -775,10 +771,8 @@ void jsc_class_add_methodv(JSCClass* jscClass, const char* name, GCallback callb
     g_return_if_fail(!parametersCount || parameterTypes);
     g_return_if_fail(jscClass->priv->context);
 
-    Vector<GType> parameters(parametersCount, [&](size_t i) -> GType {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    Vector<GType> parameters(parametersCount, [parameterTypes = unsafeMakeSpan(parameterTypes, parametersCount)](size_t i) -> GType {
         return parameterTypes[i];
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     });
 
     jscClassAddMethod(jscClass, name, callback, userData, destroyNotify, returnType, WTF::move(parameters));

--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -35,6 +35,7 @@
 #include "JSWithScope.h"
 #include "OpaqueJSString.h"
 #include "Parser.h"
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/MakeString.h>
@@ -289,10 +290,8 @@ JSValueRef jscContextGArrayToJSArray(JSCContext* context, GPtrArray* gArray, JSV
     if (*exception)
         return JSValueMakeUndefined(priv->jsContext.get());
 
-    for (unsigned i = 0; i < gArray->len; ++i) {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        gpointer item = g_ptr_array_index(gArray, i);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto i = 0;
+    for (auto& item : span(gArray)) {
         if (!item)
             JSObjectSetPropertyAtIndex(priv->jsContext.get(), jsArrayObject, i, JSValueMakeNull(priv->jsContext.get()), exception);
         else if (JSC_IS_VALUE(item))
@@ -302,6 +301,7 @@ JSValueRef jscContextGArrayToJSArray(JSCContext* context, GPtrArray* gArray, JSV
 
         if (*exception)
             return JSValueMakeUndefined(priv->jsContext.get());
+        i++;
     }
 
     return jsArray;
@@ -373,7 +373,11 @@ GUniquePtr<char*> jscContextJSArrayToGStrv(JSCContext* context, JSValueRef jsArr
     if (*exception)
         return nullptr;
 
-    GUniquePtr<char*> strv(static_cast<char**>(g_new0(char*, length + 1)));
+    auto sizeInBytes = checkedSum<size_t>(length + 1);
+    sizeInBytes *= sizeof(char*);
+    if (sizeInBytes.hasOverflowed())
+        return nullptr;
+    auto strv = GMallocSpan<char*>::zeroedMalloc(sizeInBytes);
     for (unsigned i = 0; i < length; ++i) {
         auto* jsItem = JSObjectGetPropertyAtIndex(priv->jsContext.get(), jsArrayObject, i, exception);
         if (*exception)
@@ -384,13 +388,10 @@ GUniquePtr<char*> jscContextJSArrayToGStrv(JSCContext* context, JSValueRef jsArr
             *exception = toRef(JSC::createTypeError(globalObject, makeString("invalid js type for GStrv: item "_s, i, " is not a string"_s)));
             return nullptr;
         }
-
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        strv.get()[i] = jsc_value_to_string(jsValueItem.get());
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        strv[i] = jsc_value_to_string(jsValueItem.get());
     }
 
-    return strv;
+    return GUniquePtr<char*> { strv.leakSpan().data() };
 }
 
 JSValueRef jscContextGValueToJSValue(JSCContext* context, const GValue* value, JSValueRef* exception)
@@ -447,13 +448,11 @@ JSValueRef jscContextGValueToJSValue(JSCContext* context, const GValue* value, J
                 return jscContextGArrayToJSArray(context, static_cast<GPtrArray*>(ptr), exception);
 
             if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_STRV)) {
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
                 auto** strv = static_cast<char**>(ptr);
                 auto strvLength = g_strv_length(strv);
                 GRefPtr<GPtrArray> gArray = adoptGRef(g_ptr_array_new_full(strvLength, g_object_unref));
-                for (unsigned i = 0; i < strvLength; i++)
-                    g_ptr_array_add(gArray.get(), jsc_value_new_string(context, strv[i]));
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+                for (auto* item : span(strv))
+                    g_ptr_array_add(gArray.get(), jsc_value_new_string(context, item));
                 return jscContextGArrayToJSArray(context, gArray.get(), exception);
             }
         } else
@@ -880,9 +879,7 @@ JSCValue* jsc_context_evaluate_with_source_uri(JSCContext* context, const char* 
     g_return_val_if_fail(code, nullptr);
 
     JSValueRef exception = nullptr;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     JSValueRef result = evaluateScriptInContext(context->priv->jsContext.get(), String::fromUTF8(std::span(code, length < 0 ? strlen(code) : length)), uri, lineNumber, &exception);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (jscContextHandleExceptionIfNeeded(context, exception))
         return jsc_value_new_undefined(context);
 
@@ -922,9 +919,7 @@ JSCValue* jsc_context_evaluate_in_object(JSCContext* context, const char* code, 
     JSC::JSLockHolder locker(globalObject);
     globalObject->setGlobalScopeExtension(JSC::JSWithScope::create(vm, globalObject, globalObject->globalScope(), toJS(JSContextGetGlobalObject(context->priv->jsContext.get()))));
     JSValueRef exception = nullptr;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     JSValueRef result = evaluateScriptInContext(objectContext.get(), String::fromUTF8(std::span(code, length < 0 ? strlen(code) : length)), uri, lineNumber, &exception);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (jscContextHandleExceptionIfNeeded(context, exception))
         return jsc_value_new_undefined(context);
 
@@ -984,10 +979,8 @@ JSCCheckSyntaxResult jsc_context_check_syntax(JSCContext* context, const char* c
     JSC::JSLockHolder locker(vm);
 
     URL sourceURL = uri ? URL(String::fromLatin1(uri)) : URL();
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     JSC::SourceCode source = JSC::makeSource(String::fromUTF8(std::span(code, length < 0 ? strlen(code) : length)), JSC::SourceOrigin { sourceURL }, JSC::SourceTaintedOrigin::Untainted,
         sourceURL.string() , TextPosition(OrdinalNumber::fromOneBasedInt(lineNumber), OrdinalNumber()));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool success = false;
     JSC::ParserError error;
     switch (mode) {

--- a/Source/JavaScriptCore/API/glib/JSCException.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCException.cpp
@@ -387,26 +387,23 @@ char* jsc_exception_report(JSCException* exception)
     g_return_val_if_fail(priv->context, nullptr);
 
     jscExceptionEnsureProperties(exception);
-    GString* report = g_string_new(nullptr);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    auto report = StringBuilder();
     if (priv->sourceURI)
-        report = g_string_append(report, priv->sourceURI.get());
+        report.append(unsafeSpan(priv->sourceURI.get()));
     if (priv->lineNumber)
-        g_string_append_printf(report, ":%d", priv->lineNumber);
+        report.append(':', priv->lineNumber);
     if (priv->columnNumber)
-        g_string_append_printf(report, ":%d", priv->columnNumber);
-    report = g_string_append_c(report, ' ');
+        report.append(':', priv->columnNumber);
+    report.append(' ');
     GUniquePtr<char> errorMessage(jsc_exception_to_string(exception));
     if (errorMessage)
-        report = g_string_append(report, errorMessage.get());
-    report = g_string_append_c(report, '\n');
+        report.append(unsafeSpan(errorMessage.get()));
+    report.append('\n');
 
     if (priv->backtrace) {
-        GUniquePtr<char*> lines(g_strsplit(priv->backtrace.get(), "\n", 0));
-        for (unsigned i = 0; lines.get()[i]; ++i)
-            g_string_append_printf(report, "  %s\n", lines.get()[i]);
+        for (auto line : StringView::fromLatin1(priv->backtrace.get()).split('\n'))
+            report.append("  "_s, line, '\n');
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    return g_string_free(report, FALSE);
+    return g_strdup(report.toString().utf8().data());
 }

--- a/Source/JavaScriptCore/API/glib/JSCOptions.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCOptions.cpp
@@ -23,6 +23,7 @@
 #include "Options.h"
 #include <glib/gi18n-lib.h>
 #include <wtf/Vector.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 
 /**
@@ -688,27 +689,25 @@ GOptionGroup* jsc_options_get_option_group(void)
     });
     g_option_group_set_translation_domain(group, GETTEXT_PACKAGE);
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    GArray* entries = g_array_new(TRUE, TRUE, sizeof(GOptionEntry));
+    Vector<GOptionEntry> entries;
 #define REGISTER_OPTION(type_, name_, defaultValue_, availability_, description_) \
     if (Options::Availability::availability_ == Options::Availability::Normal \
         || Options::isAvailable(Options::name_##ID, Options::Availability::availability_)) { \
         GUniquePtr<char> name(g_strdup_printf("jsc-%s", #name_));       \
-        entries = g_array_set_size(entries, entries->len + 1); \
-        GOptionEntry* entry = &g_array_index(entries, GOptionEntry, entries->len - 1); \
-        entry->long_name = name.get();                                  \
-        entry->arg = G_OPTION_ARG_CALLBACK;                             \
-        entry->arg_data = reinterpret_cast<gpointer>(setOptionEntry);   \
-        entry->description = description_;                              \
-        names->append(WTF::move(name));                                   \
+        GOptionEntry entry { };                                         \
+        entry.long_name = name.get();                                   \
+        entry.arg = G_OPTION_ARG_CALLBACK;                              \
+        entry.arg_data = reinterpret_cast<gpointer>(setOptionEntry);    \
+        entry.description = description_;                               \
+        entries.append(entry);                                          \
+        names->append(WTF::move(name));                                 \
     }
-
     Options::initialize([] { });
     FOR_EACH_JSC_OPTION(REGISTER_OPTION)
 #undef REGISTER_OPTION
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    g_option_group_add_entries(group, reinterpret_cast<GOptionEntry*>(entries->data));
+    entries.append(GOptionEntry { });
+    g_option_group_add_entries(group, entries.span().data());
     return group;
 }
 

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -1902,7 +1902,7 @@ JSCTypedArrayType jsc_value_typed_array_get_type(JSCValue *value)
  *     g_error ("Only arrays of uint32_t are supported");
  *
  * gsize count = 0;
- * uint32_t *elements = jsc_value_typed_array_get_contents (value, &count);
+ * uint32_t *elements = jsc_value_typed_array_get_data (value, &count);
  * for (gsize i = 0; i < count; i++)
  *      g_print ("index %zu, value %" PRIu32 "\n", i, elements[i]);
  * ]|

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -120,6 +120,11 @@ static inline std::span<char*> span(char** strv LIFETIME_BOUND)
     return unsafeMakeSpan(strv, size);
 }
 
+static inline std::span<char*> span(const GUniquePtr<char*>& strv LIFETIME_BOUND)
+{
+    return span(strv.get());
+}
+
 static inline std::span<const char* const> span(const char* const* strv LIFETIME_BOUND)
 {
     auto size = g_strv_length(const_cast<char**>(strv));


### PR DESCRIPTION
#### f07e028002c66c04a3c6b7c1f9e372b9b8b5f971
<pre>
[GLIB] Reduce unsafe buffer usage in JSC API
<a href="https://bugs.webkit.org/show_bug.cgi?id=309060">https://bugs.webkit.org/show_bug.cgi?id=309060</a>

Reviewed by Adrian Perez de Castro.

* Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp:
(JSC::JSCCallbackFunction::call):
(JSC::JSCCallbackFunction::construct):
* Source/JavaScriptCore/API/glib/JSCClass.cpp:
(getPropertyNames):
(jsc_class_add_constructorv):
(jsc_class_add_methodv):
* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jscContextGArrayToJSArray):
(jscContextGValueToJSValue):
(jsc_context_evaluate_with_source_uri):
(jsc_context_evaluate_in_object):
(jsc_context_check_syntax):
* Source/JavaScriptCore/API/glib/JSCException.cpp:
(jsc_exception_report):
* Source/JavaScriptCore/API/glib/JSCOptions.cpp:
(jsc_options_get_option_group):
* Source/JavaScriptCore/API/glib/JSCValue.cpp:
* Source/WTF/wtf/glib/GSpanExtras.h:

Canonical link: <a href="https://commits.webkit.org/308608@main">https://commits.webkit.org/308608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/868aff598a482cef5fcdb6a7ce01c8a569d6a9f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81275 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94736 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15370 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13156 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3963 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139810 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158858 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8628 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122004 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122205 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76468 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9256 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179262 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83702 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45926 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19669 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->