### PR TITLE
[Dictation] Add DictationStreamingOpacity document marker for streaming partial results

### DIFF
--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -99,6 +99,7 @@ enum class DocumentMarkerType : uint32_t {
     WritingToolsTextSuggestion = 1 << 16,
 #endif
     TransparentContent = 1 << 17,
+    DictationStreamingOpacity = 1 << 18,
 };
 
 // A range of a node within a document that is "marked", such as the range of a misspelled word.
@@ -142,6 +143,11 @@ public:
         WTF::UUID uuid;
     };
 
+    struct DictationStreamingOpacityData {
+        float opacity;
+        WTF::UUID identifier;
+    };
+
     using Data = Variant<
         String
         , DictationData // DictationAlternatives
@@ -157,6 +163,7 @@ public:
         , WritingToolsTextSuggestionData // WritingToolsTextSuggestion
 #endif
         , TransparentContentData // TransparentContent
+        , DictationStreamingOpacityData // DictationStreamingOpacity
     >;
 
     DocumentMarker(DocumentMarkerType, OffsetRange, Data&& = { });
@@ -211,6 +218,7 @@ constexpr auto DocumentMarker::allMarkers() -> OptionSet<DocumentMarkerType>
         DocumentMarkerType::WritingToolsTextSuggestion,
 #endif
         DocumentMarkerType::TransparentContent,
+        DocumentMarkerType::DictationStreamingOpacity,
     };
 }
 

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -133,6 +133,25 @@ void DocumentMarkerController::addTransparentContentMarker(const SimpleRange& ra
         addMarker(textPiece.node, { DocumentMarkerType::TransparentContent, textPiece.range, DocumentMarker::TransparentContentData { { textPiece.node.ptr() }, uuid } });
 }
 
+void DocumentMarkerController::addDictationStreamingOpacityMarker(const SimpleRange& range, float opacity, WTF::UUID identifier)
+{
+    for (auto& textPiece : collectTextRanges(range))
+        addMarker(textPiece.node, { DocumentMarkerType::DictationStreamingOpacity, textPiece.range, DocumentMarker::DictationStreamingOpacityData { opacity, identifier } });
+}
+
+void DocumentMarkerController::removeDictationStreamingOpacityMarkers(const WTF::UUID& identifier)
+{
+    removeMarkers({ DocumentMarkerType::DictationStreamingOpacity }, [&identifier](const RenderedDocumentMarker& marker) {
+        auto& data = std::get<DocumentMarker::DictationStreamingOpacityData>(marker.data());
+        return data.identifier == identifier ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
+    });
+}
+
+void DocumentMarkerController::removeAllDictationStreamingOpacityMarkers()
+{
+    removeMarkers({ DocumentMarkerType::DictationStreamingOpacity });
+}
+
 void DocumentMarkerController::removeMarkers(const SimpleRange& range, OptionSet<DocumentMarkerType> types, RemovePartiallyOverlappingMarker overlapRule)
 {
     filterMarkers(range, nullptr, types, overlapRule);

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -68,6 +68,9 @@ public:
     WEBCORE_EXPORT bool addMarker(Node&, DocumentMarker&&);
     void addDraggedContentMarker(const SimpleRange&);
     WEBCORE_EXPORT void addTransparentContentMarker(const SimpleRange&, WTF::UUID);
+    WEBCORE_EXPORT void addDictationStreamingOpacityMarker(const SimpleRange&, float opacity, WTF::UUID);
+    WEBCORE_EXPORT void removeDictationStreamingOpacityMarkers(const WTF::UUID&);
+    WEBCORE_EXPORT void removeAllDictationStreamingOpacityMarkers();
 
     void copyMarkers(Node& source, OffsetRange, Node& destination);
     bool hasMarkers() const;

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -353,4 +353,27 @@ Vector<MarkedText> MarkedText::collectForDraggedAndTransparentContent(const Docu
     });
 }
 
+Vector<MarkedText> MarkedText::collectForDictationStreamingOpacity(const RenderText& renderer, const TextBoxSelectableRange& selectableRange)
+{
+    if (!renderer.textNode())
+        return { };
+
+    CheckedPtr markerController = renderer.document().markersIfExists();
+    if (!markerController)
+        return { };
+
+    auto markers = markerController->markersFor(*renderer.textNode(), DocumentMarkerType::DictationStreamingOpacity);
+    if (markers.isEmpty())
+        return { };
+
+    Vector<MarkedText> result;
+    result.reserveInitialCapacity(markers.size());
+    for (auto& marker : markers) {
+        auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
+        if (clampedStart < clampedEnd)
+            result.append({ clampedStart, clampedEnd, MarkedText::Type::DictationStreamingOpacity, marker.get() });
+    }
+    return result;
+}
+
 }

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -67,6 +67,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
         Selection,
         DraggedContent,
         TransparentContent,
+        DictationStreamingOpacity,
     };
 
     enum class PaintPhase {
@@ -94,6 +95,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
     static Vector<MarkedText> collectForDocumentMarkers(const RenderText&, const TextBoxSelectableRange&, PaintPhase);
     static Vector<MarkedText> collectForHighlights(const RenderText&, const TextBoxSelectableRange&, PaintPhase);
     static Vector<MarkedText> collectForDraggedAndTransparentContent(const DocumentMarkerType, const RenderText& renderer, const TextBoxSelectableRange&);
+    static Vector<MarkedText> collectForDictationStreamingOpacity(const RenderText&, const TextBoxSelectableRange&);
 
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -32,6 +32,7 @@
 #include "RenderStyle+GettersInlines.h"
 #include "RenderText.h"
 #include "RenderTheme.h"
+#include "RenderedDocumentMarker.h"
 
 namespace WebCore {
 
@@ -123,6 +124,12 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         break;
     case MarkedText::Type::TransparentContent:
         style.alpha = 0.0;
+        break;
+    case MarkedText::Type::DictationStreamingOpacity:
+        if (markedText.marker)
+            style.alpha = std::get<DocumentMarker::DictationStreamingOpacityData>(markedText.marker->data()).opacity;
+        else
+            style.alpha = 0.5;
         break;
     case MarkedText::Type::Selection: {
         style.textStyles = computeTextSelectionPaintStyle(style.textStyles, renderer, lineStyle, paintInfo, style.textShadow);

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -438,6 +438,9 @@ void TextBoxPainter::paintForegroundAndDecorations()
             auto markedTextsForTransparentContent = MarkedText::collectForDraggedAndTransparentContent(DocumentMarkerType::TransparentContent, m_renderer, m_selectableRange);
             if (!markedTextsForTransparentContent.isEmpty())
                 markedTexts.appendVector(WTF::move(markedTextsForTransparentContent));
+            auto markedTextsForDictationStreamingOpacity = MarkedText::collectForDictationStreamingOpacity(m_renderer, m_selectableRange);
+            if (!markedTextsForDictationStreamingOpacity.isEmpty())
+                markedTexts.appendVector(WTF::move(markedTextsForDictationStreamingOpacity));
         }
     }
     // The selection marked text acts as a placeholder when computing the marked texts for the gaps...
@@ -654,7 +657,8 @@ void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)
         m_isCombinedText ? &downcast<RenderCombineText>(m_renderer.get()) : nullptr
     };
 
-    bool isTransparentMarkedText = markedText.type == MarkedText::Type::DraggedContent || markedText.type == MarkedText::Type::TransparentContent;
+    bool isTransparentMarkedText = markedText.type == MarkedText::Type::DraggedContent || markedText.type == MarkedText::Type::TransparentContent
+        || markedText.type == MarkedText::Type::DictationStreamingOpacity;
     GraphicsContextStateSaver stateSaver(context, markedText.style.textStyles.strokeWidth > 0 || isTransparentMarkedText);
     if (isTransparentMarkedText)
         context.setAlpha(markedText.style.alpha);
@@ -716,7 +720,8 @@ TextDecorationPainter TextBoxPainter::createDecorationPainter(const StyledMarked
     // Note that if the text is truncated, we let the thing being painted in the truncation
     // draw its own decoration.
     GraphicsContextStateSaver stateSaver { context, false };
-    bool isTransparentContent = markedText.type == MarkedText::Type::DraggedContent || markedText.type == MarkedText::Type::TransparentContent;
+    bool isTransparentContent = markedText.type == MarkedText::Type::DraggedContent || markedText.type == MarkedText::Type::TransparentContent
+        || markedText.type == MarkedText::Type::DictationStreamingOpacity;
     if (isTransparentContent || !clipOutRect.isEmpty()) {
         stateSaver.save();
         if (isTransparentContent)
@@ -1240,6 +1245,8 @@ void TextBoxPainter::paintPlatformDocumentMarkers()
     // the other marked texts when being subdivided so that they do not get painted.
     Vector<MarkedText> allMarkedTexts;
     allMarkedTexts.appendVector(transparentContentMarkedTexts);
+    auto dictationStreamingOpacityMarkedTexts = MarkedText::collectForDictationStreamingOpacity(m_renderer, m_selectableRange);
+    allMarkedTexts.appendVector(dictationStreamingOpacityMarkedTexts);
     allMarkedTexts.appendVector(markedTexts);
     if (textDecorationLineSpellingErrorAsMarkedText)
         allMarkedTexts.append(*textDecorationLineSpellingErrorAsMarkedText);
@@ -1250,6 +1257,7 @@ void TextBoxPainter::paintPlatformDocumentMarkers()
         switch (markedText.type) {
         case MarkedText::Type::DraggedContent:
         case MarkedText::Type::TransparentContent:
+        case MarkedText::Type::DictationStreamingOpacity:
             continue;
 
         default:

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -590,6 +590,22 @@ void WebPageProxy::clearDictationAlternatives(Vector<DictationContext>&& alterna
     protect(legacyMainFrameProcess())->send(Messages::WebPage::ClearDictationAlternatives(WTF::move(alternativesToClear)), webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::setDictationStreamingOpacity(const String& hypothesisText, const WebCore::CharacterRange& streamingRangeInHypothesis, float opacity, const WTF::UUID& identifier)
+{
+    if (!hasRunningProcess())
+        return;
+
+    protect(legacyMainFrameProcess())->send(Messages::WebPage::SetDictationStreamingOpacity(hypothesisText, streamingRangeInHypothesis, opacity, identifier), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::clearDictationStreamingOpacity()
+{
+    if (!hasRunningProcess())
+        return;
+
+    protect(legacyMainFrameProcess())->send(Messages::WebPage::ClearDictationStreamingOpacity(), webPageIDInMainFrameProcess());
+}
+
 ResourceError WebPageProxy::errorForUnpermittedAppBoundDomainNavigation(const URL& url)
 {
     return { WKErrorDomain, WKErrorNavigationAppBoundDomain, url, localizedDescriptionForErrorCode(WKErrorNavigationAppBoundDomain).get() };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1383,6 +1383,8 @@ public:
     void addDictationAlternative(WebCore::TextAlternativeWithRange&&);
     void dictationAlternativesAtSelection(CompletionHandler<void(Vector<WebCore::DictationContext>&&)>&&);
     void clearDictationAlternatives(Vector<WebCore::DictationContext>&&);
+    void setDictationStreamingOpacity(const String& hypothesisText, const WebCore::CharacterRange& streamingRangeInHypothesis, float opacity, const WTF::UUID&);
+    void clearDictationStreamingOpacity();
 
     void hasMarkedText(CompletionHandler<void(bool)>&&);
     void getMarkedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -116,6 +116,7 @@
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <UniformTypeIdentifiers/UTCoreTypes.h>
 #import <WebCore/AppHighlight.h>
+#import <WebCore/CharacterRange.h>
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/CompositionHighlight.h>
@@ -6000,6 +6001,27 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
     _autocorrectionContextNeedsUpdate = YES;
     protect(_page)->replaceDictatedText(oldText, newText);
+}
+
+- (void)_setDictationStreamingOpacity:(CGFloat)opacity forHypothesisText:(NSString *)hypothesisText streamingRange:(NSRange)streamingRange identifier:(NSUUID *)identifier
+{
+    if (!_page || !identifier || !hypothesisText)
+        return;
+
+    auto uuid = WTF::UUID::fromNSUUID(identifier);
+    if (!uuid)
+        return;
+
+    WebCore::CharacterRange characterRange { streamingRange.location, streamingRange.length };
+    protect(_page)->setDictationStreamingOpacity(hypothesisText, characterRange, static_cast<float>(opacity), *uuid);
+}
+
+- (void)_clearDictationStreamingOpacity
+{
+    if (!_page)
+        return;
+
+    protect(_page)->clearDictationStreamingOpacity();
 }
 
 // The completion handler should pass the rect of the correction text after replacing the input text, or nil if the replacement could not be performed.

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -139,6 +139,7 @@
 #import <WebCore/UTIRegistry.h>
 #import <WebCore/UTIUtilities.h>
 #import <WebCore/UserTypingGestureIndicator.h>
+#import <WebCore/VisibleUnits.h>
 #import <WebCore/WebAccessibilityObjectWrapperMac.h>
 #import <WebCore/markup.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
@@ -543,6 +544,58 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
             return FilterMarkerResult::Keep;
         return setOfContextsToRemove.contains(std::get<WebCore::DocumentMarker::DictationData>(marker.data()).context) ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
     }, DocumentMarkerType::DictationAlternatives);
+}
+
+std::optional<SimpleRange> WebPage::findDictatedTextRangeBeforeCursor(LocalFrame& frame, const String& text)
+{
+    VisiblePosition position = frame.selection().selection().start();
+    for (auto i = numGraphemeClusters(text); i; --i)
+        position = position.previous();
+    if (position.isNull())
+        position = startOfDocument(frame.document());
+
+    auto range = makeSimpleRange(position, frame.selection().selection().start());
+    if (!range || plainTextForContext(*range) != text)
+        return std::nullopt;
+    return range;
+}
+
+void WebPage::setDictationStreamingOpacity(const String& hypothesisText, const WebCore::CharacterRange& streamingRangeInHypothesis, float opacity, const WTF::UUID& identifier)
+{
+    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (!frame) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - no focused frame");
+        return;
+    }
+
+    if (frame->selection().isNone() || !frame->selection().selection().isContentEditable()) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - no editable selection");
+        return;
+    }
+
+    auto hypothesisRange = findDictatedTextRangeBeforeCursor(*frame, hypothesisText);
+    if (!hypothesisRange) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - hypothesis text not found, expected length %u", hypothesisText.length());
+        return;
+    }
+
+    auto streamingRange = resolveCharacterRange(*hypothesisRange, streamingRangeInHypothesis);
+    if (streamingRange.collapsed()) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - resolved streaming range is collapsed");
+        return;
+    }
+
+    protect(frame->document()->markers())->removeDictationStreamingOpacityMarkers(identifier);
+    protect(frame->document()->markers())->addDictationStreamingOpacityMarker(streamingRange, opacity, identifier);
+}
+
+void WebPage::clearDictationStreamingOpacity()
+{
+    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (!frame || !frame->document())
+        return;
+
+    protect(frame->document()->markers())->removeAllDictationStreamingOpacityMarkers();
 }
 
 void WebPage::accessibilityTransferRemoteToken(RetainPtr<NSData> remoteToken)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1345,6 +1345,9 @@ public:
     void addDictationAlternative(const String& text, WebCore::DictationContext, CompletionHandler<void(bool)>&&);
     void dictationAlternativesAtSelection(CompletionHandler<void(Vector<WebCore::DictationContext>&&)>&&);
     void clearDictationAlternatives(Vector<WebCore::DictationContext>&&);
+    std::optional<WebCore::SimpleRange> findDictatedTextRangeBeforeCursor(WebCore::LocalFrame&, const String&);
+    void setDictationStreamingOpacity(const String& hypothesisText, const WebCore::CharacterRange& streamingRangeInHypothesis, float opacity, const WTF::UUID&);
+    void clearDictationStreamingOpacity();
 #endif // PLATFORM(COCOA)
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -584,6 +584,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     AddDictationAlternative(String text, WebCore::DictationContext context) -> (bool success) Async
     DictationAlternativesAtSelection() -> (Vector<WebCore::DictationContext> contexts) Async
     ClearDictationAlternatives(Vector<WebCore::DictationContext> contexts)
+    SetDictationStreamingOpacity(String hypothesisText, struct WebCore::CharacterRange streamingRangeInHypothesis, float opacity, WTF::UUID identifier)
+    ClearDictationStreamingOpacity()
 
     HasMarkedText() -> (bool hasMarkedText)
     GetMarkedRangeAsync() -> (struct WebKit::EditingRange range)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2208,24 +2208,19 @@ void WebPage::replaceDictatedText(const String& oldText, const String& newText)
 
     if (frame->selection().isNone())
         return;
-    
+
     if (frame->selection().isRange()) {
         protect(frame->editor())->deleteSelectionWithSmartDelete(false);
         return;
     }
-    VisiblePosition position = frame->selection().selection().start();
-    for (auto i = numGraphemeClusters(oldText); i; --i)
-        position = position.previous();
-    if (position.isNull())
-        position = startOfDocument(protect(frame->document()));
-    auto range = makeSimpleRange(position, frame->selection().selection().start());
 
-    if (plainTextForContext(range) != oldText)
+    auto range = findDictatedTextRangeBeforeCursor(*frame, oldText);
+    if (!range)
         return;
 
     // We don't want to notify the client that the selection has changed until we are done inserting the new text.
     IgnoreSelectionChangeForScope ignoreSelectionChanges { *frame };
-    protect(frame->selection())->setSelectedRange(range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes);
+    protect(frame->selection())->setSelectedRange(*range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes);
     protect(frame->editor())->insertText(newText, 0);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -72,6 +72,8 @@ std::ostream& operator<<(std::ostream& os, MarkedText::Type type)
 #endif
     case MarkedText::Type::TransparentContent:
         return os << "TransparentContent";
+    case MarkedText::Type::DictationStreamingOpacity:
+        return os << "DictationStreamingOpacity";
     case MarkedText::Type::Unmarked:
         return os << "Unmarked";
     }


### PR DESCRIPTION
#### e7fe98f3c9cee9a91f54e086bf2f94172cf737eb
<pre>
[Dictation] Add DictationStreamingOpacity document marker for streaming partial results
<a href="https://bugs.webkit.org/show_bug.cgi?id=309109">https://bugs.webkit.org/show_bug.cgi?id=309109</a>
<a href="https://rdar.apple.com/169476197">rdar://169476197</a>

Reviewed by NOBODY (OOPS!).

Add a new DocumentMarkerType::DictationStreamingOpacity that renders text at a
variable alpha. This is used to show unconfirmed speech recognition text at
reduced opacity while the recognizer is still processing.

The marker carries an opacity value and a UUID identifier for targeted removal.
The rendering pipeline reads the opacity from the marker data and applies it via
context.setAlpha(), following the same pattern as TransparentContent and
DraggedContent markers.

IPC messages (SetDictationStreamingOpacity, ClearDictationStreamingOpacity) are
in the PLATFORM(COCOA) block. The WebProcess handler locates the hypothesis text
by walking backward from the cursor and applies the marker to the streaming
sub-range. WKContentView SPI entry points are added for the UIProcess.

The cursor-walking logic is extracted into findDictatedTextRangeBeforeCursor,
shared with replaceDictatedText.

* Source/WebCore/dom/DocumentMarker.h:
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::addDictationStreamingOpacityMarker):
(WebCore::DocumentMarkerController::removeDictationStreamingOpacityMarkers):
(WebCore::DocumentMarkerController::removeAllDictationStreamingOpacityMarkers):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDictationStreamingOpacity):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintForegroundAndDecorations):
(WebCore::TextBoxPainter::paintForeground):
(WebCore::TextBoxPainter::createDecorationPainter):
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setDictationStreamingOpacity):
(WebKit::WebPageProxy::clearDictationStreamingOpacity):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _setDictationStreamingOpacity:forHypothesisText:streamingRange:identifier:]):
(-[WKContentView _clearDictationStreamingOpacity]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::findDictatedTextRangeBeforeCursor):
(WebKit::WebPage::setDictationStreamingOpacity):
(WebKit::WebPage::clearDictationStreamingOpacity):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::replaceDictatedText):
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(WebCore::operator&lt;&lt;):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7fe98f3c9cee9a91f54e086bf2f94172cf737eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81337 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13247 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158965 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122092 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122295 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132583 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76585 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9343 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20051 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83810 "Found 8 new failures in WebProcess/WebPage/Cocoa/WebPageCocoa.mm and found 1 fixed file: rendering/MarkedText.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19780 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->