### PR TITLE
REGRESSION(307567@main): many tests in imported/w3c/web-platform-tests/webvtt time out

### DIFF
--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1109,8 +1109,7 @@ void MediaElementSession::mediaEngineUpdated()
         setWirelessVideoPlaybackDisabled(true);
     if (m_playbackTarget)
         client().setWirelessPlaybackTarget(*m_playbackTarget.copyRef());
-    if (m_shouldPlayToPlaybackTarget)
-        client().setShouldPlayToPlaybackTarget(true);
+    client().setShouldPlayToPlaybackTarget(m_shouldPlayToPlaybackTarget);
 #endif
 
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -88,17 +88,16 @@ static bool supportsURL(const URL& url)
     return url.protocolIsInHTTPFamily();
 }
 
-void MediaPlayerPrivateWirelessPlayback::load(const String& urlString)
+void MediaPlayerPrivateWirelessPlayback::load(const URL& url, const LoadOptions&)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    URL url { urlString };
     if (!supportsURL(url)) {
         setNetworkState(MediaPlayer::NetworkState::FormatError);
         return;
     }
 
-    m_url = WTF::move(url);
+    m_url = url;
     updateURLIfNeeded();
 }
 
@@ -144,7 +143,7 @@ OptionSet<MediaPlaybackTargetType> MediaPlayerPrivateWirelessPlayback::supported
 bool MediaPlayerPrivateWirelessPlayback::isCurrentPlaybackTargetWireless() const
 {
     if (RefPtr playbackTarget = m_playbackTarget)
-        return m_shouldPlayToTarget && playbackTarget->hasActiveRoute();
+        return m_shouldPlayToTarget == ShouldPlayToTarget::Yes && playbackTarget->hasActiveRoute();
     return false;
 }
 
@@ -169,17 +168,24 @@ void MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget(Ref<MediaPlay
     setNetworkState(MediaPlayer::NetworkState::FormatError);
 }
 
-void MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget(bool shouldPlayToTarget)
+void MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget(bool shouldPlay)
 {
+    auto shouldPlayToTarget = shouldPlay ? ShouldPlayToTarget::Yes : ShouldPlayToTarget::No;
     if (shouldPlayToTarget == m_shouldPlayToTarget)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, shouldPlayToTarget);
     m_shouldPlayToTarget = shouldPlayToTarget;
+
+    if (!isCurrentPlaybackTargetWireless()) {
+        setNetworkState(MediaPlayer::NetworkState::FormatError);
+        return;
+    }
+
     updateURLIfNeeded();
 
     if (RefPtr player = m_player.get())
-        player->currentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless());
+        player->currentPlaybackTargetIsWirelessChanged(true);
 }
 
 MediaPlaybackTargetWirelessPlayback* MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTarget() const
@@ -197,7 +203,7 @@ MediaDeviceRoute* MediaPlayerPrivateWirelessPlayback::route() const
 void MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded()
 {
     RefPtr route = this->route();
-    if (!route || !m_shouldPlayToTarget || networkState() >= MediaPlayer::NetworkState::Loading)
+    if (!route || m_shouldPlayToTarget != ShouldPlayToTarget::Yes || networkState() >= MediaPlayer::NetworkState::Loading)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -343,6 +349,12 @@ void MediaPlayerPrivateWirelessPlayback::setReadyState(MediaPlayer::ReadyState r
     m_readyState = readyState;
     if (RefPtr player = m_player.get())
         player->readyStateChanged();
+}
+
+String MediaPlayerPrivateWirelessPlayback::engineDescription() const
+{
+    static NeverDestroyed<String> description(MAKE_STATIC_STRING_IMPL("Cocoa Wireless Playback Engine"));
+    return description;
 }
 
 void MediaPlayerPrivateWirelessPlayback::timeRangeDidChange(MediaDeviceRoute& route)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -76,7 +76,7 @@ private:
 
     // MediaPlayerPrivateInterface
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::WirelessPlayback; }
-    void load(const String&) final;
+    void load(const URL&, const LoadOptions&) final;
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) final { }
 #endif
@@ -119,6 +119,7 @@ private:
     void setVolume(float) final { }
     float volume() const final { return 0; }
     void setMuted(bool) final { }
+    String engineDescription() const final;
 
     // MediaDeviceRouteClient
     void timeRangeDidChange(MediaDeviceRoute&) final;
@@ -134,6 +135,8 @@ private:
     uint64_t logIdentifier() const final { return m_logIdentifier; }
 #endif
 
+    enum class ShouldPlayToTarget : uint8_t { Unknown, No, Yes };
+
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     PlatformTimeRanges m_buffered;
     URL m_url;
@@ -141,7 +144,7 @@ private:
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     bool m_didLoadingProgress { false };
     bool m_allowsWirelessVideoPlayback { true };
-    bool m_shouldPlayToTarget { false };
+    ShouldPlayToTarget m_shouldPlayToTarget { ShouldPlayToTarget::Unknown };
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
     MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;
     std::optional<SeekTarget> m_pendingSeekTarget;


### PR DESCRIPTION
#### 06bdf1c6610d9bedd2bf2a677dbbf553af541ff2
<pre>
REGRESSION(307567@main): many tests in imported/w3c/web-platform-tests/webvtt time out
<a href="https://bugs.webkit.org/show_bug.cgi?id=309136">https://bugs.webkit.org/show_bug.cgi?id=309136</a>
<a href="https://rdar.apple.com/171659558">rdar://171659558</a>

Reviewed by Eric Carlson.

When MediaPlayer::loadWithNextMediaEngine is called and there is no next &quot;best&quot; media engine, it
attempts to load with the next media engine in installedMediaEngines() regardless of whether it
claims to support the current load parameters. This means that MediaPlayerPrivateWirelessPlayback
may be asked to load during local playback. When MediaPlayerPrivateWirelessPlayback::load is called
it returns early since it has not yet been told about a wireless playback target, and since it will
*never* be told about such a target the engine&apos;s network and ready states will never advance and
the MediaPlayer will be stuck using a non-viable engine for local playback.

Resolved this by changing MediaPlayerPrivateWirelessPlayback::m_shouldPlayToTarget from a boolean
to a tri-state enumeration. It starts out in an Unknown state, and later, if
setShouldPlayToPlaybackTarget() is called with false then it advances its network state to
FormatError so that MediaPlayer knows to load the next media engine. Otherwise it calls
updateURLIfNeeded() as it did before.

MediaElementSession::mediaEngineUpdated() was also changed to unconditionally call
setShouldPlayToPlaybackTarget() with the value of m_shouldPlayToPlaybackTarget so that the new
media engine is given a chance to advance to an error state if it doesn&apos;t support the current
playback target.

Drive-by fix: Changed MediaPlayerPrivateWirelessPlayback to override the load method that takes a
URL and LoadOptions to avoid an unnecessary URL-&gt;String-&gt;URL round-trip conversation.

Covered by existing tests.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::mediaEngineUpdated):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::load):
(WebCore::MediaPlayerPrivateWirelessPlayback::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded):
(WebCore::MediaPlayerPrivateWirelessPlayback::engineDescription const):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:

Canonical link: <a href="https://commits.webkit.org/308646@main">https://commits.webkit.org/308646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ec01ad8b4b46c0ad11672d526fae2ba7576a83a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2326061c-a7ec-41a0-a9d2-78237af4459c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114096 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81361 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b52d80f-db07-4f8f-80a2-6985c8d7ab24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94861 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd23f2a3-542e-4a66-96f7-c658e345728c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15473 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4128 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125079 "Found 1 new API test failure: TestWebKitAPI.WKScrollViewTests.WheelEventDispatchedToSubframe (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159024 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2158 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122127 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31376 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76643 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9380 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83868 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19895 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->