### PR TITLE
FairPlay VP9 content fails to play.

### DIFF
--- a/LayoutTests/media/media-source/media-source-istypesupported-mimetype-expected.txt
+++ b/LayoutTests/media/media-source/media-source-istypesupported-mimetype-expected.txt
@@ -1,0 +1,17 @@
+
+video/mp4; codecs="avc1.640028" : true
+video/mp4; codecs="dvh1.04.07" : true
+video/mp4; codecs="dvh1.05.07" : true
+video/mp4; codecs="dvh1.08.07" : true
+video/mp4; codecs="dva1.09.05" : true
+video/mp4; codecs="dav1.10.05" : true
+video/mp4; codecs="hvc1.1.6.L93.B0" : true
+video/mp4; codecs="hvc1.2.4.L153.B0" : true
+video/mp4; codecs="av01.0.01M.08" : true
+video/mp4; codecs="av01.0.12M.08" : true
+video/mp4; codecs="av01.0.13M.10" : true
+video/mp4; codecs="vp09.00.51.08.01.01.01.01" : true
+video/webm; codecs="vp8" : true
+video/webm; codecs="vp09.00.10.08" : true
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-istypesupported-mimetype.html
+++ b/LayoutTests/media/media-source/media-source-istypesupported-mimetype.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-istypesupported-mimetype</title>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+
+    const MediaSource = self.ManagedMediaSource || self.MediaSource;
+    window.addEventListener('load', async event => {
+        findMediaElement();
+        let videoCodecs = [
+            { name: "AVC/H264", container: "mp4", codec: "avc1.640028", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "Dolby Vision Profile 4", container: "mp4", codec: "dvh1.04.07", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "Dolby Vision Profile 5", container: "mp4", codec: "dvh1.05.07", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "Dolby Vision Profile 8", container: "mp4", codec: "dvh1.08.07", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "Dolby Vision Profile 9", container: "mp4", codec: "dva1.09.05", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "Dolby Vision Profile 10", container: "mp4", codec: "dav1.10.05", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "HEVC/H265 Main Profile", container: "mp4", codec: "hvc1.1.6.L93.B0", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "HEVC/H265 Main 10 Profile", container: "mp4", codec: "hvc1.2.4.L153.B0", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "AV1 (Main, Level 2.1)", container: "mp4", codec: "av01.0.01M.08", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "AV1 (Main, Level 5.0, 4K)", container: "mp4", codec: "av01.0.12M.08", width: 3140, height: 2160, bitrate: 1000, frameRate: 30 },
+            { name: "AV1 (Main, Level 5.0, 4K HDR)", container: "mp4", codec: "av01.0.13M.10", width: 3140, height: 2160, bitrate: 1000, frameRate: 30 },
+            { name: "VP9 video", container: "mp4", codec: "vp09.00.51.08.01.01.01.01", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "VP8 video", container: "webm", codec: "vp8", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+            { name: "VP9 video", container: "webm", codec: "vp09.00.10.08", width: 640, height: 360, bitrate: 1000, frameRate: 30 },
+        ];
+
+        videoCodecs.forEach(async videoCodec => {
+            let mime = `video/${videoCodec.container}; codecs="${videoCodec.codec}"`
+            let canPlayType = video.canPlayType(mime) == 'probably';
+            let isTypeSupported = MediaSource.isTypeSupported(mime);
+            consoleWrite(`${mime} : ${isTypeSupported == canPlayType}`);
+        });
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+<video/>
+</body>

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -34,6 +34,7 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/NowPlayingManager.h>
+#include <WebCore/PlatformMediaDecodingType.h>
 #include <wtf/BitSet.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -45,6 +46,7 @@ class AudioDestination;
 class AudioIOCallback;
 class AudioVideoRenderer;
 class CDMFactory;
+class ContentType;
 class NowPlayingManager;
 class VideoFrame;
 
@@ -73,6 +75,7 @@ public:
 
 #if ENABLE(VIDEO)
     virtual void nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&&);
+    virtual bool canDecodeExtendedType(PlatformMediaDecodingType, const ContentType&) { return false; }
 #endif
 
     virtual bool enableWebMMediaPlayer() const { return true; }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -112,17 +112,17 @@ struct VideoFrameMetadata;
 
 struct MediaEngineSupportParameters {
     ContentType type;
-    URL url;
+    URL url { };
     bool isMediaSource { false };
     bool isMediaStream { false };
     bool requiresRemotePlayback { false };
     bool supportsLimitedMatroska { false };
-    Vector<ContentType> contentTypesRequiringHardwareSupport;
-    std::optional<Vector<String>> allowedMediaContainerTypes;
-    std::optional<Vector<String>> allowedMediaCodecTypes;
-    std::optional<Vector<FourCC>> allowedMediaVideoCodecIDs;
-    std::optional<Vector<FourCC>> allowedMediaAudioCodecIDs;
-    std::optional<Vector<FourCC>> allowedMediaCaptionFormatTypes;
+    Vector<ContentType> contentTypesRequiringHardwareSupport { };
+    std::optional<Vector<String>> allowedMediaContainerTypes { };
+    std::optional<Vector<String>> allowedMediaCodecTypes { };
+    std::optional<Vector<FourCC>> allowedMediaVideoCodecIDs { };
+    std::optional<Vector<FourCC>> allowedMediaAudioCodecIDs { };
+    std::optional<Vector<FourCC>> allowedMediaCaptionFormatTypes { };
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     MediaPlaybackTargetType playbackTargetType { MediaPlaybackTargetType::None };
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
@@ -30,6 +30,8 @@
 
 #import "AVAssetMIMETypeCache.h"
 #import "ContentType.h"
+#import <WebCore/MediaStrategy.h>
+#import <WebCore/PlatformStrategies.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/HashSet.h>
 
@@ -91,8 +93,11 @@ bool AVStreamDataParserMIMETypeCache::canDecodeExtendedType(const ContentType& t
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
     ASSERT(isAvailable());
 
-    if ([PAL::getAVStreamDataParserClassSingleton() respondsToSelector:@selector(canParseExtendedMIMEType:)])
-        return [PAL::getAVStreamDataParserClassSingleton() canParseExtendedMIMEType:type.raw().createNSString().get()];
+    if ([PAL::getAVStreamDataParserClassSingleton() respondsToSelector:@selector(canParseExtendedMIMEType:)]) {
+        if ([PAL::getAVStreamDataParserClassSingleton() canParseExtendedMIMEType:type.raw().createNSString().get()])
+            return true;
+        return hasPlatformStrategies() && platformStrategies()->mediaStrategy()->canDecodeExtendedType(PlatformMediaDecodingType::MediaSource, type);
+    }
 
     // FIXME(rdar://50502771) AVStreamDataParser does not have an -canParseExtendedMIMEType: method on this system,
     //  so just replace the container type with a valid one from AVAssetMIMETypeCache and ask that cache if it

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -627,6 +627,17 @@ RemoteAudioVideoRendererProxyManager& GPUConnectionToWebProcess::remoteAudioVide
 
     return *m_remoteAudioVideoRendererProxyManager;
 }
+
+void GPUConnectionToWebProcess::canDecodeExtendedType(PlatformMediaDecodingType platformType, ContentType contentType, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    MediaEngineSupportParameters parameters {
+        .type = contentType,
+#if ENABLE(MEDIA_SOURCE)
+        .isMediaSource = platformType == PlatformMediaDecodingType::MediaSource
+#endif
+    };
+    completionHandler(MediaPlayer::supportsType(parameters) != MediaPlayer::SupportsType::IsNotSupported);
+}
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -168,6 +168,7 @@ public:
 
 #if ENABLE(VIDEO)
     RemoteAudioVideoRendererProxyManager& remoteAudioVideoRendererProxyManager();
+    void canDecodeExtendedType(WebCore::PlatformMediaDecodingType, WebCore::ContentType, CompletionHandler<void(bool)>&&) const;
 #endif
 
     PAL::SessionID sessionID() const { return m_sessionID; }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -61,6 +61,9 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
 #if ENABLE(MEDIA_SOURCE)
     [EnabledBy=MediaSourceEnabled || ManagedMediaSourceEnabled] EnableMockMediaSource();
 #endif
+#if ENABLE(VIDEO)
+    CanDecodeExtendedType(enum:uint8_t WebCore::PlatformMediaDecodingType platformType, WebCore::ContentType contentType) -> (bool supported);
+#endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     UpdateSampleBufferDisplayLayerBoundsAndPosition(WebKit::SampleBufferDisplayLayerIdentifier identifier, WebCore::FloatRect bounds, std::optional<MachSendRightAnnotated> fence);

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -38,7 +38,8 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/NowPlayingManager.h>
 #include <WebCore/SharedAudioDestination.h>
-
+#include <wtf/NeverDestroyed.h>
+#include <wtf/threads/BinarySemaphore.h>
 #if PLATFORM(COCOA)
 #include <WebCore/MediaSessionManagerCocoa.h>
 #endif
@@ -75,6 +76,28 @@ Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(const We
 RefPtr<AudioVideoRenderer> WebMediaStrategy::createAudioVideoRenderer(LoggerHelper* loggerHelper, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) const
 {
     return AudioVideoRendererRemote::create(loggerHelper, mediaElementIdentifier, playerIdentifier, protect(WebProcess::singleton().ensureGPUProcessConnection()));
+}
+
+static WorkQueue& webMediaStrategyQueueSingleton()
+{
+    static const NeverDestroyed<Ref<WorkQueue>> workQueue = WorkQueue::create("WebMediaStrategy"_s);
+    return workQueue.get();
+}
+
+bool WebMediaStrategy::canDecodeExtendedType(PlatformMediaDecodingType platformType, const ContentType& contentType)
+{
+    std::atomic<bool> isSupported = false;
+    BinarySemaphore semaphore;
+    webMediaStrategyQueueSingleton().dispatch([&] {
+        if (RefPtr connection = WebProcess::singleton().existingGPUProcessConnection()) {
+            connection->connection().sendWithAsyncReplyOnDispatcher(Messages::GPUConnectionToWebProcess::CanDecodeExtendedType(platformType, contentType), webMediaStrategyQueueSingleton(), [&semaphore, &isSupported](bool supported) {
+                isSupported = supported;
+                semaphore.signal();
+            });
+        }
+    });
+    semaphore.wait();
+    return isSupported;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -48,6 +48,7 @@ private:
 #endif
 #if ENABLE(VIDEO) && ENABLE(GPU_PROCESS)
     RefPtr<WebCore::AudioVideoRenderer> createAudioVideoRenderer(LoggerHelper*, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier) const final;
+    bool canDecodeExtendedType(WebCore::PlatformMediaDecodingType, const WebCore::ContentType&) final;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
     bool hasThreadSafeMediaSourceSupport() const final;


### PR DESCRIPTION
#### 793355bed17d40d60394a37a35847066f32115fa
<pre>
FairPlay VP9 content fails to play.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309090">https://bugs.webkit.org/show_bug.cgi?id=309090</a>
<a href="https://rdar.apple.com/171210968">rdar://171210968</a>

Reviewed by Jer Noble.

MediaSource.isTypeSupported queried the AVStreamDataParser in the web content process.
For some codecs, this will attempt to check for hardware support and fails
due to the sandbox.
We add a fallback, that should the test fail, we will query the AVStreamDataParser
in the GPU process instead via a new MediaStrategy API.

Test: media/media-source/media-source-istypesupported-mimetype.html

* LayoutTests/media/media-source/media-source-istypesupported-mimetype-expected.txt: Added.
* LayoutTests/media/media-source/media-source-istypesupported-mimetype.html: Added.
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/graphics/MediaPlayer.h: Add explicit default constructor to allow for field initializers list.
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::canDecodeExtendedType):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::canDecodeExtendedType const):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::canDecodeExtendedType):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:

Canonical link: <a href="https://commits.webkit.org/308622@main">https://commits.webkit.org/308622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4550eed92ff5f3c2b74877011174878aace88f61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148038 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156720 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e31841b-0a98-4ebd-9127-e628b30bf4f2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114126 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3f7aabd-27f2-4aeb-b1db-87f9b9c0c5aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94892 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/767b9565-8cb0-4e3e-8d4a-63e9cc419e0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15497 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4158 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159054 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122155 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122369 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31362 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76673 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9408 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83898 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20016 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->