### PR TITLE
[hanging-punctuation] U+0027 and U+0022 should work as hangable quotes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { margin:1em }
+</style>
+<div class="hang" id="ref1">"This should hang.</div>
+<div class="hang" id="ref2">'This should hang.</div>
+<script>
+function setIndent(id, char) {
+    const probe = document.createElement('span');
+    probe.textContent = char;
+    probe.style.visibility = 'hidden';
+    document.body.appendChild(probe);
+    const width = probe.getBoundingClientRect().width;
+    document.body.removeChild(probe);
+    document.getElementById(id).style.textIndent = `-${width}px`;
+}
+setIndent('ref1', '"');
+setIndent('ref2', "'");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text: hanging-punctuation first with ASCII quote characters</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#hanging-punctuation-property">
+<link rel="match" href="reference/hanging-punctuation-first-ascii-quote-ref.html">
+<meta name="assert" content="hanging-punctuation: first causes U+0022 QUOTATION MARK and U+0027 APOSTROPHE to hang at the start of the first line.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { hanging-punctuation: first; margin:1em }
+</style>
+<div class="hang">"This should hang.</div>
+<div class="hang">'This should hang.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { margin:1em }
+</style>
+<div class="hang" style="width:5em;">Yes <span>"</span></div>
+<div class="hang" style="width:5em;">Yes <span>'</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Text: hanging-punctuation last with ASCII quote characters</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#hanging-punctuation-property">
+<link rel="match" href="reference/hanging-punctuation-last-ascii-quote-ref.html">
+<meta name="assert" content="hanging-punctuation: last causes U+0022 QUOTATION MARK and U+0027 APOSTROPHE to hang at the end of the last line.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { hanging-punctuation: last; margin:1em }
+</style>
+<div class="hang" style="width:4em;">Yes <span>"</span></div>
+<div class="hang" style="width:4em;">Yes <span>'</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-ascii-quote-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-ascii-quote-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { margin:1em }
+</style>
+<div class="hang" id="ref1">"This should hang.</div>
+<div class="hang" id="ref2">'This should hang.</div>
+<script>
+function setIndent(id, char) {
+    const probe = document.createElement('span');
+    probe.textContent = char;
+    probe.style.visibility = 'hidden';
+    document.body.appendChild(probe);
+    const width = probe.getBoundingClientRect().width;
+    document.body.removeChild(probe);
+    document.getElementById(id).style.textIndent = `-${width}px`;
+}
+setIndent('ref1', '"');
+setIndent('ref2', "'");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-ascii-quote-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-ascii-quote-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+    body { font-family: 'Ahem'; color:green }
+    .hang { margin:1em }
+</style>
+<div class="hang" style="width:5em;">Yes <span>"</span></div>
+<div class="hang" style="width:5em;">Yes <span>'</span></div>

--- a/Source/WTF/wtf/unicode/CharacterNames.h
+++ b/Source/WTF/wtf/unicode/CharacterNames.h
@@ -195,6 +195,7 @@ using WTF::Unicode::aegeanWordSeparatorLine;
 using WTF::Unicode::arabicIndicPerMilleSign;
 using WTF::Unicode::arabicIndicPerTenThousandSign;
 using WTF::Unicode::arabicPercentSign;
+using WTF::Unicode::apostrophe;
 using WTF::Unicode::blackCircle;
 using WTF::Unicode::blackDownPointingSmallTriangle;
 using WTF::Unicode::blackDownPointingTriangle;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -622,12 +622,33 @@ InlineLayoutUnit TextUtil::hyphenWidth(const RenderStyle& style)
     return std::max(0.f, protect(style.fontCascade())->width(StringView { style.hyphenString() }));
 }
 
+static bool isASCIIHangableQuote(char32_t character)
+{
+    return character == quotationMark || character == apostrophe;
+}
+
+static bool isHangableOpenPunctuation(char32_t character)
+{
+    // https://drafts.csswg.org/css-text-3/#hanging-punctuation-property
+    if (isASCIIHangableQuote(character))
+        return true;
+    return U_GET_GC_MASK(character) & (U_GC_PS_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
+}
+
+static bool isHangableClosePunctuation(char32_t character)
+{
+    // https://drafts.csswg.org/css-text-3/#hanging-punctuation-property
+    if (isASCIIHangableQuote(character))
+        return true;
+    return U_GET_GC_MASK(character) & (U_GC_PE_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
+}
+
 bool TextUtil::hasHangablePunctuationStart(const InlineTextItem& inlineTextItem, const RenderStyle& style)
 {
     if (!inlineTextItem.length() || !style.hangingPunctuation().contains(Style::HangingPunctuationValue::First))
         return false;
     auto leadingCharacter = inlineTextItem.inlineTextBox().content()[inlineTextItem.start()];
-    return U_GET_GC_MASK(leadingCharacter) & (U_GC_PS_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
+    return isHangableOpenPunctuation(leadingCharacter);
 }
 
 float TextUtil::hangablePunctuationStartWidth(const InlineTextItem& inlineTextItem, const RenderStyle& style)
@@ -644,7 +665,7 @@ bool TextUtil::hasHangablePunctuationEnd(const InlineTextItem& inlineTextItem, c
     if (!inlineTextItem.length() || !style.hangingPunctuation().contains(Style::HangingPunctuationValue::Last))
         return false;
     auto trailingCharacter = inlineTextItem.inlineTextBox().content()[inlineTextItem.end() - 1];
-    return U_GET_GC_MASK(trailingCharacter) & (U_GC_PE_MASK | U_GC_PI_MASK | U_GC_PF_MASK);
+    return isHangableClosePunctuation(trailingCharacter);
 }
 
 float TextUtil::hangablePunctuationEndWidth(const InlineTextItem& inlineTextItem, const RenderStyle& style)


### PR DESCRIPTION
#### 8b655c16c21088dd9fda21c34118a7d2152184c6
<pre>
[hanging-punctuation] U+0027 and U+0022 should work as hangable quotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309123">https://bugs.webkit.org/show_bug.cgi?id=309123</a>
<a href="https://rdar.apple.com/171672576">rdar://171672576</a>

Reviewed by Alan Baradlay.

These ASCII quotes are explicitly listed as exceptions for first/last quotes: <a href="https://drafts.csswg.org/css-text/#hanging-punctuation-property">https://drafts.csswg.org/css-text/#hanging-punctuation-property</a>

Tests: imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote.html
       imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-first-ascii-quote.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/hanging-punctuation-last-ascii-quote.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-ascii-quote-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-ascii-quote-ref.html: Added.
* Source/WTF/wtf/unicode/CharacterNames.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::isASCIIHangableQuote):
(WebCore::Layout::isHangableOpenPunctuation):
(WebCore::Layout::isHangableClosePunctuation):
(WebCore::Layout::TextUtil::hasHangablePunctuationStart):
(WebCore::Layout::TextUtil::hasHangablePunctuationEnd):

Canonical link: <a href="https://commits.webkit.org/308597@main">https://commits.webkit.org/308597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b73213aa10034665b26c462b6a1aadb3324f836f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156680 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149858 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20575 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150945 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/94855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139952 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159001 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8772 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12306 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122325 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132613 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22800 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179405 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/19963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->