### PR TITLE
Unreviewed, reverting 308519@main (f5d46cd3ff98) and 308485@main (293a7d44cdd5)

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -77,7 +77,7 @@ public:
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
         : m_impl(object ? &object->weakImpl() : nullptr)
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
@@ -87,7 +87,7 @@ public:
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>> WeakPtr(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
         : m_impl(&object.weakImpl())
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
@@ -136,7 +136,7 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
+        ASSERT(canSafelyBeUsed());
         return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
     }
 
@@ -165,7 +165,7 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
+        ASSERT(canSafelyBeUsed());
         auto* result = get();
         RELEASE_ASSERT(result);
         return result;
@@ -180,7 +180,7 @@ public:
             !IsDeprecatedWeakRefSmartPointerException<std::remove_cv_t<T>>::value || (!HasRefPtrMemberFunctions<T>::value && !HasCheckedPtrMemberFunctions<T>::value),
             "IsDeprecatedWeakRefSmartPointerException specialization is no longer needed for this class, please remove it.");
 
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
+        ASSERT(canSafelyBeUsed());
         auto* result = get();
         RELEASE_ASSERT(result);
         return *result;
@@ -190,7 +190,7 @@ public:
 
     EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions() const
     {
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         return m_shouldEnableAssertions ? EnableWeakPtrThreadingAssertions::Yes : EnableWeakPtrThreadingAssertions::No;
 #else
         return EnableWeakPtrThreadingAssertions::No;
@@ -204,26 +204,26 @@ private:
 
     explicit WeakPtr(Ref<WeakPtrImpl>&& ref, EnableWeakPtrThreadingAssertions shouldEnableAssertions)
         : m_impl(WTF::move(ref))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
         UNUSED_PARAM(shouldEnableAssertions);
     }
 
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     inline bool canSafelyBeUsed() const
     {
         // FIXME: Our GC threads currently need to get opaque pointers from WeakPtrs and have to be special-cased.
         return !m_impl
             || !m_shouldEnableAssertions
-            || m_impl->threadAssertion().isCurrent()
-            || Thread::mayBeGCThread();
+            || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
+            || m_impl->wasConstructedOnMainThread() == isMainThread();
     }
 #endif
 
     RefPtr<WeakPtrImpl, PtrTraits> m_impl;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     bool m_shouldEnableAssertions { true };
 #endif
 } SWIFT_ESCAPABLE;
@@ -242,7 +242,7 @@ template<typename T, typename U, typename WeakPtrImpl> inline WeakPtrImpl& weak_
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>::WeakPtr(const WeakPtr<U, WeakPtrImpl, PtrTraits>& o)
     : m_impl(weak_ptr_impl_cast<T, U>(o.m_impl.get()))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     , m_shouldEnableAssertions(o.m_shouldEnableAssertions)
 #endif
 {
@@ -250,7 +250,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>::WeakPtr(WeakPtr<U, WeakPtrImpl, PtrTraits>&& o)
     : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef())))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     , m_shouldEnableAssertions(o.m_shouldEnableAssertions)
 #endif
 {
@@ -258,7 +258,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>::WeakPtr(const WeakRef<U, WeakPtrImpl>& o)
     : m_impl(&weak_ptr_impl_cast<T, U>(o.impl()))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     , m_shouldEnableAssertions(o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes)
 #endif
 {
@@ -266,7 +266,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>::WeakPtr(WeakRef<U, WeakPtrImpl>&& o)
     : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.releaseImpl().leakRef())))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     , m_shouldEnableAssertions(o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes)
 #endif
 {
@@ -275,7 +275,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>& WeakPtr<T, WeakPtrImpl, PtrTraits>::operator=(const WeakPtr<U, WeakPtrImpl, PtrTraits>& o)
 {
     m_impl = weak_ptr_impl_cast<T, U>(o.m_impl.get());
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     m_shouldEnableAssertions = o.m_shouldEnableAssertions;
 #endif
     return *this;
@@ -284,7 +284,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>& WeakPtr<T, WeakPtrImpl, PtrTraits>::operator=(WeakPtr<U, WeakPtrImpl, PtrTraits>&& o)
 {
     m_impl = adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef()));
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     m_shouldEnableAssertions = o.m_shouldEnableAssertions;
 #endif
     return *this;
@@ -293,7 +293,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>& WeakPtr<T, WeakPtrImpl, PtrTraits>::operator=(const WeakRef<U, WeakPtrImpl>& o)
 {
     m_impl = &weak_ptr_impl_cast<T, U>(o.m_impl.get());
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     m_shouldEnableAssertions = o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes;
 #endif
     return *this;
@@ -302,7 +302,7 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename
 template<typename T, typename WeakPtrImpl, typename PtrTraits> template<typename U> inline WeakPtr<T, WeakPtrImpl, PtrTraits>& WeakPtr<T, WeakPtrImpl, PtrTraits>::operator=(WeakRef<U, WeakPtrImpl>&& o)
 {
     m_impl = adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef()));
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     m_shouldEnableAssertions = o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes;
 #endif
     return *this;

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -30,7 +30,6 @@
 #include <wtf/Forward.h>
 #include <wtf/Packed.h>
 #include <wtf/RefPtr.h>
-#include <wtf/ThreadAssertions.h>
 #include <wtf/WeakRef.h>
 
 namespace WTF {
@@ -51,23 +50,24 @@ public:
     using WeakPtrImplType = WeakPtrImpl;
 
     WeakPtrFactory()
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        : m_thread(currentThreadLike)
+#if ASSERT_ENABLED
+        : m_wasConstructedOnMainThread(isMainThread())
 #endif
     {
     }
 
     void prepareForUseOnlyOnMainThread()
     {
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = mainThreadLike;
+#if ASSERT_ENABLED
+        m_wasConstructedOnMainThread = true;
 #endif
     }
 
     void prepareForUseOnlyOnNonMainThread()
     {
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
+#if ASSERT_ENABLED
+        ASSERT(m_wasConstructedOnMainThread);
+        m_wasConstructedOnMainThread = false;
 #endif
     }
 
@@ -75,9 +75,6 @@ public:
     {
         if (m_impl)
             m_impl->clear();
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
     }
 
     WeakPtrImpl* impl() const LIFETIME_BOUND
@@ -90,9 +87,7 @@ public:
         if (m_impl)
             return;
 
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        assertIsCurrent(m_thread);
-#endif
+        ASSERT(m_wasConstructedOnMainThread == isMainThread());
 
         static_assert(std::is_final_v<WeakPtrImpl>);
         m_impl = adoptRef(*new WeakPtrImpl(const_cast<T*>(&object)));
@@ -126,8 +121,8 @@ private:
     template<typename, typename> friend class WeakRef;
 
     mutable RefPtr<WeakPtrImpl> m_impl;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_thread;
+#if ASSERT_ENABLED
+    bool m_wasConstructedOnMainThread;
 #endif
 };
 
@@ -141,8 +136,8 @@ public:
     using WeakPtrImplType = WeakPtrImpl;
 
     WeakPtrFactoryWithBitField()
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        : m_thread(currentThreadLike)
+#if ASSERT_ENABLED
+        : m_wasConstructedOnMainThread(isMainThread())
 #endif
     {
     }
@@ -151,9 +146,6 @@ public:
     {
         if (auto* pointer = m_impl.pointer())
             pointer->clear();
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
     }
 
     WeakPtrImpl* impl() const LIFETIME_BOUND
@@ -166,9 +158,7 @@ public:
         if (m_impl.pointer())
             return;
 
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        assertIsCurrent(m_thread);
-#endif
+        ASSERT(m_wasConstructedOnMainThread == isMainThread());
 
         static_assert(std::is_final_v<WeakPtrImpl>);
         m_impl.setPointer(adoptRef(*new WeakPtrImpl(const_cast<T*>(&object))));
@@ -209,8 +199,8 @@ private:
     template<typename, typename> friend class WeakRef;
 
     mutable CompactRefPtrTuple<WeakPtrImpl, uint16_t> m_impl;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_thread;
+#if ASSERT_ENABLED
+    bool m_wasConstructedOnMainThread;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakPtrImpl.h
+++ b/Source/WTF/wtf/WeakPtrImpl.h
@@ -28,7 +28,6 @@
 #include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/SingleThreadIntegralWrapper.h>
-#include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
@@ -48,38 +47,25 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear()
-    {
-        m_ptr = nullptr;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
-    }
+    void clear() { m_ptr = nullptr; }
 
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    const ThreadLikeAssertion& threadAssertion() const { return m_thread; }
+#if ASSERT_ENABLED
+    bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
 #endif
 
     template<typename T>
     explicit WeakPtrImplBase(T* ptr)
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        , m_thread(currentThreadLike)
+#if ASSERT_ENABLED
+        , m_wasConstructedOnMainThread(isMainThread())
 #endif
     {
-    }
-
-    ~WeakPtrImplBase()
-    {
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
     }
 
 private:
     void* m_ptr;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    NO_UNIQUE_ADDRESS mutable ThreadLikeAssertion m_thread;
+#if ASSERT_ENABLED
+    bool m_wasConstructedOnMainThread;
 #endif
 };
 
@@ -105,32 +91,19 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear()
-    {
-        m_ptr = nullptr;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
-    }
+    void clear() { m_ptr = nullptr; }
 
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    const ThreadLikeAssertion& threadAssertion() const { return m_thread; }
+#if ASSERT_ENABLED
+    bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
 #endif
 
     template<typename T>
     explicit WeakPtrImplBaseSingleThread(T* ptr)
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        , m_thread(currentThreadLike)
+#if ASSERT_ENABLED
+        , m_wasConstructedOnMainThread(isMainThread())
 #endif
     {
-    }
-
-    ~WeakPtrImplBaseSingleThread()
-    {
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
     }
 
     uint32_t refCount() const { return m_refCount; }
@@ -148,8 +121,8 @@ public:
 private:
     mutable SingleThreadIntegralWrapper<uint32_t> m_refCount { 1 };
     void* m_ptr;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    NO_UNIQUE_ADDRESS mutable ThreadLikeAssertion m_thread;
+#if ASSERT_ENABLED
+    bool m_wasConstructedOnMainThread;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -56,7 +56,7 @@ class WeakRef {
 public:
     WeakRef(const T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes) requires (!IsSmartPtr<T>::value && !std::is_pointer_v<T>)
         : m_impl(object.weakImpl())
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
@@ -65,7 +65,7 @@ public:
 
     explicit WeakRef(Ref<WeakPtrImpl>&& impl, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
         : m_impl(WTF::move(impl))
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
 #endif
     {
@@ -116,13 +116,13 @@ public:
 
     T* operator->() const
     {
-        ASSERT_WITH_SECURITY_IMPLICATION(canSafelyBeUsed());
+        ASSERT(canSafelyBeUsed());
         return ptr();
     }
 
     EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions() const
     {
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
         return m_shouldEnableAssertions ? EnableWeakPtrThreadingAssertions::Yes : EnableWeakPtrThreadingAssertions::No;
 #else
         return EnableWeakPtrThreadingAssertions::No;
@@ -130,19 +130,19 @@ public:
     }
 
 private:
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     inline bool canSafelyBeUsed() const
     {
         // FIXME: Our GC threads currently need to get opaque pointers from WeakPtrs and have to be special-cased.
         return !m_impl
             || !m_shouldEnableAssertions
-            || m_impl->threadAssertion().isCurrent()
-            || Thread::mayBeGCThread();
+            || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
+            || m_impl->wasConstructedOnMainThread() == isMainThread();
     }
 #endif
 
     Ref<WeakPtrImpl> m_impl;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+#if ASSERT_ENABLED
     bool m_shouldEnableAssertions { true };
 #endif
 };

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -53,7 +53,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_audio_file_reader_debug);
 #define GST_CAT_DEFAULT webkit_audio_file_reader_debug
 
-class AudioFileReader : public CanMakeWeakPtr<AudioFileReader, WeakPtrFactoryInitialization::Eager> {
+class AudioFileReader : public CanMakeWeakPtr<AudioFileReader> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioFileReader);
     WTF_MAKE_NONCOPYABLE(AudioFileReader);
 public:

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -44,9 +44,7 @@ class CDMProxyDecryptionClientImplementation final : public WebCore::CDMProxyDec
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDMProxyDecryptionClientImplementation);
 public:
     CDMProxyDecryptionClientImplementation(WebKitMediaCommonEncryptionDecrypt* decryptor)
-        : m_decryptor(decryptor)
-    {
-    }
+        : m_decryptor(decryptor) { }
     virtual bool isAborting()
     {
         return webKitMediaCommonEncryptionDecryptIsAborting(m_decryptor);
@@ -503,8 +501,7 @@ bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDec
 WeakPtr<WebCore::CDMProxyDecryptionClient> webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient(WebKitMediaCommonEncryptionDecrypt* self)
 {
     WebKitMediaCommonEncryptionDecryptPrivate* priv = WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(self);
-    // FXIME: We should not need EnableWeakPtrThreadingAssertions::No here. This is likely indicative of a bug.
-    return WeakPtr { *priv->cdmProxyDecryptionClientImplementation, EnableWeakPtrThreadingAssertions::No };
+    return *priv->cdmProxyDecryptionClientImplementation;
 }
 
 static GstStateChangeReturn changeState(GstElement* element, GstStateChange transition)

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -3176,13 +3176,7 @@ public:
     }
 
     explicit operator bool() const { return m_ptr; }
-    void clear()
-    {
-        m_ptr = nullptr;
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-        m_thread = anyThreadLike;
-#endif
-    }
+    void clear() { m_ptr = nullptr; }
 
     template<typename T>
     explicit DidUpdateRefCountWeakPtrImpl(T* ptr)
@@ -3190,10 +3184,8 @@ public:
     {
     }
 
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    ~DidUpdateRefCountWeakPtrImpl() { m_thread = anyThreadLike; }
-
-    const ThreadLikeAssertion& threadAssertion() const { return m_thread; }
+#if ASSERT_ENABLED
+    bool wasConstructedOnMainThread() const { return true; }
 #endif
 
     void resetDidUpdateRefCount() { m_didUpdateRefCount = false; }
@@ -3219,9 +3211,6 @@ private:
     mutable uint32_t m_refCount { 1 };
     void* m_ptr;
     mutable bool m_didUpdateRefCount { false };
-#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
-    NO_UNIQUE_ADDRESS mutable ThreadLikeAssertion m_thread { mainThreadLike };
-#endif
 };
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DidUpdateRefCountWeakPtrImpl);
 


### PR DESCRIPTION
#### 49defa8a19f3a4b8feccd9eace8b8b937fc42032
<pre>
Unreviewed, reverting 308519@main (f5d46cd3ff98) and 308485@main (293a7d44cdd5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309074">https://bugs.webkit.org/show_bug.cgi?id=309074</a>
<a href="https://rdar.apple.com/171588125">rdar://171588125</a>

REGRESSION(308485@main): Use of undeclared identifier &apos;m_shouldEnableAssertions&apos;

Reverted changes:

    REGRESSION(308485@main): Use of undeclared identifier &apos;m_shouldEnableAssertions&apos; under ASAN
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309036">https://bugs.webkit.org/show_bug.cgi?id=309036</a>
    <a href="https://rdar.apple.com/171588125">rdar://171588125</a>
    308519@main (f5d46cd3ff98)

    Update WeakPtr threading assertions to catch more bugs
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308941">https://bugs.webkit.org/show_bug.cgi?id=308941</a>
    308485@main (293a7d44cdd5)

Canonical link: <a href="https://commits.webkit.org/308553@main">https://commits.webkit.org/308553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cec51159a112e4edc9d4cc27eda427f634acded

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20543 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156541 "Failed to checkout and rebase branch from PR 59804") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20447 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/156541 "Failed to checkout and rebase branch from PR 59804") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150820 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/156541 "Failed to checkout and rebase branch from PR 59804") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139828 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/14136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158876 "Failed to checkout and rebase branch from PR 59804") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8646 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2010 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/158876 "Failed to checkout and rebase branch from PR 59804") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/158876 "Failed to checkout and rebase branch from PR 59804") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20353 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76493 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22777 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/179280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83720 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/179280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19745 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->