### PR TITLE
[Safer CPP] Address remaining issues in WebCore/page/FocusController.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -308,7 +308,6 @@ page/DOMWindow.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
-page/FocusController.cpp
 page/FrameSnapshotting.cpp
 page/IntelligenceTextEffectsSupport.cpp
 page/InteractionRegion.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -38,7 +38,6 @@ layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
 [ iOS ] page/DOMTimer.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
-[ iOS ] page/FocusController.cpp
 page/InteractionRegion.cpp
 page/IntersectionObserver.cpp
 page/LocalFrameView.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -401,7 +401,6 @@ page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
 page/EventSource.cpp
-page/FocusController.cpp
 page/FrameDestructionObserver.cpp
 page/FrameSnapshotting.cpp
 page/ImageOverlayController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -82,7 +82,6 @@ inspector/agents/page/PageCanvasAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp
 [ iOS ] loader/cache/CachedRawResource.cpp
 page/EventHandler.cpp
-page/FocusController.cpp
 page/InteractionRegion.cpp
 page/IntersectionObserver.cpp
 [ iOS ] page/LocalDOMWindow.cpp

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -112,7 +112,7 @@ static inline bool isFocusScopeOwner(const Element& element)
         return true;
     if (is<HTMLSlotElement>(element)) {
         RefPtr root = element.containingShadowRoot();
-        if (!root || !root->host() || !hasCustomFocusLogic(*root->host()))
+        if (!root || !root->host() || !hasCustomFocusLogic(protect(*root->host())))
             return true;
     }
     if (invokerForOpenPopover(&element))
@@ -156,7 +156,7 @@ static void clearSelectionIfNeeded(LocalFrame* oldFocusedFrame, LocalFrame* newF
         }
     }
 
-    oldFocusedFrame->selection().clear();
+    protect(oldFocusedFrame->selection())->clear();
 }
 
 class FocusNavigationScope {
@@ -269,7 +269,7 @@ Node* FocusNavigationScope::previousSiblingInScope(const Node& node) const
 Node* FocusNavigationScope::firstNodeInScope() const
 {
     if (m_slotElement) [[unlikely]] {
-        auto* assignedNodes = m_slotElement->assignedNodes();
+        auto* assignedNodes = protect(m_slotElement)->assignedNodes();
         if (m_slotKind == SlotKind::Assigned) {
             ASSERT(assignedNodes);
             return assignedNodes->first().get();
@@ -287,7 +287,7 @@ Node* FocusNavigationScope::firstNodeInScope() const
 Node* FocusNavigationScope::lastNodeInScope() const
 {
     if (m_slotElement) [[unlikely]] {
-        auto* assignedNodes = m_slotElement->assignedNodes();
+        auto* assignedNodes = protect(m_slotElement)->assignedNodes();
         if (m_slotKind == SlotKind::Assigned) {
             ASSERT(assignedNodes);
             return assignedNodes->last().get();
@@ -416,26 +416,26 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
             return;
     }
 
-    if (!focused && document->focusedElement()) {
-        if (document->focusedElement()->transferredFocusToPicker()) {
+    if (RefPtr focusedElement = document->focusedElement(); !focused && focusedElement) {
+        if (focusedElement->transferredFocusToPicker()) {
             // The webpage lost focus because the focused element transferred focus to
             // a non-web-content picker when it was activated. We don't want to post any
             // web-exposed events (e.g. blur) in these cases, so return.
-            document->focusedElement()->didSuppressBlurDueToPickerFocusTransfer();
+            focusedElement->didSuppressBlurDueToPickerFocusTransfer();
             return;
         }
 
-        if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(*document->focusedElement())) {
+        if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(focusedElement.get())) {
             if (formControlElement->wasChangedSinceLastFormControlChangeEvent())
                 formControlElement->dispatchFormControlChangeEvent();
         }
 
-        document->focusedElement()->dispatchBlurEvent(nullptr);
+        focusedElement->dispatchBlurEvent(nullptr);
     }
 
     document->dispatchWindowEvent(Event::create(focused ? eventNames().focusEvent : eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
-    if (focused && document->focusedElement())
-        document->focusedElement()->dispatchFocusEvent(nullptr, { });
+    if (RefPtr focusedElement = document->focusedElement(); focused && focusedElement)
+        focusedElement->dispatchFocusEvent(nullptr, { });
 }
 
 static inline bool isFocusableElementOrScopeOwner(Element& element, const FocusEventData& focusEventData)
@@ -488,12 +488,12 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
     // Now that the frame is updated, fire events and update the selection focused states of both frames.
     if (RefPtr oldFrameView = oldFrame ? oldFrame->view() : nullptr) {
         oldFrameView->stopKeyboardScrollAnimation();
-        oldFrame->selection().setFocused(false);
-        oldFrame->document()->dispatchWindowEvent(Event::create(eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        protect(oldFrame->selection())->setFocused(false);
+        protect(oldFrame->document())->dispatchWindowEvent(Event::create(eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
         RefPtr<Frame> frame = oldFrame;
         do {
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
-                localFrame->document()->updateServiceWorkerClientData();
+                protect(localFrame->document())->updateServiceWorkerClientData();
             frame = frame->tree().parent();
         } while (frame);
     }
@@ -504,8 +504,8 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
 #endif
 
     if (newFrame && newFrame->view() && isFocused()) {
-        newFrame->selection().setFocused(true);
-        newFrame->document()->dispatchWindowEvent(Event::create(eventNames().focusEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        protect(newFrame->selection())->setFocused(true);
+        protect(newFrame->document())->dispatchWindowEvent(Event::create(eventNames().focusEvent, Event::CanBubble::No, Event::IsCancelable::No));
         RefPtr<Frame> frame = newFrame;
         do {
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
@@ -514,7 +514,7 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
         } while (frame);
     } else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(frame)) {
         RefPtr focusedOrMainFrame = this->focusedOrMainFrame();
-        if (CheckedPtr cache = focusedOrMainFrame ? focusedOrMainFrame->document()->existingAXObjectCache() : nullptr)
+        if (CheckedPtr cache = focusedOrMainFrame ? protect(focusedOrMainFrame->document())->existingAXObjectCache() : nullptr)
             cache->onRemoteFrameGainedFocus(*remoteFrame);
     }
 
@@ -592,7 +592,7 @@ FocusableElementSearchResult FocusController::findFocusableElementContinuingFrom
 
         // Chrome doesn't want focus, so we should wrap focus.
         // FIXME: We probably want to travel up the document tree
-        RefPtr localTopDocument = m_page->localTopDocument();
+        RefPtr localTopDocument = protect(m_page)->localTopDocument();
         if (!localTopDocument)
             return findResult;
 
@@ -621,7 +621,7 @@ FocusableElementSearchResult FocusController::findFocusableElementDescendingInto
             return { nullptr, ContinuedSearchInRemoteFrame::Yes };
         }
 
-        auto* localContentFrame = dynamicDowncast<LocalFrame>(owner->contentFrame());
+        RefPtr localContentFrame = dynamicDowncast<LocalFrame>(owner->contentFrame());
         if (!localContentFrame || !localContentFrame->document())
             break;
         protect(localContentFrame->document())->updateLayoutIgnorePendingStylesheets();
@@ -642,8 +642,8 @@ bool FocusController::setInitialFocus(FocusDirection direction, KeyboardEvent* p
     // into the web area again, even if focus did not change within WebCore. PostNotification is called instead
     // of handleFocusedUIElementChanged, because this will send the notification even if the element is the same.
     RefPtr focusedOrMainFrame = this->focusedOrMainFrame();
-    if (CheckedPtr cache = focusedOrMainFrame ? focusedOrMainFrame->document()->existingAXObjectCache() : nullptr)
-        cache->onDocumentInitialFocus(*focusedOrMainFrame->document());
+    if (CheckedPtr cache = focusedOrMainFrame ? protect(focusedOrMainFrame->document())->existingAXObjectCache() : nullptr)
+        cache->onDocumentInitialFocus(protect(*focusedOrMainFrame->document()));
 
     return didAdvanceFocus;
 }
@@ -739,7 +739,7 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
         }
 
         // Chrome doesn't want focus, so we should wrap focus.
-        RefPtr localTopDocument = m_page->localTopDocument();
+        RefPtr localTopDocument = protect(m_page)->localTopDocument();
         if (!localTopDocument)
             return findResult;
         findResult = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(*localTopDocument), nullptr, focusEventData, shouldFocusElement);
@@ -784,9 +784,9 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
 
     if (caretBrowsing) {
         VisibleSelection newSelection(firstPositionInOrBeforeNode(element.get()), Affinity::Downstream);
-        if (frame->selection().shouldChangeSelection(newSelection)) {
+        if (protect(frame->selection())->shouldChangeSelection(newSelection)) {
             AXTextStateChangeIntent intent(AXTextStateChangeType::SelectionMove, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, true });
-            frame->selection().setSelection(newSelection, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes), intent);
+            protect(frame->selection())->setSelection(newSelection, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes), intent);
         }
     }
 
@@ -865,7 +865,7 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
                     if (shouldFocusElement == ShouldFocusElement::Yes) {
                         RefPtr currentFrame = currentNode->document().frame();
                         clearSelectionIfNeeded(currentFrame.get(), nullptr, nullptr);
-                        currentNode->document().setFocusedElement(nullptr);
+                        protect(currentNode->document())->setFocusedElement(nullptr);
                     }
                     downcast<RemoteFrame>(frame)->client().findFocusableElementContinuingFromFrame(direction, currentNode->document().frame()->frameID(), focusEventData, shouldFocusElement);
                     return { nullptr, ContinuedSearchInRemoteFrame::Yes };
@@ -1032,7 +1032,7 @@ Element* FocusController::nextFocusableElementOrScopeOwner(const FocusNavigation
 
     // There are no nodes with a tabindex greater than start's tabindex,
     // so find the first node with a tabindex of 0.
-    return findElementWithExactTabIndex(scope, scope.firstNodeInScope(), 0, focusEventData, FocusDirection::Forward);
+    return findElementWithExactTabIndex(scope, protect(scope.firstNodeInScope()), 0, focusEventData, FocusDirection::Forward);
 }
 
 Element* FocusController::previousFocusableElementOrScopeOwner(const FocusNavigationScope& scope, Node* start, const FocusEventData& focusEventData)
@@ -1083,7 +1083,7 @@ static bool relinquishesEditingFocus(Element& element)
     if (!frame || !root)
         return false;
 
-    return frame->editor().shouldEndEditing(makeRangeSelectingNodeContents(*root));
+    return protect(frame->editor())->shouldEndEditing(makeRangeSelectingNodeContents(*root));
 }
 
 static bool shouldClearSelectionWhenChangingFocusedElement(const Page& page, RefPtr<Element> oldFocusedElement, RefPtr<Element> newFocusedElement)
@@ -1208,7 +1208,7 @@ void FocusController::setActiveInternal(bool active)
     }
 
     if (RefPtr focusedOrMainFrame = this->focusedOrMainFrame())
-        focusedOrMainFrame->selection().pageActivationChanged();
+        protect(focusedOrMainFrame->selection())->pageActivationChanged();
 
     RefPtr focusedFrame = focusedLocalFrame();
     if (focusedFrame && isFocused())
@@ -1226,7 +1226,7 @@ static void contentAreaDidShowOrHide(ScrollableArea* scrollableArea, bool didSho
 void FocusController::setIsVisibleAndActiveInternal(bool contentIsVisible)
 {
     Ref page = m_page.get();
-    RefPtr view = page->mainFrame().virtualView();
+    RefPtr view = protect(page->mainFrame())->virtualView();
     if (!view)
         return;
 
@@ -1378,7 +1378,7 @@ bool FocusController::advanceFocusDirectionallyInContainer(const ContainerNode& 
         if (focusedElement && !hasOffscreenRect(*focusedElement))
             rect = nodeRectInAbsoluteCoordinates(*focusedElement, true /* ignore border */);
         protect(dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document())->updateLayoutIgnorePendingStylesheets();
-        if (!advanceFocusDirectionallyInContainer(*dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document(), rect, direction, focusEventData)) {
+        if (!advanceFocusDirectionallyInContainer(protect(*dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document()), rect, direction, focusEventData)) {
             // The new frame had nothing interesting, need to find another candidate.
             RefPtr visibleNode = focusCandidate.visibleNode.get();
             return advanceFocusDirectionallyInContainer(container, nodeRectInAbsoluteCoordinates(*visibleNode, true), direction, focusEventData);
@@ -1472,7 +1472,7 @@ void FocusController::focusRepaintTimerFired()
         return;
 
     if (focusedElement->renderer())
-        focusedElement->renderer()->repaint();
+        protect(focusedElement->renderer())->repaint();
 }
 
 Seconds FocusController::timeSinceFocusWasSet() const


### PR DESCRIPTION
#### ded1ec5619ce5da5f41fdbb67019b38464a7bdbf
<pre>
[Safer CPP] Address remaining issues in WebCore/page/FocusController.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=309130">https://bugs.webkit.org/show_bug.cgi?id=309130</a>
<a href="https://rdar.apple.com/171678207">rdar://171678207</a>

Reviewed by NOBODY (OOPS!).

Address all remaining safer cpp issues in file WebCore/page/FocusController.cpp

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/FocusController.cpp:
(WebCore::isFocusScopeOwner):
(WebCore::clearSelectionIfNeeded):
(WebCore::FocusNavigationScope::firstNodeInScope const):
(WebCore::FocusNavigationScope::lastNodeInScope const):
(WebCore::dispatchEventsOnWindowAndFocusedElement):
(WebCore::FocusController::setFocusedFrame):
(WebCore::FocusController::findFocusableElementContinuingFromFrame):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::setInitialFocus):
(WebCore::FocusController::findFocusableElementInDocumentOrderStartingWithFrame):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
(WebCore::FocusController::nextFocusableElementOrScopeOwner):
(WebCore::relinquishesEditingFocus):
(WebCore::FocusController::setActiveInternal):
(WebCore::FocusController::setIsVisibleAndActiveInternal):
(WebCore::FocusController::advanceFocusDirectionallyInContainer):
(WebCore::FocusController::focusRepaintTimerFired):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ded1ec5619ce5da5f41fdbb67019b38464a7bdbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101406 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c3093ec-da98-4b63-b763-aceeeee79142) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114087 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81352 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/642ea3bf-cdae-4495-9792-0f02333e77e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94850 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8551c91-14cc-481a-9b31-1830932839e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15469 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13273 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4113 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159009 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2143 "Found 3 new failures in page/FocusController.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122119 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122327 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76628 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9365 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20094 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83853 "Found 2 new failures in page/FocusController.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->