### PR TITLE
Introduce a WebCore class that wraps a VideoToolbox decoder

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -733,6 +733,7 @@ platform/text/cocoa/LocalizedDateCache.mm @nonARC
 platform/text/cocoa/TextBoundaries.mm @nonARC
 platform/text/mac/TextCheckingMac.mm @nonARC
 platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm @nonARC
+platform/video-codecs/cocoa/VideoDecoderVTB.mm @nonARC
 platform/video-codecs/cocoa/WebRTCVideoDecoder.mm @nonARC
 platform/xr/cocoa/PlatformXRPose.cpp
 rendering/AttachmentLayout.mm @nonARC

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -50,6 +50,7 @@ typedef struct OpaqueVTDecompressionSession*  VTDecompressionSessionRef;
 namespace WebCore {
 
 class VideoDecoder;
+class VideoDecoderVTB;
 struct PlatformVideoColorSpace;
 
 class WebCoreDecompressionSession : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCoreDecompressionSession> {
@@ -81,7 +82,7 @@ private:
     WEBCORE_EXPORT WebCoreDecompressionSession(NSDictionary *, GuaranteedSerialFunctionDispatcher*);
     static NSDictionary *defaultPixelBufferAttributes();
 
-    Expected<RetainPtr<VTDecompressionSessionRef>, OSStatus> ensureDecompressionSessionForSample(CMSampleBufferRef);
+    Expected<RefPtr<VideoDecoderVTB>, OSStatus> ensureDecoderForSample(CMSampleBufferRef);
 
     Ref<DecodingPromise> decodeSampleInternal(CMSampleBufferRef, DecodingFlags);
     void assignResourceOwner(CVImageBufferRef);
@@ -94,7 +95,7 @@ private:
     const Ref<GuaranteedSerialFunctionDispatcher> m_dispatcher;
 
     mutable Lock m_lock;
-    RetainPtr<VTDecompressionSessionRef> m_decompressionSession WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<VideoDecoderVTB> m_videoDecoderVTB WTF_GUARDED_BY_LOCK(m_lock);
     mutable std::optional<bool> m_isHardwareAccelerated WTF_GUARDED_BY_LOCK(m_lock);
 
     std::atomic<uint32_t> m_flushId { 0 };

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -32,6 +32,7 @@
 #import "MediaSampleAVFObjC.h"
 #import "PixelBufferConformerCV.h"
 #import "VideoDecoder.h"
+#import "VideoDecoderVTB.h"
 #import "VideoFrame.h"
 #import <CoreFoundation/CoreFoundation.h>
 #import <CoreMedia/CMBufferQueue.h>
@@ -246,7 +247,7 @@ static RetainPtr<CMTaggedBufferGroupRef> createTaggedBufferGroupWithRequiredVide
     return adoptCF(refinedTaggedBufferGroup);
 }
 
-Expected<RetainPtr<VTDecompressionSessionRef>, OSStatus> WebCoreDecompressionSession::ensureDecompressionSessionForSample(CMSampleBufferRef cmSample)
+Expected<RefPtr<VideoDecoderVTB>, OSStatus> WebCoreDecompressionSession::ensureDecoderForSample(CMSampleBufferRef cmSample)
 {
     Locker lock { m_lock };
 
@@ -260,12 +261,13 @@ Expected<RetainPtr<VTDecompressionSessionRef>, OSStatus> WebCoreDecompressionSes
         std::exchange(m_videoDecoder, nullptr)->close();
 
     if (m_videoDecoder)
-        return RetainPtr<VTDecompressionSessionRef> { };
+        return RefPtr<VideoDecoderVTB> { };
 
-    if (m_decompressionSession && videoFormatDescriptionChanged && !VTDecompressionSessionCanAcceptFormatDescription(m_decompressionSession.get(), videoFormatDescription.get())) {
-        auto status = VTDecompressionSessionWaitForAsynchronousFrames(m_decompressionSession.get());
+    RefPtr videoDecoderVTB = m_videoDecoderVTB;
+    if (videoFormatDescriptionChanged && videoDecoderVTB && !videoDecoderVTB->canAccept(videoFormatDescription.get())) {
+        auto status = videoDecoderVTB->flush();
         Ref sample = MediaSampleAVFObjC::create(cmSample, 0);
-        m_decompressionSession = nullptr;
+        m_videoDecoderVTB = nullptr;
         m_isHardwareAccelerated.reset();
         if (!(sample->flags() & MediaSample::IsSync)) {
             RELEASE_LOG_INFO(Media, "VTDecompressionSession can't accept format description change on non-keyframe status:%d", int(status));
@@ -275,14 +277,8 @@ Expected<RetainPtr<VTDecompressionSessionRef>, OSStatus> WebCoreDecompressionSes
     }
     m_lastFormatDescription = videoFormatDescription;
 
-    if (!m_decompressionSession) {
-        auto videoDecoderSpecification = @{ (__bridge NSString *)kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder: @YES };
-        ASSERT(m_pixelBufferAttributes);
-
-        VTDecompressionSessionRef decompressionSessionOut = nullptr;
-        auto result = VTDecompressionSessionCreate(kCFAllocatorDefault, videoFormatDescription.get(), (__bridge CFDictionaryRef)videoDecoderSpecification, (__bridge CFDictionaryRef)m_pixelBufferAttributes.get(), nullptr, &decompressionSessionOut);
-        if (noErr == result)
-            m_decompressionSession = adoptCF(decompressionSessionOut);
+    if (!m_videoDecoderVTB) {
+        m_videoDecoderVTB = VideoDecoderVTB::create(videoFormatDescription.get(), (__bridge CFDictionaryRef)m_pixelBufferAttributes.get());
         if (m_dispatcher->isCurrent()) {
             assertIsCurrent(m_dispatcher.get());
 
@@ -292,7 +288,7 @@ Expected<RetainPtr<VTDecompressionSessionRef>, OSStatus> WebCoreDecompressionSes
         }
     }
 
-    return m_decompressionSession;
+    return m_videoDecoderVTB;
 }
 
 static bool NODELETE isNonRecoverableError(OSStatus status)
@@ -417,12 +413,12 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
     m_lastDecodedSamples = { };
     m_lastDecodedSamples.reserveInitialCapacity(numberOfSamples);
 
-    auto result = ensureDecompressionSessionForSample(sample);
+    auto result = ensureDecoderForSample(sample);
     if (!result)
         return DecodingPromise::createAndReject(result.error());
-    RetainPtr decompressionSession = WTF::move(*result);
+    RefPtr videoDecoderVTB = WTF::move(*result);
 
-    if (!decompressionSession && !m_videoDecoderCreationFailed) {
+    if (!videoDecoderVTB && !m_videoDecoderCreationFailed) {
         RefPtr<MediaPromise> initPromise;
 
         {
@@ -510,7 +506,7 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
         return decode();
     }
 
-    if (!decompressionSession)
+    if (!videoDecoderVTB)
         return DecodingPromise::createAndReject(kVTVideoDecoderNotAvailableNowErr);
 
     DecodingPromise::Producer producer;
@@ -566,32 +562,30 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
         m_stereoConfigured = true;
         RetainPtr videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
         if (RetainPtr layers = createMVHEVCVideoLayersArray(videoFormatDescription.get()))
-            VTSessionSetProperty(decompressionSession.get(), kVTDecompressionPropertyKey_RequestedMVHEVCVideoLayerIDs, layers.get());
+            videoDecoderVTB->setProperty(kVTDecompressionPropertyKey_RequestedMVHEVCVideoLayerIDs, layers.get());
     }
 
-    if (auto result = VTDecompressionSessionDecodeFrameWithMultiImageCapableOutputHandler(decompressionSession.get(), sample, decodeInfoFlags, nullptr, handler.get()); result != noErr)
-        handler(result, 0, nullptr, nullptr, PAL::kCMTimeInvalid, PAL::kCMTimeInvalid); // If VTDecompressionSessionDecodeFrameWithOutputHandler returned an error, the handler would not have been called.
-
+    videoDecoderVTB->decodeMultiImageFrame(sample, decodeInfoFlags, handler.get());
     return promise;
 }
 
 RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::decodeSampleSync(CMSampleBufferRef sample)
 {
-    auto result = ensureDecompressionSessionForSample(sample);
+    auto result = ensureDecoderForSample(sample);
     if (!result || !*result)
         return nullptr;
 
-    RetainPtr decompressionSession = WTF::move(*result);
+    RefPtr videoDecoderVTB = WTF::move(*result);
     RetainPtr<CVPixelBufferRef> pixelBuffer;
     VTDecodeInfoFlags flags { 0 };
     WTF::Semaphore syncDecompressionOutputSemaphore { 0 };
     Ref protectedThis { *this };
-    VTDecompressionSessionDecodeFrameWithOutputHandler(decompressionSession.get(), sample, flags, nullptr, [&protectedThis, &pixelBuffer, &syncDecompressionOutputSemaphore] (OSStatus, VTDecodeInfoFlags, CVImageBufferRef imageBuffer, CMTime, CMTime) mutable {
+    videoDecoderVTB->decodeFrame(sample, flags, makeBlockPtr([&protectedThis, &pixelBuffer, &syncDecompressionOutputSemaphore] (OSStatus, RetainPtr<CVPixelBufferRef>&& imageBuffer, CMTime) mutable {
         protectedThis->assignResourceOwner(imageBuffer);
         if (imageBuffer && CFGetTypeID(imageBuffer) == CVPixelBufferGetTypeID())
-            pixelBuffer = (CVPixelBufferRef)imageBuffer;
+            pixelBuffer = WTF::move(imageBuffer);
         syncDecompressionOutputSemaphore.signal();
-    });
+    }));
     syncDecompressionOutputSemaphore.wait();
     return pixelBuffer;
 }
@@ -657,11 +651,8 @@ bool WebCoreDecompressionSession::isHardwareAccelerated() const
         return false;
     if (m_isHardwareAccelerated)
         return *m_isHardwareAccelerated;
-    if (!m_decompressionSession)
-        return false;
-    CFBooleanRef isHardwareAccelerated = NULL;
-    VTSessionCopyProperty(m_decompressionSession.get(), kVTDecompressionPropertyKey_UsingHardwareAcceleratedVideoDecoder, kCFAllocatorDefault, &isHardwareAccelerated);
-    m_isHardwareAccelerated = isHardwareAccelerated && isHardwareAccelerated == kCFBooleanTrue;
+
+    m_isHardwareAccelerated = m_videoDecoderVTB && protect(*m_videoDecoderVTB)->isHardwareAccelerated();
     return *m_isHardwareAccelerated;
 }
 

--- a/Source/WebCore/platform/video-codecs/cocoa/VideoDecoderVTB.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/VideoDecoderVTB.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(AVFOUNDATION)
+
+#include <CoreMedia/CMTime.h>
+#include <wtf/BlockPtr.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
+typedef struct OpaqueCMTaggedBufferGroup *CMTaggedBufferGroupRef;
+typedef UInt32 VTDecodeInfoFlags;
+typedef struct OpaqueVTDecompressionSession*  VTDecompressionSessionRef;
+typedef const struct opaqueCMFormatDescription* CMVideoFormatDescriptionRef;
+
+namespace WebCore {
+
+class VideoDecoderVTB : public ThreadSafeRefCounted<VideoDecoderVTB> {
+public:
+    static RefPtr<VideoDecoderVTB> create(CMVideoFormatDescriptionRef, CFDictionaryRef);
+    ~VideoDecoderVTB();
+
+    OSStatus flush();
+
+    bool isHardwareAccelerated() const;
+    bool canAccept(CMVideoFormatDescriptionRef) const;
+    void setProperty(CFStringRef, CFTypeRef);
+
+    // Callback may be called on any thread.
+    using Callback = BlockPtr<void(OSStatus, RetainPtr<CVPixelBufferRef>&&, CMTime)>;
+    void decodeFrame(CMSampleBufferRef, VTDecodeInfoFlags, Callback&&);
+
+    // Callback may be called on any thread.
+    using CallbackMultiImage = BlockPtr<void(OSStatus, VTDecodeInfoFlags, CVImageBufferRef, CMTaggedBufferGroupRef, CMTime, CMTime)>;
+    void decodeMultiImageFrame(CMSampleBufferRef, VTDecodeInfoFlags, CallbackMultiImage&&);
+
+private:
+    explicit VideoDecoderVTB(RetainPtr<VTDecompressionSessionRef>&& session)
+        : m_decompressionSession(WTF::move(session))
+    {
+    }
+
+    const RetainPtr<VTDecompressionSessionRef> m_decompressionSession;
+};
+
+}
+
+#endif

--- a/Source/WebCore/platform/video-codecs/cocoa/VideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/VideoDecoderVTB.mm
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "VideoDecoderVTB.h"
+
+#if USE(AVFOUNDATION)
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <CoreMedia/CMFormatDescription.h>
+
+#import "CoreVideoSoftLink.h"
+#import "VideoToolboxSoftLink.h"
+#import <pal/cf/CoreMediaSoftLink.h>
+
+namespace WebCore {
+
+RefPtr<VideoDecoderVTB> VideoDecoderVTB::create(CMVideoFormatDescriptionRef videoFormatDescription, CFDictionaryRef pixelBufferAttributes)
+{
+    auto videoDecoderSpecification = @{ (__bridge NSString *)kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder: @YES };
+
+    VTDecompressionSessionRef decompressionSession = nullptr;
+    auto result = VTDecompressionSessionCreate(kCFAllocatorDefault, videoFormatDescription, (__bridge CFDictionaryRef)videoDecoderSpecification, pixelBufferAttributes, nullptr, &decompressionSession);
+    if (result != noErr)
+        return nullptr;
+    return adoptRef(*new VideoDecoderVTB(adoptCF(decompressionSession)));
+}
+
+VideoDecoderVTB::~VideoDecoderVTB() = default;
+
+OSStatus VideoDecoderVTB::flush()
+{
+    return VTDecompressionSessionWaitForAsynchronousFrames(m_decompressionSession.get());
+}
+
+bool VideoDecoderVTB::isHardwareAccelerated() const
+{
+    CFBooleanRef isHardwareAccelerated = NULL;
+    VTSessionCopyProperty(m_decompressionSession.get(), kVTDecompressionPropertyKey_UsingHardwareAcceleratedVideoDecoder, kCFAllocatorDefault, &isHardwareAccelerated);
+    return isHardwareAccelerated && isHardwareAccelerated == kCFBooleanTrue;
+}
+
+bool VideoDecoderVTB::canAccept(CMVideoFormatDescriptionRef videoFormatDescription) const
+{
+    return VTDecompressionSessionCanAcceptFormatDescription(m_decompressionSession.get(), videoFormatDescription);
+}
+
+void VideoDecoderVTB::setProperty(CFStringRef key, CFTypeRef value)
+{
+    VTSessionSetProperty(m_decompressionSession.get(), key, value);
+}
+
+void VideoDecoderVTB::decodeFrame(CMSampleBufferRef sample, VTDecodeInfoFlags flags, Callback&& callback)
+{
+    auto result = VTDecompressionSessionDecodeFrameWithOutputHandler(m_decompressionSession.get(), sample, flags, nullptr, makeBlockPtr([callback](OSStatus status, VTDecodeInfoFlags, CVImageBufferRef imageBuffer, CMTime presentationTime, CMTime) mutable {
+        callback(status, (CVPixelBufferRef)imageBuffer, presentationTime);
+    }).get());
+    if (result != noErr) {
+        // If VTDecompressionSessionDecodeFrameWithOutputHandler returns an error, the handler will not be called.
+        callback(result, nullptr, PAL::kCMTimeInvalid);
+    }
+}
+
+void VideoDecoderVTB::decodeMultiImageFrame(CMSampleBufferRef sample, VTDecodeInfoFlags flags, CallbackMultiImage&& callback)
+{
+    auto result = VTDecompressionSessionDecodeFrameWithMultiImageCapableOutputHandler(m_decompressionSession.get(), sample, flags, nullptr, callback.get());
+    if (result != noErr) {
+        // If VTDecompressionSessionDecodeFrameWithMultiImageCapableOutputHandler returns an error, the handler will not be called.
+        callback(result, 0, nullptr, nullptr, PAL::kCMTimeInvalid, PAL::kCMTimeInvalid);
+    }
+}
+
+} // namespace WebCore
+
+#endif


### PR DESCRIPTION
#### bca5f9593bc16774f4754365a8ef6e318f2a9569
<pre>
Introduce a WebCore class that wraps a VideoToolbox decoder
<a href="https://rdar.apple.com/171617092">rdar://171617092</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309068">https://bugs.webkit.org/show_bug.cgi?id=309068</a>

Reviewed by Jean-Yves Avenard.

We introduce a WebCore wrapper named VideoDecoderVTB around VTDecompressionSession.
We make WebCoreDecompressionSession use this wrapper.
Follow-up PRs will make use of VideoDecoderVTB for AV1 as a replacement to VideoDecoderVTB, and for VP9/H264 as replacements to libwebrtc VTB decoders.

Each user of VideoDecoderVTB needs to use it appropriately.
In particular, it needs to ensure that the calls are thread-safe and it needs to handle the fact that the output callbacks are called on an arbitrary queue.
WebCoreDecompressionSession uses a lock for the former and is dispatching to a specific queue for the latter.
AV1 replacement decoder will use a specific queue to call VideoDecoderVTB APIs and will use existing LibWebRTCCodecsProxy code to handle the output callbacks (basically send IPC).

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/309829@main">https://commits.webkit.org/309829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cb3b504828ba11fd53cdfd87b31ff8f9b61e2dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160604 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62faa338-ad7f-4f98-861a-a2b6b650cdd6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3022d282-89aa-4fd1-9fb7-45b2c18b8a0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154822 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98013 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/141ff563-7f2d-4e42-bdfa-617b7b4b7fac) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8439 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125315 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81018 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12752 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88345 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23751 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->