### PR TITLE
[Site Isolation] Partially fix WKNavigation.Frames

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1356,7 +1356,7 @@ void LocalFrame::didAccessWindowProxyPropertyViaOpener(WindowProxyProperty prope
     if (m_accessedWindowProxyPropertiesViaOpener.contains(property))
         return;
 
-    auto origin = SecurityOriginData::fromFrame(this);
+    auto origin = SecurityOriginData::fromLocalFrame(this);
     if (origin.isNull() || origin.isOpaque())
         return;
 

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -432,7 +432,7 @@ void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<Deferre
         return;
     }
 
-    page->badgeClient().setAppBadge(frame.get(), SecurityOriginData::fromFrame(frame.get()), badge);
+    page->badgeClient().setAppBadge(frame.get(), SecurityOriginData::fromLocalFrame(frame.get()), badge);
     promise->resolve();
 }
 

--- a/Source/WebCore/page/SecurityOriginData.cpp
+++ b/Source/WebCore/page/SecurityOriginData.cpp
@@ -64,16 +64,20 @@ URL SecurityOriginData::toURL() const
     return URL { toString() };
 }
 
-SecurityOriginData SecurityOriginData::fromFrame(LocalFrame* frame)
+SecurityOriginData SecurityOriginData::fromLocalFrame(LocalFrame* frame)
 {
     if (!frame)
         return SecurityOriginData { };
 
-    RefPtr document = frame->document();
-    if (!document)
-        return SecurityOriginData { };
+    return fromFrame(*frame);
+}
 
-    return document->securityOrigin().data();
+SecurityOriginData SecurityOriginData::fromFrame(const Frame& frame)
+{
+    if (RefPtr securityOrigin = frame.frameDocumentSecurityOrigin())
+        return securityOrigin->data();
+
+    return SecurityOriginData { };
 }
 
 SecurityOriginData SecurityOriginData::fromURL(const URL& url)

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 
+class Frame;
 class LocalFrame;
 class SecurityOrigin;
 
@@ -64,7 +65,8 @@ public:
     SecurityOriginData(WTF::HashTableDeletedValueType)
         : m_data { Tuple { WTF::HashTableDeletedValue, { }, { } } } { }
     
-    WEBCORE_EXPORT static SecurityOriginData fromFrame(LocalFrame*);
+    WEBCORE_EXPORT static SecurityOriginData fromLocalFrame(LocalFrame*);
+    WEBCORE_EXPORT static SecurityOriginData fromFrame(const Frame&);
     WEBCORE_EXPORT static SecurityOriginData fromURL(const URL&);
     WEBCORE_EXPORT static SecurityOriginData fromURLWithoutStrictOpaqueness(const URL&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7361,6 +7361,11 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
             // FIXME: We need to actually notify m_navigationClient somehow.
             frame->frameLoadState().didFailProvisionalLoad();
         }
+
+        // A provisional frame does not necessarily know the current frame URL as previous URL is not sent to provisional process.
+        auto currentFrameURL = frame->url();
+        if (frameInfo.request.url() != currentFrameURL)
+            frameInfo.request = ResourceRequest { WTF::move(currentFrameURL) };
     }
 
     // If the page starts a new main frame provisional load, then cancel any pending one in a provisional process.
@@ -7593,6 +7598,13 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
     RefPtr<API::Navigation> navigation;
     if (frame.isMainFrame() && navigationID)
         navigation = m_navigationState->takeNavigation(*navigationID);
+
+    if (protect(preferences())->siteIsolationEnabled()) {
+        // A provisional frame does not necessarily know the current frame URL as previous URL is not sent to provisional process.
+        auto currentFrameURL = frame.url();
+        if (frameInfo.request.url() != currentFrameURL)
+            frameInfo.request = ResourceRequest { WTF::move(currentFrameURL) };
+    }
 
     Ref protectedPageLoadState = pageLoadState();
     auto transaction = protectedPageLoadState->transaction();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -292,8 +292,12 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
     RefPtr coreLocalFrame = this->coreLocalFrame();
     RefPtr document = coreLocalFrame ? coreLocalFrame->document() : nullptr;
     RefPtr page = m_page.get();
+    RefPtr loadingFrame = m_provisionalFrame ? m_provisionalFrame : coreLocalFrame;
 
     WebFrameMetrics metrics;
+    SecurityOriginData securityOriginData;
+    FrameType frameType = FrameType::Local;
+    String frameName;
     if (coreFrame) {
         if (RefPtr coreView = coreFrame->virtualView()) {
             IsScrollable isScrollable = hasHorizontalScrollbar() || hasVerticalScrollbar() ? IsScrollable::Yes : IsScrollable::No;
@@ -302,15 +306,19 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
             auto visibleContentSizeExcludingScrollbars = coreView->visibleContentRect().size();
             metrics = { isScrollable, contentSize, visibleContentSize, visibleContentSizeExcludingScrollbars };
         }
+        securityOriginData = SecurityOriginData::fromFrame(*coreFrame);
+        if (coreFrame->frameType() == WebCore::Frame::FrameType::Remote)
+            frameType = FrameType::Remote;
+        frameName = coreFrame->tree().specifiedName().string();
     }
 
     return {
         isMainFrame(),
-        coreLocalFrame ? FrameType::Local : FrameType::Remote,
+        frameType,
         // FIXME: This should use the full request.
         ResourceRequest(url()),
-        SecurityOriginData::fromFrame(coreLocalFrame.get()),
-        coreFrame ? coreFrame->tree().specifiedName().string() : String(),
+        WTF::move(securityOriginData),
+        WTF::move(frameName),
         frameID(),
         page ? std::optional { page->webPageProxyIdentifier() } : std::nullopt,
         parent ? std::optional { parent->frameID() } : std::nullopt,
@@ -318,7 +326,7 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
         withCertificateInfo == WithCertificateInfo::Yes ? certificateInfo() : CertificateInfo(),
         getCurrentProcessID(),
         isFocused(),
-        coreLocalFrame && coreLocalFrame->loader().errorOccurredInLoading(),
+        loadingFrame && loadingFrame->loader().errorOccurredInLoading(),
         WTF::move(metrics)
     };
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -180,6 +180,13 @@ TEST(WKNavigation, UserAgentAndAccept)
     TestWebKitAPI::Util::run(&done);
 }
 
+struct ExpectedStrings {
+    const char* callback;
+    const char* frameRequest;
+    const char* frameSecurityOriginHost;
+    const char* request;
+};
+
 @interface FrameNavigationDelegate : NSObject <WKNavigationDelegate>
 - (void)waitForNavigations:(size_t)count;
 - (void)clearState;
@@ -193,6 +200,23 @@ TEST(WKNavigation, UserAgentAndAccept)
     RetainPtr<NSMutableArray<WKFrameInfo *>> _frames;
     RetainPtr<NSMutableArray<NSString *>> _callbacks;
     size_t _navigationCount;
+}
+
+- (void)validateCallbacks:(const Vector<ExpectedStrings>&)expectedVector
+{
+    EXPECT_EQ(_requests.get().count, expectedVector.size());
+    EXPECT_EQ(_frames.get().count, expectedVector.size());
+    EXPECT_EQ(_callbacks.get().count, expectedVector.size());
+
+    auto validateCallback = [] (NSString *callback, WKFrameInfo *frame, NSURLRequest *request, const ExpectedStrings& expected) {
+        EXPECT_WK_STREQ(callback, expected.callback);
+        EXPECT_WK_STREQ(frame.request.URL.absoluteString, expected.frameRequest);
+        EXPECT_WK_STREQ(frame.securityOrigin.host, expected.frameSecurityOriginHost);
+        EXPECT_WK_STREQ(request.URL.absoluteString, expected.request);
+    };
+
+    for (size_t i = 0; i < expectedVector.size(); ++i)
+        validateCallback(_callbacks.get()[i], _frames.get()[i], _requests.get()[i], expectedVector[i]);
 }
 
 - (void)waitForNavigations:(size_t)expectedNavigationCount
@@ -276,6 +300,11 @@ TEST(WKNavigation, UserAgentAndAccept)
     _navigationCount++;
 }
 
+- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+}
+
 @end
 
 TEST(WKNavigation, Frames)
@@ -307,13 +336,6 @@ TEST(WKNavigation, Frames)
     webView.get().navigationDelegate = delegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"frame://host1/"]]];
     [delegate waitForNavigations:3];
-
-    struct ExpectedStrings {
-        const char* callback;
-        const char* frameRequest;
-        const char* frameSecurityOriginHost;
-        const char* request;
-    };
 
     auto checkCallbacks = [delegate] (Vector<ExpectedStrings> expectedVector) {
         NSArray<NSURLRequest *> *requests = delegate.get().requests;
@@ -382,8 +404,7 @@ TEST(WKNavigation, Frames)
     [delegate clearState];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"frame://host4/"]]];
     [delegate waitForNavigations:1];
-
-    checkCallbacks({
+    [delegate validateCallbacks: {
         {
             "start provisional",
             "frame://host1/",
@@ -400,7 +421,126 @@ TEST(WKNavigation, Frames)
             "host4",
             "frame://host4/"
         }
-    });
+    }];
+}
+
+TEST(WKNavigation, FramesWithHTTPSNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<iframe src='https://frame.com/navigate'></iframe>"_s } },
+        { "/navigate"_s, { "<script>function navigate() { window.location='https://frame2.com/frame' }</script><body onload='navigate()'></body>"_s } },
+        { "/frame"_s, { "hi"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([FrameNavigationDelegate new]);
+    webView.get().navigationDelegate = delegate.get();
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+
+    // Three navigation completions: main-frame finish, frame.com/navigate finish, and frame2.com/frame finish.
+    [delegate waitForNavigations:3];
+    // FIXME: Site Isolation has a bug that initial document security origin will be set to null instead of inheriting from parent.
+    const char* initialIframeDocumentSecurityOrigin = isSiteIsolationEnabled(webView.get()) ? "" : "example.com";
+    [delegate validateCallbacks: {
+        {
+            "start provisional",
+            "",
+            "",
+            "https://example.com/main"
+        }, {
+            "commit",
+            "https://example.com/main",
+            "example.com",
+            "https://example.com/main"
+        }, {
+            "start provisional",
+            "",
+            initialIframeDocumentSecurityOrigin,
+            "https://frame.com/navigate"
+        }, {
+            "commit",
+            "https://frame.com/navigate",
+            "frame.com",
+            "https://frame.com/navigate"
+        }, {
+            "finish",
+            "https://frame.com/navigate",
+            "frame.com",
+            "https://frame.com/navigate"
+        }, {
+            "finish",
+            "https://example.com/main",
+            "example.com",
+            "https://example.com/main"
+        }, {
+            "start provisional",
+            "https://frame.com/navigate",
+            "frame.com",
+            "https://frame2.com/frame"
+        }, {
+            "commit",
+            "https://frame2.com/frame",
+            "frame2.com",
+            "https://frame2.com/frame"
+        }, {
+            "finish",
+            "https://frame2.com/frame",
+            "frame2.com",
+            "https://frame2.com/frame"
+        }
+    }];
+}
+
+TEST(WKNavigation, FramesWithLoadingError)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<iframe src='frameswitherror://frame'></iframe>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        [task didFailWithError:[NSError errorWithDomain:@"testErrorDomain" code:42 userInfo:nil]];
+    }];
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"frameswitherror"];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([FrameNavigationDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+
+    // Three navigation completions: main-frame finish, frame.com/frame finish.
+    [delegate waitForNavigations:2];
+    // FIXME: Site Isolation has a bug that initial document security origin will be set to null instead of inheriting from parent.
+    const char* initialIframeDocumentSecurityOrigin = isSiteIsolationEnabled(webView.get()) ? "" : "example.com";
+    [delegate validateCallbacks: {
+        {
+            "start provisional",
+            "",
+            "",
+            "https://example.com/main"
+        }, {
+            "commit",
+            "https://example.com/main",
+            "example.com",
+            "https://example.com/main"
+        }, {
+            "start provisional",
+            "",
+            initialIframeDocumentSecurityOrigin,
+            "frameswitherror://frame"
+        }, {
+            "fail provisional",
+            "",
+            initialIframeDocumentSecurityOrigin,
+            "frameswitherror://frame"
+        }, {
+            "finish",
+            "https://example.com/main",
+            "example.com",
+            "https://example.com/main"
+        }
+    }];
 }
 
 @interface DidFailProvisionalNavigationDelegate : NSObject <WKNavigationDelegate>


### PR DESCRIPTION
#### e95d3cb282b586c54897b153b498c4fa46310d0a
<pre>
[Site Isolation] Partially fix WKNavigation.Frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=309103">https://bugs.webkit.org/show_bug.cgi?id=309103</a>
<a href="https://rdar.apple.com/171660809">rdar://171660809</a>

Reviewed by Per Arne Vollan.

API test WKNavigation.Frames is a complex test case that involves multiple navigations and delegate callbacks. It is
currently failing under Site Isolation due to multiple issues. This patch fixes some of them and adds dedicated tests.
Here are the issues and fixes:
1. The test expects `WKFrameInfo._errorOccurred` to be the value from currently loading frame. However, `WebFrame::info`
returns the value of `coreLocalFrame`, which is not necessarily the loading frame and it can be null (because the core
frame is remote) when the frame is doing provisional load.
To fix it, make `WebFrame::info` check for `m_provisionalFrame` when trying to set `FrameInfoData::errorOccurred`.
2. The test expects `WKFrameInfo.securityOrigin` to be the last committed origin of frame (i.e. if the frame loads a
non-null URL before, then security origin should be origin of that URL). However, `WebFrame::info` returns the security
origin of  `coreLocalFrame`. As mentioned in 1, `coreLocalFrame` can be null if frame is doing provisional load; in this
case we can get the origin from the `coreRemoteFrame` or simply `coreFrame`.
To fix it, this patch renames `SecurityOriginData::fromFrame` to `SecurityOriginData::fromLocalFrame` and adds a new
function `SecurityOriginData::fromFrame`, which takes a `WebCore::Frame`, and use the new function in `WebFrame::info`.
3. The test expects `WKFrameInfo.request` to include the frame&apos;s current URL (last committed URL). Under Site Isolation,
when UI process tells a different web process to start a provisonal frame load, it does not tell that web process about
the current frame URL, as the web process shouldn&apos;t depend on previous URL for loading (and process has strict access to
sensitive information under Site Isolation). So for these web processes, when they create `FrameDataInfo` and include it
in `WebPageProxy::DidStartProvisionalLoadForFrame` and `WebPageProxy::DidFailProvisionalLoadForFrame` messages, they
won&apos;t be able to create requests the test (or existing clients) expects.
To fix it, this patch makes UI process update the request in `WebPageProxy::didFailProvisionalLoadForFrameShare` and
`WebPageProxy::didStartProvisionalLoadForFrame` with correct URLs before invoking delegate callbacks.

API tests: WKNavigation.FramesWithHTTPSNavigation
           WKNavigation.FramesWithLoadingError

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::didAccessWindowProxyPropertyViaOpener):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::setAppBadge):
* Source/WebCore/page/SecurityOriginData.cpp:
(WebCore::SecurityOriginData::fromLocalFrame):
(WebCore::SecurityOriginData::fromFrame):
* Source/WebCore/page/SecurityOriginData.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::info const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(-[FrameNavigationDelegate validateCallbacks:]):
(-[FrameNavigationDelegate webView:didReceiveAuthenticationChallenge:completionHandler:]):
(TEST(WKNavigation, Frames)):
(TEST(WKNavigation, FramesWithHTTPSNavigation)):
(TEST(WKNavigation, FramesWithLoadingError)):

Canonical link: <a href="https://commits.webkit.org/308774@main">https://commits.webkit.org/308774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f901b94e969d7921a949fa1f172cb423c45e69e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101355 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ac9a574-8947-4e1a-a6d9-e1b23b7d8040) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81332 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d1c06c9-2c7a-467b-bda5-72b82ad71b6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94814 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17a16a8a-2bee-453c-934e-2d4fbe802523) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15441 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13240 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4062 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158957 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122087 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122290 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33360 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9342 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83802 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19772 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19829 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->