### PR TITLE
AX: Fix crashes and null-dereferences with ENABLE(ACCESSIBILITY_LOCAL_FRAME)

### DIFF
--- a/LayoutTests/accessibility/aria-modal.html
+++ b/LayoutTests/accessibility/aria-modal.html
@@ -48,7 +48,10 @@
             });
             debug("Dialog is displaying")
             shouldBeFalse("backgroundAccessible()");
-            window.okButton = accessibilityController.accessibleElementById("ok");
+            await waitFor(() => {
+                window.okButton = accessibilityController.accessibleElementById("ok");
+                return window.okButton && !window.okButton.isIgnored;
+            });
             shouldBeFalse("okButton.isIgnored");
 
             // Test the case that aria-modal=true when dialog is not displaying won't affect other objects.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -894,8 +894,6 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
             properties.append({ AXProperty::LinethroughColor, axObject.lineDecorationStyle().linethroughColor });
             break;
         case AXProperty::RevealableText: {
-            // We should only cache this property for ignored objects.
-            AX_ASSERT(axObject.isIgnored());
             if (String text = axObject.revealableText(); !text.isEmpty())
                 properties.append({ AXProperty::RevealableText, WTF::move(text).isolatedCopy() });
             break;
@@ -1673,7 +1671,7 @@ void AXIsolatedTree::processQueuedNodeUpdates()
             updateNodeProperties(*axObject, propertyUpdate.value);
     }
 
-    if (m_relationsNeedUpdate)
+    if (m_relationsNeedUpdate && cache)
         updateRelations(cache->relations());
 
     if (m_mostRecentlyPaintedTextIsDirty) {
@@ -1692,7 +1690,7 @@ void AXIsolatedTree::processQueuedNodeUpdates()
         //
         // So it's crucial to resolve the mostRecentlyPaintedText structure before the m_changeLogLock critical section,
         // and only perform a move or copy while in the critical section to avoid a deadlock.
-        auto mostRecentlyPaintedText = cache->mostRecentlyPaintedText();
+        auto mostRecentlyPaintedText = cache ? cache->mostRecentlyPaintedText() : HashMap<AXID, LineRange> { };
         Locker lock { m_changeLogLock };
         m_pendingMostRecentlyPaintedText = WTF::move(mostRecentlyPaintedText);
     }


### PR DESCRIPTION
#### d0dcddea0dd774ab14417e77ad39c8ccbb1b1bc1
<pre>
AX: Fix crashes and null-dereferences with ENABLE(ACCESSIBILITY_LOCAL_FRAME)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309127">https://bugs.webkit.org/show_bug.cgi?id=309127</a>
<a href="https://rdar.apple.com/171676758">rdar://171676758</a>

Reviewed by Joshua Hoffman.

Remove the AX_ASSERT(axObject.isIgnored()) in the RevealableText property
handler, which crashes when an object&apos;s ignored state changes between when a
property update is queued and when it is processed. With
ENABLE(ACCESSIBILITY_LOCAL_FRAME), the ignored-state computation changes for
certain objects (e.g. AccessibilityScrollView), causing this assertion to fire.

Also fix two null-dereferences in processQueuedNodeUpdates where the
AXObjectCache WeakPtr can become null during the property update loop but was
used without null-checks for updateRelations and mostRecentlyPaintedText.

Update aria-modal.html to use waitFor() when retrieving the OK button, since
with ENABLE(ACCESSIBILITY_LOCAL_FRAME) the button may not be immediately
unignored after the dialog is shown.

Fixes aria-modal.html with ITM + ENABLE(ACCESSIBILITY_LOCAL_FRAME).

* LayoutTests/accessibility/aria-modal.html:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:

Canonical link: <a href="https://commits.webkit.org/308645@main">https://commits.webkit.org/308645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41eeab1b5dd5171f904124b07e5213c5053fe26e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101439 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd0d60e5-0084-4cb2-b1f6-3c2e93cdfd48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114114 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81370 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fda98b73-2411-4ab2-82b8-803ef1e65285) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94880 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15487 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4146 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159042 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2176 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122145 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31375 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76661 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9399 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83886 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19857 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->