### PR TITLE
AX: Accessibility layout tests can dirty style at invalid times via JS notification handlers, causing incorrect behavior and asserts

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame.html
@@ -29,7 +29,9 @@ function notificationCallback(element, notificationName) {
                 // and style remain clean, causing crashes. Note this is a layout-test only problem, as actual ATs can't
                 // synchronously trigger JS in response to notifications like our testing infrastructure allows for tests.
                 eventSender.keyDown("\t");
-            }, 5);
+                // Avoid leaving lingering dirty style and layout by forcing it to be clean.
+                document.body.offsetHeight;
+            }, 50);
         }
 
         // We should get a total of 2 focus changes.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2499,4 +2499,3 @@ webkit.org/b/308845 [ Debug arm64 ] fast/scrolling/latching/scroll-div-no-latchi
 
 webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html [ Failure Pass ]
 
-webkit.org/b/309022 http/tests/site-isolation/accessibility/focus-in-remote-frame.html [ Skip ]

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -705,7 +705,12 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject*, 
     if (!rootWebArea)
         return;
 
-    [rootWebArea->wrapper() accessibilityPostedNotification:NSAccessibilityFocusChangedNotification userInfo:nil];
+    callOnMainThread([webArea = rootWebArea] {
+        // Do not post focus-changed notifications to layout tests synchronously. Otherwise JS event
+        // handlers could dirty style / layout in the middle of contexts where we expect clean style
+        // and layout, e.g. AXObjectCache::performDeferredCacheUpdate.
+        [webArea->wrapper() accessibilityPostedNotification:NSAccessibilityFocusChangedNotification userInfo:nil];
+    });
 }
 
 void AXObjectCache::handleScrolledToAnchor(const Node&)


### PR DESCRIPTION
#### 294e3d8df2e686e1a5761eb4f86ea3017aa8fa51
<pre>
AX: Accessibility layout tests can dirty style at invalid times via JS notification handlers, causing incorrect behavior and asserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=309087">https://bugs.webkit.org/show_bug.cgi?id=309087</a>
<a href="https://rdar.apple.com/171643206">rdar://171643206</a>

Reviewed by Joshua Hoffman.

accessibility/focus-in-remote-frame.html was marked as Skip because it occasionally dirtied style in the middle
contexts that expected clean style (namely AXObjectCache::performDeferredCacheUpdate). Fix this by reposting
focused-change notifications to layout tests asynchronously, allowing performDeferredCacheUpdate to complete
without dirtying style in the middle.

Also make accessibility/focus-in-remote-frame.html less likely to trigger this issue by forcing clean style and layout
immediately after dirtying it.

* LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):

Canonical link: <a href="https://commits.webkit.org/308603@main">https://commits.webkit.org/308603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84759fad0bc7fed52c83795163789a803b04c724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101303 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a75ee28e-4c14-48f9-8631-1224544ddfee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114013 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81307 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9623571-25e3-4f23-88bb-43ddb38075df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94776 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13198 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4010 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158905 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2040 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122045 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122246 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31348 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132524 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76525 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9290 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83750 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19776 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->