### PR TITLE
[iOS] imported/mozilla/svg/as-image/list-simple-1.html is a flaky image diff

### DIFF
--- a/LayoutTests/imported/mozilla/svg/as-image/list-simple-1-expected.html
+++ b/LayoutTests/imported/mozilla/svg/as-image/list-simple-1-expected.html
@@ -1,6 +1,6 @@
 <html>
 <body style="margin-left: 100px">
-  <ul style="list-style-image: url('lime100x100.png')">
+  <ul style="list-style-image: url('resources/lime100x100.png')">
     <li>abc
     <li>def
   </ul>

--- a/LayoutTests/imported/mozilla/svg/as-image/list-simple-1.html
+++ b/LayoutTests/imported/mozilla/svg/as-image/list-simple-1.html
@@ -1,6 +1,6 @@
 <html>
 <body style="margin-left: 100px">
-  <ul style="list-style-image: url('lime100x100.svg')">
+  <ul style="list-style-image: url('resources/lime100x100.svg')">
     <li>abc
     <li>def
   </ul>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8485,8 +8485,6 @@ imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-across-elem
 pdf/annotations [ Skip ]
 pdf/pdf-in-iframe-with-text-annotation.html [ Skip ]
 
-webkit.org/b/309016 imported/mozilla/svg/as-image/list-simple-1.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/309019 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html?include=root-scrollBy-auto [ Pass Failure ]
 
 webkit.org/b/308658 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 95a7a2dc313525a604f68ba5cb7fa87242a74bbd
<pre>
[iOS] imported/mozilla/svg/as-image/list-simple-1.html is a flaky image diff
<a href="https://rdar.apple.com/171562611">rdar://171562611</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309016">https://bugs.webkit.org/show_bug.cgi?id=309016</a>

Unreviewed rebaseline to account for 306349@main.

Because the images failed to load, both test and reference fell back to default bullet points. Before the subpixel layout changes (commit 13ea287431a2),
bullets were positioned at integral (whole number) pixel positions, so they matched perfectly. After subpixel positioning was introduced, bullets could be
positioned at fractional pixels, causing tiny differences (30 pixels) and intermittent failures.

* LayoutTests/imported/mozilla/svg/as-image/list-simple-1-expected.html:
* LayoutTests/imported/mozilla/svg/as-image/list-simple-1.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/308570@main">https://commits.webkit.org/308570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d474bea37943d0e76da831189d72dbf31c23aa43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113999 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13185 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3996 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158891 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122030 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31324 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76510 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17732 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9276 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19973 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19853 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19761 "Failed to checkout and rebase branch from PR 59810") | | | 
<!--EWS-Status-Bubble-End-->