### PR TITLE
Add preference to disable WebBackForwardCache

### DIFF
--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
@@ -29,6 +29,10 @@
 #include "WebProcessPool.h"
 #include "WebsiteDataStore.h"
 
+#if USE(CF)
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 namespace API {
 
 Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::create()
@@ -86,6 +90,16 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
 #endif
     copy->m_prewarmedProcessCountLimitForTesting = this->m_prewarmedProcessCountLimitForTesting;
     return copy;
+}
+
+bool ProcessPoolConfiguration::defaultUsesWebBackForwardCache()
+{
+#if !USE(CF)
+    return true;
+#else
+    static bool enabledByDefault = !CFPreferencesGetAppBooleanValue(CFSTR("DebugDisableWebBackForwardCache"), kCFPreferencesCurrentApplication, nullptr);
+    return enabledByDefault;
+#endif
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -71,6 +71,7 @@ public:
 
     void setUsesBackForwardCache(bool value) { m_usesBackForwardCache = value; }
     bool usesBackForwardCache() const { return m_usesBackForwardCache; }
+    static bool defaultUsesWebBackForwardCache();
 
     const WTF::String& injectedBundlePath() const LIFETIME_BOUND { return m_injectedBundlePath; }
     void setInjectedBundlePath(const WTF::String& injectedBundlePath) { m_injectedBundlePath = injectedBundlePath; }
@@ -186,7 +187,7 @@ private:
     bool m_processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol { false };
     std::optional<bool> m_isAutomaticProcessWarmingEnabledByClient;
     bool m_usesWebProcessCache { false };
-    bool m_usesBackForwardCache { true };
+    bool m_usesBackForwardCache { defaultUsesWebBackForwardCache() };
     bool m_clientWouldBenefitFromAutomaticProcessPrewarming { false };
     bool m_shouldConfigureJSCForTesting { false };
     bool m_isJITEnabled { true };


### PR DESCRIPTION
#### 2c06c9e5afe0600a4dd22a6d2e5cebfaa6b4920f
<pre>
Add preference to disable WebBackForwardCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=309084">https://bugs.webkit.org/show_bug.cgi?id=309084</a>
<a href="https://rdar.apple.com/171639121">rdar://171639121</a>

Reviewed by Per Arne Vollan.

This is similar to 307395@main, but gives us the ability to turn off only WebBackForwardCache in
UIProcess. 307395@main&apos;s pref turns off both WebBackForwardCache in UIProcess and BackForwardCache
in WebCore. Using the latter pref in perf tests is tripping asserts.

* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp:
(API::ProcessPoolConfiguration::defaultUsesWebBackForwardCache):
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/308564@main">https://commits.webkit.org/308564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeadb8edda1448bbb47b5a06beb76370c71a2233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20561 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156559 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79d06f8f-6a4e-46cb-b227-f241b89ed39d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16247 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94765 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ee55637-8a9f-4e48-97a5-5d5279290ade) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15394 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13193 "Failed to checkout and rebase branch from PR 59811") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3999 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124999 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158894 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2028 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122036 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20360 "Failed to checkout and rebase branch from PR 59811") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122237 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31317 "Built successfully and passed tests") | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20371 "Failed to checkout and rebase branch from PR 59811") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83738 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19705 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->