### PR TITLE
[EvaluationTimeZoom][Cleanup] StyleInheritedRareData::deviceScaleFactor is unused

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -343,11 +343,6 @@ inline bool RenderStyle::evaluationTimeZoomEnabled() const
     return m_computedStyle.evaluationTimeZoomEnabled();
 }
 
-inline float RenderStyle::deviceScaleFactor() const
-{
-    return m_computedStyle.deviceScaleFactor();
-}
-
 inline bool RenderStyle::useSVGZoomRulesForLength() const
 {
     return m_computedStyle.useSVGZoomRulesForLength();

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -299,11 +299,6 @@ inline void RenderStyle::setEvaluationTimeZoomEnabled(bool value)
     m_computedStyle.setEvaluationTimeZoomEnabled(value);
 }
 
-inline void RenderStyle::setDeviceScaleFactor(float value)
-{
-    m_computedStyle.setDeviceScaleFactor(value);
-}
-
 inline void RenderStyle::setUseSVGZoomRulesForLength(bool value)
 {
     m_computedStyle.setUseSVGZoomRulesForLength(value);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -234,9 +234,6 @@ public:
     inline bool evaluationTimeZoomEnabled() const;
     inline void setEvaluationTimeZoomEnabled(bool);
 
-    inline float deviceScaleFactor() const;
-    inline void setDeviceScaleFactor(float);
-
     inline bool useSVGZoomRulesForLength() const;
     inline void setUseSVGZoomRulesForLength(bool);
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -116,8 +116,6 @@ RenderStyle resolveForDocument(const Document& document)
 
     documentStyle.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());
 
-    documentStyle.setDeviceScaleFactor(document.deviceScaleFactor());
-
     return documentStyle;
 }
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -302,11 +302,6 @@ inline bool ComputedStyleBase::evaluationTimeZoomEnabled() const
     return m_inheritedRareData->evaluationTimeZoomEnabled;
 }
 
-inline float ComputedStyleBase::deviceScaleFactor() const
-{
-    return m_inheritedRareData->deviceScaleFactor;
-}
-
 inline bool ComputedStyleBase::useSVGZoomRulesForLength() const
 {
     return m_nonInheritedData->rareData->useSVGZoomRulesForLength;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -242,11 +242,6 @@ inline void ComputedStyleBase::setEvaluationTimeZoomEnabled(bool value)
     SET(m_inheritedRareData, evaluationTimeZoomEnabled, value);
 }
 
-inline void ComputedStyleBase::setDeviceScaleFactor(float value)
-{
-    SET(m_inheritedRareData, deviceScaleFactor, value);
-}
-
 inline void ComputedStyleBase::setUseSVGZoomRulesForLength(bool value)
 {
     SET_NESTED(m_nonInheritedData, rareData, useSVGZoomRulesForLength, value);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -610,9 +610,6 @@ public:
     inline bool evaluationTimeZoomEnabled() const;
     inline void setEvaluationTimeZoomEnabled(bool);
 
-    inline float deviceScaleFactor() const;
-    inline void setDeviceScaleFactor(float);
-
     inline bool useSVGZoomRulesForLength() const;
     inline void setUseSVGZoomRulesForLength(bool);
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -35,7 +35,6 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedRareData);
 
 InheritedRareData::InheritedRareData()
     : usedZoom(1.0f)
-    , deviceScaleFactor(1.0f)
     , textStrokeWidth(ComputedStyle::initialTextStrokeWidth())
     , textStrokeColor(ComputedStyle::initialTextStrokeColor())
     , textFillColor(ComputedStyle::initialTextFillColor())
@@ -141,7 +140,6 @@ InheritedRareData::InheritedRareData()
 inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     : RefCounted<InheritedRareData>()
     , usedZoom(o.usedZoom)
-    , deviceScaleFactor(o.deviceScaleFactor)
     , textStrokeWidth(o.textStrokeWidth)
     , textStrokeColor(o.textStrokeColor)
     , textFillColor(o.textFillColor)
@@ -353,7 +351,6 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && listStyleType == o.listStyleType
         && blockEllipsis == o.blockEllipsis
         && evaluationTimeZoomEnabled == o.evaluationTimeZoomEnabled
-        && deviceScaleFactor == o.deviceScaleFactor
         && mathDepth == o.mathDepth;
 }
 
@@ -363,7 +360,6 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     customProperties->dumpDifferences(ts, other.customProperties);
 
     LOG_IF_DIFFERENT(usedZoom);
-    LOG_IF_DIFFERENT(deviceScaleFactor);
 
     LOG_IF_DIFFERENT(listStyleImage);
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -105,7 +105,6 @@ public:
 #endif
 
     float usedZoom;
-    float deviceScaleFactor { 1.0f };
     WebkitTextStrokeWidth textStrokeWidth;
 
     Color textStrokeColor;


### PR DESCRIPTION
#### 53fe05ad80c3f3be0434500b89fc601e4fe4cd79
<pre>
[EvaluationTimeZoom][Cleanup] StyleInheritedRareData::deviceScaleFactor is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=309119">https://bugs.webkit.org/show_bug.cgi?id=309119</a>
<a href="https://rdar.apple.com/171669443">rdar://171669443</a>

Reviewed by Vitor Roriz and Tim Nguyen.

This field within StyleInheritedRareData is currently unused. The default
value is 1.0f, but often times it will get set to some other value. This
seems like it can result in unnecessary copies of StyleInheritedRareData
since this field is not used. We can remove it for now and add it back
in the future if we end up needing to use it here.

Canonical link: <a href="https://commits.webkit.org/308616@main">https://commits.webkit.org/308616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fecb9a010c14b47373c2a7b086bd7f9a396e0a77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101379 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b24d24df-9e87-4ce2-b5a0-f02e4f864d40) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114074 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81343 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cd1a01f-c881-45db-8a51-be1633cd1f70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94837 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15461 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4086 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158981 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122107 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31358 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76601 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9351 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83826 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19796 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->