### PR TITLE
[Gardening]: REGRESSION(308412@main): [macOS Debug] TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText is flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -196,7 +196,12 @@ TEST(EditorStateTests, TypingAttributesTextAlignmentAbsoluteAlignmentOptions)
     EXPECT_WK_STREQ("right\njustified\ncenter\nleft", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
 }
 
+// FIXME when webkit.org/b/309007 is resolved.
+#if PLATFORM(MAC) && !defined(NDEBUG)
+TEST(EditorStateTests, DISABLED_TypingAttributesTextAlignmentStartEnd)
+#else
 TEST(EditorStateTests, TypingAttributesTextAlignmentStartEnd)
+#endif
 {
     auto testHarness = setUpEditorStateTestHarness();
     TestWKWebView *webView = [testHarness webView];
@@ -219,7 +224,12 @@ TEST(EditorStateTests, TypingAttributesTextAlignmentStartEnd)
     [testHarness insertParagraphAndExpectEditorStateWith:@{ @"text-alignment": @(NSTextAlignmentRight) }];
 }
 
+// FIXME when webkit.org/b/309007 is resolved.
+#if PLATFORM(MAC) && !defined(NDEBUG)
+TEST(EditorStateTests, DISABLED_TypingAttributesTextAlignmentDirectionalText)
+#else
 TEST(EditorStateTests, TypingAttributesTextAlignmentDirectionalText)
+#endif
 {
     auto testHarness = setUpEditorStateTestHarness();
     [[testHarness webView] stringByEvaluatingJavaScript:@"document.body.setAttribute('dir', 'auto')"];


### PR DESCRIPTION
#### 622392e2326a9988e3adc6ca6dcc14393fd01833
<pre>
[Gardening]: REGRESSION(308412@main): [macOS Debug] TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText is flaky failure
<a href="https://rdar.apple.com/171554884">rdar://171554884</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309007">https://bugs.webkit.org/show_bug.cgi?id=309007</a>

Unreviewed test gardening

Skipping the tests that are flaky in macOS Debug till they are fixed.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, TypingAttributesTextAlignmentStartEnd)):
(TestWebKitAPI::TEST(EditorStateTests, TypingAttributesTextAlignmentDirectionalText)):

Canonical link: <a href="https://commits.webkit.org/308584@main">https://commits.webkit.org/308584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/257e9ddab270a15c44e3bf82c531b5d74ba43b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101317 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1588d06-18df-46af-8d80-f8d271231857) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114022 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d25eda2-cb12-4548-917d-6ab5f8460955) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/411e68e5-71b8-470d-9bba-e3e47178dd89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15412 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13205 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4024 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158919 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122257 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76539 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9304 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20004 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19734 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->