### PR TITLE
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/dom/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -83,7 +83,6 @@ dom/BoundaryPoint.cpp
 dom/CollectionIndexCacheInlines.h
 dom/ComposedTreeIterator.h
 dom/ContainerNode.cpp
-dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CurrentScriptIncrementer.h
 [ iOS ] dom/DataTransfer.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -204,11 +204,8 @@ dom/ChildListMutationScope.h
 dom/CollectionIndexCacheInlines.h
 dom/ComposedTreeIterator.h
 dom/ContainerNode.cpp
-dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CurrentScriptIncrementer.h
-dom/CustomElementDefaultARIA.cpp
-dom/CustomElementRegistry.cpp
 dom/DataTransfer.cpp
 dom/Document.cpp
 dom/Element.cpp
@@ -218,7 +215,6 @@ dom/ElementIteratorInlines.h
 dom/EventPath.cpp
 dom/ExtensionStyleSheets.cpp
 dom/GCReachableRef.h
-dom/IdleCallbackController.cpp
 dom/ImageOverlay.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/LiveNodeListInlines.h

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -78,10 +78,10 @@ void notifyChildNodeInserted(ContainerNode& parentOfInsertedTree, Node& node, No
 {
     ASSERT(ScriptDisallowedScope::InMainThread::hasDisallowedScope());
 
-    InspectorInstrumentation::didInsertDOMNode(node.document(), node);
-
-    Ref protectDocument { node.document() };
+    Ref document { node.document() };
     Ref protectNode { node };
+
+    InspectorInstrumentation::didInsertDOMNode(document, node);
 
     // Tree scope has changed if the container node into which "node" is inserted is in a document or a shadow root.
     auto treeScopeChange = parentOfInsertedTree.isInTreeScope() ? TreeScopeChange::Changed : TreeScopeChange::DidNotChange;

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -93,7 +93,7 @@ RefPtr<Element> CustomElementDefaultARIA::elementForAttribute(const Element& thi
     RefPtr<Element> result;
     WTF::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
         if (thisElement.isInTreeScope())
-            result = thisElement.treeScope().elementByIdResolvingReferenceTarget(stringValue);
+            result = protect(thisElement.treeScope())->elementByIdResolvingReferenceTarget(stringValue);
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) {
         RefPtr elementValue = weakElementValue.get();
         if (elementValue && isElementVisible(*elementValue, thisElement))

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -264,8 +264,10 @@ template<typename Visitor>
 void CustomElementRegistry::visitJSCustomElementInterfacesInGCThread(Visitor& visitor) const
 {
     Locker locker { m_constructorMapLock };
-    for (const auto& iterator : m_constructorMap)
-        iterator.value->visitJSFunctionsInGCThread(visitor);
+    for (const auto& iterator : m_constructorMap) {
+        // Cannot ref iterator.value here since this may get called on a GC thread.
+        SUPPRESS_UNCOUNTED_ARG iterator.value->visitJSFunctionsInGCThread(visitor);
+    }
 }
 
 template void CustomElementRegistry::visitJSCustomElementInterfacesInGCThread(JSC::AbstractSlotVisitor&) const;

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -130,7 +130,7 @@ bool IdleCallbackController::invokeIdleCallbacks()
 
     auto request = m_runnableIdleCallbacks.takeFirst();
     auto idleDeadline = IdleDeadline::create(request.timeout && *request.timeout < now ? IdleDeadline::DidTimeout::Yes : IdleDeadline::DidTimeout::No);
-    request.callback->invoke(idleDeadline.get());
+    protect(request.callback)->invoke(idleDeadline.get());
 
     return !m_runnableIdleCallbacks.isEmpty();
 }


### PR DESCRIPTION
#### 42553a8834622c16c52a028074e54463e62817a0
<pre>
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/dom/
<a href="https://bugs.webkit.org/show_bug.cgi?id=309131">https://bugs.webkit.org/show_bug.cgi?id=309131</a>
<a href="https://rdar.apple.com/171678414">rdar://171678414</a>

Reviewed by Ryosuke Niwa.

As dictated by the SaferCPP bot.

No new tests since no change in behavior.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyChildNodeInserted):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::elementForAttribute const):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::visitJSCustomElementInterfaces):
* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::invokeIdleCallbacks):

Canonical link: <a href="https://commits.webkit.org/309297@main">https://commits.webkit.org/309297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f84856420b6f3b54681c8bbbda71bf83e3b2e58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103677 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115907 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82357 "4 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96639 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17120 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15064 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6802 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161429 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123909 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124114 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33694 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79140 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11255 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86203 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22117 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->