### PR TITLE
Do some security hardening after 308536@main

### DIFF
--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -578,7 +578,11 @@ static std::unique_ptr<Decoder> createMessageDecoder(mach_msg_header_t* header, 
         if (!sharedMemory)
             return nullptr;
 
-        return Decoder::create(sharedMemory->span(), [sharedMemory = WTF::move(sharedMemory)](auto) { }, WTF::move(attachments));
+        // Create a copy of the shared memory before decoding the data to guard against TOCTOU bugs.
+        Ref copy = WebCore::SharedBuffer::create(Vector<uint8_t> { sharedMemory->span() });
+        sharedMemory = nullptr;
+        auto span = copy->span();
+        return Decoder::create(span, [copy = WTF::move(copy)](auto) { }, WTF::move(attachments));
     }
 
     ASSERT(std::to_address(message.subspan(sizeWithPortDescriptors.value()).begin()) == std::to_address(remaining.begin()));


### PR DESCRIPTION
#### b55fd4fb194517386a86c5c5d316c8b2d888620f
<pre>
Do some security hardening after 308536@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=309064">https://bugs.webkit.org/show_bug.cgi?id=309064</a>

Reviewed by Per Arne Vollan.

Create a copy of the SharedMemory data on the recipient side before we
attempt to decode it, to guard against TOCTOU bugs. This is not
performance sensitive anyway as this IPC logic is only a fallback when
hitting a MACH_SEND_TOO_LARGE when sending.

No new tests, covered by IPC.SharedMemoryFallback which is still passing.

* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::createMessageDecoder):

Canonical link: <a href="https://commits.webkit.org/308585@main">https://commits.webkit.org/308585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4804f9d5c20d243be7be0f7dcc6a5f61c6bbdc99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156603 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c86d6c1-41f6-42f6-a885-5cce310b9d60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114039 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06fa8bb7-75bb-489a-a87b-676ef4b8207b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16286 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a73ebba-6793-43ab-9dd1-50f0ef70aa52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15432 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13225 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4043 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158938 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122073 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122276 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31330 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76558 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9322 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83783 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19753 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19901 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->