### PR TITLE
WIP: Stop adding scrollbar width inside computeIntrinsicLogicalWidths.

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2266,10 +2266,6 @@ void RenderBlock::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Lay
         computeBlockPreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
 
     maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
-
-    int scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-    maxLogicalWidth += scrollbarWidth;
-    minLogicalWidth += scrollbarWidth;
 }
 
 void RenderBlock::computePreferredLogicalWidths()
@@ -2287,12 +2283,19 @@ void RenderBlock::computePreferredLogicalWidths()
     } else if (logicalWidth.isMaxContent()) {
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth;
+        auto scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
+        m_minPreferredLogicalWidth += scrollbarWidth;
+        m_maxPreferredLogicalWidth += scrollbarWidth;
     } else if (shouldComputeLogicalWidthFromAspectRatio()) {
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = (computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
         m_minPreferredLogicalWidth = std::max(0_lu, m_minPreferredLogicalWidth);
         m_maxPreferredLogicalWidth = std::max(0_lu, m_maxPreferredLogicalWidth);
-    } else 
+    } else {
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+        auto scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
+        m_minPreferredLogicalWidth += scrollbarWidth;
+        m_maxPreferredLogicalWidth += scrollbarWidth;
+    }
 
     RenderBox::computePreferredLogicalWidths(styleToUse.logicalMinWidth(), styleToUse.logicalMaxWidth(), borderAndPaddingLogicalWidth());
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -374,10 +374,6 @@ void RenderBlockFlow::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth,
         if (auto fixedTableCellWidth = tableCellWidth.tryFixed(); fixedTableCellWidth && fixedTableCellWidth->isPositive())
             maxLogicalWidth = std::max(minLogicalWidth, adjustContentBoxLogicalWidthForBoxSizing(*fixedTableCellWidth));
     }
-
-    int scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-    maxLogicalWidth += scrollbarWidth;
-    minLogicalWidth += scrollbarWidth;
 }
 
 bool RenderBlockFlow::recomputeLogicalWidthAndColumnWidth()

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -202,18 +202,11 @@ void RenderDeprecatedFlexibleBox::styleWillChange(Style::Difference diff, const 
 
 void RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
-    auto addScrollbarWidth = [&]() {
-        LayoutUnit scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-        maxLogicalWidth += scrollbarWidth;
-        minLogicalWidth += scrollbarWidth;
-    };
-
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto width = explicitIntrinsicInnerLogicalWidth()) {
             minLogicalWidth = width.value();
             maxLogicalWidth = width.value();
         }
-        addScrollbarWidth();
         return;
     }
 
@@ -241,7 +234,6 @@ void RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minL
     }
 
     maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
-    addScrollbarWidth();
 }
 
 void RenderDeprecatedFlexibleBox::computePreferredLogicalWidths()
@@ -251,8 +243,12 @@ void RenderDeprecatedFlexibleBox::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = 0;
     if (auto fixedWidth = style().width().tryFixed(); fixedWidth && fixedWidth->isPositive())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedWidth);
-    else
+    else {
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
+        int scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
+        m_minPreferredLogicalWidth += scrollbarWidth;
+        m_maxPreferredLogicalWidth += scrollbarWidth;
+    }
 
     RenderBox::computePreferredLogicalWidths(style().minWidth(), style().maxWidth(), borderAndPaddingLogicalWidth());
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -143,18 +143,11 @@ ASCIILiteral RenderFlexibleBox::renderName() const
 
 void RenderFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
-    auto addScrollbarWidth = [&]() {
-        LayoutUnit scrollbarWidth(scrollbarLogicalWidth());
-        maxLogicalWidth += scrollbarWidth;
-        minLogicalWidth += scrollbarWidth;
-    };
-
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto width = explicitIntrinsicInnerLogicalWidth()) {
             minLogicalWidth = width.value();
             maxLogicalWidth = width.value();
         }
-        addScrollbarWidth();
         return;
     }
 
@@ -217,8 +210,6 @@ void RenderFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
         minLogicalWidth = std::max(minLogicalWidth, flexItemMinWidth);
         maxLogicalWidth = std::max(maxLogicalWidth, flexItemMaxWidth);
     }
-
-    addScrollbarWidth();
 }
 
 #define SET_OR_CLEAR_OVERRIDING_SIZE(box, SizeType, size)       \

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -808,11 +808,6 @@ void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Layo
         auto gridLayout = LayoutIntegration::GridLayout { const_cast<RenderGrid&>(*this) };
         gridLayout.updateFormattingContextGeometries();
         std::tie(minLogicalWidth, maxLogicalWidth) = gridLayout.computeIntrinsicWidths();
-
-        // Add scrollbar width
-        LayoutUnit scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-        minLogicalWidth += scrollbarWidth;
-        maxLogicalWidth += scrollbarWidth;
         return;
     }
 
@@ -857,10 +852,6 @@ void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Layo
         minLogicalWidth = std::max(minLogicalWidth, gridItemMinWidth);
         maxLogicalWidth = std::max(maxLogicalWidth, gridItemMaxWidth);
     }
-
-    LayoutUnit scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
-    minLogicalWidth += scrollbarWidth;
-    maxLogicalWidth += scrollbarWidth;
 }
 
 void RenderGrid::computeTrackSizesForIndefiniteSize(GridTrackSizingAlgorithm& algorithm, Style::GridTrackSizingDirection direction, RenderGridLayoutState& gridLayoutState, LayoutUnit* minIntrinsicSize, LayoutUnit* maxIntrinsicSize) const


### PR DESCRIPTION
#### 74a1f2a26bb2dde3bf83de3d79b77d8a96f9c2e2
<pre>
WIP: Stop adding scrollbar width inside computeIntrinsicLogicalWidths.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeIntrinsicLogicalWidths const):
(WebCore::RenderBlock::computePreferredLogicalWidths):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidths const):
(WebCore::RenderDeprecatedFlexibleBox::computePreferredLogicalWidths):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a1f2a26bb2dde3bf83de3d79b77d8a96f9c2e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101373 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20550 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114063 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html imported/w3c/web-platform-tests/css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81342 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4f9704f-cf26-47d1-bdaf-9f007ffc8338) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94826 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98656008-4cd9-4aa1-8749-766ea3ac0f86) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15454 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html imported/w3c/web-platform-tests/css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13253 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4080 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158975 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2110 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12283 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html imported/w3c/web-platform-tests/css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122096 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html imported/w3c/web-platform-tests/css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20444 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17182 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html imported/w3c/web-platform-tests/css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76595 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17783 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9350 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html imported/w3c/web-platform-tests/css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19790 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19938 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->