### PR TITLE
Make <option> and <optgroup> label showing conditional on <select> owner

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
+
+<div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
+<link rel=match href="standalone-optgroup-no-shadow-tree-ref.html">
+<meta name=assert content="An optgroup element moved out of a select element should not render a UA shadow tree and should render its child text content.">
+
+<select><optgroup label="label attribute">child text</optgroup></select>
+<script>
+const select = document.querySelector("select");
+const optgroup = document.querySelector("optgroup");
+select.offsetTop;
+document.body.appendChild(optgroup);
+select.remove();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
+
+<div>child text</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">
+<link rel=match href="standalone-option-no-shadow-tree-ref.html">
+<meta name=assert content="An option element moved out of a select element should not render a UA shadow tree and should render its child text content.">
+
+<select><option label="label attribute">child text</option></select>
+<script>
+const select = document.querySelector("select");
+const option = document.querySelector("option");
+select.offsetTop;
+document.body.appendChild(option);
+select.remove();
+</script>

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -79,7 +79,7 @@ void HTMLOptGroupElement::updateUserAgentShadowTree()
     m_shadowTreeNeedsUpdate = false;
     protect(document())->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
 
-    if (!m_ownerSelect)
+    if (!m_ownerSelect && !userAgentShadowRoot())
         return;
 
     if (!userAgentShadowRoot()) {
@@ -95,7 +95,7 @@ void HTMLOptGroupElement::updateUserAgentShadowTree()
     ScriptDisallowedScope::EventAllowedScope labelContainerScope { labelContainer };
 
     labelContainer->setTextContent(String { labelValue });
-    if (!labelValue.isNull() && !m_legendChildCount)
+    if (m_ownerSelect && !labelValue.isNull() && !m_legendChildCount)
         labelContainer->setInlineStyleProperty(CSSPropertyDisplay, CSSValueBlock);
     else
         labelContainer->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
@@ -151,8 +151,10 @@ void HTMLOptGroupElement::removedFromAncestor(RemovalType removalType, Container
         return;
     }
 
-    if (RefPtr select = std::exchange(m_ownerSelect, nullptr).get())
+    if (RefPtr select = std::exchange(m_ownerSelect, nullptr).get()) {
         select->setRecalcListItems();
+        invalidateShadowTree();
+    }
 }
 
 bool HTMLOptGroupElement::isDisabledFormControl() const

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -133,7 +133,7 @@ void HTMLOptionElement::updateUserAgentShadowTree()
     m_shadowTreeNeedsUpdate = false;
     protect(document())->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
 
-    if (!m_ownerSelect)
+    if (!m_ownerSelect && !userAgentShadowRoot())
         return;
 
     if (!userAgentShadowRoot()) {
@@ -150,7 +150,7 @@ void HTMLOptionElement::updateUserAgentShadowTree()
     ScriptDisallowedScope::EventAllowedScope slotScope { slot };
 
     labelContainer->setTextContent(String { labelValue });
-    if (!labelValue.isNull()) {
+    if (m_ownerSelect && !labelValue.isNull()) {
         labelContainer->setInlineStyleProperty(CSSPropertyDisplay, CSSValueInline);
         slot->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
     } else {
@@ -192,8 +192,10 @@ void HTMLOptionElement::removedFromAncestor(RemovalType removalType, ContainerNo
         return;
     }
 
-    if (RefPtr select = std::exchange(m_ownerSelect, nullptr).get())
+    if (RefPtr select = std::exchange(m_ownerSelect, nullptr).get()) {
         select->setRecalcListItems();
+        invalidateShadowTree();
+    }
 }
 
 void HTMLOptionElement::finishParsingChildren()


### PR DESCRIPTION
#### b60eab17a4bbaa6ed6134531e7b6137411c97f92
<pre>
Make &lt;option&gt; and &lt;optgroup&gt; label showing conditional on &lt;select&gt; owner
<a href="https://bugs.webkit.org/show_bug.cgi?id=309076">https://bugs.webkit.org/show_bug.cgi?id=309076</a>

Reviewed by Ryosuke Niwa.

I noticed a small oversight after 308464@main and 308511@main which is
that an &lt;option&gt; or &lt;optgroup&gt; would still show its label attribute
outside of a &lt;select&gt; element if it previously had been inside a
&lt;select&gt; element. These extra conditionals and invalidation take care
of that.

Tests: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-option-no-shadow-tree-after-select.html

Upstreamed here: <a href="https://github.com/web-platform-tests/wpt/pull/58228">https://github.com/web-platform-tests/wpt/pull/58228</a>

Canonical link: <a href="https://commits.webkit.org/308573@main">https://commits.webkit.org/308573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1f9dba9362f9ecd9fb389642cdde530d292c710

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101281 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81297 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d876d5b7-8801-4744-9331-8743430b530b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94756 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45019863-923b-4a92-9645-178fed9f27ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15388 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13178 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158884 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122026 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76503 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9278 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83728 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19753 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->