### PR TITLE
[Cocoa] Add IsAudible test for 308503@main

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -184,14 +184,6 @@ private:
     explicit NullMediaPlayerPrivate(MediaPlayer&) { }
 };
 
-#if !RELEASE_LOG_DISABLED
-static RefPtr<Logger>& nullLogger()
-{
-    static NeverDestroyed<RefPtr<Logger>> logger;
-    return logger;
-}
-#endif
-
 static const Vector<WebCore::ContentType>& nullContentTypeVector()
 {
     static NeverDestroyed<Vector<WebCore::ContentType>> vector;
@@ -210,6 +202,58 @@ static const std::optional<Vector<FourCC>>& nullOptionalFourCCVector()
     return vector;
 }
 
+const Vector<ContentType>& MediaPlayerClient::mediaContentTypesRequiringHardwareSupport() const
+{
+    return nullContentTypeVector();
+}
+
+const std::optional<Vector<String>>& MediaPlayerClient::allowedMediaContainerTypes() const
+{
+    return nullOptionalStringVector();
+}
+
+const std::optional<Vector<String>>& MediaPlayerClient::allowedMediaCodecTypes() const
+{
+    return nullOptionalStringVector();
+}
+
+const std::optional<Vector<FourCC>>& MediaPlayerClient::allowedMediaVideoCodecIDs() const
+{
+    return nullOptionalFourCCVector();
+}
+
+const std::optional<Vector<FourCC>>& MediaPlayerClient::allowedMediaAudioCodecIDs() const
+{
+    return nullOptionalFourCCVector();
+}
+
+const std::optional<Vector<FourCC>>& MediaPlayerClient::allowedMediaCaptionFormatTypes() const
+{
+    return nullOptionalFourCCVector();
+}
+
+class NullMediaResourceLoader final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NullMediaResourceLoader>
+    , public PlatformMediaResourceLoader {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(NullMediaResourceLoader);
+public:
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock(); }
+    uint32_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); }
+private:
+    void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler) final
+    {
+        completionHandler(makeUnexpected(ResourceError { }));
+    }
+    RefPtr<PlatformMediaResource> requestResource(ResourceRequest&&, LoadOptions) final { return nullptr; }
+};
+
+Ref<PlatformMediaResourceLoader> MediaPlayerClient::mediaPlayerCreateResourceLoader()
+{
+    return *new NullMediaResourceLoader;
+}
+
 class NullMediaPlayerClient final
     : public MediaPlayerClient
     , public RefCounted<NullMediaPlayerClient>
@@ -225,66 +269,8 @@ public:
 
 private:
     NullMediaPlayerClient() = default;
-
-#if !RELEASE_LOG_DISABLED
-    const Logger& mediaPlayerLogger() final
-    {
-        if (!nullLogger().get()) {
-            nullLogger() = Logger::create(this);
-            nullLogger()->setEnabled(this, false);
-        }
-
-        return *nullLogger().get();
-    }
-#endif
-
-    const Vector<WebCore::ContentType>& mediaContentTypesRequiringHardwareSupport() const final { return nullContentTypeVector(); }
-
-    Ref<PlatformMediaResourceLoader> mediaPlayerCreateResourceLoader() final
-    {
-        ASSERT_NOT_REACHED();
-        return adoptRef(*new NullMediaResourceLoader());
-    }
-
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const final { return nullptr; }
-#endif
-
-    const std::optional<Vector<String>>& allowedMediaContainerTypes() const final { return nullOptionalStringVector(); }
-    const std::optional<Vector<String>>& allowedMediaCodecTypes() const final { return nullOptionalStringVector(); }
-    const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const final { return nullOptionalFourCCVector(); }
-    const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const final { return nullOptionalFourCCVector(); }
-    const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const final { return nullOptionalFourCCVector(); }
-
     MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const final { return identifier(); }
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    MediaPlaybackTargetType playbackTargetType() const final { return MediaPlaybackTargetType::None; }
-#endif
-
-    class NullMediaResourceLoader final
-        : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NullMediaResourceLoader>
-        , public PlatformMediaResourceLoader {
-        WTF_MAKE_TZONE_ALLOCATED_INLINE(NullMediaResourceLoader);
-    public:
-        void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-        void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
-        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock(); }
-        uint32_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); }
-    private:
-        void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler) final
-        {
-            completionHandler(makeUnexpected(ResourceError { }));
-        }
-        RefPtr<PlatformMediaResource> requestResource(ResourceRequest&&, LoadOptions) final { return nullptr; }
-    };
 };
-
-const Vector<ContentType>& MediaPlayerClient::mediaContentTypesRequiringHardwareSupport() const
-{
-    static NeverDestroyed<Vector<ContentType>> contentTypes;
-    return contentTypes;
-}
 
 static MediaPlayerClient& nullMediaPlayerClient()
 {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -182,7 +182,7 @@ struct MediaPlayerLoadOptions {
     VideoRendererPreferences videoRendererPreferences { };
 };
 
-class MediaPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaPlayerClient> {
+class WEBCORE_EXPORT MediaPlayerClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaPlayerClient> {
 public:
     virtual ~MediaPlayerClient() = default;
 
@@ -216,7 +216,7 @@ public:
     // The MediaPlayer could not discover an engine which supports the requested resource.
     virtual void mediaPlayerResourceNotSupported() { }
 
-// Presentation-related methods
+    // Presentation-related methods
     // a new frame of video is available
     virtual void mediaPlayerRepaint() { }
 
@@ -245,7 +245,7 @@ public:
     virtual void mediaPlayerActiveSourceBuffersChanged() { }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    virtual RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const = 0;
+    virtual RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const { return nullptr; }
     virtual void mediaPlayerKeyNeeded(const SharedBuffer&) { }
 #endif
 
@@ -275,7 +275,7 @@ public:
     virtual bool mediaPlayerPlatformVolumeConfigurationRequired() const { return false; }
     virtual bool mediaPlayerIsLooping() const { return false; }
     virtual CachedResourceLoader* mediaPlayerCachedResourceLoader() const { return nullptr; }
-    virtual Ref<PlatformMediaResourceLoader> mediaPlayerCreateResourceLoader() = 0;
+    virtual Ref<PlatformMediaResourceLoader> mediaPlayerCreateResourceLoader();
     virtual bool doesHaveAttribute(const AtomString&, AtomString* = nullptr) const { return false; }
     virtual bool mediaPlayerShouldUsePersistentCache() const { return true; }
     virtual String mediaPlayerMediaCacheDirectory() const { return emptyString(); }
@@ -313,14 +313,14 @@ public:
     virtual Vector<String> mediaPlayerPreferredAudioCharacteristics() const { return Vector<String>(); }
 
     virtual bool mediaPlayerShouldDisableSleep() const { return false; }
-    virtual const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const = 0;
+    virtual const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const;
     virtual bool mediaPlayerShouldCheckHardwareSupport() const { return false; }
 
-    virtual const std::optional<Vector<String>>& allowedMediaContainerTypes() const = 0;
-    virtual const std::optional<Vector<String>>& allowedMediaCodecTypes() const = 0;
-    virtual const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const = 0;
-    virtual const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const = 0;
-    virtual const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const = 0;
+    virtual const std::optional<Vector<String>>& allowedMediaContainerTypes() const;
+    virtual const std::optional<Vector<String>>& allowedMediaCodecTypes() const;
+    virtual const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const;
+    virtual const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const;
+    virtual const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const;
 
     virtual void mediaPlayerBufferedTimeRangesChanged() { }
     virtual void mediaPlayerSeekableTimeRangesChanged() { }
@@ -351,7 +351,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual uint64_t mediaPlayerLogIdentifier() { return 0; }
-    virtual const Logger& mediaPlayerLogger() = 0;
+    virtual const Logger& mediaPlayerLogger() { return emptyLogger(); }
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -359,7 +359,7 @@ public:
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    virtual MediaPlaybackTargetType playbackTargetType() const = 0;
+    virtual MediaPlaybackTargetType playbackTargetType() const { return MediaPlaybackTargetType::None; }
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -342,11 +342,13 @@ void MediaPlayerPrivateAVFoundation::setHasVideo(bool b)
 
 void MediaPlayerPrivateAVFoundation::setHasAudio(bool b)
 {
-    if (m_cachedHasAudio != b) {
-        m_cachedHasAudio = b;
-        characteristicsChanged();
-        updateIsAudible();
-    }
+    if (m_cachedHasAudio == b)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, b);
+    m_cachedHasAudio = b;
+    characteristicsChanged();
+    updateIsAudible();
 }
 
 void MediaPlayerPrivateAVFoundation::setHasClosedCaptions(bool b)

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -27,10 +27,9 @@
 
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 
-#include "FloatSize.h"
-#include "InbandTextTrackPrivateAVF.h"
-#include "MediaPlayerPrivate.h"
-#include "Timer.h"
+#include <WebCore/FloatSize.h>
+#include <WebCore/MediaPlayerPrivate.h>
+#include <WebCore/Timer.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -27,10 +27,10 @@
 
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 
-#include "MediaPlayerPrivateAVFoundation.h"
-#include "SharedBuffer.h"
-#include "VideoFrameMetadata.h"
 #include <CoreMedia/CMTime.h>
+#include <WebCore/MediaPlayerPrivateAVFoundation.h>
+#include <WebCore/SharedBuffer.h>
+#include <WebCore/VideoFrameMetadata.h>
 #include <wtf/Forward.h>
 #include <wtf/MainThreadDispatcher.h>
 #include <wtf/Observer.h>
@@ -78,7 +78,7 @@ class VideoLayerManagerObjC;
 class VideoTrackPrivateAVFObjC;
 class WebCoreAVFResourceLoader;
 
-class MediaPlayerPrivateAVFoundationObjC final : public MediaPlayerPrivateAVFoundation {
+class WEBCORE_EXPORT MediaPlayerPrivateAVFoundationObjC final : public MediaPlayerPrivateAVFoundation {
 public:
     explicit MediaPlayerPrivateAVFoundationObjC(MediaPlayer&);
     virtual ~MediaPlayerPrivateAVFoundationObjC();
@@ -135,6 +135,8 @@ public:
     void processChapterTracks();
 
     Ref<WebCoreAVFResourceLoader> ensureAVFResourceLoader(AVAssetResourceLoadingRequest *);
+
+    bool isAudible() const { return m_isAudible; }
 
 private:
 #if ENABLE(ENCRYPTED_MEDIA)
@@ -550,5 +552,9 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaPlayerPrivateAVFoundationObjC)
+static bool isType(const WebCore::MediaPlayerPrivateInterface& player) { return player.mediaPlayerType() == WebCore::MediaPlayerType::AVFObjC; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1347,6 +1347,7 @@
 		C54237F116B8957D00E638FC /* PasteboardNotifications_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C54237ED16B8955800E638FC /* PasteboardNotifications_Bundle.cpp */; };
 		C9E6DD351EA97D0800DD78AA /* FirstResponderSuppression.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E6DD311EA972D800DD78AA /* FirstResponderSuppression.mm */; };
 		CD0BD0A61F79924D001AB2CF /* ContextMenuImgWithVideo.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */; };
+		CD21458A2F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */; };
 		CD27A1C123C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */; };
 		CD48A87324C8A66F00F5800C /* Observer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD48A87224C8A66F00F5800C /* Observer.cpp */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
@@ -4042,6 +4043,7 @@
 		CD0370E224A44B7A00BA3CAE /* MediaLoading.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaLoading.mm; sourceTree = "<group>"; };
 		CD0BD0A51F799220001AB2CF /* ContextMenuImgWithVideo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuImgWithVideo.mm; sourceTree = "<group>"; };
 		CD0BD0A71F7997C2001AB2CF /* ContextMenuImgWithVideo.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ContextMenuImgWithVideo.html; sourceTree = "<group>"; };
+		CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaPlayerPrivateAVFoundationObjCTests.mm; sourceTree = "<group>"; };
 		CD225C071C45A69200140761 /* ParsedContentRange.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParsedContentRange.cpp; sourceTree = "<group>"; };
 		CD227E43211A4D5D00D285AF /* PreferredAudioBufferSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PreferredAudioBufferSize.mm; sourceTree = "<group>"; };
 		CD27A1C023C661ED006E11DD /* WKWebViewPausePlayingAudioTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewPausePlayingAudioTests.mm; sourceTree = "<group>"; };
@@ -7018,6 +7020,7 @@
 				751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */,
 				41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */,
 				7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */,
+				CD2145892F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm */,
 				57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */,
 				EB1F62962D19E07E000B3A04 /* ResourceMonitor.mm */,
 				1AF86FBF2CD5526B00AD337C /* ScrollbarWidthCrash.mm */,
@@ -8053,6 +8056,7 @@
 				CE1866491F72E8F100A0CAB6 /* MarkedText.cpp in Sources */,
 				A17C57EB2C9A5383009DD0B5 /* MediaLoading.mm in Sources */,
 				CDA315981ED53651009F60D3 /* MediaPlaybackSleepAssertion.mm in Sources */,
+				CD21458A2F56305100DF59D1 /* MediaPlayerPrivateAVFoundationObjCTests.mm in Sources */,
 				518C1C532E2149EE00083695 /* MediaReorderQueue.cpp in Sources */,
 				075A9CF526177218006DFA3A /* MediaSessionCoordinatorTest.mm in Sources */,
 				CDC9442E1EF1FC080059C3C4 /* MediaStreamTrackDetached.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "PlatformUtilities.h"
+#include "TestNSBundleExtras.h"
+#include "WebCoreTestSupport.h"
+#include <WebCore/MediaPlayerPrivateAVFoundationObjC.h>
+#include <wtf/Identified.h>
+
+namespace TestWebKitAPI {
+
+class MediaPlayerPrivateAVFoundationObjCTest
+    : public testing::Test
+    , public WebCore::MediaPlayerClient
+    , public Identified<WebCore::MediaPlayerClientIdentifier> {
+public:
+    // Pretend to be reference counted:
+    void ref() const final { }
+    void deref() const final { }
+
+    // MediaPlayerPrivateInterface:
+    WebCore::MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const { return identifier(); }
+
+    // testing::Test:
+    void SetUp() final
+    {
+        mediaPlayer = WebCore::MediaPlayer::create(*this, WebCore::MediaPlayerMediaEngineIdentifier::AVFoundation);
+    }
+
+    void TearDown() final
+    {
+        mediaPlayer = nullptr;
+    }
+
+    // Utility methods:
+    RefPtr<WebCore::MediaPlayerPrivateAVFoundationObjC> playerPrivate() const
+    {
+        if (mediaPlayer)
+            return dynamicDowncast<WebCore::MediaPlayerPrivateAVFoundationObjC>(mediaPlayer->playerPrivate());
+        return nullptr;
+    }
+
+    URL videoWithAudioURL() const
+    {
+        return [NSBundle.test_resourcesBundle URLForResource:@"video-with-audio" withExtension:@"mp4"];
+    }
+
+    URL videoWithoutAudioURL() const
+    {
+        return [NSBundle.test_resourcesBundle URLForResource:@"video-without-audio" withExtension:@"mp4"];
+    }
+
+    void waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState readyState)
+    {
+        Util::waitFor([&] { return mediaPlayer->readyState() > readyState; });
+        EXPECT_GE(mediaPlayer->readyState(), readyState);
+    }
+
+    RefPtr<WebCore::MediaPlayer> mediaPlayer;
+};
+
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, Basic)
+{
+    mediaPlayer->load(videoWithAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveCurrentData);
+}
+
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudible)
+{
+    mediaPlayer->load(videoWithAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveNothing);
+
+    RefPtr playerPrivate = this->playerPrivate();
+    ASSERT_NE(playerPrivate.get(), nullptr);
+
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(false);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setMuted(true);
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+
+    mediaPlayer->setVolume(0);
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(1);
+    mediaPlayer->setMuted(false);
+    EXPECT_EQ(playerPrivate->isAudible(), true);
+}
+
+TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleSilentVideo)
+{
+    mediaPlayer->load(videoWithoutAudioURL(), { });
+    waitForReadyStateGreaterThan(WebCore::MediaPlayerReadyState::HaveNothing);
+
+    RefPtr playerPrivate = this->playerPrivate();
+    ASSERT_NE(playerPrivate.get(), nullptr);
+
+    mediaPlayer->setMuted(false);
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(true);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setMuted(false);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(0);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+
+    mediaPlayer->setVolume(1);
+    EXPECT_EQ(playerPrivate->isAudible(), false);
+}
+
+
+}


### PR DESCRIPTION
#### 53f9008a438290492ab7cf44e50f9102b8e18f56
<pre>
[Cocoa] Add IsAudible test for 308503@main
<a href="https://rdar.apple.com/171583006">rdar://171583006</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309033">https://bugs.webkit.org/show_bug.cgi?id=309033</a>

Reviewed by Jean-Yves Avenard.

Add a test for the behavior fixed by 308503@main, where depending upon the order in which
setMuted() and setVolume() were called, the MediaPlayer PrivateAVFoundationObjC object would not
update whether it was audible.

To do so, give default implementations to (nearly) all the methods in MediaPlayerClient, which makes
writing unit tests for MediaPlayer very simple. Additionally, add a type traits macro to
MediaPlayerPrivateAVFoundationObjC to enable the test code to safely cast to that type from
MediaPlayerPrivateInterface.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayerClient::mediaContentTypesRequiringHardwareSupport const):
(WebCore::MediaPlayerClient::allowedMediaContainerTypes const):
(WebCore::MediaPlayerClient::allowedMediaCodecTypes const):
(WebCore::MediaPlayerClient::allowedMediaVideoCodecIDs const):
(WebCore::MediaPlayerClient::allowedMediaAudioCodecIDs const):
(WebCore::MediaPlayerClient::allowedMediaCaptionFormatTypes const):
(WebCore::MediaPlayerClient::mediaPlayerCreateResourceLoader):
(WebCore::nullLogger): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerNetworkStateChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerReadyStateChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerVolumeChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerMuteChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerSeeked): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerTimeChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDurationChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerRateChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerPlaybackStateChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerResourceNotSupported): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerRepaint): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerSizeChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerEngineUpdated): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerFirstVideoFrameAvailable): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerCharacteristicChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerRenderingCanBeAccelerated): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerRenderingModeChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerAcceleratedCompositingEnabled): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerActiveSourceBuffersChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerKeyNeeded): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerMediaKeysStorageDirectory const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerInitializationDataEncountered): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerWaitingForKeyChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerCurrentPlaybackTargetIsWirelessChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerWillInitializeMediaEngine): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidInitializeMediaEngine): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerReferrer const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerUserAgent const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerIsFullscreen const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerIsFullscreenPermitted const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerIsVideo const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerContentBoxRect const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerContentsScale const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerPlatformVolumeConfigurationRequired const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerIsLooping const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerCachedResourceLoader const): Deleted.
(WebCore::MediaPlayerClient::doesHaveAttribute const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerShouldUsePersistentCache const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerMediaCacheDirectory const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidAddAudioTrack): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidAddTextTrack): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidAddVideoTrack): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidRemoveAudioTrack): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidRemoveTextTrack): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidRemoveVideoTrack): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerDidReportGPUMemoryFootprint): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerReloadAndResumePlaybackIfNeeded): Deleted.
(WebCore::MediaPlayerClient::textTrackRepresentationBoundsChanged): Deleted.
(WebCore::MediaPlayerClient::outOfBandTrackSources): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerNetworkInterfaceName const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerGetRawCookies const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerSourceApplicationIdentifier const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerElementId const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerEngineFailedToLoad): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerRequestedPlaybackRate const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerFullscreenMode const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerIsVideoFullscreenStandby const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerPreferredAudioCharacteristics const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerShouldDisableSleep const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerShouldCheckHardwareSupport const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerBufferedTimeRangesChanged): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerSeekableTimeRangesChanged): Deleted.
(WebCore::MediaPlayerClient::documentSecurityOrigin const): Deleted.
(WebCore::MediaPlayerClient::audioOutputDeviceId const): Deleted.
(WebCore::MediaPlayerClient::audioOutputDeviceIdOverride const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerQueueTaskOnEventLoop): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerOnNewVideoFrameMetadata): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerShouldDisableHDR const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerVideoLayerSize const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerVideoLayerSizeDidChange): Deleted.
(WebCore::MediaPlayerClient::isGStreamerHolePunchingEnabled const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerVideoTarget const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerSoundStageSize const): Deleted.
(WebCore::MediaPlayerClient::mediaPlayerLogIdentifier): Deleted.
(WebCore::MediaPlayerClient::canShowWhileLocked const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::setHasAudio):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
(isType):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm: Added.
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::mediaPlayerClientIdentifier const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::playerPrivate const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::videoWithAudioURL const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::videoWithoutAudioURL const):
(TestWebKitAPI::MediaPlayerPrivateAVFoundationObjCTest::waitForReadyStateGreaterThan):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, Basic)):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudible)):
(TestWebKitAPI::TEST_F(MediaPlayerPrivateAVFoundationObjCTest, IsAudibleSilentVideo)):

Canonical link: <a href="https://commits.webkit.org/308568@main">https://commits.webkit.org/308568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3527a3dda66f81fff52a4d767887c38fd1f82f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147857 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101272 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113990 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81287 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cca27495-fb42-4d76-9557-9fb784af3792) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52675592-3bcc-480b-af8b-2ea897db00e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13174 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3980 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158875 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122221 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76492 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9269 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83719 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19686 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19744 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->