### PR TITLE
[WebXR Layers] Implement projection layer

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3189,7 +3189,7 @@ imported/w3c/web-platform-tests/webxr/hand-input/ [ Pass ]
 
 imported/w3c/web-platform-tests/webxr/hit-test [ Pass ]
 
-imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState.https.html [ Pass ]
+imported/w3c/web-platform-tests/webxr/layers [ Pass ]
 
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -10136,8 +10136,10 @@ WebXRLayersAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
+      "ENABLE(WEBXR_LAYERS)": true
       default: false
     WebCore:
+      "ENABLE(WEBXR_LAYERS)": true
       default: false
 
 WebXRWebGPUBindingsEnabled:

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
@@ -47,17 +47,17 @@ XRProjectionLayerImpl::XRProjectionLayerImpl(WebGPUPtr<WGPUXRProjectionLayer>&& 
 
 XRProjectionLayerImpl::~XRProjectionLayerImpl() = default;
 
-uint32_t XRProjectionLayerImpl::textureWidth() const
+uint32_t XRProjectionLayerImpl::colorTextureWidth() const
 {
     return 0;
 }
 
-uint32_t XRProjectionLayerImpl::textureHeight() const
+uint32_t XRProjectionLayerImpl::colorTextureHeight() const
 {
     return 0;
 }
 
-uint32_t XRProjectionLayerImpl::textureArrayLength() const
+uint32_t XRProjectionLayerImpl::colorTextureArrayLength() const
 {
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
     return 1;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h
@@ -40,7 +40,7 @@ namespace WebCore::WebGPU {
 
 class ConvertToBackingContext;
 
-class XRProjectionLayerImpl final : public XRProjectionLayer {
+class XRProjectionLayerImpl final : public WebCore::WebGPU::XRProjectionLayer {
     WTF_MAKE_TZONE_ALLOCATED(XRProjectionLayerImpl);
 public:
     static Ref<XRProjectionLayerImpl> create(WebGPUPtr<WGPUXRProjectionLayer>&& projectionLayer, ConvertToBackingContext& convertToBackingContext)
@@ -62,9 +62,9 @@ private:
     XRProjectionLayerImpl& operator=(const XRProjectionLayerImpl&) = delete;
     XRProjectionLayerImpl& operator=(XRProjectionLayerImpl&&) = delete;
 
-    uint32_t NODELETE textureWidth() const final;
-    uint32_t NODELETE textureHeight() const final;
-    uint32_t NODELETE textureArrayLength() const final;
+    uint32_t NODELETE colorTextureWidth() const final;
+    uint32_t NODELETE colorTextureHeight() const final;
+    uint32_t NODELETE colorTextureArrayLength() const final;
 
     bool NODELETE ignoreDepthValues() const final;
     std::optional<float> NODELETE fixedFoveation() const final;
@@ -75,8 +75,8 @@ private:
     // WebXRLayer
 #if PLATFORM(COCOA)
     void NODELETE startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) final;
-#endif
     void NODELETE endFrame() final;
+#endif
 
     WebGPUPtr<WGPUXRProjectionLayer> m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.cpp
+++ b/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,38 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingContext;
+#include "config.h"
+#include "WebGLOpaqueTexture.h"
 
-// https://immersive-web.github.io/layers/#XRWebGLBindingtype
-[
-    Conditional=WEBXR_LAYERS,
-    EnabledBySetting=WebXRLayersAPIEnabled,
-    Exposed=Window
-] interface XRWebGLBinding {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context);
+#if ENABLE(WEBXR_LAYERS)
 
-    readonly attribute double nativeProjectionScaleFactor;
-    readonly attribute boolean usesDepthValues;
+#include "WebGLRenderingContextBase.h"
 
-    [CallWith=CurrentScriptExecutionContext] XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});
-    XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
-    XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
-    XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+namespace WebCore {
 
-    XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
-    XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
-};
+RefPtr<WebGLOpaqueTexture> WebGLOpaqueTexture::create(WebGLRenderingContextBase& context, PlatformGLObject object)
+{
+    return adoptRef(*new WebGLOpaqueTexture { context, object });
+}
+
+WebGLOpaqueTexture::WebGLOpaqueTexture(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLTexture(context, object)
+{
+}
+
+void WebGLOpaqueTexture::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject)
+{
+    // Don't do anything as the context does not own the texture.
+}
+
+WebGLOpaqueTexture::~WebGLOpaqueTexture()
+{
+    if (!m_context)
+        return;
+
+    runDestructor();
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.h
+++ b/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingContext;
+#pragma once
 
-// https://immersive-web.github.io/layers/#XRWebGLBindingtype
-[
-    Conditional=WEBXR_LAYERS,
-    EnabledBySetting=WebXRLayersAPIEnabled,
-    Exposed=Window
-] interface XRWebGLBinding {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context);
+#if ENABLE(WEBXR_LAYERS)
 
-    readonly attribute double nativeProjectionScaleFactor;
-    readonly attribute boolean usesDepthValues;
+#include "WebGLTexture.h"
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 
-    [CallWith=CurrentScriptExecutionContext] XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});
-    XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
-    XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
-    XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+namespace WebCore {
 
-    XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
-    XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
+class WebGLOpaqueTexture final : public WebGLTexture {
+public:
+    virtual ~WebGLOpaqueTexture();
+
+    static RefPtr<WebGLOpaqueTexture> create(WebGLRenderingContextBase&, PlatformGLObject);
+
+private:
+    WebGLOpaqueTexture(WebGLRenderingContextBase&, PlatformGLObject);
+    void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 };
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -708,8 +708,10 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
                 if (session.m_activeRenderState->baseLayer())
                     session.m_activeRenderState->baseLayer()->startFrame(session.m_frameData);
 #if ENABLE(WEBXR_LAYERS)
-                else if (session.m_activeRenderState->layers().size())
-                    session.m_activeRenderState->layers()[0]->startFrame(session.m_frameData);
+                else if (session.m_activeRenderState->layers().size()) {
+                    for (auto& layer : session.m_activeRenderState->layers())
+                        layer->startFrame(session.m_frameData);
+                }
 #endif
             }
 
@@ -755,6 +757,12 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             Vector<PlatformXR::DeviceLayer> frameLayers;
             if (isImmersive(session.m_mode) && session.m_activeRenderState->baseLayer())
                 frameLayers.append(session.m_activeRenderState->baseLayer()->endFrame());
+#if ENABLE(WEBXR_LAYERS)
+            else if (!session.m_activeRenderState->layers().isEmpty()) {
+                for (auto& layer : session.m_activeRenderState->layers())
+                    frameLayers.append(layer->endFrame());
+            }
+#endif
 
             if (auto device = session.m_device.get())
                 device->submitFrame(WTF::move(frameLayers));

--- a/Source/WebCore/Modules/webxr/WebXRSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRSwapchain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,47 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingContext;
+#pragma once
 
-// https://immersive-web.github.io/layers/#XRWebGLBindingtype
-[
-    Conditional=WEBXR_LAYERS,
-    EnabledBySetting=WebXRLayersAPIEnabled,
-    Exposed=Window
-] interface XRWebGLBinding {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context);
+#if ENABLE(WEBXR_LAYERS)
 
-    readonly attribute double nativeProjectionScaleFactor;
-    readonly attribute boolean usesDepthValues;
+#include "GraphicsContextGL.h"
 
-    [CallWith=CurrentScriptExecutionContext] XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});
-    XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
-    XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
-    XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+namespace WebCore {
 
-    XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
-    XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
+class WebXRSwapchain {
+public:
+    virtual ~WebXRSwapchain() = default;
+    virtual PlatformGLObject currentTexture() = 0;
+
+    enum class SwapchainTargetFlags : uint8_t {
+        Color = 1 << 0,
+        Depth = 1 << 1,
+        Stencil = 1 << 2,
+    };
+    using SwapchainTargets = OptionSet<SwapchainTargetFlags>;
+protected:
+    WebXRSwapchain(SwapchainTargets targets, bool clearOnAccess)
+        : m_targetFlags(targets)
+        , m_clearOnAccess(clearOnAccess)
+    { };
+
+    SwapchainTargets m_targetFlags;
+    bool m_clearOnAccess { false };
 };
+
+} // namespace WebCore
+
+namespace WTF {
+template<> struct EnumTraits<WebCore::WebXRSwapchain::SwapchainTargetFlags> {
+    using values = EnumValues<
+        WebCore::WebXRSwapchain::SwapchainTargetFlags,
+        WebCore::WebXRSwapchain::SwapchainTargetFlags::Color,
+        WebCore::WebXRSwapchain::SwapchainTargetFlags::Depth,
+        WebCore::WebXRSwapchain::SwapchainTargetFlags::Stencil
+    >;
+};
+
+} // namespace WTF
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -1,0 +1,375 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebXRWebGLSwapchain.h"
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "IntSize.h"
+#include "Logging.h"
+#include "WebGLRenderingContextBase.h"
+#include "WebGLUtilities.h"
+#include <wtf/Scope.h>
+#include <wtf/SystemTracing.h>
+
+namespace WebCore {
+
+using GL = GraphicsContextGL;
+
+WebXRWebGLSwapchain::WebXRWebGLSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, bool clearOnAccess)
+    : WebXRSwapchain(targets, clearOnAccess)
+    , m_context(context)
+{
+    if (clearOnAccess)
+        m_framebufferForClearing = m_context->createFramebuffer();
+}
+
+void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+{
+    ASSERT(m_context);
+
+    if (!m_framebufferForClearing)
+        return;
+
+    auto texture = currentTexture();
+    if (!texture)
+        return;
+
+    auto computeClearMask = [](const SwapchainTargets& targets) {
+        GCGLenum clearMask = 0;
+        if (targets.contains(SwapchainTargetFlags::Color))
+            clearMask |= GL::COLOR_BUFFER_BIT;
+        if (targets.contains(SwapchainTargetFlags::Depth))
+            clearMask |= GL::DEPTH_BUFFER_BIT;
+        if (targets.contains(SwapchainTargetFlags::Stencil))
+            clearMask |= GL::STENCIL_BUFFER_BIT;
+        return clearMask;
+    };
+
+    auto computeAttachment = [](const SwapchainTargets& target) {
+        if (target.contains(SwapchainTargetFlags::Color))
+            return GL::COLOR_ATTACHMENT0;
+        if (target.contains(SwapchainTargetFlags::Depth) && target.contains(SwapchainTargetFlags::Stencil))
+            return GL::DEPTH_STENCIL_ATTACHMENT;
+        if (target.contains(SwapchainTargetFlags::Depth))
+            return GL::DEPTH_ATTACHMENT;
+        ASSERT(target.contains(SwapchainTargetFlags::Stencil));
+        return GL::STENCIL_ATTACHMENT;
+    };
+
+    ScopedWebGLRestoreFramebuffer restoreFramebuffer { *m_context };
+    ScopedDisableRasterizerDiscard disableRasterizerDiscard { *m_context };
+    ScopedEnableBackbuffer enableBackBuffer { *m_context };
+    ScopedDisableScissorTest disableScissorTest { *m_context };
+    ScopedClearColorAndMask zeroClear { *m_context, 0.f, 0.f, 0.f, 0.f, true, true, true, true, };
+    ScopedClearDepthAndMask zeroDepth { *m_context, 1.0f, true, m_targetFlags.contains(SwapchainTargetFlags::Depth) };
+    ScopedClearStencilAndMask zeroStencil { *m_context, 0, 0xFFFFFFFF, m_targetFlags.contains(SwapchainTargetFlags::Stencil) };
+    GCGLenum clearMask = computeClearMask(m_targetFlags);
+    gl.bindFramebuffer(GL::FRAMEBUFFER, m_framebufferForClearing->object());
+    gl.framebufferTexture2D(GL::FRAMEBUFFER, computeAttachment(m_targetFlags), GL::TEXTURE_2D, texture, 0);
+    gl.clear(clearMask);
+}
+
+std::unique_ptr<WebXRWebGLSharedImageSwapchain> WebXRWebGLSharedImageSwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, bool clearOnAccess)
+{
+    return std::unique_ptr<WebXRWebGLSharedImageSwapchain>(new WebXRWebGLSharedImageSwapchain(context, targets, format, clearOnAccess));
+}
+
+WebXRWebGLSharedImageSwapchain::WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, bool clearOnAccess)
+    : WebXRWebGLSwapchain(context, targets, clearOnAccess)
+    , m_format(format)
+{
+}
+
+WebXRWebGLSharedImageSwapchain::~WebXRWebGLSharedImageSwapchain()
+{
+    for (size_t i = 0; i < m_displayImagesSets.size(); ++i)
+        releaseTexturesAtIndex(i);
+    m_displayImagesSets.clear();
+}
+
+PlatformGLObject WebXRWebGLSharedImageSwapchain::currentTexture()
+{
+    RELEASE_ASSERT(m_displayImagesSets.size() > m_currentImageIndex);
+    return m_displayImagesSets[m_currentImageIndex].colorBuffer.tex;
+}
+
+static IntSize calcImagePhysicalSize(const IntSize& leftPhysicalSize, const IntSize& rightPhysicalSize)
+{
+    if (rightPhysicalSize.isEmpty())
+        return leftPhysicalSize;
+    RELEASE_ASSERT(leftPhysicalSize.height() == rightPhysicalSize.height(), "Only side-by-side shared framebuffer layout is supported");
+    return { leftPhysicalSize.width() + rightPhysicalSize.width(), leftPhysicalSize.height() };
+}
+
+static IntSize toIntSize(const auto& size)
+{
+    return IntSize(size[0], size[1]);
+}
+
+void WebXRWebGLSharedImageSwapchain::setupExternalImage(GraphicsContextGL&, const PlatformXR::FrameData::LayerSetupData& data)
+{
+    auto leftPhysicalSize = toIntSize(data.physicalSize[0]);
+    auto rightPhysicalSize = toIntSize(data.physicalSize[1]);
+    m_texSize = calcImagePhysicalSize(leftPhysicalSize, rightPhysicalSize);
+}
+
+const WebXRExternalImages* WebXRWebGLSharedImageSwapchain::reusableTextures(const PlatformXR::FrameData::ExternalTextureData& textureData) const
+{
+    if (textureData.colorTexture)
+        return nullptr;
+
+    auto reusableTextureIndex = textureData.reusableTextureIndex;
+    if (reusableTextureIndex >= m_displayImagesSets.size() || !m_displayImagesSets[reusableTextureIndex]) {
+        RELEASE_LOG_FAULT(XR, "Unable to find reusable texture at index: %" PRIu64, reusableTextureIndex);
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return &m_displayImagesSets[reusableTextureIndex];
+}
+
+void WebXRWebGLSharedImageSwapchain::releaseTexturesAtIndex(size_t index)
+{
+    if (index >= m_displayImagesSets.size())
+        return;
+
+
+    if (RefPtr gl = m_context->graphicsContextGL())
+        m_displayImagesSets[index].release(*gl);
+    else
+        m_displayImagesSets[index].leakObject();
+}
+
+static void createAndBindCompositorTexture(GL& gl, WebXRExternalImage& externalImage, GCGLenum internalFormat, GL::ExternalImageSource source, GCGLint layer)
+{
+    auto image = gl.createExternalImage(WTF::move(source), internalFormat, layer);
+    if (!image)
+        return;
+
+    externalImage.tex = gl.createTexture();
+    gl.bindTexture(GL::TEXTURE_2D, externalImage.tex);
+    gl.bindExternalImage(GL::TEXTURE_2D, image);
+    externalImage.image.adopt(gl, image);
+}
+
+static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::ExternalTexture& imageSource, const IntSize& size)
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    return GraphicsContextGLExternalImageSource {
+        .fds = WTF::move(imageSource.fds),
+        .strides = WTF::move(imageSource.strides),
+        .offsets = WTF::move(imageSource.offsets),
+        .fourcc = imageSource.fourcc,
+        .modifier = imageSource.modifier,
+        .size = size
+    };
+#else
+    UNUSED_PARAM(imageSource);
+    UNUSED_PARAM(size);
+    return GraphicsContextGLExternalImageSource { };
+#endif
+}
+
+void WebXRWebGLSharedImageSwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)
+{
+    m_currentImageIndex = layerData.textureData ? layerData.textureData->reusableTextureIndex : 0;
+    if (m_displayImagesSets.size() <= m_currentImageIndex)
+        m_displayImagesSets.resizeToFit(m_currentImageIndex + 1);
+
+    IntSize texSize = layerData.layerSetup ? toIntSize(layerData.layerSetup->physicalSize[0]) : IntSize(32, 32);
+    if (!layerData.textureData) {
+        m_currentImageIndex = 0;
+        return;
+    }
+
+    auto displayAttachments = reusableTextures(*(layerData.textureData));
+    if (displayAttachments)
+        return;
+
+    releaseTexturesAtIndex(m_currentImageIndex);
+
+    if (!layerData.textureData->colorTexture)
+        return;
+
+    auto colorTextureSource = makeExternalImageSource(layerData.textureData->colorTexture, texSize);
+#if PLATFORM(COCOA)
+    constexpr auto kColorFormat = GL::BGRA_EXT;
+#else
+    constexpr auto kColorFormat = GL::RGBA8;
+#endif
+    // FIXME: add support for texture arrays.
+    GCGLint layer = 0;
+    createAndBindCompositorTexture(gl, m_displayImagesSets[m_currentImageIndex].colorBuffer, kColorFormat, WTF::move(colorTextureSource), layer);
+    ASSERT(m_displayImagesSets[m_currentImageIndex].colorBuffer.tex);
+    if (!m_displayImagesSets[m_currentImageIndex].colorBuffer.tex)
+        return;
+
+    // We should be able to use depth textures from the XR compositor passed via layerData.textureData->depthStencilBuffer. However that would force us to change the design
+    // of the XR swapchains as it currently assumes that a given swapchain does only provide one type of texture. This could be revisited in the future.
+}
+
+void WebXRWebGLSharedImageSwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    ASSERT(!m_fenceFD);
+#endif
+
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    if (data.layerSetup)
+        setupExternalImage(*gl, *data.layerSetup);
+
+    bindCompositorTexturesForDisplay(*gl, data);
+
+    if (m_clearOnAccess)
+        clearCurrentTexture(*gl);
+}
+
+void WebXRWebGLSharedImageSwapchain::endFrame(PlatformXR::DeviceLayer& layerData)
+{
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    ASSERT(gl->checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    if (auto sync = gl->createExternalSync({ })) {
+        layerData.fenceFD = gl->exportExternalSync(sync);
+        gl->deleteExternalSync(sync);
+        return;
+    }
+#else
+    UNUSED_PARAM(layerData);
+#endif
+    gl->finish();
+}
+
+void WebXRExternalImage::destroyImage(GraphicsContextGL& gl)
+{
+    gl.deleteTexture(tex);
+    image.release(gl);
+}
+
+void WebXRExternalImage::release(GraphicsContextGL& gl)
+{
+    gl.deleteTexture(tex);
+    image.release(gl);
+}
+
+void WebXRExternalImage::leakObject()
+{
+    tex = { };
+    image.leakObject();
+}
+
+std::unique_ptr<WebXRWebGLStaticImageSwapchain> WebXRWebGLStaticImageSwapchain::create(WebGLRenderingContextBase& context, StaticImageAttributes attributes)
+{
+    return std::unique_ptr<WebXRWebGLStaticImageSwapchain>(new WebXRWebGLStaticImageSwapchain(context, attributes));
+}
+
+WebXRWebGLStaticImageSwapchain::WebXRWebGLStaticImageSwapchain(WebGLRenderingContextBase& context, StaticImageAttributes attributes)
+    : WebXRWebGLSwapchain(context, attributes.targets, attributes.clearOnAccess)
+    , m_imageAttributes(attributes)
+{
+    m_texSize = attributes.size;
+}
+
+WebXRWebGLStaticImageSwapchain::~WebXRWebGLStaticImageSwapchain()
+{
+    for (size_t i = 0; i < m_textures.size(); ++i)
+        releaseDisplayImagesAtIndex(i);
+    m_textures.clear();
+}
+
+PlatformGLObject WebXRWebGLStaticImageSwapchain::currentTexture()
+{
+    RELEASE_ASSERT(m_textures.size() > m_currentImageIndex);
+    return m_textures[m_currentImageIndex];
+}
+
+void WebXRWebGLStaticImageSwapchain::releaseDisplayImagesAtIndex(size_t index)
+{
+    if (index >= m_textures.size())
+        return;
+
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    gl->deleteTexture(std::exchange(m_textures[index], { }));
+}
+
+void WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)
+{
+    bool shouldCreateNewTexture = false;
+    m_currentImageIndex = layerData.textureData ? layerData.textureData->reusableTextureIndex : 0;
+    if (m_textures.size() <= m_currentImageIndex) {
+        m_textures.resizeToFit(m_currentImageIndex + 1);
+        shouldCreateNewTexture = true;
+    }
+
+    if (!shouldCreateNewTexture)
+        return;
+
+    releaseDisplayImagesAtIndex(m_currentImageIndex);
+
+    // FIXME: add support for texture arrays.
+    GCGLenum target = GL::TEXTURE_2D;
+    PlatformGLObject texture = gl.createTexture();
+    gl.bindTexture(target, texture);
+
+    if (m_context->isWebGL2())
+        gl.texStorage2D(target, 1, m_imageAttributes.internalFormat, m_texSize.width(), m_texSize.height());
+    else
+        gl.texImage2D(target, 0, m_imageAttributes.internalFormat, m_texSize.width(), m_texSize.height(), 0, m_imageAttributes.format, GL::UNSIGNED_INT, { });
+
+    m_textures[m_currentImageIndex] = texture;
+}
+
+void WebXRWebGLStaticImageSwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
+{
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    bindCompositorTexturesForDisplay(*gl, data);
+
+    if (m_clearOnAccess)
+        clearCurrentTexture(*gl);
+}
+
+void WebXRWebGLStaticImageSwapchain::endFrame(PlatformXR::DeviceLayer&)
+{
+
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "GraphicsContextGL.h"
+#include "GraphicsTypesGL.h"
+#include "PlatformXR.h"
+#include "WebXRSwapchain.h"
+#include <wtf/Ref.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class IntSize;
+class WebGLFramebuffer;
+class WebGLOpaqueTexture;
+class WebGLRenderingContextBase;
+struct XRWebGLLayerInit;
+
+struct WebXRExternalImage {
+    PlatformGLObject tex;
+    GCGLOwnedExternalImage image;
+
+    explicit operator bool() const { return !!image; }
+
+    void destroyImage(GraphicsContextGL&);
+    void release(GraphicsContextGL&);
+    void leakObject();
+};
+
+template<typename T>
+struct WebXRImageSet {
+    T colorBuffer;
+
+    operator bool() const
+    {
+        return !!colorBuffer;
+    }
+
+    void release(GraphicsContextGL& gl)
+    {
+        colorBuffer.release(gl);
+    }
+
+    void leakObject()
+    {
+        colorBuffer.leakObject();
+    }
+};
+
+using WebXRExternalImages = WebXRImageSet<WebXRExternalImage>;
+
+class WebXRWebGLSwapchain : public WebXRSwapchain {
+public:
+    ~WebXRWebGLSwapchain() override = default;
+
+    RefPtr<WebGLRenderingContextBase> context() { return m_context; }
+
+    IntSize size() const { return m_texSize; }
+
+    virtual void startFrame(PlatformXR::FrameData::LayerData&) = 0;
+    virtual void endFrame(PlatformXR::DeviceLayer&) = 0;
+
+protected:
+    WebXRWebGLSwapchain(WebGLRenderingContextBase&, SwapchainTargets, bool clearOnAccess);
+    void clearCurrentTexture(GraphicsContextGL&);
+
+    PlatformXR::LayerHandle m_handle;
+    RefPtr<WebGLRenderingContextBase> m_context;
+
+    RefPtr<WebGLFramebuffer> m_framebufferForClearing;
+
+    size_t m_currentImageIndex { 0 };
+    IntSize m_texSize;
+};
+
+// This class represents a swapchain that uses shared images provided by the platform's XR compositor.
+// It manages the lifecycle of these shared images and binds them to the WebGL context for rendering.
+class WebXRWebGLSharedImageSwapchain final : public WebXRWebGLSwapchain {
+public:
+    static std::unique_ptr<WebXRWebGLSharedImageSwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, bool clearOnAccess);
+    ~WebXRWebGLSharedImageSwapchain() override;
+
+    PlatformGLObject currentTexture() override;
+
+    void startFrame(PlatformXR::FrameData::LayerData&) override;
+    void endFrame(PlatformXR::DeviceLayer&) override;
+
+private:
+    WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, bool clearOnAccess);
+    void setupExternalImage(GraphicsContextGL&, const PlatformXR::FrameData::LayerSetupData&);
+
+    const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;
+    void releaseTexturesAtIndex(size_t index);
+    void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
+    const WebXRExternalImages* reusableTexturesAtIndex(size_t);
+
+    GCGLenum m_format;
+#if USE(OPENXR)
+    WTF::UnixFileDescriptor m_fenceFD;
+#endif
+
+    Vector<WebXRExternalImages> m_displayImagesSets;
+};
+
+// This class represents a swapchain that uses "static" images for display, i.e., images that are not
+// shared with the platform's XR compositor. Examples of those are the textures used for depth and stencil
+// which do not necesarily need to be shared with the compositor and can be managed by WebXR itself.
+class WebXRWebGLStaticImageSwapchain final : public WebXRWebGLSwapchain {
+public:
+    struct StaticImageAttributes {
+        GCGLenum format { 0 };
+        GCGLenum internalFormat { 0 };
+        IntSize size;
+        bool clearOnAccess { false };
+        SwapchainTargets targets;
+    };
+    static std::unique_ptr<WebXRWebGLStaticImageSwapchain> create(WebGLRenderingContextBase&, StaticImageAttributes);
+    ~WebXRWebGLStaticImageSwapchain() override;
+
+    PlatformGLObject currentTexture() override;
+
+    void startFrame(PlatformXR::FrameData::LayerData&) override;
+    void endFrame(PlatformXR::DeviceLayer&) override;
+
+private:
+    WebXRWebGLStaticImageSwapchain(WebGLRenderingContextBase&, StaticImageAttributes);
+    void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
+    void releaseDisplayImagesAtIndex(size_t);
+
+    StaticImageAttributes m_imageAttributes;
+#if USE(OPENXR)
+    WTF::UnixFileDescriptor m_fenceFD;
+#endif
+    Vector<PlatformGLObject> m_textures;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "WebGLOpaqueTexture.h"
 #include "XRLayerBacking.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -35,9 +36,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRCompositionLayer);
 
-XRCompositionLayer::XRCompositionLayer(ScriptExecutionContext* scriptExecutionContext, Ref<XRLayerBacking>&& backing)
+XRCompositionLayer::XRCompositionLayer(ScriptExecutionContext* scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing)
     : WebXRLayer(scriptExecutionContext)
     , m_backing(WTF::move(backing))
+    , m_session(session)
 {
 }
 
@@ -46,6 +48,16 @@ XRCompositionLayer::~XRCompositionLayer() = default;
 XRLayerBacking& XRCompositionLayer::backing()
 {
     return m_backing;
+}
+
+void XRCompositionLayer::setColorTextures(Vector<RefPtr<WebGLOpaqueTexture>>&& colorTextures)
+{
+    m_colorTextures = WTF::move(colorTextures);
+}
+
+void XRCompositionLayer::setDepthStencilTextures(Vector<RefPtr<WebGLOpaqueTexture>>&& depthStencilTextures)
+{
+    m_depthStencilTextures = WTF::move(depthStencilTextures);
 }
 
 }

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.h
@@ -30,11 +30,12 @@
 #include "WebXRLayer.h"
 #include "XRLayerLayout.h"
 #include "XRLayerQuality.h"
-
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
+class WebGLOpaqueTexture;
+class WebXRSession;
 class XRLayerBacking;
 
 class XRCompositionLayer : public WebXRLayer {
@@ -42,7 +43,8 @@ class XRCompositionLayer : public WebXRLayer {
 public:
     virtual ~XRCompositionLayer();
 
-    XRLayerLayout layout() const { return XRLayerLayout::Stereo; }
+    XRLayerLayout layout() const { return m_layout; }
+    void setLayout(XRLayerLayout layout) { m_layout = layout; }
 
     bool blendTextureSourceAlpha() const { return false; }
     void setBlendTextureSourceAlpha(bool) { }
@@ -58,17 +60,39 @@ public:
     XRLayerQuality quality() const { return XRLayerQuality::Default; }
     void setQuality(XRLayerQuality) { }
 
-    bool needsRedraw() const { return true; }
+    bool needsRedraw() const { return m_needsRedraw; }
+    void setNeedsRedraw(bool needsRedraw) { m_needsRedraw = needsRedraw; }
+
+    bool isStatic() const { return m_isStatic; }
+    void setIsStatic(bool isStatic) { m_isStatic = isStatic; }
 
     XRLayerBacking& backing();
+    WebXRSession* session() const { return m_session.get(); }
 
     void destroy() { }
+
+    const Vector<RefPtr<WebGLOpaqueTexture>>& colorTextures() const { return m_colorTextures; }
+    void setColorTextures(Vector<RefPtr<WebGLOpaqueTexture>>&&);
+
+    const Vector<RefPtr<WebGLOpaqueTexture>>& depthStencilTextures() const { return m_depthStencilTextures; }
+    void setDepthStencilTextures(Vector<RefPtr<WebGLOpaqueTexture>>&&);
+
 protected:
-    explicit XRCompositionLayer(ScriptExecutionContext*, Ref<XRLayerBacking>&&);
+    explicit XRCompositionLayer(ScriptExecutionContext*, WebXRSession&, Ref<XRLayerBacking>&&);
+
     const Ref<XRLayerBacking> m_backing;
 
 private:
     bool isXRCompositionLayer() const final { return true; }
+
+    WeakPtr<WebXRSession> m_session;
+
+    bool m_isStatic { false };
+    bool m_needsRedraw { true };
+    XRLayerLayout m_layout { XRLayerLayout::Stereo };
+
+    Vector<RefPtr<WebGLOpaqueTexture>> m_colorTextures;
+    Vector<RefPtr<WebGLOpaqueTexture>> m_depthStencilTextures;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
@@ -90,7 +90,7 @@ ExceptionOr<Ref<XRProjectionLayer>> XRGPUBinding::createProjectionLayer(ScriptEx
         return Exception { ExceptionCode::AbortError };
 
     m_init = init;
-    return XRProjectionLayer::create(scriptExecutionContext, projectionLayer.releaseNonNull());
+    return XRProjectionLayer::create(scriptExecutionContext, *m_session, projectionLayer.releaseNonNull(), { });
 }
 
 double XRGPUBinding::nativeProjectionScaleFactor() const

--- a/Source/WebCore/Modules/webxr/XRLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRLayerBacking.h
@@ -33,6 +33,8 @@
 namespace PlatformXR {
 struct FrameData;
 struct RateMapDescription;
+using LayerHandle = int;
+struct DeviceLayer;
 }
 
 namespace WebCore {
@@ -40,18 +42,28 @@ namespace WebCore {
 class XRLayerBacking : public RefCountedAndCanMakeWeakPtr<XRLayerBacking> {
     WTF_MAKE_TZONE_ALLOCATED(XRLayerBacking);
 public:
-    virtual uint32_t textureWidth() const = 0;
-    virtual uint32_t textureHeight() const = 0;
-    virtual uint32_t textureArrayLength() const = 0;
+    virtual uint32_t colorTextureWidth() const = 0;
+    virtual uint32_t colorTextureHeight() const = 0;
+    virtual uint32_t colorTextureArrayLength() const = 0;
+
+    virtual std::optional<uint32_t> depthTextureWidth() const { return std::nullopt; }
+    virtual std::optional<uint32_t> depthTextureHeight() const { return std::nullopt; }
 
 #if PLATFORM(COCOA)
     virtual void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) = 0;
-#else
-    virtual void startFrame(PlatformXR::FrameData&) { RELEASE_ASSERT_NOT_REACHED(); };
-#endif
     virtual void endFrame() = 0;
+#else
+    virtual void startFrame(PlatformXR::FrameData&) = 0;
+    virtual void endFrame(PlatformXR::DeviceLayer&) = 0;
+#endif
 
     virtual ~XRLayerBacking() = default;
+
+    PlatformXR::LayerHandle handle() { return m_handle; }
+    void setHandle(PlatformXR::LayerHandle handle) { m_handle = handle; }
+
+private:
+    PlatformXR::LayerHandle m_handle;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,15 +30,20 @@
 #if ENABLE(WEBXR_LAYERS)
 
 #include "PlatformXR.h"
+#include "WebXRRigidTransform.h"
+#include "WebXRSession.h"
 #include "XRLayerBacking.h"
+#include <WebCore/IntSize.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRProjectionLayer);
 
-XRProjectionLayer::XRProjectionLayer(ScriptExecutionContext& scriptExecutionContext, Ref<XRLayerBacking>&& backing)
-    : XRCompositionLayer(&scriptExecutionContext, WTF::move(backing))
+XRProjectionLayer::XRProjectionLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRProjectionLayerInit& init)
+    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing))
+    , m_init(init)
 {
 }
 
@@ -45,15 +51,19 @@ XRProjectionLayer::~XRProjectionLayer() = default;
 
 void XRProjectionLayer::startFrame(PlatformXR::FrameData& data)
 {
-#if ENABLE(WEBGPU)
+#if PLATFORM(COCOA)
     static constexpr auto defaultLayerHandle = 1;
     auto it = data.layers.find(defaultLayerHandle);
+#else
+    auto it = data.layers.find(m_backing->handle());
+#endif
     if (it == data.layers.end()) {
         // For some reason the device didn't provide a texture for this frame.
         // The frame is ignored and the device can recover the texture in future frames;
         return;
     }
 
+#if ENABLE(WEBGPU)
     auto& frameData = it->value;
     if (frameData->layerSetup && frameData->textureData) {
         m_layerData = frameData;
@@ -61,7 +71,7 @@ void XRProjectionLayer::startFrame(PlatformXR::FrameData& data)
         m_backing->startFrame(frameData->renderingFrameIndex, WTF::move(textureData->colorTexture.handle), WTF::move(textureData->depthStencilBuffer.handle), WTF::move(frameData->layerSetup->completionSyncEvent), textureData->reusableTextureIndex, WTF::move(frameData->layerSetup->foveationRateMapDesc));
     }
 #else
-    UNUSED_PARAM(data);
+    m_backing->startFrame(data);
 #endif
 }
 
@@ -72,37 +82,74 @@ std::optional<PlatformXR::FrameData::LayerData> XRProjectionLayer::layerData() c
 }
 #endif
 
+Vector<IntRect> XRProjectionLayer::computeViewports()
+{
+    auto roundDownShared = [](double value) -> int {
+        return std::max(1, static_cast<int>(std::floor(value)));
+    };
+
+    auto width = m_backing->colorTextureWidth();
+    auto height = m_backing->colorTextureHeight();
+
+    if (!session() || !PlatformXR::isImmersive(session()->mode()) || session()->views().size() <= 1)
+        return { { 0, 0, roundDownShared(width), roundDownShared(height) } };
+
+    auto perViewWidth = roundDownShared(width / session()->views().size());
+    auto perViewHeight = roundDownShared(height);
+
+    Vector<IntRect> viewports;
+    int viewportOriginX = 0;
+    for (size_t i = 0; i < session()->views().size(); ++i) {
+        viewports.append({ viewportOriginX, 0, perViewWidth, perViewHeight });
+        viewportOriginX += perViewWidth;
+    }
+
+    return viewports;
+}
+
 PlatformXR::DeviceLayer XRProjectionLayer::endFrame()
 {
+    PlatformXR::DeviceLayer layerData;
+#if PLATFORM(COCOA)
     m_backing->endFrame();
-    return PlatformXR::DeviceLayer {
-        .handle = 0,
-        .visible = true,
-        .views = { },
-#if PLATFORM(GTK) || PLATFORM(WPE)
-        .fenceFD = { }
+#else
+    m_backing->endFrame(layerData);
 #endif
-    };
+
+    if (m_viewports.isEmpty()) [[unlikely]]
+        m_viewports = computeViewports();
+    ASSERT(m_viewports.size() == 1 || m_viewports.size() == 2);
+    Vector<PlatformXR::DeviceLayer::LayerView> views(m_viewports.size());
+    if (m_viewports.size() == 1)
+        views[0] = { PlatformXR::Eye::None, m_viewports[0] };
+    else {
+        views[0] = { PlatformXR::Eye::Left, m_viewports[0] };
+        views[1] = { PlatformXR::Eye::Right, m_viewports[1] };
+    }
+
+    layerData.handle = m_backing->handle();
+    layerData.visible = true;
+    layerData.views = WTF::move(views);
+
+    return layerData;
 }
 
 uint32_t XRProjectionLayer::textureWidth() const
 {
-    return m_backing->textureWidth();
+    return m_backing->colorTextureWidth();
 }
 
 uint32_t XRProjectionLayer::textureHeight() const
 {
-    return m_backing->textureHeight();
+    return m_backing->colorTextureHeight();
 }
 
 uint32_t XRProjectionLayer::textureArrayLength() const
 {
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
     ASSERT(m_backing->textureArrayLength() == 1);
-#else
-    ASSERT(m_backing->textureArrayLength() == 2);
 #endif
-    return m_backing->textureArrayLength();
+    return m_backing->colorTextureArrayLength();
 }
 
 bool XRProjectionLayer::ignoreDepthValues() const

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.h
@@ -28,8 +28,10 @@
 #if ENABLE(WEBXR_LAYERS)
 
 #include "PlatformXR.h"
-#include "WebXRRigidTransform.h"
 #include "XRCompositionLayer.h"
+#include "XRProjectionLayerInit.h"
+#include <WebCore/IntRect.h>
+#include <wtf/RefPtr.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/MachSendRight.h>
@@ -38,13 +40,14 @@
 namespace WebCore {
 
 class GPUTexture;
+class WebXRRigidTransform;
 
 class XRProjectionLayer : public XRCompositionLayer {
     WTF_MAKE_TZONE_ALLOCATED(XRProjectionLayer);
 public:
-    static Ref<XRProjectionLayer> create(ScriptExecutionContext& scriptExecutionContext, Ref<XRLayerBacking>&& backing)
+    static Ref<XRProjectionLayer> create(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRProjectionLayerInit& init)
     {
-        return adoptRef(*new XRProjectionLayer(scriptExecutionContext, WTF::move(backing)));
+        return adoptRef(*new XRProjectionLayer(scriptExecutionContext, session, WTF::move(backing), init));
     }
     virtual ~XRProjectionLayer();
 
@@ -53,10 +56,14 @@ public:
     uint32_t textureArrayLength() const;
 
     bool ignoreDepthValues() const;
+    void setIgnoreDepthValues(bool ignoreDepthValues) { m_ignoreDepthValues = ignoreDepthValues; }
+
     std::optional<float> fixedFoveation() const;
     void setFixedFoveation(std::optional<float>);
     WebXRRigidTransform* NODELETE deltaPose() const;
     void setDeltaPose(WebXRRigidTransform*);
+
+    const XRProjectionLayerInit& init() const { return m_init; }
 
     // WebXRLayer
     void startFrame(PlatformXR::FrameData&) final;
@@ -66,12 +73,18 @@ public:
 #endif
 
 private:
-    XRProjectionLayer(ScriptExecutionContext&, Ref<XRLayerBacking>&&);
+    XRProjectionLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XRProjectionLayerInit&);
 
     bool isXRProjectionLayer() const final { return true; }
+    Vector<IntRect> computeViewports();
 
+    XRProjectionLayerInit m_init;
+    bool m_ignoreDepthValues { false };
+#if ENABLE(WEBGPU)
     std::optional<PlatformXR::FrameData::LayerData> m_layerData;
+#endif
     RefPtr<WebXRRigidTransform> m_transform;
+    Vector<IntRect> m_viewports;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,12 +31,22 @@
 
 #include "ExceptionOr.h"
 #include "WebGL2RenderingContext.h"
+#include "WebGLOpaqueTexture.h"
 #include "WebGLRenderingContext.h"
 #include "WebGLRenderingContextBase.h"
 #include "WebXRSession.h"
+#include "WebXRView.h"
+#include "WebXRViewport.h"
+#include "XRProjectionLayer.h"
+#include "XRProjectionLayerInit.h"
+#include "XRWebGLProjectionLayerBacking.h"
+#include "XRWebGLSubImage.h"
+#include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+using GL = GraphicsContextGL;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLBinding);
 
@@ -66,7 +77,282 @@ XRWebGLBinding::XRWebGLBinding(Ref<WebXRSession>&& session, WebXRWebGLRenderingC
 {
 }
 
+// https://immersive-web.github.io/layers/#initialize-a-composition-layer
+void XRWebGLBinding::initializeCompositionLayer(XRCompositionLayer& layer)
+{
+    layer.setBlendTextureSourceAlpha(true);
+    layer.setOpacity(1.0);
+}
+
+// https://immersive-web.github.io/layers/#determine-the-layout-attribute
+ExceptionOr<XRLayerLayout> XRWebGLBinding::determineLayout(XRTextureType textureType, XRLayerLayout layout)
+{
+    if (layout == XRLayerLayout::Mono)
+        return layout;
+
+    auto determineLayoutInternal = [&]() {
+        if (layout == XRLayerLayout::Default) {
+            if (m_session->views().size() == 1)
+                return XRLayerLayout::Mono;
+            if (textureType == XRTextureType::TextureArray)
+                return layout;
+        }
+        if (layout == XRLayerLayout::Default || layout == XRLayerLayout::Stereo)
+            return XRLayerLayout::StereoLeftRight;
+        return layout;
+    };
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGL2RenderingContext>&) -> ExceptionOr<XRLayerLayout> {
+            return determineLayoutInternal();
+        },
+        [&](const Ref<WebGLRenderingContext>&) -> ExceptionOr<XRLayerLayout> {
+            if (textureType == XRTextureType::TextureArray)
+                return Exception { ExceptionCode::TypeError };
+            return determineLayoutInternal();
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return XRLayerLayout::Mono;
+        });
+}
+
+// https://immersive-web.github.io/layers/#list-of-color-formats-for-projection-layers
+bool XRWebGLBinding::colorFormatIsSupportedForProjectionLayer(GCGLenum textureFormat) const
+{
+    Vector<GCGLenum> supportedFormats = { GL::RGBA, GL::RGB };
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGL2RenderingContext>&) -> bool {
+            const Vector<GCGLenum> supportedWebGL2Formats = { GL::RGBA8, GL::RGB8, GL::SRGB8, GL::SRGB8_ALPHA8 };
+            return supportedFormats.contains(textureFormat) || supportedWebGL2Formats.contains(textureFormat);
+        },
+        [&](const Ref<WebGLRenderingContext>& context) -> bool {
+            const Vector<GCGLenum> additionalWebGLFormats = { GL::SRGB_EXT, GL::SRGB_ALPHA_EXT };
+            return supportedFormats.contains(textureFormat) || (additionalWebGLFormats.contains(textureFormat) && context->extensionIsEnabled("EXT_sRGB"_s));
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return false;
+        });
+}
+
+// https://immersive-web.github.io/layers/#list-of-depth-formats-for-projection-layers
+bool XRWebGLBinding::depthFormatIsSupportedForProjectionLayer(GCGLenum textureFormat) const
+{
+    Vector<GCGLenum> supportedFormats = { GL::DEPTH_COMPONENT, GL::DEPTH_STENCIL };
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGL2RenderingContext>&) -> bool {
+            const Vector<GCGLenum> supportedWebGL2Formats = { GL::DEPTH_COMPONENT24, GL::DEPTH24_STENCIL8 };
+            return supportedFormats.contains(textureFormat) || supportedWebGL2Formats.contains(textureFormat);
+        },
+        [&](const Ref<WebGLRenderingContext>& context) -> bool {
+            return supportedFormats.contains(textureFormat) && context->extensionIsEnabled("WEBGL_depth_texture"_s);
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return false;
+        });
+}
+
+
+ExceptionOr<Ref<XRProjectionLayer>> XRWebGLBinding::createProjectionLayer(ScriptExecutionContext& scriptExecutionContext, const XRProjectionLayerInit& init)
+{
+    if (m_session->ended())
+        return Exception { ExceptionCode::InvalidStateError, "Cannot create an projection layer with an XRSession that has ended."_s };
+
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Ref<XRProjectionLayer>> {
+            if (baseContext->isContextLost())
+                return Exception { ExceptionCode::InvalidStateError, "Cannot create a projection layer with a lost WebGL context"_s };
+
+            // The following two checks are really part of the allocate textures algorithm, but we need to fail early for the projection layer case
+            // as the allocation happens lazily when getViewSubImage() is called.
+            if (!colorFormatIsSupportedForProjectionLayer(init.colorFormat))
+                return Exception { ExceptionCode::NotSupportedError, "Unsupported texture format."_s };
+
+            if (init.depthFormat && !depthFormatIsSupportedForProjectionLayer(init.depthFormat))
+                return Exception { ExceptionCode::NotSupportedError, "Unsupported depth texture format."_s };
+
+            auto createBackingResult = XRWebGLProjectionLayerBacking::create(m_session, baseContext, init);
+            if (createBackingResult.hasException())
+                return createBackingResult.releaseException();
+            auto backing = createBackingResult.releaseReturnValue();
+
+            auto layer = XRProjectionLayer::create(scriptExecutionContext, m_session, WTF::move(backing), init);
+            initializeCompositionLayer(layer.get());
+            layer->setIsStatic(false);
+            layer->setIgnoreDepthValues(!!init.depthFormat);
+            layer->setFixedFoveation(0);
+
+            auto layoutResult = determineLayout(init.textureType, XRLayerLayout::Default);
+            if (layoutResult.hasException())
+                return layoutResult.releaseException();
+            auto layout = layoutResult.releaseReturnValue();
+            layer->setLayout(layout);
+            layer->setNeedsRedraw(true);
+
+            return layer;
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return Exception { ExceptionCode::OperationError, "Could not get a WebGL rendering context."_s };
+        }
+    );
+}
+
+bool XRWebGLBinding::validateXRWebGLSubImageCreation(const XRProjectionLayer& layer, const WebXRFrame& frame) const
+{
+
+    if (&frame.session() != layer.session())
+        return false;
+
+    if (!frame.isActive())
+        return false;
+
+    if (!frame.isAnimationFrame())
+        return false;
+
+    if (&m_session.get() != layer.session())
+        return false;
+
+    if (layer.colorTextures().isEmpty())
+        return false;
+
+    if (layer.isStatic() && !layer.needsRedraw())
+        return false;
+
+    return true;
+}
+
+IntRect XRWebGLBinding::rectForView(const XRProjectionLayer& layer, const WebXRView& view) const
+{
+    // If the layer is not side-by-side return the full texture size adjusted by the viewport scale.
+    if (layer.textureArrayLength() > 1)
+        return { 0, 0, static_cast<int>(layer.textureWidth() * view.requestedViewportScale()), static_cast<int>(layer.textureHeight() * view.requestedViewportScale()) };
+
+    // Otherwise the layer is side-by-side, so the viewports should be distributed across the texture width.
+    int viewportWidth = layer.textureWidth() / m_session->views().size();
+    int viewportOffset = viewportWidth * (view.eye() == XREye::Left ? 0 : 1);
+    return { viewportOffset, 0, static_cast<int>(viewportWidth * view.requestedViewportScale()), static_cast<int>(layer.textureHeight() * view.requestedViewportScale()) };
+}
+
+ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTexturesForProjectionLayer(XRProjectionLayer& layer, XRTextureType textureType, GCGLenum textureFormat, double scaleFactor)
+{
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> {
+            if (baseContext->isContextLost())
+                return Exception { ExceptionCode::InvalidStateError, "Cannot create a projection layer with a lost WebGL context"_s };
+
+            Vector<RefPtr<WebGLOpaqueTexture>> textures;
+            switch (layer.layout()) {
+            case XRLayerLayout::Default:
+            case XRLayerLayout::Mono:
+                return Exception { ExceptionCode::NotSupportedError, "Mono layout not implemented."_s };
+            case XRLayerLayout::Stereo:
+                if (textureType == XRTextureType::TextureArray)
+                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
+                for (auto& view : m_session->views()) {
+                    if (!view.active)
+                        continue;
+                    textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture());
+                }
+                break;
+            case XRLayerLayout::StereoLeftRight: {
+                if (textureType == XRTextureType::TextureArray)
+                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
+                textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture());
+                break;
+            }
+            case XRLayerLayout::StereoTopBottom:
+                return Exception { ExceptionCode::NotSupportedError, "Stereo top bottom not implemented."_s };
+            };
+
+            UNUSED_PARAM(textureFormat);
+            UNUSED_PARAM(scaleFactor);
+
+            if (textures.isEmpty())
+                return Exception { ExceptionCode::OperationError };
+            return textures;
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return Exception { ExceptionCode::OperationError, "Could not get a WebGL rendering context."_s };
+        }
+    );
+}
+
+ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTexturesForProjectionLayer(XRProjectionLayer& layer, XRTextureType textureType, GCGLenum textureFormat, double scaleFactor)
+{
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> {
+            if (baseContext->isContextLost())
+                return Exception { ExceptionCode::InvalidStateError, "Cannot create a projection layer with a lost WebGL context"_s };
+
+            Vector<RefPtr<WebGLOpaqueTexture>> textures;
+            if (!textureFormat)
+                return textures;
+
+            if (baseContext->isWebGL1() && !baseContext->extensionIsEnabled("WEBGL_depth_texture"_s))
+                return textures;
+
+            switch (layer.layout()) {
+            case XRLayerLayout::Default:
+            case XRLayerLayout::Mono:
+                return Exception { ExceptionCode::NotSupportedError, "Mono layout not implemented."_s };
+            case XRLayerLayout::Stereo:
+                if (textureType == XRTextureType::TextureArray)
+                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
+                for (auto& view : m_session->views()) {
+                    if (!view.active)
+                        continue;
+                    textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture());
+                }
+                break;
+            case XRLayerLayout::StereoLeftRight: {
+                if (textureType == XRTextureType::TextureArray)
+                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
+                textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture());
+                break;
+            }
+            case XRLayerLayout::StereoTopBottom:
+                return Exception { ExceptionCode::NotSupportedError, "Stereo top bottom not implemented."_s };
+            };
+
+            UNUSED_PARAM(textureFormat);
+            UNUSED_PARAM(scaleFactor);
+
+            if (textures.isEmpty())
+                return Exception { ExceptionCode::OperationError };
+            return textures;
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return Exception { ExceptionCode::OperationError, "Could not get a WebGL rendering context."_s };
+        }
+    );
+}
+
+ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getViewSubImage(XRProjectionLayer& layer, const WebXRView& view)
+{
+    // In the specs this is part of the createProjectionLayer algorithm. However by that time the platform textures are not available yet.
+    auto colorTexturesResult = allocateColorTexturesForProjectionLayer(layer, layer.init().textureType, layer.init().colorFormat, layer.init().scaleFactor);
+    if (colorTexturesResult.hasException())
+        return colorTexturesResult.releaseException();
+    layer.setColorTextures(colorTexturesResult.releaseReturnValue());
+
+    auto depthTexturesResult = allocateDepthTexturesForProjectionLayer(layer, layer.init().textureType, layer.init().depthFormat, layer.init().scaleFactor);
+    if (depthTexturesResult.hasException())
+        return depthTexturesResult.releaseException();
+    layer.setDepthStencilTextures(depthTexturesResult.releaseReturnValue());
+
+    auto& frame = view.frame();
+    if (!validateXRWebGLSubImageCreation(layer, frame))
+        return Exception { ExceptionCode::InvalidStateError, "Cannot get view subimage."_s };
+
+    // FIXME: if getViewSubImage() was called previously with the same binding, layer and view, the UA MAY return the same XRWebGLSubImage object as was returned previously.
+    Ref viewport = WebXRViewport::create(rectForView(layer, view));
+    return XRWebGLSubImage::create(WTF::move(viewport), layer);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEBXR_LAYERS)
-

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +30,9 @@
 
 #include "ExceptionOr.h"
 #include "XREye.h"
+#include "XRLayerLayout.h"
+#include "XRProjectionLayerInit.h"
+#include "XRTextureType.h"
 
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -36,7 +40,9 @@
 
 namespace WebCore {
 
+class ScriptExecutionContext;
 class WebGL2RenderingContext;
+class WebGLOpaqueTexture;
 class WebGLRenderingContext;
 class WebXRFrame;
 class WebXRSession;
@@ -52,14 +58,12 @@ class XRWebGLSubImage;
 struct XRCubeLayerInit;
 struct XRCylinderLayerInit;
 struct XREquirectLayerInit;
-struct XRProjectionLayerInit;
 struct XRQuadLayerInit;
 
 // https://immersive-web.github.io/layers/#XRWebGLBindingtype
 class XRWebGLBinding : public RefCounted<XRWebGLBinding> {
     WTF_MAKE_TZONE_ALLOCATED(XRWebGLBinding);
 public:
-
     using WebXRWebGLRenderingContext = Variant<
         Ref<WebGLRenderingContext>,
         Ref<WebGL2RenderingContext>
@@ -70,17 +74,27 @@ public:
     double nativeProjectionScaleFactor() const { RELEASE_ASSERT_NOT_REACHED(); }
     bool usesDepthValues() const { RELEASE_ASSERT_NOT_REACHED(); }
 
-    ExceptionOr<Ref<XRProjectionLayer>> createProjectionLayer(const XRProjectionLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
+    ExceptionOr<Ref<XRProjectionLayer>> createProjectionLayer(ScriptExecutionContext&, const XRProjectionLayerInit&);
     ExceptionOr<Ref<XRQuadLayer>> createQuadLayer(const XRQuadLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
     ExceptionOr<Ref<XRCylinderLayer>> createCylinderLayer(const XRCylinderLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
     ExceptionOr<Ref<XREquirectLayer>> createEquirectLayer(const XREquirectLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
     ExceptionOr<Ref<XRCubeLayer>> createCubeLayer(const XRCubeLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     ExceptionOr<Ref<XRWebGLSubImage>> getSubImage(const XRCompositionLayer&, const WebXRFrame&, XREye) { RELEASE_ASSERT_NOT_REACHED(); }
-    ExceptionOr<Ref<XRWebGLSubImage>> getViewSubImage(const XRProjectionLayer&, const WebXRView&) { RELEASE_ASSERT_NOT_REACHED(); }
+    ExceptionOr<Ref<XRWebGLSubImage>> getViewSubImage(XRProjectionLayer&, const WebXRView&);
 
 private:
     XRWebGLBinding(Ref<WebXRSession>&&, WebXRWebGLRenderingContext&&);
+
+    void initializeCompositionLayer(XRCompositionLayer&);
+    ExceptionOr<XRLayerLayout> determineLayout(XRTextureType, XRLayerLayout);
+    bool colorFormatIsSupportedForProjectionLayer(GCGLenum) const;
+    bool depthFormatIsSupportedForProjectionLayer(GCGLenum) const;
+    ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateColorTexturesForProjectionLayer(XRProjectionLayer&, XRTextureType, GCGLenum textureFormat, double scaleFactor);
+    ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateDepthTexturesForProjectionLayer(XRProjectionLayer&, XRTextureType, GCGLenum textureFormat, double scaleFactor);
+    bool validateXRWebGLSubImageCreation(const XRProjectionLayer&, const WebXRFrame&) const;
+
+    IntRect rectForView(const XRProjectionLayer&, const WebXRView&) const;
 
     const Ref<WebXRSession> m_session;
     WebXRWebGLRenderingContext m_context;

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "XRWebGLLayerBacking.h"
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "GraphicsContextGL.h"
+#include "WebGLOpaqueTexture.h"
+#include "WebGLRenderingContextBase.h"
+#include "WebXROpaqueFramebuffer.h"
+#include "WebXRWebGLSwapchain.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLLayerBacking);
+
+using GL = GraphicsContextGL;
+
+XRWebGLLayerBacking::XRWebGLLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain)
+    : m_colorSwapchain(WTF::move(colorSwapchain))
+    , m_depthSwapchain(WTF::move(depthSwapchain))
+{
+    setHandle(handle);
+}
+
+uint32_t XRWebGLLayerBacking::colorTextureWidth() const
+{
+    return m_colorSwapchain->size().width();
+};
+
+uint32_t XRWebGLLayerBacking::colorTextureHeight() const
+{
+    return m_colorSwapchain->size().height();
+};
+
+uint32_t XRWebGLLayerBacking::colorTextureArrayLength() const
+{
+    // FIXME: Support texture arrays for multiview.
+    return 1;
+};
+
+std::optional<uint32_t> XRWebGLLayerBacking::depthTextureWidth() const
+{
+    return m_depthSwapchain ? std::make_optional(m_depthSwapchain->size().width()) : std::nullopt;
+}
+
+std::optional<uint32_t> XRWebGLLayerBacking::depthTextureHeight() const
+{
+    return m_depthSwapchain ? std::make_optional(m_depthSwapchain->size().height()) : std::nullopt;
+}
+
+#if PLATFORM(COCOA)
+void XRWebGLLayerBacking::startFrame(size_t, MachSendRight&&, MachSendRight&&, MachSendRight&&, size_t, PlatformXR::RateMapDescription&&)
+{
+}
+
+void XRWebGLLayerBacking::endFrame()
+{
+}
+
+#else
+void XRWebGLLayerBacking::startFrame(PlatformXR::FrameData& data)
+{
+    ASSERT(m_colorSwapchain);
+
+    auto it = data.layers.find(handle());
+    if (it == data.layers.end())
+        return;
+
+    m_colorSwapchain->startFrame(it->value);
+    if (m_depthSwapchain)
+        m_depthSwapchain->startFrame(it->value);
+}
+
+void XRWebGLLayerBacking::endFrame(PlatformXR::DeviceLayer& layerData)
+{
+    ASSERT(m_colorSwapchain);
+    m_colorSwapchain->endFrame(layerData);
+    if (m_depthSwapchain)
+        m_depthSwapchain->endFrame(layerData);
+}
+#endif
+
+RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentColorTexture() const
+{
+    return WebGLOpaqueTexture::create(*m_colorSwapchain->context(), m_colorSwapchain->currentTexture());
+}
+
+RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentDepthTexture() const
+{
+    return WebGLOpaqueTexture::create(*m_depthSwapchain->context(), m_depthSwapchain->currentTexture());
+}
+
+// Based on https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/xr/xr_webgl_binding.cc
+XRWebGLLayerBacking::SwapchainFormats XRWebGLLayerBacking::swapchainFormatsForLayerFormat(GCGLenum layerFormat)
+{
+    switch (layerFormat) {
+    case GL::RGBA:
+    case GL::RGBA8:
+        return { GL::RGBA, GL::RGBA8 };
+
+    case GL::RGB:
+    case GL::RGB8:
+        return { GL::RGB, GL::RGB8 };
+
+    case GL::SRGB_EXT:
+    case GL::SRGB8:
+        return { GL::SRGB_EXT, GL::SRGB8 };
+
+    case GL::SRGB_ALPHA_EXT:
+    case GL::SRGB8_ALPHA8:
+        return { GL::SRGB_ALPHA_EXT, GL::SRGB8_ALPHA8 };
+
+    case GL::DEPTH_COMPONENT:
+    case GL::DEPTH_COMPONENT24:
+        return { GL::DEPTH_COMPONENT, GL::DEPTH_COMPONENT24 };
+
+    case GL::DEPTH_STENCIL:
+    case GL::DEPTH24_STENCIL8:
+        return { GL::DEPTH_STENCIL, GL::DEPTH24_STENCIL8 };
+
+    default:
+        ASSERT_NOT_REACHED();
+        return { 0, 0 };
+    };
+}
+
+bool XRWebGLLayerBacking::formatHasStencil(GCGLenum layerFormat)
+{
+    switch (layerFormat) {
+    case GL::DEPTH_STENCIL:
+    case GL::DEPTH24_STENCIL8:
+        return true;
+    default:
+        return false;
+    };
+}
+
+} // namespace WebCore
+
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "XRLayerBacking.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace PlatformXR {
+struct FrameData;
+class Device;
+struct Layer;
+}
+
+namespace WebCore {
+
+class WebGLOpaqueTexture;
+class WebXROpaqueFramebuffer;
+class WebXRWebGLSwapchain;
+
+class XRWebGLLayerBacking : public XRLayerBacking {
+    WTF_MAKE_TZONE_ALLOCATED(XRWebGLLayerBacking);
+public:
+    uint32_t colorTextureWidth() const final;
+    uint32_t colorTextureHeight() const final;
+    uint32_t colorTextureArrayLength() const final;
+
+    std::optional<uint32_t> depthTextureWidth() const final;
+    std::optional<uint32_t> depthTextureHeight() const final;
+
+#if PLATFORM(COCOA)
+    void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) final;
+    void endFrame() final;
+#else
+    void startFrame(PlatformXR::FrameData&) final;
+    void endFrame(PlatformXR::DeviceLayer&) final;
+#endif
+
+    RefPtr<WebGLOpaqueTexture> currentColorTexture() const;
+    RefPtr<WebGLOpaqueTexture> currentDepthTexture() const;
+
+protected:
+    XRWebGLLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain);
+
+    struct SwapchainFormats {
+        GCGLenum format { 0 };
+        GCGLenum internalFormat { 0 };
+    };
+    static SwapchainFormats swapchainFormatsForLayerFormat(GCGLenum);
+    static bool formatHasStencil(GCGLenum);
+
+    std::unique_ptr<WebXRWebGLSwapchain> m_colorSwapchain;
+    std::unique_ptr<WebXRWebGLSwapchain> m_depthSwapchain;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "XRWebGLProjectionLayerBacking.h"
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "WebXRSession.h"
+#include "WebXRWebGLLayer.h"
+#include "WebXRWebGLSwapchain.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLProjectionLayerBacking);
+
+// Arbitrary value for minimum texture scaling. Below this threshold the resulting texture would be too small to see.
+constexpr double MinTextureScalingFactor = 0.2;
+
+ExceptionOr<Ref<XRWebGLProjectionLayerBacking>> XRWebGLProjectionLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XRProjectionLayerInit& init)
+{
+    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess);
+    if (!colorSwapchain)
+        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
+
+    auto device = session.device();
+    if (!device)
+        return Exception { ExceptionCode::OperationError, "Cannot create a projection layer without a valid device."_s };
+
+    float scaleFactor = std::clamp(init.scaleFactor, MinTextureScalingFactor, device->maxFramebufferScalingFactor());
+    FloatSize recommendedSize = session.recommendedWebGLFramebufferResolution();
+    IntSize size = expandedIntSize(recommendedSize.scaled(scaleFactor));
+
+    auto layerHandle = device->createLayerProjection(size.width(), size.height(), true);
+    if (!layerHandle)
+        return Exception { ExceptionCode::OperationError, "Unable to create a projection layer."_s };
+
+    std::unique_ptr<WebXRWebGLSwapchain> depthStencilSwapchain;
+    if (init.depthFormat) {
+        auto formats = XRWebGLLayerBacking::swapchainFormatsForLayerFormat(init.depthFormat);
+        WebXRSwapchain::SwapchainTargets targets = { WebXRSwapchain::SwapchainTargetFlags::Depth };
+        if (XRWebGLLayerBacking::formatHasStencil(init.depthFormat))
+            targets.add(WebXRSwapchain::SwapchainTargetFlags::Stencil);
+        WebXRWebGLStaticImageSwapchain::StaticImageAttributes attributes = {
+            .format = formats.format,
+            .internalFormat = formats.internalFormat,
+            .size = size,
+            .clearOnAccess = init.clearOnAccess,
+            .targets = targets,
+        };
+        depthStencilSwapchain = WebXRWebGLStaticImageSwapchain::create(context, attributes);
+    }
+    return adoptRef(*new XRWebGLProjectionLayerBacking(*layerHandle, WTF::move(colorSwapchain), WTF::move(depthStencilSwapchain)));
+}
+
+XRWebGLProjectionLayerBacking::XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+{
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,32 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingContext;
+#pragma once
 
-// https://immersive-web.github.io/layers/#XRWebGLBindingtype
-[
-    Conditional=WEBXR_LAYERS,
-    EnabledBySetting=WebXRLayersAPIEnabled,
-    Exposed=Window
-] interface XRWebGLBinding {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context);
+#if ENABLE(WEBXR_LAYERS)
 
-    readonly attribute double nativeProjectionScaleFactor;
-    readonly attribute boolean usesDepthValues;
+#include "ExceptionOr.h"
+#include "XRWebGLLayerBacking.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
-    [CallWith=CurrentScriptExecutionContext] XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});
-    XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
-    XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
-    XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+namespace WebCore {
 
-    XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
-    XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
+class WebGLRenderingContextBase;
+class WebXRWebGLSwapchain;
+class WebXRSession;
+struct XRProjectionLayerInit;
+
+class XRWebGLProjectionLayerBacking : public XRWebGLLayerBacking {
+    WTF_MAKE_TZONE_ALLOCATED(XRWebGLProjectionLayerBacking);
+public:
+    static ExceptionOr<Ref<XRWebGLProjectionLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XRProjectionLayerInit&);
+
+private:
+    XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain);
 };
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,9 +26,14 @@
 
 #include "config.h"
 #include "XRWebGLSubImage.h"
+#include "XRLayerBacking.h"
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "WebGLOpaqueTexture.h"
+#include "WebXRSession.h"
+#include "WebXRViewport.h"
+#include "XRProjectionLayer.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -35,6 +41,57 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLSubImage);
 
 XRWebGLSubImage::~XRWebGLSubImage() = default;
+
+XRWebGLSubImage::XRWebGLSubImage(Ref<WebXRViewport>&& viewport, WebGLTexture& colorTexture, IntSize colorTextureSize, WebGLTexture* depthStencilTexture, std::optional<IntSize> depthStencilTextureSize)
+    : m_viewport(WTF::move(viewport))
+    , m_colorTexture(colorTexture)
+    , m_colorTextureSize(colorTextureSize)
+    , m_depthStencilTexture(depthStencilTexture)
+    , m_depthStencilTextureSize(WTF::move(depthStencilTextureSize))
+{
+}
+
+ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLSubImage::create(Ref<WebXRViewport>&& viewport, XRProjectionLayer& layer)
+{
+    auto colorTexture = layer.colorTextures()[0].get();
+    if (!colorTexture || !colorTexture->isUsable())
+        return Exception { ExceptionCode::InvalidStateError, "Cannot get a usable texture for the subimage."_s };
+
+    IntSize colorTextureSize { static_cast<int>(layer.backing().colorTextureWidth()), static_cast<int>(layer.backing().colorTextureHeight()) };
+
+    std::optional<IntSize> depthTextureSize;
+    WebGLOpaqueTexture* depthTexture = nullptr;
+    if (!layer.depthStencilTextures().isEmpty()) {
+        depthTexture = layer.depthStencilTextures()[0].get();
+        if (!depthTexture || !depthTexture->isUsable())
+            depthTexture = nullptr;
+        else
+            depthTextureSize = IntSize { static_cast<int>(layer.backing().depthTextureWidth().value()), static_cast<int>(layer.backing().depthTextureHeight().value()) };
+    }
+
+    return adoptRef(*new XRWebGLSubImage(WTF::move(viewport), *colorTexture, colorTextureSize, depthTexture, depthTextureSize));
+}
+
+const WebGLTexture& XRWebGLSubImage::colorTexture() const
+{
+    return m_colorTexture.get();
+}
+
+RefPtr<WebGLTexture> XRWebGLSubImage::depthStencilTexture() const
+{
+    return m_depthStencilTexture;
+}
+
+std::optional<uint32_t> XRWebGLSubImage::depthStencilTextureWidth() const
+{
+    return !m_depthStencilTexture ? std::nullopt : std::make_optional<uint32_t>(m_viewport->width());
+}
+
+std::optional<uint32_t> XRWebGLSubImage::depthStencilTextureHeight() const
+{
+    return !m_depthStencilTexture ? std::nullopt : std::make_optional<uint32_t>(m_viewport->height());
+}
+
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webxr/XRWebGLSubImage.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLSubImage.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "ExceptionOr.h"
+#include "IntSize.h"
 #include "XRSubImage.h"
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -35,28 +37,40 @@
 namespace WebCore {
 
 class WebGLTexture;
+class XRProjectionLayer;
 
 // https://immersive-web.github.io/layers/#xrwebglsubimagetype
 class XRWebGLSubImage : public XRSubImage {
     WTF_MAKE_TZONE_ALLOCATED(XRWebGLSubImage);
 public:
+    static ExceptionOr<Ref<XRWebGLSubImage>> create(Ref<WebXRViewport>&&, XRProjectionLayer&);
     virtual ~XRWebGLSubImage();
 
-    const WebXRViewport& viewport() const final { RELEASE_ASSERT_NOT_REACHED(); }
-    Ref<WebGLTexture> colorTexture() const { RELEASE_ASSERT_NOT_REACHED(); }
-    RefPtr<WebGLTexture> depthStencilTexture() const { RELEASE_ASSERT_NOT_REACHED(); }
-    RefPtr<WebGLTexture> motionVectorTexture() const { RELEASE_ASSERT_NOT_REACHED(); }
+    const WebXRViewport& viewport() const final { return m_viewport.get(); }
+    const WebGLTexture& colorTexture() const;
+    RefPtr<WebGLTexture> depthStencilTexture() const;
+    RefPtr<WebGLTexture> motionVectorTexture() const { return nullptr; }
 
-    std::optional<uint32_t> imageIndex() const { RELEASE_ASSERT_NOT_REACHED(); }
-    uint32_t colorTextureWidth() const { RELEASE_ASSERT_NOT_REACHED(); }
-    uint32_t colorTextureHeight() const { RELEASE_ASSERT_NOT_REACHED(); }
-    std::optional<uint32_t> depthStencilTextureWidth() const { RELEASE_ASSERT_NOT_REACHED(); }
-    std::optional<uint32_t> depthStencilTextureHeight() const { RELEASE_ASSERT_NOT_REACHED(); }
-    std::optional<uint32_t> motionVectorTextureWidth() const { RELEASE_ASSERT_NOT_REACHED(); }
-    std::optional<uint32_t> motionVectorTextureHeight() const { RELEASE_ASSERT_NOT_REACHED(); }
+    std::optional<uint32_t> imageIndex() const { return std::nullopt; }
+    uint32_t colorTextureWidth() const { return m_colorTextureSize.width(); }
+    uint32_t colorTextureHeight() const { return m_colorTextureSize.height(); }
+    std::optional<uint32_t> depthStencilTextureWidth() const;
+    std::optional<uint32_t> depthStencilTextureHeight() const;
+    std::optional<uint32_t> motionVectorTextureWidth() const { return std::nullopt; }
+    std::optional<uint32_t> motionVectorTextureHeight() const { return std::nullopt; }
 
 private:
+    XRWebGLSubImage(Ref<WebXRViewport>&&, WebGLTexture& colorTexture, IntSize colorTextureSize, WebGLTexture* depthStencilTexture, std::optional<IntSize> depthStencilTextureSize);
+
     bool isXRWebGLSubImage() const final { return true; }
+
+    Ref<WebXRViewport> m_viewport;
+
+    Ref<WebGLTexture> m_colorTexture;
+    IntSize m_colorTextureSize;
+
+    RefPtr<WebGLTexture> m_depthStencilTexture;
+    std::optional<IntSize> m_depthStencilTextureSize;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -538,6 +538,7 @@ Modules/webtransport/WebTransportSendStreamSink.cpp
 Modules/webtransport/WebTransportSession.cpp
 Modules/webtransport/WorkerWebTransportSession.cpp
 Modules/webxr/NavigatorWebXR.cpp
+Modules/webxr/WebGLOpaqueTexture.cpp
 Modules/webxr/WebXRBoundedReferenceSpace.cpp
 Modules/webxr/WebXRFrame.cpp
 Modules/webxr/WebXRGamepad.cpp
@@ -560,6 +561,7 @@ Modules/webxr/WebXRView.cpp
 Modules/webxr/WebXRViewerPose.cpp
 Modules/webxr/WebXRViewport.cpp
 Modules/webxr/WebXRWebGLLayer.cpp
+Modules/webxr/WebXRWebGLSwapchain.cpp
 Modules/webxr/XRCompositionLayer.cpp
 Modules/webxr/XRGPUBinding.cpp
 Modules/webxr/XRGPUSubImage.cpp
@@ -577,6 +579,8 @@ Modules/webxr/WebXRRay.cpp
 Modules/webxr/XRReferenceSpaceEvent.cpp
 Modules/webxr/XRSessionEvent.cpp
 Modules/webxr/XRSubImage.cpp
+Modules/webxr/XRWebGLLayerBacking.cpp
+Modules/webxr/XRWebGLProjectionLayerBacking.cpp
 Modules/webxr/WebXRTransientInputHitTestResult.cpp
 Modules/webxr/WebXRTransientInputHitTestSource.cpp
 Modules/webxr/XRWebGLBinding.cpp

--- a/Source/WebCore/html/canvas/WebGLTexture.h
+++ b/Source/WebCore/html/canvas/WebGLTexture.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class WebGLTexture final : public WebGLObject {
+class WebGLTexture : public WebGLObject {
 public:
 
     virtual ~WebGLTexture();
@@ -48,7 +48,7 @@ public:
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return m_target; }
 
-private:
+protected:
     WebGLTexture(WebGLRenderingContextBase&, PlatformGLObject);
     WebGLTexture();
 

--- a/Source/WebCore/html/canvas/WebGLTexture.idl
+++ b/Source/WebCore/html/canvas/WebGLTexture.idl
@@ -27,6 +27,7 @@
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
+    SkipVTableValidation,
     Exposed=(Window,Worker)
 ] interface WebGLTexture {
 };

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -52,7 +52,11 @@
 #define Supporthdrdisplay_feature_status Testable
 #endif
 
+#if defined(ENABLE_WEBXR_LAYERS) && ENABLE_WEBXR_LAYERS
+#define Webxr_layers_feature_status Testable
+#else
 #define Webxr_layers_feature_status Unstable
+#endif
 
 #if defined(ENABLE_WEBXR_WEBGPU) && ENABLE_WEBXR_WEBGPU && PLATFORM(VISION)
 #define Webgpu_webxr_feature_status Stable

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -33,5 +33,3 @@ struct WebKit::XRDeviceInfo {
 };
 
 #endif
-
-#endif

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -347,7 +347,7 @@ void OpenXRCoordinator::scheduleAnimationFrame(WebPageProxy& page, std::optional
             }
 
             active.renderQueue->dispatch([this, renderState = active.renderState, requestData = WTF::move(requestData), onFrameUpdateCallback = WTF::move(onFrameUpdateCallback)]() mutable {
-                renderState->passthroughFullyObscured = requestData && requestData->isPassthroughFullyObscured;
+                renderState->passthroughFullyObscured = requestData ? requestData->isPassthroughFullyObscured : false;
                 renderState->onFrameUpdate = WTF::move(onFrameUpdateCallback);
                 renderLoop(renderState);
             });

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
@@ -70,23 +70,27 @@ void RemoteXRProjectionLayerProxy::startFrame(size_t frameIndex, MachSendRight&&
 }
 #endif
 
+#if PLATFORM(COCOA)
 void RemoteXRProjectionLayerProxy::endFrame()
+#else
+void RemoteXRProjectionLayerProxy::endFrame(PlatformXR::DeviceLayer&)
+#endif
 {
     auto sendResult = send(Messages::RemoteXRProjectionLayer::EndFrame());
     UNUSED_VARIABLE(sendResult);
 }
 
-uint32_t RemoteXRProjectionLayerProxy::textureWidth() const
+uint32_t RemoteXRProjectionLayerProxy::colorTextureWidth() const
 {
     return 0;
 }
 
-uint32_t RemoteXRProjectionLayerProxy::textureHeight() const
+uint32_t RemoteXRProjectionLayerProxy::colorTextureHeight() const
 {
     return 0;
 }
 
-uint32_t RemoteXRProjectionLayerProxy::textureArrayLength() const
+uint32_t RemoteXRProjectionLayerProxy::colorTextureArrayLength() const
 {
     return 0;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
@@ -29,11 +29,8 @@
 
 #include "RemoteGPUProxy.h"
 #include "WebGPUIdentifier.h"
+#include <WebCore/PlatformXR.h>
 #include <WebCore/WebGPUXRProjectionLayer.h>
-
-namespace PlatformXR {
-struct FrameData;
-}
 
 namespace WebCore {
 class ImageBuffer;
@@ -71,9 +68,9 @@ private:
     RemoteXRProjectionLayerProxy& operator=(const RemoteXRProjectionLayerProxy&) = delete;
     RemoteXRProjectionLayerProxy& operator=(RemoteXRProjectionLayerProxy&&) = delete;
 
-    uint32_t textureWidth() const final;
-    uint32_t textureHeight() const final;
-    uint32_t textureArrayLength() const final;
+    uint32_t colorTextureWidth() const final;
+    uint32_t colorTextureHeight() const final;
+    uint32_t colorTextureArrayLength() const final;
 
     bool ignoreDepthValues() const final;
     std::optional<float> fixedFoveation() const final;
@@ -84,8 +81,11 @@ private:
     // WebXRLayer
 #if PLATFORM(COCOA)
     void startFrame(size_t frameIndex, MachSendRight&&, MachSendRight&&, MachSendRight&&, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) final;
-#endif
     void endFrame() final;
+#else
+    void startFrame(PlatformXR::FrameData&) final { RELEASE_ASSERT_NOT_REACHED(); }
+    void endFrame(PlatformXR::DeviceLayer&) final;
+#endif
 
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)


### PR DESCRIPTION
#### a965fc6b218eb6f1808d3d7f11ff86cfee23faf0
<pre>
[WebXR Layers] Implement projection layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=309063">https://bugs.webkit.org/show_bug.cgi?id=309063</a>

Reviewed by Dan Glastonbury.

This provides an initial working implementation of WebXR projection
layer using the WebGL bindings. It&apos;s still far from being complete as
there are several parameters that are not obeyed but it works. So far we
are only providing an implementation for WPE and GTK ports although
migrating the COCOA ports should be quite straightforward as it uses
most of the concepts already in place for regular WebXR.

A new class called WebXROpaqueTexture was introduced to represent a
WebGL texture that is not managed by the GL context but the app. The
destruction code is run on purpose in this subclass to avoid the
superclass calls to the Graphics Context.

Those opaque textures are the objects that would be used in the web app
to render (regular WebXR uses framebuffers). The spec supports 3
different types of textures: color, depth and motion. So far we&apos;re only
adding support for the 2 first ones as proper rendering could not be
achieved without them.

Those opaque textures are managed by some new entities called the
XRSwapchains. As the name suggests their responsible for providing the
textures. The code will instance a different swapchain per texture type
(color, depth, motion). Swapchains are generic and could be eventually
extended to be used with the WebGPU bindings. So far we&apos;re only
providing an implementation for the WebGL bindings

There are 2 types of swapchains so far, shared and static. The former
use textures created by the XR compositor in the UIProcess (the
color textures) and those that are not shared with the UIProcess and
only used locally in the WebProcess (&quot;static&quot;) for rendering (like the
depth/stencil textures). It should be possible to have also shared
textures for depth, and in fact, the current IPC already supports that
without further changes, but ports using DMABuf or GBM for texture
sharing could not benefit from that as there is no reliable way to share
those depth textures between processes.

A new WebXRSessionListener object was also added to listen to session
end events. We were already notifying the WebXRSystem about that but now
we do in a more generic way for those listeners (currently the
WebXRSystem and the XRWebGLBinding).

The creation of the XRProjectionLayer happens inside the XRWebGLBinding
object wich performs several validation steps and is the one that
eventually creates the projection layer and the backing object which is
the one that holds references to the swapchains.

It&apos;s important to mention that the spec is not fully supported. The
WebXR Layers spec allows multiple setups for the views (only left to
right stereo is supported right now) and multiple types of textures
(regular or texture arrays) but so far only regular textures can be used.

Apart from adding the feature this change allows us to unskip several WPT
tests that PASS now. Feature moved to testable state for those builds
with WEBXR_LAYERS enabled.

* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp:
(WebCore::WebGPU::XRProjectionLayerImpl::colorTextureWidth const):
(WebCore::WebGPU::XRProjectionLayerImpl::colorTextureHeight const):
(WebCore::WebGPU::XRProjectionLayerImpl::colorTextureArrayLength const):
(WebCore::WebGPU::XRProjectionLayerImpl::textureWidth const): Deleted.
(WebCore::WebGPU::XRProjectionLayerImpl::textureHeight const): Deleted.
(WebCore::WebGPU::XRProjectionLayerImpl::textureArrayLength const): Deleted.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h:
* Source/WebCore/Modules/webxr/WebGLOpaqueTexture.cpp:
(WebCore::WebGLOpaqueTexture::create):
(WebCore::WebGLOpaqueTexture::WebGLOpaqueTexture):
(WebCore::WebGLOpaqueTexture::deleteObjectImpl):
(WebCore::WebGLOpaqueTexture::~WebGLOpaqueTexture):
* Source/WebCore/Modules/webxr/WebGLOpaqueTexture.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::onFrame):
* Source/WebCore/Modules/webxr/WebXRSwapchain.h:
(WebCore::WebXRSwapchain::WebXRSwapchain):
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp: Added.
(WebCore::WebXRWebGLSwapchain::WebXRWebGLSwapchain):
(WebCore::WebXRWebGLSwapchain::clearCurrentTexture):
(WebCore::WebXRWebGLSharedImageSwapchain::create):
(WebCore::WebXRWebGLSharedImageSwapchain::WebXRWebGLSharedImageSwapchain):
(WebCore::WebXRWebGLSharedImageSwapchain::~WebXRWebGLSharedImageSwapchain):
(WebCore::WebXRWebGLSharedImageSwapchain::currentTexture):
(WebCore::calcImagePhysicalSize):
(WebCore::toIntSize):
(WebCore::WebXRWebGLSharedImageSwapchain::setupExternalImage):
(WebCore::WebXRWebGLSharedImageSwapchain::reusableTextures const):
(WebCore::WebXRWebGLSharedImageSwapchain::releaseTexturesAtIndex):
(WebCore::createAndBindCompositorTexture):
(WebCore::makeExternalImageSource):
(WebCore::WebXRWebGLSharedImageSwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLSharedImageSwapchain::startFrame):
(WebCore::WebXRWebGLSharedImageSwapchain::endFrame):
(WebCore::WebXRExternalImage::destroyImage):
(WebCore::WebXRExternalImage::release):
(WebCore::WebXRExternalImage::leakObject):
(WebCore::WebXRWebGLStaticImageSwapchain::create):
(WebCore::WebXRWebGLStaticImageSwapchain::WebXRWebGLStaticImageSwapchain):
(WebCore::WebXRWebGLStaticImageSwapchain::~WebXRWebGLStaticImageSwapchain):
(WebCore::WebXRWebGLStaticImageSwapchain::currentTexture):
(WebCore::WebXRWebGLStaticImageSwapchain::releaseDisplayImagesAtIndex):
(WebCore::WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLStaticImageSwapchain::startFrame):
(WebCore::WebXRWebGLStaticImageSwapchain::endFrame):
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h: Added.
(WebCore::WebXRExternalImage::operator bool const):
(WebCore::WebXRImageSet::operator bool const):
(WebCore::WebXRImageSet::release):
(WebCore::WebXRImageSet::leakObject):
(WebCore::WebXRWebGLSwapchain::context):
(WebCore::WebXRWebGLSwapchain::size const):
* Source/WebCore/Modules/webxr/XRCompositionLayer.cpp:
(WebCore::XRCompositionLayer::XRCompositionLayer):
(WebCore::XRCompositionLayer::setColorTextures):
(WebCore::XRCompositionLayer::setDepthStencilTextures):
* Source/WebCore/Modules/webxr/XRCompositionLayer.h:
(WebCore::XRCompositionLayer::layout const):
(WebCore::XRCompositionLayer::setLayout):
(WebCore::XRCompositionLayer::needsRedraw const):
(WebCore::XRCompositionLayer::setNeedsRedraw):
(WebCore::XRCompositionLayer::isStatic const):
(WebCore::XRCompositionLayer::setIsStatic):
(WebCore::XRCompositionLayer::session const):
(WebCore::XRCompositionLayer::colorTextures const):
(WebCore::XRCompositionLayer::depthStencilTextures const):
* Source/WebCore/Modules/webxr/XRGPUBinding.cpp:
(WebCore::XRGPUBinding::createProjectionLayer):
* Source/WebCore/Modules/webxr/XRLayerBacking.h:
(WebCore::XRLayerBacking::depthTextureWidth const):
(WebCore::XRLayerBacking::depthTextureHeight const):
(WebCore::XRLayerBacking::handle):
(WebCore::XRLayerBacking::setHandle):
(WebCore::XRLayerBacking::startFrame): Deleted.
* Source/WebCore/Modules/webxr/XRProjectionLayer.cpp:
(WebCore::XRProjectionLayer::XRProjectionLayer):
(WebCore::XRProjectionLayer::startFrame):
(WebCore::XRProjectionLayer::computeViewports):
(WebCore::XRProjectionLayer::endFrame):
(WebCore::XRProjectionLayer::textureWidth const):
(WebCore::XRProjectionLayer::textureHeight const):
(WebCore::XRProjectionLayer::textureArrayLength const):
* Source/WebCore/Modules/webxr/XRProjectionLayer.h:
(WebCore::XRProjectionLayer::create):
(WebCore::XRProjectionLayer::setIgnoreDepthValues):
(WebCore::XRProjectionLayer::init const):
* Source/WebCore/Modules/webxr/XRSwapchain.h: Added.
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::initializeCompositionLayer):
(WebCore::XRWebGLBinding::determineLayout):
(WebCore::XRWebGLBinding::colorFormatIsSupportedForProjectionLayer const):
(WebCore::XRWebGLBinding::depthFormatIsSupportedForProjectionLayer const):
(WebCore::XRWebGLBinding::createProjectionLayer):
(WebCore::XRWebGLBinding::validateXRWebGLSubImageCreation const):
(WebCore::XRWebGLBinding::rectForView const):
(WebCore::XRWebGLBinding::allocateColorTexturesForProjectionLayer):
(WebCore::XRWebGLBinding::allocateDepthTexturesForProjectionLayer):
(WebCore::XRWebGLBinding::getViewSubImage):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
(WebCore::XRWebGLBinding::createProjectionLayer): Deleted.
(WebCore::XRWebGLBinding::getViewSubImage): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLBinding.idl:
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp: Added.
(WebCore::XRWebGLLayerBacking::XRWebGLLayerBacking):
(WebCore::XRWebGLLayerBacking::colorTextureWidth const):
(WebCore::XRWebGLLayerBacking::colorTextureHeight const):
(WebCore::XRWebGLLayerBacking::colorTextureArrayLength const):
(WebCore::XRWebGLLayerBacking::depthTextureWidth const):
(WebCore::XRWebGLLayerBacking::depthTextureHeight const):
(WebCore::XRWebGLLayerBacking::startFrame):
(WebCore::XRWebGLLayerBacking::endFrame):
(WebCore::XRWebGLLayerBacking::currentColorTexture const):
(WebCore::XRWebGLLayerBacking::currentDepthTexture const):
(WebCore::XRWebGLLayerBacking::swapchainFormatsForLayerFormat):
(WebCore::XRWebGLLayerBacking::formatHasStencil):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h: Copied from Source/WebCore/Modules/webxr/XRCompositionLayer.h.
* Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp: Added.
(WebCore::XRWebGLProjectionLayerBacking::create):
(WebCore::XRWebGLProjectionLayerBacking::XRWebGLProjectionLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.h: Copied from Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp.
* Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp:
(WebCore::XRWebGLSubImage::XRWebGLSubImage):
(WebCore::XRWebGLSubImage::create):
(WebCore::XRWebGLSubImage::colorTexture const):
(WebCore::XRWebGLSubImage::depthStencilTexture const):
(WebCore::XRWebGLSubImage::depthStencilTextureWidth const):
(WebCore::XRWebGLSubImage::depthStencilTextureHeight const):
* Source/WebCore/Modules/webxr/XRWebGLSubImage.h:
(WebCore::XRWebGLSubImage::motionVectorTexture const):
(WebCore::XRWebGLSubImage::imageIndex const):
(WebCore::XRWebGLSubImage::colorTextureWidth const):
(WebCore::XRWebGLSubImage::colorTextureHeight const):
(WebCore::XRWebGLSubImage::motionVectorTextureWidth const):
(WebCore::XRWebGLSubImage::motionVectorTextureHeight const):
(WebCore::XRWebGLSubImage::colorTexture const): Deleted.
(WebCore::XRWebGLSubImage::depthStencilTexture const): Deleted.
(WebCore::XRWebGLSubImage::depthStencilTextureWidth const): Deleted.
(WebCore::XRWebGLSubImage::depthStencilTextureHeight const): Deleted.
* Source/WebCore/Sources.txt:
* Source/WebCore/html/canvas/WebGLTexture.h:
* Source/WebCore/html/canvas/WebGLTexture.idl:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/XR/XRSystem.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::scheduleAnimationFrame):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp:
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::endFrame):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::colorTextureWidth const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::colorTextureHeight const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::colorTextureArrayLength const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::textureWidth const): Deleted.
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::textureHeight const): Deleted.
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::textureArrayLength const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h:

Canonical link: <a href="https://commits.webkit.org/310069@main">https://commits.webkit.org/310069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3be56b2d5377497e989eb4686bd11d06a8a9af97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25424 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/19023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161387 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106099 "Failed to checkout and rebase branch from PR 59802") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/117955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/106099 "Failed to checkout and rebase branch from PR 59802") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155602 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/98667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9221 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/144654 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128896 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163858 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/13447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6997 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/16506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/25222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126172 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34223 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25224 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/81827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/21137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/13487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/184275 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24840 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89126 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47042 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/24532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/24691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/24592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->