### PR TITLE
[JSC] Micro-optimize MicrotaskQueue drain code

### DIFF
--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -55,16 +55,16 @@ bool QueuedTask::isRunnable() const
     return jsCast<JSGlobalObject*>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
 }
 
-void runMicrotask(JSGlobalObject* globalObject, VM& vm, QueuedTask& task)
+static bool runMicrotask(JSGlobalObject* globalObject, TopExceptionScope& catchScope, VM& vm, QueuedTask& task)
 {
-    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     runInternalMicrotask(globalObject, vm, task.job(), task.payload(), task.arguments());
     if (auto* exception = catchScope.exception()) [[unlikely]] {
         if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
-            return;
+            return false;
         globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        catchScope.clearExceptionExceptTermination();
+        return catchScope.clearExceptionExceptTermination();
     }
+    return true;
 }
 
 void runMicrotaskWithDebugger(JSGlobalObject* globalObject, VM& vm, QueuedTask& task)
@@ -79,8 +79,7 @@ void runMicrotaskWithDebugger(JSGlobalObject* globalObject, VM& vm, QueuedTask& 
             return;
     }
 
-    runMicrotask(globalObject, vm, task);
-    if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+    if (!runMicrotask(globalObject, catchScope, vm, task)) [[unlikely]]
         return;
 
     if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]] {
@@ -168,7 +167,8 @@ void MarkedMicrotaskDeque::visitAggregateImpl(Visitor& visitor)
 }
 DEFINE_VISIT_AGGREGATE(MarkedMicrotaskDeque);
 
-std::pair<JSGlobalObject*, bool> MicrotaskQueue::drain(bool useCallOnEachMicrotask, JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
+template<bool useCallOnEachMicrotask>
+ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
 {
     while (!m_queue.isEmpty()) {
         auto& front = m_queue.front();
@@ -187,7 +187,10 @@ std::pair<JSGlobalObject*, bool> MicrotaskQueue::drain(bool useCallOnEachMicrota
                 return { globalObject, false };
 
             auto task = m_queue.dequeue();
-            runMicrotask(globalObject, vm, task);
+            if (!runMicrotask(globalObject, catchScope, vm, task)) [[unlikely]] {
+                clear();
+                return { nullptr, true };
+            }
         } else {
             auto* jsMicrotaskDispatcher = jsCast<JSMicrotaskDispatcher*>(front.dispatcher());
             auto* globalObject = front.globalObject();
@@ -211,14 +214,14 @@ std::pair<JSGlobalObject*, bool> MicrotaskQueue::drain(bool useCallOnEachMicrota
                 m_toKeep.enqueue(WTF::move(task));
                 break;
             }
+
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                clear();
+                return { nullptr, true };
+            }
         }
 
-        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
-            clear();
-            return { nullptr, true };
-        }
-
-        if (useCallOnEachMicrotask) {
+        if constexpr (useCallOnEachMicrotask) {
             vm.callOnEachMicrotaskTick();
             if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
                 clear();
@@ -228,6 +231,16 @@ std::pair<JSGlobalObject*, bool> MicrotaskQueue::drain(bool useCallOnEachMicrota
     }
 
     return { nullptr, true };
+}
+
+std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainWithoutUseCallOnEachMicrotask(JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
+{
+    return drainImpl</* useCallOnEachMicrotask */ false>(currentGlobalObject, vm, catchScope);
+}
+
+std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainWithUseCallOnEachMicrotask(JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
+{
+    return drainImpl</* useCallOnEachMicrotask */ true>(currentGlobalObject, vm, catchScope);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -254,13 +254,25 @@ protected:
     bool m_isScheduledToRun { false };
 
 private:
-    JS_EXPORT_PRIVATE std::pair<JSGlobalObject*, bool> drain(bool useCallOnEachMicrotask, JSGlobalObject* currentGlobalObject, VM&, TopExceptionScope&);
+    JS_EXPORT_PRIVATE std::pair<JSGlobalObject*, bool> drainWithUseCallOnEachMicrotask(JSGlobalObject* currentGlobalObject, VM&, TopExceptionScope&);
+    JS_EXPORT_PRIVATE std::pair<JSGlobalObject*, bool> drainWithoutUseCallOnEachMicrotask(JSGlobalObject* currentGlobalObject, VM&, TopExceptionScope&);
+
+    template<bool useCallOnEachMicrotask>
+    ALWAYS_INLINE std::pair<JSGlobalObject*, bool> drain(JSGlobalObject* globalObject, VM& vm, TopExceptionScope& scope)
+    {
+        if constexpr (useCallOnEachMicrotask)
+            return drainWithUseCallOnEachMicrotask(globalObject, vm, scope);
+        else
+            return drainWithoutUseCallOnEachMicrotask(globalObject, vm, scope);
+    }
+
+    template<bool useCallOnEachMicrotask>
+    std::pair<JSGlobalObject*, bool> drainImpl(JSGlobalObject*, VM&, TopExceptionScope&);
 
     MarkedMicrotaskDeque m_queue;
     MarkedMicrotaskDeque m_toKeep;
 };
 
-void runMicrotask(JSGlobalObject*, VM&, QueuedTask&);
 JS_EXPORT_PRIVATE void runMicrotaskWithDebugger(JSGlobalObject*, VM&, QueuedTask&);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -88,7 +88,7 @@ inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const In
         JSGlobalObject* currentGlobalObject = nullptr;
 
         while (true) {
-            auto [nextGlobalObject, done] = drain(useCallOnEachMicrotask, currentGlobalObject, vm, catchScope);
+            auto [nextGlobalObject, done] = drain<useCallOnEachMicrotask>(currentGlobalObject, vm, catchScope);
             if (done)
                 break;
 


### PR DESCRIPTION
#### 3692b888d679c7ba3759f4394f46bf0f36b5bbf3
<pre>
[JSC] Micro-optimize MicrotaskQueue drain code
<a href="https://bugs.webkit.org/show_bug.cgi?id=309139">https://bugs.webkit.org/show_bug.cgi?id=309139</a>
<a href="https://rdar.apple.com/171685259">rdar://171685259</a>

Reviewed by Justin Michaud.

We carefully analyze the sampling profiler data and clean up some
unnecessary code.

1. We specialize drainImpl&lt;true&gt; / drainImpl&lt;false&gt; to make sure that we
   do not need to have a code for useCallOnEachMicrotask.
2. Use TopLevelScope in runMicrotask too, carrying Termination exception
   information to the caller.

* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::runMicrotask):
(JSC::runMicrotaskWithDebugger):
(JSC::MicrotaskQueue::drainImpl):
(JSC::MicrotaskQueue::drainWithoutUseCallOnEachMicrotask):
(JSC::MicrotaskQueue::drainWithUseCallOnEachMicrotask):
(JSC::MicrotaskQueue::drain): Deleted.
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::MicrotaskQueue::drain):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::MicrotaskQueue::performMicrotaskCheckpoint):

Canonical link: <a href="https://commits.webkit.org/308635@main">https://commits.webkit.org/308635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11965367736a41e8a3df61e601632738a6fd6392

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101426 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a469dcd-30dc-4b79-9857-e2002f8f35cd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114106 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81363 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f943a131-1795-4556-b250-0aa0333dc251) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94872 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b87f8d8-66c8-46dc-80c9-b56e1db5e4da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13286 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4133 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139980 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159029 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8800 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2163 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122138 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122351 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76648 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22810 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9385 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179433 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20114 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83873 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45954 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->