### PR TITLE
Resync `mathml` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -13127,6 +13127,7 @@
         "web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-arabic-002-ref.html",
         "web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-empty-and-three-chars-ref.html",
         "web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001-ref.html",
+        "web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-ref.html",
         "web-platform-tests/mathml/presentation-markup/operators/stretchy-underbar-1-ref.xhtml",
         "web-platform-tests/mathml/presentation-markup/radicals/dynamic-radical-paint-invalidation-001-ref.html",
         "web-platform-tests/mathml/presentation-markup/radicals/empty-msqrt-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html
@@ -16,7 +16,7 @@
   math, mspace {
     /* OS/2.sxHeight = 800 */
     /* post.underlineThickness == 20 */
-    font-family: Ahem;
+    font-family: Ahem, math;
     font-size: 10px;
   }
   div.shrink-wrap {

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width.html
@@ -48,6 +48,17 @@
       });
     }, "Preferred width of mrow with mn and mo children");
 
+    test(function() {
+      assert_true(MathMLFeatureDetection.has_operator_spacing());
+
+      Array.from(document.getElementById("embellished-op-tests").getElementsByClassName("shrink-wrap")).forEach((container) => {
+        var containerWidth = container.getBoundingClientRect().width;
+        var mrow = container.getElementsByClassName("mrow-like")[0];
+        var mrowWidth = MrowWidthFromChildren(mrow);
+        assert_approx_equals(containerWidth, mrowWidth, epsilon, mrow.tagName);
+      });
+    }, "Preferred width of mrow with mn and embellished op children");
+
     done();
   }
 </script>
@@ -87,6 +98,9 @@ div.shrink-wrap {
       </div>
     </div>
     <div>
+      <div class="shrink-wrap">
+        <math class="mrow-like"><mspace width="30px" height="15px" style="background: blue"/><mspace width="20px" depth="30px" style="background: green"/><mspace width="15px" height="5px" depth="10px" style="background: black"/></math>
+      </div>
     </div>
   </div>
   <div id="tokens-tests">
@@ -123,6 +137,53 @@ div.shrink-wrap {
     <div>
       <div class="shrink-wrap">
       <math><a class="mrow-like"><mtext>blah</mtext><mo lspace="30px" rspace="20px">|</mo><mn>2</mn></a></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math class="mrow-like"><mtext>blah</mtext><mo lspace="30px" rspace="20px">|</mo><mn>2</mn></math>
+      </div>
+    </div>
+  </div>
+  <div id="embellished-op-tests">
+    <div>
+      <div class="shrink-wrap">
+      <math><mrow class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></mrow></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math><mstyle class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></mstyle></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math><mphantom class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></mphantom></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math><unknown class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></unknown></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math><mfenced class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></mfenced></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math><a class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></a></math>
+      </div>
+    </div>
+    <div>
+      <div class="shrink-wrap">
+      <math class="mrow-like"><mtext>blah</mtext><mfrac><msub><mrow><mo lspace="30px" rspace="20px">|</mo></mrow><mn>3</mn></msub><mn>4</mn></mfrac><mn>2</mn></math>
       </div>
     </div>
   </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt
@@ -1,22 +1,58 @@
 
-FAIL Spacing inside <mfrac>. assert_less_than_equal: expected a number less than or equal to 100 but got 227
-PASS Spacing around <mfrac>.
-FAIL Spacing inside <msub>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
-PASS Spacing around <msub>.
-FAIL Spacing inside <msup>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
-PASS Spacing around <msup>.
-FAIL Spacing inside <msubsup>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
-PASS Spacing around <msubsup>.
-FAIL Spacing inside <mmultiscripts>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
-PASS Spacing around <mmultiscripts>.
-FAIL Spacing inside <munder>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
-PASS Spacing around <munder>.
-FAIL Spacing inside <mover>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
-PASS Spacing around <mover>.
-FAIL Spacing inside <munderover>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
-PASS Spacing around <munderover>.
-FAIL Spacing inside <mroot>. assert_less_than_equal: expected a number less than or equal to 100 but got 268.0625
-FAIL Spacing around <mroot>. assert_less_than_equal: expected a number less than or equal to 100 but got 268.0625
+FAIL Spacing inside an <mfrac> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 227
+PASS Spacing around an <mfrac> child of an <math>.
+FAIL Spacing inside an <mfrac> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 227
+PASS Spacing around an <mfrac> child of an <mrow>.
+FAIL Spacing inside an <mfrac> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 227
+PASS Spacing around an <mfrac> child of an <mtd>.
+FAIL Spacing inside an <msub> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msub> child of an <math>.
+FAIL Spacing inside an <msub> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msub> child of an <mrow>.
+FAIL Spacing inside an <msub> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msub> child of an <mtd>.
+FAIL Spacing inside an <msup> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msup> child of an <math>.
+FAIL Spacing inside an <msup> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msup> child of an <mrow>.
+FAIL Spacing inside an <msup> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msup> child of an <mtd>.
+FAIL Spacing inside an <msubsup> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msubsup> child of an <math>.
+FAIL Spacing inside an <msubsup> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msubsup> child of an <mrow>.
+FAIL Spacing inside an <msubsup> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+PASS Spacing around an <msubsup> child of an <mtd>.
+FAIL Spacing inside an <mmultiscripts> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
+PASS Spacing around an <mmultiscripts> child of an <math>.
+FAIL Spacing inside an <mmultiscripts> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
+PASS Spacing around an <mmultiscripts> child of an <mrow>.
+FAIL Spacing inside an <mmultiscripts> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
+PASS Spacing around an <mmultiscripts> child of an <mtd>.
+FAIL Spacing inside an <munder> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <munder> child of an <math>.
+FAIL Spacing inside an <munder> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <munder> child of an <mrow>.
+FAIL Spacing inside an <munder> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <munder> child of an <mtd>.
+FAIL Spacing inside an <mover> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <mover> child of an <math>.
+FAIL Spacing inside an <mover> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <mover> child of an <mrow>.
+FAIL Spacing inside an <mover> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <mover> child of an <mtd>.
+FAIL Spacing inside an <munderover> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <munderover> child of an <math>.
+FAIL Spacing inside an <munderover> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <munderover> child of an <mrow>.
+FAIL Spacing inside an <munderover> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+PASS Spacing around an <munderover> child of an <mtd>.
+FAIL Spacing inside an <mroot> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 468.0625
+FAIL Spacing around an <mroot> child of an <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 468.0625
+FAIL Spacing inside an <mroot> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 468.0625
+FAIL Spacing around an <mroot> child of an <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 468.0625
+FAIL Spacing inside an <mroot> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 468.0625
+FAIL Spacing around an <mroot> child of an <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 488.0625
 X
 X
 
@@ -26,6 +62,71 @@ X
 X
 X
 
+
+X
+X
+X
+X
+X
+X
+
+
+X
+X
+X
+X
+X
+X
+
+
+X
+X
+X
+X
+X
+X
+X
+X
+X
+
+
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+
+
+X
+X
+
+X
+X
+
+X
+X
+
+
+X
+X
+
+X
+X
+
+X
+X
+
+
 X
 X
 X
@@ -33,19 +134,16 @@ X
 X
 X
 X
-X
-X
-
-X
-X
-
-X
-X
 
 X
 X
 X
 
+
+X
+X
+X
+X
 X
 X
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html
@@ -28,7 +28,7 @@
               let box = e.getBoundingClientRect();
               let spacing = 100;
               assert_less_than_equal(box.width, spacing);
-          }, `Spacing inside <${e.tagName}>.`);
+          }, `Spacing inside an <${e.tagName}> child of <${e.parentNode.tagName}>.`);
 
           test(function() {
               assert_true(MathMLFeatureDetection.has_operator_spacing());
@@ -38,7 +38,7 @@
                   assert_greater_than_equal(box.width, spacing * 2);
               else
                   assert_less_than_equal(box.width, spacing);
-          }, `Spacing around <${e.tagName}>.`);
+          }, `Spacing around an <${e.tagName}> child of an <${e.parentNode.tagName}>.`);
       });
       done();
   }
@@ -64,6 +64,27 @@
         <mo lspace="100px" rspace="100px">X</mo>
       </mfrac>
     </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <mfrac class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </mfrac>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <mfrac class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </mfrac>
+          </mtd>
+        </mtr>
+      </mtable>
+    </math>
   </p>
   <p>
     <math>
@@ -71,6 +92,27 @@
         <mo lspace="100px" rspace="100px">X</mo>
         <mo lspace="100px" rspace="100px">X</mo>
       </msub>
+    </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <msub class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </msub>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <msub class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </msub>
+          </mtd>
+        </mtr>
+      </mtable>
     </math>
   </p>
   <p>
@@ -80,6 +122,27 @@
         <mo lspace="100px" rspace="100px">X</mo>
       </msup>
     </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <msup class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </msup>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <msup class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </msup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </math>
   </p>
   <p>
     <math>
@@ -88,6 +151,29 @@
         <mo lspace="100px" rspace="100px">X</mo>
         <mo lspace="100px" rspace="100px">X</mo>
       </msubsup>
+    </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <msubsup class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </msubsup>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <msubsup class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </msubsup>
+          </mtd>
+        </mtr>
+      </mtable>
     </math>
   </p>
   <p>
@@ -101,6 +187,35 @@
         <mo lspace="100px" rspace="100px">X</mo>
       </mmultiscripts>
     </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <mmultiscripts class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mprescripts/>
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </mmultiscripts>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <mmultiscripts class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mprescripts/>
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </mmultiscripts>
+          </mtd>
+        </mtr>
+      </mtable>
+    </math>
   </p>
   <p>
     <math>
@@ -109,6 +224,27 @@
         <mo lspace="100px" rspace="100px">X</mo>
       </munder>
     </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <munder class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </munder>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <munder class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </munder>
+          </mtd>
+        </mtr>
+      </mtable>
+    </math>
   </p>
   <p>
     <math>
@@ -116,6 +252,27 @@
         <mo lspace="100px" rspace="100px">X</mo>
         <mo lspace="100px" rspace="100px">X</mo>
       </mover>
+    </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <mover class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </mover>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <mover class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </mover>
+          </mtd>
+        </mtr>
+      </mtable>
     </math>
   </p>
   <p>
@@ -126,13 +283,56 @@
         <mo lspace="100px" rspace="100px">X</mo>
       </munderover>
     </math>
+    <math>
+      <mrow>
+        <mn><!-- make sure parent mrow is not an embellished operator --></mn>
+        <munderover class="testedElement embellished">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </munderover>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <munderover class="testedElement embellished">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </munderover>
+          </mtd>
+        </mtr>
+      </mtable>
+    </math>
   </p>
   <p>
     <math>
       <mroot class="testedElement">
-        <mtext>X</mtext>
+        <mo lspace="100px" rspace="100px">X</mo>
         <mo lspace="100px" rspace="100px">X</mo>
       </mroot>
+    </math>
+    <math>
+      <mrow>
+        <mroot class="testedElement">
+          <mo lspace="100px" rspace="100px">X</mo>
+          <mo lspace="100px" rspace="100px">X</mo>
+        </mroot>
+      </mrow>
+    </math>
+    <math>
+      <mtable>
+        <mtr>
+          <mtd>
+            <mroot class="testedElement">
+              <mo lspace="100px" rspace="100px">X</mo>
+              <mo lspace="100px" rspace="100px">X</mo>
+            </mroot>
+          </mtd>
+        </mtr>
+      </mtable>
     </math>
   </p>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5-expected.txt
@@ -1,0 +1,141 @@
+
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, LTR, normal text). assert_approx_equals: expected 25 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, LTR, largeop variant). assert_approx_equals: expected 75 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, LTR, stretchy variant). assert_approx_equals: expected 125 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, LTR, glyph assembly). assert_approx_equals: expected 175 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, LTR, normal text). assert_approx_equals: expected 25 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, LTR, largeop variant). assert_approx_equals: expected 75 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, LTR, stretchy variant). assert_approx_equals: expected 125 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, LTR, glyph assembly). assert_approx_equals: expected 175 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, LTR, normal text). assert_approx_equals: expected 25 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, LTR, largeop variant). assert_approx_equals: expected 75 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, LTR, stretchy variant). assert_approx_equals: expected 125 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, LTR, glyph assembly). assert_approx_equals: expected 175 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, LTR, normal text). assert_approx_equals: expected 25 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, LTR, largeop variant). assert_approx_equals: expected 75 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, LTR, stretchy variant). assert_approx_equals: expected 125 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, LTR, glyph assembly). assert_approx_equals: expected 175 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, LTR, normal text). assert_approx_equals: expected 25 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, LTR, largeop variant). assert_approx_equals: expected 75 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, LTR, stretchy variant). assert_approx_equals: expected 125 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, LTR, glyph assembly). assert_approx_equals: expected 175 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, LTR, normal text). assert_approx_equals: expected 25 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, LTR, largeop variant). assert_approx_equals: expected 75 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, LTR, stretchy variant). assert_approx_equals: expected 125 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, LTR, glyph assembly). assert_approx_equals: expected 175 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, RTL, normal text). assert_approx_equals: expected 50 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, RTL, largeop variant). assert_approx_equals: expected 100 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, RTL, stretchy variant). assert_approx_equals: expected 150 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, not embellished, RTL, glyph assembly). assert_approx_equals: expected 200 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, RTL, normal text). assert_approx_equals: expected 50 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, RTL, largeop variant). assert_approx_equals: expected 100 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, RTL, stretchy variant). assert_approx_equals: expected 150 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, not embellished, RTL, glyph assembly). assert_approx_equals: expected 200 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, RTL, normal text). assert_approx_equals: expected 50 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, RTL, largeop variant). assert_approx_equals: expected 100 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, RTL, stretchy variant). assert_approx_equals: expected 150 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, not embellished, RTL, glyph assembly). assert_approx_equals: expected 200 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, RTL, normal text). assert_approx_equals: expected 50 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, RTL, largeop variant). assert_approx_equals: expected 100 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, RTL, stretchy variant). assert_approx_equals: expected 150 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mrow, embellished, RTL, glyph assembly). assert_approx_equals: expected 200 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, RTL, normal text). assert_approx_equals: expected 50 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, RTL, largeop variant). assert_approx_equals: expected 100 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, RTL, stretchy variant). assert_approx_equals: expected 150 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of math, embellished, RTL, glyph assembly). assert_approx_equals: expected 200 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, RTL, normal text). assert_approx_equals: expected 50 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, RTL, largeop variant). assert_approx_equals: expected 100 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, RTL, stretchy variant). assert_approx_equals: expected 150 +/- 1 but got 0
+FAIL lspace/rspace spacing correctly set around operator (child of mtd, embellished, RTL, glyph assembly). assert_approx_equals: expected 200 +/- 1 but got 0
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22+++4444⫿55555⥜666666⥜7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22+++4444⫿55555⥜666666⥜7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777
+22
++++
+4444
+⫿
+55555
+⥜
+666666
+⥜
+7777777

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>lspace/rspace attributes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="lspace/rspace is added around embellished operators">
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: stretchy;
+    src: url("/fonts/math/stretchy.woff");
+  }
+  @font-face {
+    font-family: largeop;
+    src: url("/fonts/math/largeop-displayoperatorminheight3000-2AFF-axisheight1000.woff");
+  }
+  div {
+      margin-bottom: 50px;
+  }
+  math {
+      font-size: 25px;
+      line-height: 1;
+      font-family: stretchy, largeop, Ahem;
+  }
+</style>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
+  const epsilon = 1;
+  const emToPx = 25;
+  function emStringToPx(value) {
+    return parseInt(value.match(/^([0-9]+)em$/)[1]) * emToPx;
+  }
+  function runTests() {
+     Array.from(document.querySelectorAll("[data-title]")).forEach(operator => {
+      test(function() {
+        let operatorBox = operator.getBoundingClientRect();
+        let beforeBox = operator.previousElementSibling.getBoundingClientRect();
+        let afterBox = operator.nextElementSibling.getBoundingClientRect();
+        let mo = operator.getElementsByTagName("mo")[0] || operator;
+        let lspace = emStringToPx(mo.getAttribute("lspace"));
+        let rspace = emStringToPx(mo.getAttribute("rspace"));
+        let isRTL = getComputedStyle(operator.parentNode).direction === "rtl";
+        if (isRTL) {
+          assert_approx_equals(operatorBox.left - afterBox.right, rspace, epsilon);
+          assert_approx_equals(beforeBox.left - operatorBox.right, lspace, epsilon);
+        } else {
+          assert_approx_equals(operatorBox.left - beforeBox.right, lspace, epsilon);
+          assert_approx_equals(afterBox.left - operatorBox.right, rspace, epsilon);
+        }
+      }, `lspace/rspace spacing correctly set around operator (${operator.dataset.title}).`);
+    });
+    done();
+  }
+</script>
+<div id="log"></div>
+<div>
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mo data-title="child of mrow, not embellished, LTR, normal text"
+          lspace="1em" rspace="2em">+++</mo>
+      <mn>4444</mn>
+      <mo data-title="child of mrow, not embellished, LTR, largeop variant"
+          lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+      <mn>55555</mn>
+      <mo data-title="child of mrow, not embellished, LTR, stretchy variant"
+          lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+      <mn>666666</mn>
+      <mo data-title="child of mrow, not embellished, LTR, glyph assembly"
+          lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+      <mn>7777777</mn>
+    </mrow>
+  </math>
+  <math>
+    <mn>22</mn>
+    <mo data-title="child of math, not embellished, LTR, normal text"
+        lspace="1em" rspace="2em">+++</mo>
+    <mn>4444</mn>
+    <mo data-title="child of math, not embellished, LTR, largeop variant"
+        lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+    <mn>55555</mn>
+    <mo data-title="child of math, not embellished, LTR, stretchy variant"
+        lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+    <mn>666666</mn>
+    <mo data-title="child of math, not embellished, LTR, glyph assembly"
+        lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+    <mn>7777777</mn>
+  </math>
+  <math>
+    <mtable>
+      <mtr>
+        <mtd>
+          <mn>22</mn>
+          <mo data-title="child of mtd, not embellished, LTR, normal text"
+              lspace="1em" rspace="2em">+++</mo>
+          <mn>4444</mn>
+          <mo data-title="child of mtd, not embellished, LTR, largeop variant"
+              lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+          <mn>55555</mn>
+          <mo data-title="child of mtd, not embellished, LTR, stretchy variant"
+              lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+          <mn>666666</mn>
+          <mo data-title="child of mtd, not embellished, LTR, glyph assembly"
+              lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+          <mn>7777777</mn>
+        </mtd>
+      </mtr>
+    </mtable>
+  </math>
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mrow data-title="child of mrow, embellished, LTR, normal text">
+        <mo lspace="1em" rspace="2em">+++</mo>
+      </mrow>
+      <mn>4444</mn>
+      <mrow data-title="child of mrow, embellished, LTR, largeop variant">
+        <mo lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+      </mrow>
+      <mn>55555</mn>
+      <mrow data-title="child of mrow, embellished, LTR, stretchy variant">
+        <mo lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+      </mrow>
+      <mn>666666</mn>
+      <mrow data-title="child of mrow, embellished, LTR, glyph assembly">
+        <mo lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+      </mrow>
+      <mn>7777777</mn>
+    </mrow>
+  </math>
+  <math>
+    <mn>22</mn>
+    <mrow data-title="child of math, embellished, LTR, normal text">
+      <mo lspace="1em" rspace="2em">+++</mo>
+    </mrow>
+    <mn>4444</mn>
+    <mrow data-title="child of math, embellished, LTR, largeop variant">
+      <mo lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+    </mrow>
+    <mn>55555</mn>
+    <mrow data-title="child of math, embellished, LTR, stretchy variant">
+      <mo lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+      </mrow>
+    <mn>666666</mn>
+    <mrow data-title="child of math, embellished, LTR, glyph assembly">
+      <mo lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+    </mrow>
+    <mn>7777777</mn>
+  </math>
+  <math>
+    <mtable>
+      <mtr>
+        <mtd>
+          <mn>22</mn>
+          <mrow data-title="child of mtd, embellished, LTR, normal text">
+            <mo lspace="1em" rspace="2em">+++</mo>
+          </mrow>
+          <mn>4444</mn>
+          <mrow data-title="child of mtd, embellished, LTR, largeop variant">
+            <mo lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+          </mrow>
+          <mn>55555</mn>
+          <mrow data-title="child of mtd, embellished, LTR, stretchy variant">
+            <mo lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+          </mrow>
+          <mn>666666</mn>
+          <mrow data-title="child of mtd, embellished, LTR, glyph assembly">
+            <mo lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+          </mrow>
+          <mn>7777777</mn>
+        </mtd>
+      </mtr>
+    </mtable>
+  </math>
+</div>
+
+
+
+<div>
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mo data-title="child of mrow, not embellished, RTL, normal text"
+          lspace="1em" rspace="2em">+++</mo>
+      <mn>4444</mn>
+      <mo data-title="child of mrow, not embellished, RTL, largeop variant"
+          lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+      <mn>55555</mn>
+      <mo data-title="child of mrow, not embellished, RTL, stretchy variant"
+          lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+      <mn>666666</mn>
+      <mo data-title="child of mrow, not embellished, RTL, glyph assembly"
+          lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+      <mn>7777777</mn>
+    </mrow>
+  </math>
+  <math dir="rtl">
+    <mn>22</mn>
+    <mo data-title="child of math, not embellished, RTL, normal text"
+        lspace="1em" rspace="2em">+++</mo>
+    <mn>4444</mn>
+    <mo data-title="child of math, not embellished, RTL, largeop variant"
+        lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+    <mn>55555</mn>
+    <mo data-title="child of math, not embellished, RTL, stretchy variant"
+        lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+    <mn>666666</mn>
+    <mo data-title="child of math, not embellished, RTL, glyph assembly"
+        lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+    <mn>7777777</mn>
+  </math>
+  <math dir="rtl">
+    <mtable>
+      <mtr>
+        <mtd>
+          <mn>22</mn>
+          <mo data-title="child of mtd, not embellished, RTL, normal text"
+              lspace="1em" rspace="2em">+++</mo>
+          <mn>4444</mn>
+          <mo data-title="child of mtd, not embellished, RTL, largeop variant"
+              lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+          <mn>55555</mn>
+          <mo data-title="child of mtd, not embellished, RTL, stretchy variant"
+              lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+          <mn>666666</mn>
+          <mo data-title="child of mtd, not embellished, RTL, glyph assembly"
+              lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+          <mn>7777777</mn>
+        </mtd>
+      </mtr>
+    </mtable>
+  </math>
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mrow data-title="child of mrow, embellished, RTL, normal text">
+        <mo lspace="1em" rspace="2em">+++</mo>
+      </mrow>
+      <mn>4444</mn>
+      <mrow data-title="child of mrow, embellished, RTL, largeop variant">
+        <mo lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+      </mrow>
+      <mn>55555</mn>
+      <mrow data-title="child of mrow, embellished, RTL, stretchy variant">
+        <mo lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+      </mrow>
+      <mn>666666</mn>
+      <mrow data-title="child of mrow, embellished, RTL, glyph assembly">
+        <mo lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+      </mrow>
+      <mn>7777777</mn>
+    </mrow>
+  </math>
+  <math dir="rtl">
+    <mn>22</mn>
+    <mrow data-title="child of math, embellished, RTL, normal text">
+      <mo lspace="1em" rspace="2em">+++</mo>
+    </mrow>
+    <mn>4444</mn>
+    <mrow data-title="child of math, embellished, RTL, largeop variant">
+      <mo lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+    </mrow>
+    <mn>55555</mn>
+    <mrow data-title="child of math, embellished, RTL, stretchy variant">
+      <mo lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+      </mrow>
+    <mn>666666</mn>
+    <mrow data-title="child of math, embellished, RTL, glyph assembly">
+      <mo lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+    </mrow>
+    <mn>7777777</mn>
+  </math>
+  <math dir="rtl">
+    <mtable>
+      <mtr>
+        <mtd>
+          <mn>22</mn>
+          <mrow data-title="child of mtd, embellished, RTL, normal text">
+            <mo lspace="1em" rspace="2em">+++</mo>
+          </mrow>
+          <mn>4444</mn>
+          <mrow data-title="child of mtd, embellished, RTL, largeop variant">
+            <mo lspace="3em" rspace="4em" largeop="true">&#x2AFF;</mo>
+          </mrow>
+          <mn>55555</mn>
+          <mrow data-title="child of mtd, embellished, RTL, stretchy variant">
+            <mo lspace="5em" rspace="6em" stretchy="true" minsize="2em">&#x295C;</mo>
+          </mrow>
+          <mn>666666</mn>
+          <mrow data-title="child of mtd, embellished, RTL, glyph assembly">
+            <mo lspace="7em" rspace="8em" stretchy="true" minsize="10em">&#x295C;</mo>
+          </mrow>
+          <mn>7777777</mn>
+        </mtd>
+      </mtr>
+    </mtable>
+  </math>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel-expected.txt
@@ -1,0 +1,9 @@
+1
+O
+2
+3
+O
+4
+
+PASS default lspace/rspace in scriptlevel = 1 is just obtained by scaling down the one for scriptlevel = 0.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>No tuning of lspace/rspace when scriptlevel is positive</title>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2018406"/>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<style>
+  math { font: 100px/1 Ahem; }
+</style>
+<math display="block">
+  <mrow id="big"><mn>1</mn><mo>O</mo><mn>2</mn></mrow>
+</math>
+<math display="block">
+  <mstyle id="small" scriptlevel="1"><mn>3</mn><mo>O</mo><mn>4</mn></mstyle>
+</math>
+<script>
+  test(function() {
+    const epsilon = 0.1;
+    let bigWidth = big.children[0].getBoundingClientRect().width;
+    let smallWidth = small.children[0].getBoundingClientRect().width;
+    let bigSpace =
+        big.getBoundingClientRect().width -
+        bigWidth * big.children.length;
+    let smallSpace =
+        small.getBoundingClientRect().width -
+        smallWidth * small.children.length;
+    assert_approx_equals(smallSpace / bigSpace,  smallWidth / bigWidth, epsilon);
+  }, `default lspace/rspace in scriptlevel = 1 is just obtained by scaling down the one for scriptlevel = 0.`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-expected.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Painting of a stretchy operator with lspace/rspace (expectation)</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="">
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: stretchy;
+    src: url("/fonts/math/stretchy.woff");
+  }
+  div {
+      margin-bottom: 50px;
+  }
+
+  math {
+      font-size: 25px;
+      line-height: 1;
+      font-family: stretchy, Ahem;
+      color: green;
+  }
+  /* In the reference file, the operator are not visible, so there is no red. */
+  .operator {
+      visibility: hidden;
+  }
+  .frame {
+      position: absolute;
+      box-sizing: border-box;
+      background: green;
+      border: 2px solid green;
+  }
+</style>
+<script>
+  function runTests() {
+    Array.from(document.getElementsByTagName('math')).forEach(math => {
+      const pxPerEm = 25;
+      let isRTL = math.getAttribute("dir") === "rtl";
+      let lspace = pxPerEm * 3;
+      let rspace = pxPerEm * 5;
+      let expectedOperatorLeft = math.getBoundingClientRect().left +
+          (isRTL ? 3 * pxPerEm + rspace : 2 * pxPerEm + lspace);
+      let expectedOperatorWidth = pxPerEm;
+      let actualOperatorBox =
+          math.querySelector(".operator").getBoundingClientRect();
+      let div = document.createElement("div");
+      div.className = 'frame';
+      div.style.left = `${expectedOperatorLeft-1}px`;
+      div.style.top = `${actualOperatorBox.top-1}px`;
+      div.style.width = `${expectedOperatorWidth+2}px`;
+      div.style.height = `${actualOperatorBox.height+2}px`;
+      document.body.appendChild(div);
+    });
+    document.documentElement.classList.remove("reftest-wait");
+  }
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
+</script>
+<p>This test passes if you see green boxes and no red.</p>
+<div>
+  <!-- Child of math. -->
+  <math>
+    <mn>22</mn>
+    <mo class="operator" lspace="3em" rspace="5em"
+        stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow. -->
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mo class="operator" lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, embellished operator. -->
+  <math>
+    <mn>22</mn>
+    <mrow class="operator">
+      <mo lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    </mrow>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, embellished operator. -->
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mrow class="operator">
+        <mo lspace="3em" rspace="5em"
+            stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      </mrow>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, RTL. -->
+  <math dir="rtl">
+    <mn>22</mn>
+    <mo class="operator" lspace="3em" rspace="5em"
+        stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, RTL. -->
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mo class="operator" lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, embellished operator, RTL. -->
+  <math dir="rtl">
+    <mn>22</mn>
+    <mrow class="operator">
+      <mo lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    </mrow>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, embellished operator, RTL. -->
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mrow class="operator">
+        <mo lspace="3em" rspace="5em"
+            stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      </mrow>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-ref.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Painting of a stretchy operator with lspace/rspace (expectation)</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="">
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: stretchy;
+    src: url("/fonts/math/stretchy.woff");
+  }
+  div {
+      margin-bottom: 50px;
+  }
+
+  math {
+      font-size: 25px;
+      line-height: 1;
+      font-family: stretchy, Ahem;
+      color: green;
+  }
+  /* In the reference file, the operator are not visible, so there is no red. */
+  .operator {
+      visibility: hidden;
+  }
+  .frame {
+      position: absolute;
+      box-sizing: border-box;
+      background: green;
+      border: 2px solid green;
+  }
+</style>
+<script>
+  function runTests() {
+    Array.from(document.getElementsByTagName('math')).forEach(math => {
+      const pxPerEm = 25;
+      let isRTL = math.getAttribute("dir") === "rtl";
+      let lspace = pxPerEm * 3;
+      let rspace = pxPerEm * 5;
+      let expectedOperatorLeft = math.getBoundingClientRect().left +
+          (isRTL ? 3 * pxPerEm + rspace : 2 * pxPerEm + lspace);
+      let expectedOperatorWidth = pxPerEm;
+      let actualOperatorBox =
+          math.querySelector(".operator").getBoundingClientRect();
+      let div = document.createElement("div");
+      div.className = 'frame';
+      div.style.left = `${expectedOperatorLeft-1}px`;
+      div.style.top = `${actualOperatorBox.top-1}px`;
+      div.style.width = `${expectedOperatorWidth+2}px`;
+      div.style.height = `${actualOperatorBox.height+2}px`;
+      document.body.appendChild(div);
+    });
+    document.documentElement.classList.remove("reftest-wait");
+  }
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
+</script>
+<p>This test passes if you see green boxes and no red.</p>
+<div>
+  <!-- Child of math. -->
+  <math>
+    <mn>22</mn>
+    <mo class="operator" lspace="3em" rspace="5em"
+        stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow. -->
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mo class="operator" lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, embellished operator. -->
+  <math>
+    <mn>22</mn>
+    <mrow class="operator">
+      <mo lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    </mrow>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, embellished operator. -->
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mrow class="operator">
+        <mo lspace="3em" rspace="5em"
+            stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      </mrow>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, RTL. -->
+  <math dir="rtl">
+    <mn>22</mn>
+    <mo class="operator" lspace="3em" rspace="5em"
+        stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, RTL. -->
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mo class="operator" lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, embellished operator, RTL. -->
+  <math dir="rtl">
+    <mn>22</mn>
+    <mrow class="operator">
+      <mo lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    </mrow>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, embellished operator, RTL. -->
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mrow class="operator">
+        <mo lspace="3em" rspace="5em"
+            stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      </mrow>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Painting of a stretchy operator with lspace/rspace</title>
+<link rel="match" href="painting-stretchy-operator-002-ref.html">
+<link rel="help" href="https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="">
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: stretchy;
+    src: url("/fonts/math/stretchy.woff");
+  }
+  div {
+      margin-bottom: 50px;
+  }
+
+  math {
+      font-size: 25px;
+      line-height: 1;
+      font-family: stretchy, Ahem;
+      color: green;
+  }
+  .operator {
+      color: red;
+  }
+  .frame {
+      position: absolute;
+      box-sizing: border-box;
+      background: green;
+      border: 2px solid green;
+  }
+</style>
+<script>
+  function runTests() {
+    Array.from(document.getElementsByTagName('math')).forEach(math => {
+      // Each math renders as a 2x1 green rectangle for <mn>22</mn>, a red
+      // rectangle for the vertical stretchy <mo> operator (with lspace=3em and
+      // rspace=5em spacing around it) and a 3x1 green rectangle for
+      // <mn>333</mn>. We try and cover the operator with a green rectangle at
+      // the expected horizontal offset. The reftest fails if the stretchy
+      // operator is painted somewhere else.
+      const pxPerEm = 25;
+      let isRTL = math.getAttribute("dir") === "rtl";
+      let lspace = pxPerEm * 3;
+      let rspace = pxPerEm * 5;
+      let expectedOperatorLeft = math.getBoundingClientRect().left +
+          (isRTL ? 3 * pxPerEm + rspace : 2 * pxPerEm + lspace);
+      let expectedOperatorWidth = pxPerEm;
+      let actualOperatorBox =
+          math.querySelector(".operator").getBoundingClientRect();
+      let div = document.createElement("div");
+      div.className = 'frame';
+      div.style.left = `${expectedOperatorLeft-1}px`;
+      div.style.top = `${actualOperatorBox.top-1}px`;
+      div.style.width = `${expectedOperatorWidth+2}px`;
+      div.style.height = `${actualOperatorBox.height+2}px`;
+      document.body.appendChild(div);
+    });
+    document.documentElement.classList.remove("reftest-wait");
+  }
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
+</script>
+<p>This test passes if you see green boxes and no red.</p>
+<div>
+  <!-- Child of math. -->
+  <math>
+    <mn>22</mn>
+    <mo class="operator" lspace="3em" rspace="5em"
+        stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow. -->
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mo class="operator" lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, embellished operator. -->
+  <math>
+    <mn>22</mn>
+    <mrow class="operator">
+      <mo lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    </mrow>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, embellished operator. -->
+  <math>
+    <mrow>
+      <mn>22</mn>
+      <mrow class="operator">
+        <mo lspace="3em" rspace="5em"
+            stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      </mrow>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, RTL. -->
+  <math dir="rtl">
+    <mn>22</mn>
+    <mo class="operator" lspace="3em" rspace="5em"
+        stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, RTL. -->
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mo class="operator" lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<div>
+  <!-- Child of math, embellished operator, RTL. -->
+  <math dir="rtl">
+    <mn>22</mn>
+    <mrow class="operator">
+      <mo lspace="3em" rspace="5em"
+          stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+    </mrow>
+    <mn>333</mn>
+  </math>
+</div>
+<div>
+  <!-- Child of mrow, embellished operator, RTL. -->
+  <math dir="rtl">
+    <mrow>
+      <mn>22</mn>
+      <mrow class="operator">
+        <mo lspace="3em" rspace="5em"
+            stretchy="true" minsize="2em" symmetric="true">&#x295C;</mo>
+      </mrow>
+      <mn>333</mn>
+    </mrow>
+  </math>
+</div>
+<script src="/mathml/support/feature-detection.js"></script>
+<script>
+  MathMLFeatureDetection.ensure_for_match_reftest("has_operator_spacing");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/w3c-import.log
@@ -114,11 +114,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-4-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-4-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-4.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-dynamic-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-dynamic-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-dynamic.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-minsize-maxsize-001.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-movablelimits-and-embellished-operator-expected.html
@@ -236,6 +238,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/size-and-position-of-stretchy-fences-with-default-font-001.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/stretchy-largeop-with-default-font-1.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/stretchy-largeop-with-default-font-2.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-1.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
-    font: 25px/1 Ahem;
+    font: 25px/1 Ahem, math;
   }
 </style>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-2.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
-    font: 25px/1 Ahem;
+      font: 25px/1 Ahem, math;
   }
 </style>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
-    font: 25px/1 Ahem;
+    font: 25px/1 Ahem, math;
   }
 </style>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
-    font: 25px/1 Ahem;
+    font: 25px/1 Ahem, math;
   }
 </style>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-parameters-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-parameters-2-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Null Italic Correction
 PASS NonNull Italic Correction (MathGlyphVariantRecord)
-FAIL NonNull Italic Correction (GlyphAssembly) assert_approx_equals: msub expected 50 +/- 1 but got 0
+FAIL NonNull Italic Correction (GlyphAssembly) assert_approx_equals: msub base width expected 70 +/- 1 but got 10
 Null Italic Correction
 
 ⫿

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-parameters-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-parameters-2.html
@@ -48,6 +48,12 @@
     test(function() {
       assert_true(MathMLFeatureDetection.has_mspace());
 
+      let w = 1000 * emToPx;
+      assert_approx_equals(getBox("base001").width, w, epsilon, "msub base width");
+      assert_approx_equals(getBox("base002").width, w, epsilon, "msup base width");
+      assert_approx_equals(getBox("base003").width, w, epsilon, "msubsup base width");
+      assert_approx_equals(getBox("base004").width, w, epsilon, "mmultiscripts base width")
+
       var v = 0;
       assert_approx_equals(getBox("base001").right - getBox("sub001").left, v, epsilon, "msub");
       assert_approx_equals(getBox("sup002").left, getBox("base002").right, epsilon, "msup");
@@ -58,6 +64,12 @@
     test(function() {
       assert_true(MathMLFeatureDetection.has_mspace());
 
+      let w = 4000 * emToPx;
+      assert_approx_equals(getBox("base011").width, w, epsilon, "msub base width");
+      assert_approx_equals(getBox("base012").width, w, epsilon, "msup base width");
+      assert_approx_equals(getBox("base013").width, w, epsilon, "msubsup base width");
+      assert_approx_equals(getBox("base014").width, w, epsilon, "mmultiscripts base width")
+
       var v = 3000 * emToPx;
       assert_approx_equals(getBox("base011").right - getBox("sub011").left, v, epsilon, "msub");
       assert_approx_equals(getBox("sup012").left, getBox("base012").right, epsilon, "msup");
@@ -67,6 +79,12 @@
     }, "NonNull Italic Correction (MathGlyphVariantRecord)");
     test(function() {
       assert_true(MathMLFeatureDetection.has_mspace());
+
+      let w = 7000 * emToPx;
+      assert_approx_equals(getBox("base021").width, w, epsilon, "msub base width");
+      assert_approx_equals(getBox("base022").width, w, epsilon, "msup base width");
+      assert_approx_equals(getBox("base023").width, w, epsilon, "msubsup base width");
+      assert_approx_equals(getBox("base024").width, w, epsilon, "mmultiscripts base width")
 
       var v = 5000 * emToPx;
       assert_approx_equals(getBox("base021").right - getBox("sub021").left, v, epsilon, "msub");
@@ -97,14 +115,14 @@
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight5000;">
       <msubsup>
-        <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
+        <mo id="base003" lspace="0px" rspace="0px">&#x2AFF;</mo>
         <mspace id="sub003" height="1em" width="1em" style="background: blue"/>
         <mspace id="sup003" height="1em" width="1em" style="background: green"/>
       </msubsup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight5000;">
       <mmultiscripts>
-        <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
+        <mo id="base004" lspace="0px" rspace="0px">&#x2AFF;</mo>
         <mspace id="sub004" height="1em" width="1em" style="background: blue"/>
         <mspace id="sup004" height="1em" width="1em" style="background: green"/>
         <mprescripts/>
@@ -129,14 +147,14 @@
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight2000-2AFF-italiccorrection3000;">
       <msubsup>
-        <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
+        <mo id="base013" lspace="0px" rspace="0px">&#x2AFF;</mo>
         <mspace id="sub013" height="1em" width="1em" style="background: blue"/>
         <mspace id="sup013" height="1em" width="1em" style="background: green"/>
       </msubsup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight2000-2AFF-italiccorrection3000;">
       <mmultiscripts>
-        <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
+        <mo id="base014" lspace="0px" rspace="0px">&#x2AFF;</mo>
         <mspace id="sub014" height="1em" width="1em" style="background: blue"/>
         <mspace id="sup014" height="1em" width="1em" style="background: green"/>
         <mprescripts/>
@@ -161,14 +179,14 @@
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight7000-2AFF-italiccorrection5000;">
       <msubsup>
-        <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
+        <mo id="base023" lspace="0px" rspace="0px">&#x2AFF;</mo>
         <mspace id="sub023" height="1em" width="1em" style="background: blue"/>
         <mspace id="sup023" height="1em" width="1em" style="background: green"/>
       </msubsup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight7000-2AFF-italiccorrection5000;">
       <mmultiscripts>
-        <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
+        <mo id="base024" lspace="0px" rspace="0px">&#x2AFF;</mo>
         <mspace id="sub024" height="1em" width="1em" style="background: blue"/>
         <mspace id="sup024" height="1em" width="1em" style="background: green"/>
         <mprescripts/>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/underover-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/underover-1.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace, mo {
-    font-family: Ahem;
+    font-family: Ahem, math;
     font-size: 10px;
   }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/w3c-import.log
@@ -115,6 +115,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-4.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-5.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6-rtl.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-legacy-scriptshift-attributes-001.tentative-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-legacy-scriptshift-attributes-001.tentative-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: clipboard-events
+  files:
+  - clipboard-event-handlers.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-001.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-001.tentative.html
@@ -20,7 +20,7 @@
 
   <p>This test passes if you see a green square.</p>
 
-  <div style="width: 150px; height: 150px; overflow: hidden; font-family: Ahem;">
+  <div style="width: 150px; height: 150px; overflow: hidden">
     <math>
       <mrow id="link" href="#target">
         <mspace id="space" width="150px" height="150px" style="background: red"/>
@@ -28,7 +28,7 @@
     </math>
     <div style="height: 500px;"></div>
     <math id="target">
-      <mspace width="150px" height="150px" style="background: green"/>
+      <mspace width="150px" height="154px" style="background: green"/>
     </math>
   </div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-002.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-002.tentative.html
@@ -20,7 +20,7 @@
 
   <p>This test passes if you see a green square.</p>
 
-  <div style="width: 150px; height: 150px; overflow: hidden; font-family: Ahem">
+  <div style="width: 150px; height: 150px; overflow: hidden">
     <math>
       <mrow href="#target">
         <mrow>
@@ -32,7 +32,7 @@
     </math>
     <div style="height: 500px;"></div>
     <math id="target">
-      <mspace width="150px" height="150px" style="background: green"/>
+      <mspace width="150px" height="154px" style="background: green"/>
     </math>
   </div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/class-1-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/class-1-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/class-1.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt
@@ -1,6 +1,7 @@
 
 PASS Preferred width of mrow with mspace children
 PASS Preferred width of mrow with mn and mo children
+PASS Preferred width of mrow with mn and embellished op children
 blah
 |
 2
@@ -18,5 +19,43 @@ blah
 2
 blah
 |
+2
+blah
+|
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
 2
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt
@@ -1,6 +1,7 @@
 
 PASS Preferred width of mrow with mspace children
 FAIL Preferred width of mrow with mn and mo children assert_approx_equals: mfenced expected 105.109375 +/- 1 but got 125.359375
+FAIL Preferred width of mrow with mn and embellished op children assert_approx_equals: mfenced expected 110.734375 +/- 1 but got 130.984375
 blah
 |
 2
@@ -18,5 +19,43 @@ blah
 2
 blah
 |
+2
+blah
+|
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
 2
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt
@@ -1,6 +1,7 @@
 
 PASS Preferred width of mrow with mspace children
 FAIL Preferred width of mrow with mn and mo children assert_approx_equals: mfenced expected 105.109375 +/- 1 but got 125.359375
+FAIL Preferred width of mrow with mn and embellished op children assert_approx_equals: mfenced expected 110.734375 +/- 1 but got 130.984375
 blah
 |
 2
@@ -18,5 +19,43 @@ blah
 2
 blah
 |
+2
+blah
+|
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
+2
+blah
+|
+3
+4
 2
 


### PR DESCRIPTION
#### 37b30988ecaa1d31b3ac6afae0befab9765424f2
<pre>
Resync `mathml` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=309061">https://bugs.webkit.org/show_bug.cgi?id=309061</a>

Reviewed by Tim Nguyen and Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0b54380e224c0779a71468c1c952bdcf50c679ce">https://github.com/web-platform-tests/wpt/commit/0b54380e224c0779a71468c1c952bdcf50c679ce</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-5.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-with-positive-scriptlevel.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-1.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-2.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-6.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-parameters-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-parameters-2.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/underover-1.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-001.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/href-click-002.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/html5-tree/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt:

Canonical link: <a href="https://commits.webkit.org/309406@main">https://commits.webkit.org/309406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0787eed233ba705008ba7501196053fe64354657

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82041 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16636 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160769 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123428 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33768 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133970 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78341 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18814 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10740 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21718 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->