### PR TITLE
[Formatting Context] Handle intrinsic height for max-content and min-content

### DIFF
--- a/LayoutTests/fast/block/positioning/max-content-height-with-absolute-position-expected.html
+++ b/LayoutTests/fast/block/positioning/max-content-height-with-absolute-position-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.box {
+    background-color: red;
+    height: max-content;
+    width: max-content;
+}
+.box-inner {
+    max-height: 100%;
+}
+</style>
+<div class="box">
+    <div class="box-inner">This test passes if the background is red.</div>
+</div>

--- a/LayoutTests/fast/block/positioning/max-content-height-with-absolute-position.html
+++ b/LayoutTests/fast/block/positioning/max-content-height-with-absolute-position.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+.box {
+    background-color: red;
+    height: max-content;
+    width: max-content;
+    position: absolute;
+}
+.box-inner {
+    max-height: 100%;
+}
+</style>
+<div class="box">
+    <div class="box-inner">This test passes if the background is red.</div>
+</div>
+<script>
+document.body.offsetHeight;
+</script>

--- a/LayoutTests/fast/block/positioning/min-content-height-with-absolute-position-expected.html
+++ b/LayoutTests/fast/block/positioning/min-content-height-with-absolute-position-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.box {
+    background-color: red;
+    height: min-content;
+    width: min-content;
+}
+.box-inner {
+    max-height: 100%;
+}
+</style>
+<div class="box">
+    <div class="box-inner">This test passes if the background is red.</div>
+</div>

--- a/LayoutTests/fast/block/positioning/min-content-height-with-absolute-position.html
+++ b/LayoutTests/fast/block/positioning/min-content-height-with-absolute-position.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+.box {
+    background-color: red;
+    height: min-content;
+    width: min-content;
+    position: absolute;
+}
+.box-inner {
+    max-height: 100%;
+}
+</style>
+<div class="box">
+    <div class="box-inner">This test passes if the background is red.</div>
+</div>
+<script>
+document.body.offsetHeight;
+</script>

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -81,12 +81,29 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
     }();
 
     if constexpr (heightType == HeightType::Max) {
-        if (height.isNone() || height.isMaxContent() || height.isMinContent() || height.isFitContent())
+        if (height.isNone())
             return { };
     } else {
-        if (height.isAuto() || height.isMaxContent() || height.isMinContent() || height.isFitContent())
+        if (height.isAuto())
             return { };
     }
+
+    // https://drafts.csswg.org/css-sizing-3/#sizing-values
+    // For both min and max content: "for a box’s block size, unless otherwise specified, this is equivalent to its automatic size."
+    if (height.isMinContent() || height.isMaxContent()) {
+        auto* elementBox = dynamicDowncast<ElementBox>(layoutBox);
+        if (!elementBox)
+            return { };
+        ASSERT(elementBox->establishesFormattingContext());
+        return contentHeightForFormattingContextRoot(*elementBox);
+    }
+
+    // FIXME:
+    // https://drafts.csswg.org/css-sizing-4/#sizing-values
+    // fit-content: Essentially fit-content(stretch) i.e. min(max-content, max(min-content, stretch)).
+    if (height.isFitContent())
+        return { };
+
     if (auto fixedHeight = height.tryFixed())
         return LayoutUnit { fixedHeight->resolveZoom(layoutBox.style().usedZoomForLength()) };
 
@@ -120,7 +137,8 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
 std::optional<LayoutUnit> FormattingGeometry::computedHeight(const Box& layoutBox, std::optional<LayoutUnit> containingBlockHeight) const
 {
     if (auto height = computedHeightValue<HeightType::Normal>(layoutBox, containingBlockHeight)) {
-        if (layoutBox.style().boxSizing() == BoxSizing::ContentBox)
+        CheckedRef style = layoutBox.style();
+        if (style->boxSizing() == BoxSizing::ContentBox || !style->logicalHeight().isSpecified())
             return height;
         auto& boxGeometry = formattingContext().geometryForBox(layoutBox);
         return *height - boxGeometry.verticalBorderAndPadding();
@@ -189,7 +207,7 @@ std::optional<LayoutUnit> FormattingGeometry::computedWidth(const Box& layoutBox
 LayoutUnit FormattingGeometry::contentHeightForFormattingContextRoot(const ElementBox& formattingContextRoot) const
 {
     ASSERT(formattingContextRoot.establishesFormattingContext());
-    ASSERT(isHeightAuto(formattingContextRoot) || formattingContextRoot.establishesTableFormattingContext() || formattingContextRoot.isTableCell());
+    ASSERT(isHeightAuto(formattingContextRoot) || formattingContextRoot.style().logicalHeight().isIntrinsic() || formattingContextRoot.establishesTableFormattingContext() || formattingContextRoot.isTableCell());
     auto usedContentHeight = LayoutUnit { }; 
     auto hasContent = formattingContextRoot.hasInFlowOrFloatingChild();
     // The used height of the containment box is determined as if performing a normal layout of the box, except that it is treated as having no content.


### PR DESCRIPTION
#### 5f64dfdf5af4983d096feaf19320d01ab0772fb3
<pre>
[Formatting Context] Handle intrinsic height for max-content and min-content
<a href="https://bugs.webkit.org/show_bug.cgi?id=289876">https://bugs.webkit.org/show_bug.cgi?id=289876</a>
&lt;<a href="https://rdar.apple.com/147333178">rdar://147333178</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR fixes a bug where FormattingGeometry::computedHeightValue was incorrectly
returning { } for max-content and min-content keywords. This PR updates
FormattingGeometry::computedHeightValue() to compute content height using
contentHeightForFormattingContextRoot().

* LayoutTests/fast/block/positioning/max-content-height-with-absolute-position-expected.html: Added.
* LayoutTests/fast/block/positioning/max-content-height-with-absolute-position.html: Added.
* LayoutTests/fast/block/positioning/min-content-height-with-absolute-position-expected.html: Added.
* LayoutTests/fast/block/positioning/min-content-height-with-absolute-position.html: Added.
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
(WebCore::Layout::FormattingGeometry::computedHeightValue const):
(WebCore::Layout::FormattingGeometry::computedHeight const):
(WebCore::Layout::FormattingGeometry::contentHeightForFormattingContextRoot const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f64dfdf5af4983d096feaf19320d01ab0772fb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104702 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24275 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116789 "Found 2 new test failures: fast/block/positioning/max-content-height-with-absolute-position.html fast/block/positioning/min-content-height-with-absolute-position.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82921 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154226 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18930 "Found 2 new test failures: fast/block/positioning/max-content-height-with-absolute-position.html fast/block/positioning/min-content-height-with-absolute-position.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97510 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18021 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15964 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7840 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162467 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5602 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15221 "Found 2 new test failures: fast/block/positioning/max-content-height-with-absolute-position.html fast/block/positioning/min-content-height-with-absolute-position.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124796 "Found 2 new test failures: fast/block/positioning/max-content-height-with-absolute-position.html fast/block/positioning/min-content-height-with-absolute-position.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23830 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20018 "Found 2 new test failures: fast/block/positioning/max-content-height-with-absolute-position.html fast/block/positioning/min-content-height-with-absolute-position.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124984 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23820 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135437 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80301 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20054 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12211 "Found 2 new test failures: fast/block/positioning/max-content-height-with-absolute-position.html fast/block/positioning/min-content-height-with-absolute-position.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87734 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->