### PR TITLE
Address unnecessary copy initialization in WebCore

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -98,7 +98,7 @@ void NavigatorBeacon::logError(const ResourceError& error)
         return;
 
     ASCIILiteral messageMiddle { ". "_s };
-    String description = error.localizedDescription();
+    auto& description = error.localizedDescription();
     if (description.isEmpty()) {
         if (error.isAccessControl())
             messageMiddle = " due to access control checks."_s;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -135,7 +135,7 @@ static inline uint64_t estimateSize(const IDBObjectStoreInfo& info)
 {
     uint64_t size = 4;
     size += info.name().sizeInBytes();
-    if (auto keyPath = info.keyPath())
+    if (auto& keyPath = info.keyPath())
         size += estimateSize(*keyPath);
     return size;
 }

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -859,7 +859,7 @@ static ContentType addVP9FullRangeVideoFlagToContentType(const ContentType& type
         if (!codec.startsWith("vp09"_s) || countPeriods(codec) != 7)
             continue;
 
-        auto rawType = type.raw();
+        auto& rawType = type.raw();
         auto position = rawType.find(codec);
         ASSERT(position != notFound);
         if (position == notFound)

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -185,7 +185,7 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
 
             if (!privateStreamOrError) {
                 RELEASE_LOG(MediaStream, "UserMediaRequest::allow failed to create media stream!");
-                auto error = privateStreamOrError.error();
+                auto& error = privateStreamOrError.error();
                 protectedThis->scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, error.errorMessage);
                 protectedThis->deny(error.denialReason, error.errorMessage, error.invalidConstraint);
                 return;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -99,7 +99,7 @@ static ScopeAndCrossOriginParent scopeAndCrossOriginParent(const Document& docum
 {
     bool isSameSite = true;
     Ref origin = document.securityOrigin();
-    auto url = document.url();
+    auto& url = document.url();
     std::optional<SecurityOriginData> crossOriginParent;
     for (RefPtr parentDocument = document.parentDocument(); parentDocument; parentDocument = parentDocument->parentDocument()) {
         if (!origin->isSameOriginDomain(protect(parentDocument->securityOrigin())) && !areRegistrableDomainsEqual(url, parentDocument->url()))

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
@@ -160,7 +160,7 @@ ExceptionOr<void> DatabaseTracker::canEstablishDatabase(DatabaseContext& context
     Locker lockDatabase { m_databaseGuard };
 
     // FIXME: What guarantees this context.securityOrigin() is non-null?
-    auto origin = context.securityOrigin();
+    auto& origin = context.securityOrigin();
 
     if (isDeletingDatabaseOrOriginFor(origin, name))
         return Exception { ExceptionCode::SecurityError };
@@ -208,7 +208,7 @@ ExceptionOr<void> DatabaseTracker::retryCanEstablishDatabase(DatabaseContext& co
     Locker lockDatabase { m_databaseGuard };
 
     // FIXME: What guarantees context.securityOrigin() is non-null?
-    auto origin = context.securityOrigin();
+    auto& origin = context.securityOrigin();
 
     // We have already eliminated other types of errors in canEstablishDatabase().
     // The only reason we're in retryCanEstablishDatabase() is because we gave

--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -376,7 +376,7 @@ bool isDataTableWithTraversal(HTMLTableElement& tableElement, AXObjectCache& cac
 
     // Check if there is an alternating row background color indicating a zebra striped style pattern.
     if (alternatingRowColorCount > 2) {
-        Color firstColor = alternatingRowColors[0];
+        auto& firstColor = alternatingRowColors[0];
         for (int k = 1; k < alternatingRowColorCount; k++) {
             // If an odd row was the same color as the first row, it's not alternating.
             if (k % 2 == 1 && alternatingRowColors[k] == firstColor)

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -176,7 +176,7 @@ RenderImage* toSimpleImage(RenderObject& renderer)
 // FIXME: This probably belongs on Element.
 bool hasRole(Element& element, StringView role)
 {
-    auto roleValue = element.attributeWithDefaultARIA(roleAttr);
+    auto& roleValue = element.attributeWithDefaultARIA(roleAttr);
     if (role.isNull())
         return roleValue.isEmpty();
     if (roleValue.isEmpty())
@@ -187,7 +187,7 @@ bool hasRole(Element& element, StringView role)
 
 bool hasAnyRole(Element& element, Vector<StringView>&& roles)
 {
-    auto roleValue = element.attributeWithDefaultARIA(roleAttr);
+    auto& roleValue = element.attributeWithDefaultARIA(roleAttr);
     if (roleValue.isEmpty())
         return false;
 

--- a/Source/WebCore/css/DOMCSSNamespace.cpp
+++ b/Source/WebCore/css/DOMCSSNamespace.cpp
@@ -50,7 +50,7 @@ bool DOMCSSNamespace::supports(Document& document, const String& property, const
     CSSParserContext parserContext(document);
     parserContext.mode = HTMLStandardMode;
 
-    auto propertyNameWithoutWhitespace = property;
+    auto& propertyNameWithoutWhitespace = property;
     CSSPropertyID propertyID = cssPropertyID(propertyNameWithoutWhitespace);
     if (propertyID == CSSPropertyInvalid && isCustomPropertyName(propertyNameWithoutWhitespace)) {
         auto dummyStyle = MutableStyleProperties::create();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -385,7 +385,7 @@ bool Element::isNonceable() const
         static constexpr auto styleString = "<style"_s;
 
         for (auto& attribute : attributes()) {
-            auto name = attribute.localNameLowercase();
+            auto& name = attribute.localNameLowercase();
             auto value = attribute.value().convertToASCIILowercase();
             if (name.contains(scriptString)
                 || name.contains(styleString)
@@ -3376,7 +3376,7 @@ static bool canAttachAuthorShadowRoot(const Element& element)
         break;
     }
 
-    if (auto localName = element.localName(); Document::validateCustomElementName(localName) == CustomElementNameValidationStatus::Valid) {
+    if (auto& localName = element.localName(); Document::validateCustomElementName(localName) == CustomElementNameValidationStatus::Valid) {
         if (RefPtr window = element.document().window()) {
             RefPtr registry = window->customElementRegistry();
             if (registry && registry->isShadowDisabled(localName))

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -343,7 +343,7 @@ VisibleSelection Editor::selectionForCommand(Event* event)
     // If the target is a text control, and the current selection is outside of its shadow tree,
     // then use the saved selection for that text control.
     if (RefPtr target = dynamicDowncast<HTMLTextFormControlElement>(event->target()); target && target->isTextField()) {
-        auto start = selection.start();
+        auto& start = selection.start();
         if (start.isNull() || event->target() != enclosingTextFormControl(start)) {
             if (auto range = target->selection())
                 return { *range, Affinity::Downstream, selection.directionality() };
@@ -464,7 +464,7 @@ static Ref<DataTransfer> createDataTransferForClipboardEvent(Document& document,
         return DataTransfer::createForCopyAndPaste(document, DataTransfer::StoreMode::ReadWrite, makeUnique<StaticPasteboard>());
     case ClipboardEventKind::PasteAsPlainText:
         if (DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
-            auto plainTextType = textPlainContentTypeAtom();
+            auto& plainTextType = textPlainContentTypeAtom();
             auto plainText = Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(document.pageID()))->readString(plainTextType);
             auto pasteboard = makeUnique<StaticPasteboard>();
             pasteboard->writeString(plainTextType, plainText);
@@ -4852,7 +4852,7 @@ void Editor::cloneAttachmentData(const String& fromIdentifier, const String& toI
 
 void Editor::didInsertAttachmentElement(HTMLAttachmentElement& attachment)
 {
-    auto identifier = attachment.uniqueIdentifier();
+    auto& identifier = attachment.uniqueIdentifier();
     if (identifier.isEmpty())
         return;
 
@@ -4863,7 +4863,7 @@ void Editor::didInsertAttachmentElement(HTMLAttachmentElement& attachment)
 
 void Editor::didRemoveAttachmentElement(HTMLAttachmentElement& attachment)
 {
-    auto identifier = attachment.uniqueIdentifier();
+    auto& identifier = attachment.uniqueIdentifier();
     if (identifier.isEmpty())
         return;
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1857,8 +1857,8 @@ ReplacementFragment* ReplaceSelectionCommand::ensureReplacementFragment()
 
 static bool fullySelectsEnclosingLink(const VisibleSelection& selection)
 {
-    auto start = selection.start();
-    auto end = selection.end();
+    auto& start = selection.start();
+    auto& end = selection.end();
     RefPtr ancestor = commonInclusiveAncestor(start, end);
     if (!ancestor)
         return false;

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -994,7 +994,7 @@ static bool shouldEmitExtraNewlineForNode(Node& node)
 
 static int collapsedSpaceLength(RenderText& renderer, int textEnd)
 {
-    auto text = renderer.text();
+    auto& text = renderer.text();
     unsigned length = text.length();
     for (unsigned i = textEnd; i < length; ++i) {
         if (!renderer.style().isCollapsibleWhiteSpace(text[i]))

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -704,7 +704,7 @@ bool StyledMarkupAccumulator::shouldPreserveMSOListStyleForElement(const Element
     if (m_inMSOList)
         return true;
     if (m_shouldPreserveMSOList) {
-        auto style = element.getAttribute(styleAttr);
+        auto& style = element.getAttribute(styleAttr);
         return style.startsWith("mso-list:"_s) || style.contains(";mso-list:"_s) || style.contains("\nmso-list:"_s);
     }
     return false;

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -370,7 +370,7 @@ static PermissionsPolicy::PolicyDirective parsePolicyDirective(StringView value,
 // https://w3c.github.io/webappsec-permissions-policy/#algo-process-policy-attributes
 PermissionsPolicy::PolicyDirective PermissionsPolicy::processPermissionsPolicyAttribute(const HTMLIFrameElement& iframe)
 {
-    auto allowAttributeValue = iframe.attributeWithoutSynchronization(allowAttr);
+    auto& allowAttributeValue = iframe.attributeWithoutSynchronization(allowAttr);
     auto policyDirective = parsePolicyDirective(allowAttributeValue, protect(iframe.document())->securityOrigin().data(), declaredOrigin(iframe)->data());
 
     if (iframe.hasAttributeWithoutSynchronization(allowfullscreenAttr) || iframe.hasAttributeWithoutSynchronization(webkitallowfullscreenAttr))

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -393,7 +393,7 @@ FloatSize InspectorOverlayLabel::expectedSize(const Vector<Content>& contents, A
                 ++currentLine;
             }
 
-            auto text = lines[i];
+            auto& text = lines[i];
             if (text.isEmpty())
                 continue;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -623,7 +623,7 @@ std::optional<InlineContentBreaker::PartialRun> InlineContentBreaker::tryBreakin
 
 std::optional<InlineContentBreaker::OverflowingTextContent::BreakingPosition> InlineContentBreaker::tryBreakingOverflowingRun(const LineStatus& lineStatus, const ContinuousContent::RunList& runs, size_t overflowingRunIndex, InlineLayoutUnit nonOverflowingContentWidth) const
 {
-    auto overflowingRun = runs[overflowingRunIndex];
+    auto& overflowingRun = runs[overflowingRunIndex];
     ASSERT(!overflowingRun.inlineItem.isOutOfFlow());
     if (!isBreakableRun(overflowingRun))
         return { };

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -134,7 +134,7 @@ void CookieJar::setCookies(Document& document, const URL& url, const String& coo
 
 bool CookieJar::cookiesEnabled(Document& document)
 {
-    auto cookieURL = document.cookieURL();
+    auto& cookieURL = document.cookieURL();
     if (cookieURL.isEmpty())
         return false;
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -954,7 +954,7 @@ void DocumentLoader::responseReceived(ResourceResponse&& response, CompletionHan
     ResourceLoaderIdentifier identifier = m_identifierForLoadWithoutResourceLoader ? *m_identifierForLoadWithoutResourceLoader : *m_mainResource->resourceLoaderIdentifier();
 
     if (m_substituteData.isValid() || !platformStrategies()->loaderStrategy()->havePerformedSecurityChecks(response)) {
-        auto url = response.url();
+        auto& url = response.url();
         RefPtr frame = m_frame.get();
         // FIXME(294912): Clean up use of bare pointers for ReportingClient
         ReportingClient* reportingClient = nullptr;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1774,7 +1774,7 @@ void FrameLoader::loadWithNavigationAction(ResourceRequest&& request, Navigation
 
     m_errorOccurredInLoading = false;
     if (request.url().protocolIsJavaScript() && !action.isInitialFrameSrcLoad()) {
-        if (auto requester = action.requester(); requester && requester->documentIdentifier) {
+        if (auto& requester = action.requester(); requester && requester->documentIdentifier) {
             if (RefPtr requestingDocument = Document::allDocumentsMap().get(requester->documentIdentifier); requestingDocument && requestingDocument->contentSecurityPolicy()) {
                 if (!requestingDocument->contentSecurityPolicy()->allowJavaScriptURLs(protect(m_frame)->document()->url().string(), { }, request.url().string(), nullptr))
                     return completionHandler();
@@ -1998,7 +1998,7 @@ bool FrameLoader::willLoadMediaElementURL(URL& url, Node& initiatorNode)
 
 bool FrameLoader::shouldReloadToHandleUnreachableURL(DocumentLoader& docLoader)
 {
-    URL unreachableURL = docLoader.unreachableURL();
+    auto& unreachableURL = docLoader.unreachableURL();
 
     if (unreachableURL.isEmpty())
         return false;

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -240,7 +240,7 @@ static inline ChildElementPosition findChild(const Element& element, const Eleme
 static inline String computeIDSelector(const Element& element)
 {
     if (element.hasID()) {
-        auto elementID = element.getIdAttribute();
+        auto& elementID = element.getIdAttribute();
         if (auto* matches = element.treeScope().getAllElementsById(elementID); matches && matches->size() == 1)
             return makeString('#', elementID);
     }
@@ -792,7 +792,7 @@ static bool isNavigationalElement(const Element& element)
     if (element.hasTagName(HTMLNames::navTag))
         return true;
 
-    auto roleValue = element.attributeWithoutSynchronization(HTMLNames::roleAttr);
+    auto& roleValue = element.attributeWithoutSynchronization(HTMLNames::roleAttr);
     return AccessibilityObject::ariaRoleToWebCoreRole(roleValue) == AccessibilityRole::LandmarkNavigation;
 }
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -3468,7 +3468,7 @@ void Quirks::determineRelevantQuirks()
         return;
 
     RegistrableDomain registrableDomain { quirksURL };
-    auto quirksDomainString = registrableDomain.string();
+    auto& quirksDomainString = registrableDomain.string();
     auto quirkDomainWithoutPSL = PublicSuffixStore::singleton().domainWithoutPublicSuffix(quirksDomainString);
 
     using QuirkHandler = void (*)(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL);

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2065,7 +2065,7 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
         needsParentContext = false;
     }
 
-    if (auto text = element.attributeWithoutSynchronization(HTMLNames::typeAttr); !text.isEmpty() && text != tagName)
+    if (auto& text = element.attributeWithoutSynchronization(HTMLNames::typeAttr); !text.isEmpty() && text != tagName)
         description.append(makeString(" of type "_s, text));
 
     if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::placeholderAttr)); !text.isEmpty()) {
@@ -2091,12 +2091,12 @@ static String textDescription(const Element& element, Vector<String>& stringsToV
         return true;
     };
 
-    if (auto text = element.attributeWithoutSynchronization(HTMLNames::idAttr); isCandidateClassOrId(text)) {
+    if (auto& text = element.attributeWithoutSynchronization(HTMLNames::idAttr); isCandidateClassOrId(text)) {
         description.append(makeString(" with id "_s, wrapWithDoubleQuotes(text)));
         needsParentContext = false;
     }
 
-    if (auto classValue = element.attributeWithoutSynchronization(HTMLNames::classAttr); !classValue.isEmpty()) {
+    if (auto& classValue = element.attributeWithoutSynchronization(HTMLNames::classAttr); !classValue.isEmpty()) {
         Vector<String, maximumNumberOfClasses> humanReadableClassNames;
         for (auto className : StringView { classValue }.split(' ')) {
             if (!isCandidateClassOrId(className))

--- a/Source/WebCore/platform/ContentType.cpp
+++ b/Source/WebCore/platform/ContentType.cpp
@@ -143,11 +143,11 @@ String ContentType::toJSONString() const
 
     object->setString("containerType"_s, containerType());
 
-    auto codecs = codecsParameter();
+    auto& codecs = codecsParameter();
     if (!codecs.isEmpty())
         object->setString("codecs"_s, codecs);
 
-    auto profiles = profilesParameter();
+    auto& profiles = profilesParameter();
     if (!profiles.isEmpty())
         object->setString("profiles"_s, profiles);
 

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
@@ -54,7 +54,7 @@ ImageBufferContextSwitcher::ImageBufferContextSwitcher(GraphicsContext& destinat
         return;
     }
 
-    auto state = destinationContext.state();
+    auto& state = destinationContext.state();
     m_sourceImage->context().mergeAllChanges(state);
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1230,17 +1230,17 @@ RealtimeMediaSource::VideoPresetConstraints RealtimeMediaSource::extractVideoPre
     VideoPresetConstraints result;
     auto& capabilities = this->capabilities();
 
-    if (auto constraint = constraints.width()) {
+    if (auto& constraint = constraints.width()) {
         if (capabilities.supportsWidth())
             result.width = constraint->valueForCapabilityRange(size().width(), capabilities.width());
     }
 
-    if (auto constraint = constraints.height()) {
+    if (auto& constraint = constraints.height()) {
         if (capabilities.supportsHeight())
             result.height = constraint->valueForCapabilityRange(size().height(), capabilities.height());
     }
 
-    if (auto constraint = constraints.aspectRatio()) {
+    if (auto& constraint = constraints.aspectRatio()) {
         if (capabilities.supportsAspectRatio()) {
             auto size = this->size();
             auto range = capabilities.aspectRatio();
@@ -1254,21 +1254,21 @@ RealtimeMediaSource::VideoPresetConstraints RealtimeMediaSource::extractVideoPre
         }
     }
 
-    if (auto constraint = constraints.frameRate()) {
+    if (auto& constraint = constraints.frameRate()) {
         if (capabilities.supportsFrameRate()) {
             auto range = capabilities.frameRate();
             result.frameRate = constraint->valueForCapabilityRange(this->frameRate(), range);
         }
     }
 
-    if (auto constraint = constraints.zoom()) {
+    if (auto& constraint = constraints.zoom()) {
         if (capabilities.supportsZoom()) {
             auto range = capabilities.zoom();
             result.zoom = constraint->valueForCapabilityRange(this->zoom(), range);
         }
     }
 
-    if (auto contraint = constraints.powerEfficient())
+    if (auto& contraint = constraints.powerEfficient())
         contraint->getExact(result.shouldPreferPowerEfficiency) || contraint->getIdeal(result.shouldPreferPowerEfficiency);
 
     return result;

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -205,7 +205,7 @@ static Vector<uint8_t> normalizeStringData(PAL::TextEncoding& encoding, const St
 
 void FormData::appendMultiPartFileValue(const File& file, Vector<uint8_t>& header, PAL::TextEncoding& encoding)
 {
-    auto name = file.name();
+    auto& name = file.name();
 
     // We have to include the filename=".." part in the header, even if the filename is empty
     FormDataBuilder::addFilenameToMultiPartHeader(header, encoding, name);

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -163,19 +163,19 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
     }
 
     if (style.hasMarkers()) {
-        if (auto markerStartResource = style.markerStart(); !markerStartResource.isNone()) {
+        if (auto& markerStartResource = style.markerStart(); !markerStartResource.isNone()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerStartResource, document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::markerTag } });
         }
 
-        if (auto markerMidResource = style.markerMid(); !markerMidResource.isNone()) {
+        if (auto& markerMidResource = style.markerMid(); !markerMidResource.isNone()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerMidResource, document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::markerTag } });
         }
 
-        if (auto markerEndResource = style.markerEnd(); !markerEndResource.isNone()) {
+        if (auto& markerEndResource = style.markerEnd(); !markerEndResource.isNone()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerEndResource, document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::markerTag } });

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -476,8 +476,8 @@ void RenderBox::updateGridPositionAfterStyleChange(const RenderStyle& style, con
 
 void RenderBox::updateShapeOutsideInfoAfterStyleChange(const RenderStyle& style, const RenderStyle* oldStyle, Style::Difference diff)
 {
-    Style::ShapeOutside shapeOutside = style.shapeOutside();
-    Style::ShapeOutside oldShapeOutside = oldStyle ? oldStyle->shapeOutside() : Style::ComputedStyle::initialShapeOutside();
+    auto& shapeOutside = style.shapeOutside();
+    auto& oldShapeOutside = oldStyle ? oldStyle->shapeOutside() : Style::ComputedStyle::initialShapeOutside();
 
     Style::ShapeMargin shapeMargin = style.shapeMargin();
     Style::ShapeMargin oldShapeMargin = oldStyle ? oldStyle->shapeMargin() : Style::ComputedStyle::initialShapeMargin();

--- a/Source/WebCore/rendering/RenderHighlight.cpp
+++ b/Source/WebCore/rendering/RenderHighlight.cpp
@@ -100,8 +100,8 @@ bool RenderHighlight::setRenderRange(const HighlightRange& highlightRange)
     if (highlightRange.startPosition().isNull() || highlightRange.endPosition().isNull())
         return false;
 
-    auto startPosition = highlightRange.startPosition();
-    auto endPosition = highlightRange.endPosition();
+    auto& startPosition = highlightRange.startPosition();
+    auto& endPosition = highlightRange.endPosition();
 
     if (!startPosition.containerNode() || !endPosition.containerNode())
         return false;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -881,7 +881,7 @@ static void writeCounterValuesFromChildren(TextStream& stream, const RenderEleme
         if (!isFirstCounter)
             stream << " ";
         isFirstCounter = false;
-        String str(counter.text());
+        auto& str = counter.text();
         stream << str;
     }
 }

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -595,7 +595,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
     }
     WTF::switchOn(style.clipPath(),
         [&](const Style::ReferencePath& clipPath) {
-            auto id = clipPath.fragment();
+            auto& id = clipPath.fragment();
             if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(renderer.treeScopeForSVGReferences(), id)) {
                 ts << indent << ' ';
                 writeNameAndQuotedValue(ts, "clipPath"_s, id);

--- a/Source/WebCore/rendering/svg/SVGTextChunk.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.cpp
@@ -36,7 +36,7 @@ SVGTextChunk::SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>& lin
     ASSERT(first < limit);
     ASSERT(limit <= lineLayoutBoxes.size());
 
-    auto firstBox = lineLayoutBoxes[first];
+    auto& firstBox = lineLayoutBoxes[first];
     CheckedRef style = firstBox->renderer().style();
 
     if (style->writingMode().isBidiRTL())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -143,9 +143,9 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
     filterData->filter->clampFilterRegionIfNeeded();
 
 #if USE(CAIRO)
-    auto colorSpace = DestinationColorSpace::SRGB();
+    auto& colorSpace = DestinationColorSpace::SRGB();
 #else
-    auto colorSpace = DestinationColorSpace::LinearSRGB();
+    auto& colorSpace = DestinationColorSpace::LinearSRGB();
 #endif
 
     auto& results = filterData->filter->ensureResults([&]() {

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1239,7 +1239,7 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
 
     float initialScale = document->page() ? document->page()->initialScaleIgnoringContentSize() : 1;
     auto adjustLineHeightIfNeeded = [&](auto computedFontSize) {
-        auto lineHeight = style.specifiedLineHeight();
+        auto& lineHeight = style.specifiedLineHeight();
         constexpr static unsigned eligibleFontSize = 12;
         if (computedFontSize * initialScale >= eligibleFontSize)
             return;

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -89,9 +89,9 @@ static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> 
         return std::nullopt;
 
 #if USE(CAIRO)
-    const auto colorSpace = filterElement.colorInterpolation() == ColorInterpolation::LinearRGB ? DestinationColorSpace::LinearSRGB() : DestinationColorSpace::SRGB();
+    auto& colorSpace = filterElement.colorInterpolation() == ColorInterpolation::LinearRGB ? DestinationColorSpace::LinearSRGB() : DestinationColorSpace::SRGB();
 #else
-    const auto colorSpace = DestinationColorSpace::SRGB();
+    auto& colorSpace = DestinationColorSpace::SRGB();
 #endif
 
     SVGFilterEffectGraph graph(SourceGraphic::create(colorSpace), SourceAlpha::create(colorSpace));

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1554,7 +1554,7 @@ void SWServer::removeContextConnection(SWServerToContextConnection& connection)
 {
     RELEASE_LOG(ServiceWorker, "SWServer::removeContextConnection %" PRIu64, connection.identifier().toUInt64());
 
-    auto site = connection.site();
+    auto& site = connection.site();
     auto serviceWorkerPageIdentifier = connection.serviceWorkerPageIdentifier();
 
     ASSERT(m_contextConnections.get(site.domain()) == &connection);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -456,7 +456,7 @@ static void switchToUTF16(xmlParserCtxtPtr ctxt)
 
 static bool shouldAllowExternalLoad(const URL& url)
 {
-    String urlString = url.string();
+    auto& urlString = url.string();
 
     // On non-Windows platforms libxml asks for this URL, the "XML_XML_DEFAULT_CATALOG", on initialization.
     if (urlString == "file:///etc/xml/catalog"_s)


### PR DESCRIPTION
#### d4bf3305de7326331afa1640e6b7b691288a9a31
<pre>
Address unnecessary copy initialization in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=309113">https://bugs.webkit.org/show_bug.cgi?id=309113</a>
<a href="https://rdar.apple.com/171666369">rdar://171666369</a>

Reviewed by NOBODY (OOPS!).

This fixes unnecessary copy initialization where variables were copy-constructed
from a const reference but were only used as const reference.

* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::logError):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::estimateSize):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::addVP9FullRangeVideoFlagToContentType):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinatorInternal::scopeAndCrossOriginParent):
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::DatabaseTracker::canEstablishDatabase):
(WebCore::DatabaseTracker::retryCanEstablishDatabase):
* Source/WebCore/accessibility/AXTableHelpers.cpp:
(WebCore::AXTableHelpers::isDataTableWithTraversal):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::hasRole):
(WebCore::hasAnyRole):
* Source/WebCore/css/DOMCSSNamespace.cpp:
(WebCore::DOMCSSNamespace::supports):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isNonceable const):
(WebCore::canAttachAuthorShadowRoot):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectionForCommand):
(WebCore::createDataTransferForClipboardEvent):
(WebCore::Editor::didInsertAttachmentElement):
(WebCore::Editor::didRemoveAttachmentElement):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::fullySelectsEnclosingLink):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::collapsedSpaceLength):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::shouldPreserveMSOListStyleForElement):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::PermissionsPolicy::processPermissionsPolicyAttribute):
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::InspectorOverlayLabel::expectedSize):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
(WebCore::Layout::InlineContentBreaker::tryBreakingOverflowingRun const):
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::cookiesEnabled):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::shouldReloadToHandleUnreachableURL):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::computeIDSelector):
(WebCore::isNavigationalElement):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::textDescription):
* Source/WebCore/platform/ContentType.cpp:
(WebCore::ContentType::toJSONString const):
* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp:
(WebCore::ImageBufferContextSwitcher::ImageBufferContextSwitcher):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::extractVideoPresetConstraints):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::appendMultiPartFileValue):
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedSVGResourceIDs):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::updateShapeOutsideInfoAfterStyleChange):
* Source/WebCore/rendering/RenderHighlight.cpp:
(WebCore::RenderHighlight::setRenderRange):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::writeCounterValuesFromChildren):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeResources):
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
(WebCore::SVGTextChunk::SVGTextChunk):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustmentForTextAutosizing):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::buildFilterEffectGraph):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::removeContextConnection):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::shouldAllowExternalLoad):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4bf3305de7326331afa1640e6b7b691288a9a31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114061 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81340 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13249 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4075 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158970 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2105 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122095 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122298 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76590 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9347 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->