### PR TITLE
Clipboard copy serialization does not preserve background-color for multi-paragraph selections

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color-expected.txt
@@ -1,0 +1,12 @@
+Pasted content should preserve background-color on block elements.
+
+Pasted multi-paragraph content:
+| <p>
+|   style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); background-color: rgb(30, 30, 30);"
+|   "First paragraph"
+| <p>
+|   style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); background-color: rgb(30, 30, 30);"
+|   "Second paragraph"
+| <p>
+|   style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); background-color: rgb(30, 30, 30);"
+|   "Third paragraph<#selection-caret>"

--- a/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color.html
+++ b/LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test verifies that copying multiple paragraphs from a container with a background-color
+preserves the background-color on the pasted block elements.</p>
+<p>To manually test, select all three paragraphs in the dark box, copy, and paste into the editable area below.</p>
+<div id="source" style="background-color: rgb(30, 30, 30); color: rgb(255, 255, 255);">
+<p>First paragraph</p>
+<p>Second paragraph</p>
+<p>Third paragraph</p>
+</div>
+<div id="destination" style="border: solid 1px black; padding: 20px;" contenteditable></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+if (window.testRunner) {
+    var source = document.getElementById('source');
+    window.getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
+    document.execCommand('Copy');
+
+    window.getSelection().setPosition(document.getElementById('destination'), 0);
+    document.execCommand('Paste');
+
+    Markup.description('Pasted content should preserve background-color on block elements.');
+    Markup.dump('destination', 'Pasted multi-paragraph content');
+} else
+    Markup.noAutoDump();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-rich-text-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-rich-text-expected.txt
@@ -5,7 +5,7 @@ Rich text
         "text/plain": ""
     },
     "drop": {
-        "text/html": "<!DOCTYPE html><body dir=\"ltr\"><strong style=\"font-family: -apple-system; font-size: 150px; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: nowrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; color: purple;\">Rich text</strong></body>",
+        "text/html": "<!DOCTYPE html><body dir=\"ltr\"><strong style=\"font-family: -apple-system; font-size: 150px; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: nowrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: purple;\">Rich text</strong></body>",
         "text/plain": "Rich text"
     }
 }

--- a/LayoutTests/fast/events/input-events-paste-rich-datatransfer-expected.txt
+++ b/LayoutTests/fast/events/input-events-paste-rich-datatransfer-expected.txt
@@ -2,7 +2,7 @@ To manually test this, copy and paste into the first contenteditable. The follow
 
 destination after pasting (text/html):
 | <b>
-|   style="caret-color: rgb(255, 0, 0); color: rgb(255, 0, 0); font-family: -webkit-standard; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"
+|   style="caret-color: rgb(255, 0, 0); color: rgb(255, 0, 0); font-family: -webkit-standard; font-size: medium; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"
 |   "LayoutTests"
 |   <i>
 |     "are"

--- a/LayoutTests/platform/glib/fast/events/input-events-paste-rich-datatransfer-expected.txt
+++ b/LayoutTests/platform/glib/fast/events/input-events-paste-rich-datatransfer-expected.txt
@@ -2,7 +2,7 @@ To manually test this, copy and paste into the first contenteditable. The follow
 
 destination after pasting (text/html):
 | <b>
-|   style="caret-color: rgb(255, 0, 0); color: rgb(255, 0, 0); font-family: -webkit-standard; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-tap-highlight-color: rgba(0, 0, 0, 0.4); -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"
+|   style="caret-color: rgb(255, 0, 0); color: rgb(255, 0, 0); font-family: -webkit-standard; font-size: medium; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-tap-highlight-color: rgba(0, 0, 0, 0.4); -webkit-text-stroke-width: 0px; text-decoration: none;"
 |   "LayoutTests"
 |   <i>
 |     "are"

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010, 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -863,9 +863,10 @@ void EditingStyle::removeStyleConflictingWithStyleOfNode(Node& node)
     if (!node.parentNode() || !m_mutableStyle)
         return;
 
-    auto parentStyle = copyPropertiesFromComputedStyle(protect(node.parentNode()).get(), PropertiesToInclude::EditingPropertiesInEffect);
-    auto nodeStyle = EditingStyle::create(&node, PropertiesToInclude::EditingPropertiesInEffect);
-    nodeStyle->removeEquivalentProperties(parentStyle.get());
+    auto parentStyle = EditingStyle::create(protect(node.parentNode()).get(), PropertiesToInclude::EditingPropertiesInEffect);
+    auto nodeStyle = EditingStyle::create(protect(node).ptr(), PropertiesToInclude::EditingPropertiesInEffect);
+    if (RefPtr parentMutableStyle = parentStyle->style())
+        nodeStyle->removeEquivalentProperties(*parentMutableStyle);
 
     RefPtr mutableStyle = style();
     for (auto property : *nodeStyle->style())
@@ -1355,7 +1356,7 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
 
         // Call collapseTextDecorationProperties first or otherwise it'll copy the value over from in-effect to text-decorations.
         wrappingStyle->collapseTextDecorationProperties();
-        
+
         return wrappingStyle;
     }
 


### PR DESCRIPTION
#### 0ab3bf3720f8d9731de8874ddd62328563cac1c0
<pre>
Clipboard copy serialization does not preserve background-color for multi-paragraph selections
<a href="https://bugs.webkit.org/show_bug.cgi?id=308854">https://bugs.webkit.org/show_bug.cgi?id=308854</a>
<a href="https://rdar.apple.com/171391621">rdar://171391621</a>

Reviewed by Ryosuke Niwa.

removeStyleConflictingWithStyleOfNode used copyPropertiesFromComputedStyle for the
parent style but EditingStyle::create for the node style. These compute background-color
differently: the former reads the raw computed value (transparent for most elements),
while the latter calls backgroundColorInEffect which walks up ancestors to find the
nearest non-transparent value. The mismatch caused background-color to be incorrectly
treated as a conflict and stripped from the wrapping style during multi-paragraph copy.

This is fixed by using EditingStyle::create for both parent and node, so both go through
backgroundColorInEffect and produce matching values.

Test: editing/pasteboard/copy-multiparagraph-with-background-color.html

* LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-multiparagraph-with-background-color.html: Added.
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-rich-text-expected.txt:
* LayoutTests/fast/events/input-events-paste-rich-datatransfer-expected.txt:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::removeStyleConflictingWithStyleOfNode):
(WebCore::EditingStyle::wrappingStyleForSerialization):

Canonical link: <a href="https://commits.webkit.org/308655@main">https://commits.webkit.org/308655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283d5d161820ba45a25c2ca93a0219de99ce6c0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15547 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13341 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159106 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2240 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122200 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122414 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132700 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76729 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9453 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83950 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19921 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->