### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in CSS

### DIFF
--- a/Source/WebCore/css/CSSAppleColorFilterValue.h
+++ b/Source/WebCore/css/CSSAppleColorFilterValue.h
@@ -33,7 +33,7 @@ class CSSAppleColorFilterValue final : public CSSValue {
 public:
     static Ref<CSSAppleColorFilterValue> create(CSS::AppleColorFilter);
 
-    const CSS::AppleColorFilter& filter() const { return m_filter; }
+    const CSS::AppleColorFilter& filter() const LIFETIME_BOUND { return m_filter; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSAppleColorFilterValue&) const;

--- a/Source/WebCore/css/CSSBasicShapeValue.h
+++ b/Source/WebCore/css/CSSBasicShapeValue.h
@@ -42,7 +42,7 @@ public:
         return adoptRef(*new CSSBasicShapeValue(WTF::move(shape)));
     }
 
-    const CSS::BasicShape& shape() const { return m_shape; }
+    const CSS::BasicShape& shape() const LIFETIME_BOUND { return m_shape; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBasicShapeValue&) const;

--- a/Source/WebCore/css/CSSBorderImageSliceValue.h
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.h
@@ -37,7 +37,7 @@ public:
     static Ref<CSSBorderImageSliceValue> create(Quad, bool fill);
     ~CSSBorderImageSliceValue();
 
-    const Quad& slices() const { return m_slices; }
+    const Quad& slices() const LIFETIME_BOUND { return m_slices; }
     bool fill() const { return m_fill; }
 
     String customCSSText(const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSBorderImageWidthValue.h
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.h
@@ -37,7 +37,7 @@ public:
     static Ref<CSSBorderImageWidthValue> create(Quad, bool overridesBorderWidths);
     ~CSSBorderImageWidthValue();
 
-    const Quad& widths() const { return m_widths; }
+    const Quad& widths() const LIFETIME_BOUND { return m_widths; }
     bool overridesBorderWidths() const { return m_overridesBorderWidths; }
 
     String customCSSText(const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSBoxShadowPropertyValue.h
+++ b/Source/WebCore/css/CSSBoxShadowPropertyValue.h
@@ -33,7 +33,7 @@ class CSSBoxShadowPropertyValue final : public CSSValue {
 public:
     static Ref<CSSBoxShadowPropertyValue> create(CSS::BoxShadowProperty);
 
-    const CSS::BoxShadowProperty& shadow() const { return m_shadow; }
+    const CSS::BoxShadowProperty& shadow() const LIFETIME_BOUND { return m_shadow; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBoxShadowPropertyValue&) const;

--- a/Source/WebCore/css/CSSColorSchemeValue.h
+++ b/Source/WebCore/css/CSSColorSchemeValue.h
@@ -39,7 +39,7 @@ public:
     bool NODELETE equals(const CSSColorSchemeValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 
-    const CSS::ColorScheme& colorScheme() const { return m_colorScheme; }
+    const CSS::ColorScheme& colorScheme() const LIFETIME_BOUND { return m_colorScheme; }
 
 private:
     CSSColorSchemeValue(CSS::ColorScheme);

--- a/Source/WebCore/css/CSSColorValue.h
+++ b/Source/WebCore/css/CSSColorValue.h
@@ -37,7 +37,7 @@ public:
     static Ref<CSSColorValue> create(CSS::Color);
     static Ref<CSSColorValue> create(WebCore::Color);
 
-    const CSS::Color& color() const { return m_color; }
+    const CSS::Color& color() const LIFETIME_BOUND { return m_color; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSColorValue&) const;

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -47,20 +47,20 @@ public:
     }
 
     String text(int, WritingMode);
-    const CSSCounterStyleDescriptors::Name& name() const { return m_descriptors.m_name; }
+    const CSSCounterStyleDescriptors::Name& name() const LIFETIME_BOUND { return m_descriptors.m_name; }
     CSSCounterStyleDescriptors::System system() const { return m_descriptors.m_system; }
-    const CSSCounterStyleDescriptors::NegativeSymbols& negative() const { return m_descriptors.m_negativeSymbols; }
-    const CSSCounterStyleDescriptors::Symbol& prefix() const { return m_descriptors.m_prefix; }
-    const CSSCounterStyleDescriptors::Symbol& suffix() const { return m_descriptors.m_suffix; }
-    const CSSCounterStyleDescriptors::Ranges& ranges() const { return m_descriptors.m_ranges; }
-    const CSSCounterStyleDescriptors::Pad& pad() const { return m_descriptors.m_pad; }
-    const CSSCounterStyleDescriptors::Name& fallbackName() const { return m_descriptors.m_fallbackName; }
-    const Vector<CSSCounterStyleDescriptors::Symbol>& symbols() const { return m_descriptors.m_symbols; }
-    const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols() const { return m_descriptors.m_additiveSymbols; }
+    const CSSCounterStyleDescriptors::NegativeSymbols& negative() const LIFETIME_BOUND { return m_descriptors.m_negativeSymbols; }
+    const CSSCounterStyleDescriptors::Symbol& prefix() const LIFETIME_BOUND { return m_descriptors.m_prefix; }
+    const CSSCounterStyleDescriptors::Symbol& suffix() const LIFETIME_BOUND { return m_descriptors.m_suffix; }
+    const CSSCounterStyleDescriptors::Ranges& ranges() const LIFETIME_BOUND { return m_descriptors.m_ranges; }
+    const CSSCounterStyleDescriptors::Pad& pad() const LIFETIME_BOUND { return m_descriptors.m_pad; }
+    const CSSCounterStyleDescriptors::Name& fallbackName() const LIFETIME_BOUND { return m_descriptors.m_fallbackName; }
+    const Vector<CSSCounterStyleDescriptors::Symbol>& symbols() const LIFETIME_BOUND { return m_descriptors.m_symbols; }
+    const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols() const LIFETIME_BOUND { return m_descriptors.m_additiveSymbols; }
     CSSCounterStyleDescriptors::SpeakAs speakAs() const { return m_descriptors.m_speakAs; }
     const CSSCounterStyleDescriptors::Name extendsName() const { return m_descriptors.m_extendsName; }
     int firstSymbolValueForFixedSystem() const { return m_descriptors.m_fixedSystemFirstSymbolValue; }
-    const OptionSet<CSSCounterStyleDescriptors::ExplicitlySetDescriptors>& explicitlySetDescriptors() const { return m_descriptors.m_explicitlySetDescriptors; }
+    const OptionSet<CSSCounterStyleDescriptors::ExplicitlySetDescriptors>& explicitlySetDescriptors() const LIFETIME_BOUND { return m_descriptors.m_explicitlySetDescriptors; }
 
     void setSystem(CSSCounterStyleDescriptors::System system) { m_descriptors.m_system = system; }
     void setNegative(const CSSCounterStyleDescriptors::NegativeSymbols& negative) { m_descriptors.m_negativeSymbols = negative; }

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -39,10 +39,10 @@ public:
 
     Ref<StyleRuleCounterStyle> copy() const { return adoptRef(*new StyleRuleCounterStyle(*this)); }
 
-    const CSSCounterStyleDescriptors& descriptors() const { return m_descriptors; };
-    CSSCounterStyleDescriptors& mutableDescriptors() { return m_descriptors; };
+    const CSSCounterStyleDescriptors& descriptors() const LIFETIME_BOUND { return m_descriptors; };
+    CSSCounterStyleDescriptors& mutableDescriptors() LIFETIME_BOUND { return m_descriptors; };
 
-    const AtomString& name() const { return m_name; }
+    const AtomString& name() const LIFETIME_BOUND { return m_name; }
     String system() const { return m_descriptors.systemCSSText(); }
     String negative() const { return m_descriptors.negativeCSSText(); }
     String prefix() const { return m_descriptors.prefixCSSText(); }
@@ -103,8 +103,8 @@ private:
 
     bool setterInternal(CSSPropertyID, const String&);
     RefPtr<CSSValue> cssValueFromText(CSSPropertyID, const String&);
-    const CSSCounterStyleDescriptors& descriptors() const { return m_counterStyleRule->descriptors(); }
-    CSSCounterStyleDescriptors& mutableDescriptors() { return m_counterStyleRule->mutableDescriptors(); }
+    const CSSCounterStyleDescriptors& descriptors() const LIFETIME_BOUND { return m_counterStyleRule->descriptors(); }
+    CSSCounterStyleDescriptors& mutableDescriptors() LIFETIME_BOUND { return m_counterStyleRule->mutableDescriptors(); }
 
     Ref<StyleRuleCounterStyle> m_counterStyleRule;
 };

--- a/Source/WebCore/css/CSSCounterValue.h
+++ b/Source/WebCore/css/CSSCounterValue.h
@@ -34,8 +34,8 @@ class CSSCounterValue final : public CSSValue {
 public:
     static Ref<CSSCounterValue> create(AtomString&& identifier, AtomString&& separator, Ref<CSSValue>&& counterStyle);
 
-    const AtomString& identifier() const { return m_identifier; }
-    const AtomString& separator() const { return m_separator; }
+    const AtomString& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const AtomString& separator() const LIFETIME_BOUND { return m_separator; }
     CSSValue& counterStyle() const { return m_counterStyle; }
     String counterStyleCSSText() const;
 

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -40,7 +40,7 @@ public:
     static Ref<CSSCursorImageValue> create(Ref<CSSValue>&& imageValue, RefPtr<CSSValue>&& hotSpot, CSS::URL&&);
     ~CSSCursorImageValue();
 
-    const CSS::URL& originalURL() const { return m_originalURL; }
+    const CSS::URL& originalURL() const LIFETIME_BOUND { return m_originalURL; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCursorImageValue&) const;

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -48,8 +48,8 @@ public:
     static Ref<CSSCustomPropertyValue> createSyntaxAll(const AtomString& name, Ref<CSSVariableData>&&);
     static Ref<CSSCustomPropertyValue> createWithCSSWideKeyword(const AtomString& name, CSSWideKeyword);
 
-    const AtomString& name() const { return m_name; }
-    const VariantValue& value() const { return m_value; }
+    const AtomString& name() const LIFETIME_BOUND { return m_name; }
+    const VariantValue& value() const LIFETIME_BOUND { return m_value; }
 
     Ref<const CSSVariableData> asVariableData() const;
 

--- a/Source/WebCore/css/CSSDynamicRangeLimitValue.h
+++ b/Source/WebCore/css/CSSDynamicRangeLimitValue.h
@@ -33,7 +33,7 @@ class CSSDynamicRangeLimitValue final : public CSSValue {
 public:
     static Ref<CSSDynamicRangeLimitValue> create(CSS::DynamicRangeLimit);
 
-    const CSS::DynamicRangeLimit& dynamicRangeLimit() const { return m_dynamicRangeLimit; }
+    const CSS::DynamicRangeLimit& dynamicRangeLimit() const LIFETIME_BOUND { return m_dynamicRangeLimit; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSDynamicRangeLimitValue&) const;

--- a/Source/WebCore/css/CSSEasingFunctionValue.h
+++ b/Source/WebCore/css/CSSEasingFunctionValue.h
@@ -34,7 +34,7 @@ class CSSEasingFunctionValue final : public CSSValue {
 public:
     static Ref<CSSEasingFunctionValue> create(CSS::EasingFunction);
 
-    const CSS::EasingFunction& easingFunction() const { return m_easingFunction; }
+    const CSS::EasingFunction& easingFunction() const LIFETIME_BOUND { return m_easingFunction; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSEasingFunctionValue&) const;

--- a/Source/WebCore/css/CSSFilterValue.h
+++ b/Source/WebCore/css/CSSFilterValue.h
@@ -33,7 +33,7 @@ class CSSFilterValue final : public CSSValue {
 public:
     static Ref<CSSFilterValue> create(CSS::Filter);
 
-    const CSS::Filter& filter() const { return m_filter; }
+    const CSS::Filter& filter() const LIFETIME_BOUND { return m_filter; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFilterValue&) const;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -45,7 +45,7 @@ public:
     ~CSSFontFaceSrcLocalValue();
 
     bool isEmpty() const { return m_fontFaceName.isEmpty(); }
-    const AtomString& fontFaceName() const { return m_fontFaceName; }
+    const AtomString& fontFaceName() const LIFETIME_BOUND { return m_fontFaceName; }
 
     SVGFontFaceElement* NODELETE svgFontFaceElement() const;
     void setSVGFontFaceElement(SVGFontFaceElement&);

--- a/Source/WebCore/css/CSSFontFeatureValue.h
+++ b/Source/WebCore/css/CSSFontFeatureValue.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new CSSFontFeatureValue(WTF::move(tag), WTF::move(value)));
     }
 
-    const FontTag& tag() const { return m_tag; }
+    const FontTag& tag() const LIFETIME_BOUND { return m_tag; }
     const CSSValue& value() const { return m_value; }
     String customCSSText(const CSS::SerializationContext&) const;
 

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.h
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.h
@@ -37,7 +37,7 @@ public:
 
     static Ref<CSSFontStyleWithAngleValue> create(ObliqueAngle&&);
 
-    const ObliqueAngle& obliqueAngle() const { return m_obliqueAngle; }
+    const ObliqueAngle& obliqueAngle() const LIFETIME_BOUND { return m_obliqueAngle; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFontStyleWithAngleValue&) const;

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new CSSFontVariationValue(tag, WTF::move(value)));
     }
 
-    const FontTag& tag() const { return m_tag; }
+    const FontTag& tag() const LIFETIME_BOUND { return m_tag; }
     const CSSValue& value() const { return m_value; }
     String customCSSText(const CSS::SerializationContext&) const;
 

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.h
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.h
@@ -41,7 +41,7 @@ public:
     static Ref<CSSGridTemplateAreasValue> create(CSS::GridTemplateAreas&&);
     static Ref<CSSGridTemplateAreasValue> create(const CSS::GridTemplateAreas&);
 
-    const CSS::GridTemplateAreas& areas() const { return m_areas; }
+    const CSS::GridTemplateAreas& areas() const LIFETIME_BOUND { return m_areas; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridTemplateAreasValue&) const;

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -56,7 +56,7 @@ public:
     CachedImage* cachedImage() const { return m_cachedImage ? m_cachedImage.value().get() : nullptr; }
 
     // Take care when using this, and read https://drafts.csswg.org/css-values/#relative-urls
-    const CSS::URL& url() const { return m_location; }
+    const CSS::URL& url() const LIFETIME_BOUND { return m_location; }
 
     String customCSSText(const CSS::SerializationContext&) const;
 

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -60,7 +60,7 @@ public:
         m_keys.append(key);
     }
 
-    const Vector<Key>& keys() const { return m_keys; };
+    const Vector<Key>& keys() const LIFETIME_BOUND { return m_keys; };
 
     const StyleProperties& properties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -48,7 +48,7 @@ public:
     void wrapperAppendKeyframe(Ref<StyleRuleKeyframe>&&);
     void wrapperRemoveKeyframe(unsigned);
 
-    const AtomString& name() const { return m_name; }
+    const AtomString& name() const LIFETIME_BOUND { return m_name; }
     void setName(const AtomString& name) { m_name = name; }
 
     std::optional<size_t> findKeyframeIndex(const String& key) const;
@@ -75,7 +75,7 @@ public:
     String cssText() const final;
     void NODELETE reattach(StyleRuleBase&) final;
 
-    const AtomString& name() const { return m_keyframesRule->name(); }
+    const AtomString& name() const LIFETIME_BOUND { return m_keyframesRule->name(); }
     void setName(const AtomString&);
 
     CSSRuleList& cssRules();

--- a/Source/WebCore/css/CSSPaintImageValue.h
+++ b/Source/WebCore/css/CSSPaintImageValue.h
@@ -46,7 +46,7 @@ public:
     }
     ~CSSPaintImageValue();
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
     bool equals(const CSSPaintImageValue& other) const { return m_name == other.m_name; }
     String customCSSText(const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSPathValue.h
+++ b/Source/WebCore/css/CSSPathValue.h
@@ -44,7 +44,7 @@ public:
         return adoptRef(*new CSSPathValue(WTF::move(path)));
     }
 
-    const CSS::PathFunction& path() const { return m_path; }
+    const CSS::PathFunction& path() const LIFETIME_BOUND { return m_path; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSPathValue&) const;

--- a/Source/WebCore/css/CSSPositionValue.h
+++ b/Source/WebCore/css/CSSPositionValue.h
@@ -33,7 +33,7 @@ class CSSPositionValue final : public CSSValue {
 public:
     static Ref<CSSPositionValue> create(CSS::Position&&);
 
-    const CSS::Position& position() const { return m_position; }
+    const CSS::Position& position() const LIFETIME_BOUND { return m_position; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSPositionValue&) const;
@@ -50,7 +50,7 @@ class CSSPositionXValue final : public CSSValue {
 public:
     static Ref<CSSPositionXValue> create(CSS::PositionX&&);
 
-    const CSS::PositionX& position() const { return m_position; }
+    const CSS::PositionX& position() const LIFETIME_BOUND { return m_position; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSPositionXValue&) const;
@@ -67,7 +67,7 @@ class CSSPositionYValue final : public CSSValue {
 public:
     static Ref<CSSPositionYValue> create(CSS::PositionY&&);
 
-    const CSS::PositionY& position() const { return m_position; }
+    const CSS::PositionY& position() const LIFETIME_BOUND { return m_position; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSPositionYValue&) const;

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -150,7 +150,7 @@ public:
     // This is used by the Inspector to filter keywords based on enabled settings.
     static bool isKeywordValidForPropertyValues(CSSPropertyID, CSSValueID, const CSSParserContext&);
 
-    const StylePropertyMetadata& metadata() const { return m_metadata; }
+    const StylePropertyMetadata& metadata() const LIFETIME_BOUND { return m_metadata; }
     static bool isColorProperty(CSSPropertyID propertyId)
     {
         return colorProperties.get(propertyId);

--- a/Source/WebCore/css/CSSRatioValue.h
+++ b/Source/WebCore/css/CSSRatioValue.h
@@ -34,7 +34,7 @@ public:
     static Ref<CSSRatioValue> create(CSS::Ratio&&);
     static Ref<CSSRatioValue> create(const CSS::Ratio&);
 
-    const CSS::Ratio& ratio() const { return m_ratio; }
+    const CSS::Ratio& ratio() const LIFETIME_BOUND { return m_ratio; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSRatioValue&) const;

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -44,7 +44,7 @@ public:
     }
 
 
-    const CSS::RayFunction& ray() const { return m_ray; }
+    const CSS::RayFunction& ray() const LIFETIME_BOUND { return m_ray; }
     CSSBoxType coordinateBox() const { return m_coordinateBox; }
 
     String customCSSText(const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSRectValue.h
+++ b/Source/WebCore/css/CSSRectValue.h
@@ -33,7 +33,7 @@ class CSSRectValue final : public CSSValue {
 public:
     static Ref<CSSRectValue> create(Rect);
 
-    const Rect& rect() const { return m_rect; }
+    const Rect& rect() const LIFETIME_BOUND { return m_rect; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSRectValue&) const;

--- a/Source/WebCore/css/CSSRuleList.h
+++ b/Source/WebCore/css/CSSRuleList.h
@@ -54,7 +54,7 @@ public:
 
     static Ref<StaticCSSRuleList> create() { return adoptRef(*new StaticCSSRuleList); }
 
-    Vector<RefPtr<CSSRule>>& rules() { return m_rules; }
+    Vector<RefPtr<CSSRule>>& rules() LIFETIME_BOUND { return m_rules; }
     
     CSSStyleSheet* styleSheet() const final { return nullptr; }
 

--- a/Source/WebCore/css/CSSSegmentedFontFace.h
+++ b/Source/WebCore/css/CSSSegmentedFontFace.h
@@ -56,7 +56,7 @@ public:
 
     FontRanges fontRanges(const FontDescription&, const FontPaletteValues&, RefPtr<FontFeatureValues>);
 
-    Vector<Ref<CSSFontFace>, 1>& constituentFaces() { return m_fontFaces; }
+    Vector<Ref<CSSFontFace>, 1>& constituentFaces() LIFETIME_BOUND { return m_fontFaces; }
 
 private:
     CSSSegmentedFontFace();

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -148,19 +148,19 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     const CSSSelector* NODELETE lastInCompound() const;
     const CSSSelector* NODELETE precedingInCompound() const;
 
-    const QualifiedName& tagQName() const;
-    const AtomString& tagLowercaseLocalName() const;
+    const QualifiedName& tagQName() const LIFETIME_BOUND;
+    const AtomString& tagLowercaseLocalName() const LIFETIME_BOUND;
 
-    const AtomString& value() const;
-    const AtomString& serializingValue() const;
-    const QualifiedName& attribute() const;
-    const AtomString& argument() const { return m_hasRareData ? m_data.rareData->argument : nullAtom(); }
+    const AtomString& value() const LIFETIME_BOUND;
+    const AtomString& serializingValue() const LIFETIME_BOUND;
+    const QualifiedName& attribute() const LIFETIME_BOUND;
+    const AtomString& argument() const LIFETIME_BOUND { return m_hasRareData ? m_data.rareData->argument : nullAtom(); }
     bool attributeValueMatchingIsCaseInsensitive() const;
-    const FixedVector<int>* integerList() const { return m_hasRareData ? std::get_if<FixedVector<int>>(&m_data.rareData->argumentList) : nullptr; }
-    const FixedVector<AtomString>* stringList() const { return m_hasRareData ? std::get_if<FixedVector<AtomString>>(&m_data.rareData->argumentList) : nullptr; }
-    const FixedVector<PossiblyQuotedIdentifier>* langList() const { return m_hasRareData ? std::get_if<FixedVector<PossiblyQuotedIdentifier>>(&m_data.rareData->argumentList) : nullptr; }
-    const CSSSelectorList* selectorList() const { return m_hasRareData ? m_data.rareData->selectorList.get() : nullptr; }
-    CSSSelectorList* selectorList() { return m_hasRareData ? m_data.rareData->selectorList.get() : nullptr; }
+    const FixedVector<int>* integerList() const LIFETIME_BOUND { return m_hasRareData ? std::get_if<FixedVector<int>>(&m_data.rareData->argumentList) : nullptr; }
+    const FixedVector<AtomString>* stringList() const LIFETIME_BOUND { return m_hasRareData ? std::get_if<FixedVector<AtomString>>(&m_data.rareData->argumentList) : nullptr; }
+    const FixedVector<PossiblyQuotedIdentifier>* langList() const LIFETIME_BOUND { return m_hasRareData ? std::get_if<FixedVector<PossiblyQuotedIdentifier>>(&m_data.rareData->argumentList) : nullptr; }
+    const CSSSelectorList* selectorList() const LIFETIME_BOUND { return m_hasRareData ? m_data.rareData->selectorList.get() : nullptr; }
+    CSSSelectorList* selectorList() LIFETIME_BOUND { return m_hasRareData ? m_data.rareData->selectorList.get() : nullptr; }
 
     bool NODELETE matchNth(int count) const;
     int NODELETE nthA() const;

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -109,14 +109,14 @@ public:
 
     void removeAdoptingTreeScope(ContainerNode&);
     void addAdoptingTreeScope(ContainerNode&);
-    const WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData>& adoptingTreeScopes() const { return m_adoptingTreeScopes; }
+    const WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData>& adoptingTreeScopes() const LIFETIME_BOUND { return m_adoptingTreeScopes; }
 
     Document* ownerDocument() const;
     CSSStyleSheet& rootStyleSheet();
     const CSSStyleSheet& rootStyleSheet() const;
     Style::Scope* NODELETE styleScope();
 
-    const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
+    const MQ::MediaQueryList& mediaQueries() const LIFETIME_BOUND { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&&);
     void setTitle(const String& title) { m_title = title; }
 

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.h
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.h
@@ -38,7 +38,7 @@ public:
     static Ref<CSSStyleSheetObservableArray> create(ContainerNode& treeScope);
 
     ExceptionOr<void> setSheets(Vector<Ref<CSSStyleSheet>>&&);
-    const Vector<Ref<CSSStyleSheet>>& sheets() const { return m_sheets; }
+    const Vector<Ref<CSSStyleSheet>>& sheets() const LIFETIME_BOUND { return m_sheets; }
 
 private:
     explicit CSSStyleSheetObservableArray(ContainerNode& treeScope);

--- a/Source/WebCore/css/CSSTextShadowPropertyValue.h
+++ b/Source/WebCore/css/CSSTextShadowPropertyValue.h
@@ -33,7 +33,7 @@ class CSSTextShadowPropertyValue final : public CSSValue {
 public:
     static Ref<CSSTextShadowPropertyValue> create(CSS::TextShadowProperty);
 
-    const CSS::TextShadowProperty& shadow() const { return m_shadow; }
+    const CSS::TextShadowProperty& shadow() const LIFETIME_BOUND { return m_shadow; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSTextShadowPropertyValue&) const;

--- a/Source/WebCore/css/CSSURLValue.h
+++ b/Source/WebCore/css/CSSURLValue.h
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new CSSURLValue(WTF::move(url)));
     }
 
-    const CSS::URL& url() const { return m_url; }
+    const CSS::URL& url() const LIFETIME_BOUND { return m_url; }
     String stringValue() const { return m_url.specified; }
 
     String customCSSText(const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -45,9 +45,9 @@ public:
     }
 
     CSSParserTokenRange tokenRange() const LIFETIME_BOUND { return m_tokens; }
-    const CSSParserContext& context() const { return m_context; }
+    const CSSParserContext& context() const LIFETIME_BOUND { return m_context; }
 
-    const Vector<CSSParserToken>& tokens() const { return m_tokens; }
+    const Vector<CSSParserToken>& tokens() const LIFETIME_BOUND { return m_tokens; }
 
     bool operator==(const CSSVariableData& other) const;
 

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -119,7 +119,7 @@ public:
 
     ExceptionOr<String> toString() const;
 
-    const TransformationMatrix& transformationMatrix() const { return m_matrix; }
+    const TransformationMatrix& transformationMatrix() const LIFETIME_BOUND { return m_matrix; }
     
     Ref<DOMMatrix> cloneAsDOMMatrix() const;
 

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -65,7 +65,7 @@ public:
     LoadStatus status() const;
 
     using ReadyPromise = DOMPromiseProxyWithResolveCallback<IDLInterface<FontFaceSet>>;
-    ReadyPromise& ready() { return m_readyPromise.get(); }
+    ReadyPromise& ready() LIFETIME_BOUND { return m_readyPromise.get(); }
     void documentDidFinishLoading();
 
     CSSFontFaceSet& backing() { return m_backing; }

--- a/Source/WebCore/css/MediaQueryListEvent.h
+++ b/Source/WebCore/css/MediaQueryListEvent.h
@@ -40,7 +40,7 @@ public:
     static Ref<MediaQueryListEvent> create(const AtomString& type, const String& media, bool matches);
     static Ref<MediaQueryListEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 
-    const String& media() const { return m_media; }
+    const String& media() const LIFETIME_BOUND { return m_media; }
     bool matches() const { return m_matches; }
 
 private:

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -123,7 +123,7 @@ public:
     Ref<StyleRule> copy() const;
     ~StyleRule();
 
-    const CSSSelectorList& selectorList() const { return m_selectorList; }
+    const CSSSelectorList& selectorList() const LIFETIME_BOUND { return m_selectorList; }
     const StyleProperties& properties() const { return m_properties.get(); }
     MutableStyleProperties& mutableProperties();
 
@@ -175,9 +175,9 @@ public:
     Ref<StyleRuleWithNesting> copy() const;
     ~StyleRuleWithNesting();
 
-    const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
-    Vector<Ref<StyleRuleBase>>& nestedRules() { return m_nestedRules; }
-    const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
+    const Vector<Ref<StyleRuleBase>>& nestedRules() const LIFETIME_BOUND { return m_nestedRules; }
+    Vector<Ref<StyleRuleBase>>& nestedRules() LIFETIME_BOUND { return m_nestedRules; }
+    const CSSSelectorList& originalSelectorList() const LIFETIME_BOUND { return m_originalSelectorList; }
 
     // Used by CSSOM.
     void wrapperAdoptOriginalSelectorList(CSSSelectorList&&);
@@ -228,11 +228,11 @@ class StyleRuleFontPaletteValues final : public StyleRuleBase {
 public:
     static Ref<StyleRuleFontPaletteValues> create(const AtomString& name, Vector<AtomString>&& fontFamilies, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&&);
 
-    const AtomString& name() const { return m_name; }
-    const Vector<AtomString>& fontFamilies() const { return m_fontFamilies; }
-    const FontPaletteValues& fontPaletteValues() const { return m_fontPaletteValues; }
+    const AtomString& name() const LIFETIME_BOUND { return m_name; }
+    const Vector<AtomString>& fontFamilies() const LIFETIME_BOUND { return m_fontFamilies; }
+    const FontPaletteValues& fontPaletteValues() const LIFETIME_BOUND { return m_fontPaletteValues; }
     std::optional<FontPaletteIndex> basePalette() const { return m_fontPaletteValues.basePalette(); }
-    const Vector<FontPaletteValues::OverriddenColor>& overrideColors() const { return m_fontPaletteValues.overrideColors(); }
+    const Vector<FontPaletteValues::OverriddenColor>& overrideColors() const LIFETIME_BOUND { return m_fontPaletteValues.overrideColors(); }
 
     Ref<StyleRuleFontPaletteValues> copy() const { return adoptRef(*new StyleRuleFontPaletteValues(*this)); }
 
@@ -254,7 +254,7 @@ public:
 
     FontFeatureValuesType fontFeatureValuesType() const { return m_type; }
 
-    const Vector<FontFeatureValuesTag>& tags() const { return m_tags; }
+    const Vector<FontFeatureValuesTag>& tags() const LIFETIME_BOUND { return m_tags; }
 
     Ref<StyleRuleFontFeatureValuesBlock> copy() const { return adoptRef(*new StyleRuleFontFeatureValuesBlock(*this)); }
 private:
@@ -269,7 +269,7 @@ class StyleRuleFontFeatureValues final : public StyleRuleBase {
 public:
     static Ref<StyleRuleFontFeatureValues> create(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&&);
 
-    const Vector<AtomString>& fontFamilies() const { return m_fontFamilies; }
+    const Vector<AtomString>& fontFamilies() const LIFETIME_BOUND { return m_fontFamilies; }
 
     Ref<FontFeatureValues> value() const { return m_value; }
 
@@ -289,7 +289,7 @@ public:
 
     ~StyleRulePage();
 
-    const CSSSelector& selector() const { return m_selectorList.first(); }
+    const CSSSelector& selector() const LIFETIME_BOUND { return m_selectorList.first(); }
     const StyleProperties& properties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
 
@@ -329,7 +329,7 @@ public:
     static Ref<StyleRuleMedia> create(MQ::MediaQueryList&&, Vector<Ref<StyleRuleBase>>&&);
     Ref<StyleRuleMedia> copy() const;
 
-    const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
+    const MQ::MediaQueryList& mediaQueries() const LIFETIME_BOUND { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&& queries) { m_mediaQueries = WTF::move(queries); }
 
     String debugDescription() const;
@@ -364,8 +364,8 @@ public:
 
     bool isStatement() const { return type() == StyleRuleType::LayerStatement; }
 
-    auto& name() const { return std::get<CascadeLayerName>(m_nameVariant); }
-    auto& nameList() const { return std::get<Vector<CascadeLayerName>>(m_nameVariant); }
+    auto& name() const LIFETIME_BOUND { return std::get<CascadeLayerName>(m_nameVariant); }
+    auto& nameList() const LIFETIME_BOUND { return std::get<Vector<CascadeLayerName>>(m_nameVariant); }
 
 private:
     StyleRuleLayer(Vector<CascadeLayerName>&&);
@@ -380,7 +380,7 @@ public:
     static Ref<StyleRuleContainer> create(CQ::ContainerQuery&&, Vector<Ref<StyleRuleBase>>&&);
     Ref<StyleRuleContainer> copy() const { return adoptRef(*new StyleRuleContainer(*this)); }
 
-    const CQ::ContainerQuery& containerQuery() const { return m_containerQuery; }
+    const CQ::ContainerQuery& containerQuery() const LIFETIME_BOUND { return m_containerQuery; }
 
 private:
     StyleRuleContainer(CQ::ContainerQuery&&, Vector<Ref<StyleRuleBase>>&&);
@@ -400,7 +400,7 @@ public:
     static Ref<StyleRuleProperty> create(Descriptor&&);
     Ref<StyleRuleProperty> copy() const { return adoptRef(*new StyleRuleProperty(*this)); }
 
-    const Descriptor& descriptor() const { return m_descriptor; }
+    const Descriptor& descriptor() const LIFETIME_BOUND { return m_descriptor; }
 
 private:
     StyleRuleProperty(Descriptor&&);
@@ -415,10 +415,10 @@ public:
     ~StyleRuleScope();
     Ref<StyleRuleScope> copy() const;
 
-    const CSSSelectorList& scopeStart() const { return m_scopeStart; }
-    const CSSSelectorList& scopeEnd() const { return m_scopeEnd; }
-    const CSSSelectorList& originalScopeStart() const { return m_originalScopeStart; }
-    const CSSSelectorList& originalScopeEnd() const { return m_originalScopeEnd; }
+    const CSSSelectorList& scopeStart() const LIFETIME_BOUND { return m_scopeStart; }
+    const CSSSelectorList& scopeEnd() const LIFETIME_BOUND { return m_scopeEnd; }
+    const CSSSelectorList& originalScopeStart() const LIFETIME_BOUND { return m_originalScopeStart; }
+    const CSSSelectorList& originalScopeEnd() const LIFETIME_BOUND { return m_originalScopeEnd; }
     void setScopeStart(CSSSelectorList&& scopeStart) { m_scopeStart = WTF::move(scopeStart); }
     void setScopeEnd(CSSSelectorList&& scopeEnd) { m_scopeEnd = WTF::move(scopeEnd); }
     WeakPtr<const StyleSheetContents> NODELETE styleSheetContents() const;

--- a/Source/WebCore/css/StyleRuleFunction.h
+++ b/Source/WebCore/css/StyleRuleFunction.h
@@ -46,8 +46,8 @@ public:
     Ref<StyleRuleFunction> copy() const { return adoptRef(*new StyleRuleFunction(*this)); }
 
     AtomString name() const { return m_name; }
-    const Vector<Parameter>& parameters() const { return m_parameters; }
-    const CSSCustomPropertySyntax& returnType() const { return m_returnType; }
+    const Vector<Parameter>& parameters() const LIFETIME_BOUND { return m_parameters; }
+    const CSSCustomPropertySyntax& returnType() const LIFETIME_BOUND { return m_returnType; }
 
 private:
     StyleRuleFunction(const AtomString& name, Vector<Parameter>&&, CSSCustomPropertySyntax&& returnType, Vector<Ref<StyleRuleBase>>&&);

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -57,14 +57,14 @@ public:
 
     bool NODELETE isLoading() const;
     
-    const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
+    const MQ::MediaQueryList& mediaQueries() const LIFETIME_BOUND { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&& queries) { m_mediaQueries = WTF::move(queries); }
 
     void requestStyleSheet();
     const CachedCSSStyleSheet* cachedCSSStyleSheet() const { return m_cachedSheet.get(); }
 
-    const std::optional<CascadeLayerName>& cascadeLayerName() const { return m_cascadeLayerName; }
-    const String& supportsText() const { return m_supportsCondition.text; }
+    const std::optional<CascadeLayerName>& cascadeLayerName() const LIFETIME_BOUND { return m_cascadeLayerName; }
+    const String& supportsText() const LIFETIME_BOUND { return m_supportsCondition.text; }
     bool supportsMatches() const { return m_supportsCondition.conditionMatches; }
 
 private:

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -64,9 +64,9 @@ public:
 
     WEBCORE_EXPORT ~StyleSheetContents();
     
-    const CSSParserContext& parserContext() const { return m_parserContext; }
+    const CSSParserContext& parserContext() const LIFETIME_BOUND { return m_parserContext; }
     
-    const AtomString& defaultNamespace() { return m_defaultNamespace; }
+    const AtomString& defaultNamespace() LIFETIME_BOUND { return m_defaultNamespace; }
     const AtomString& NODELETE namespaceURIFromPrefix(const AtomString& prefix);
 
     bool parseAuthorStyleSheet(const CachedCSSStyleSheet*, const SecurityOrigin*);
@@ -108,10 +108,10 @@ public:
     void clearRules();
 
     String encodingFromCharsetRule() const { return m_encodingFromCharsetRule; }
-    const Vector<Ref<StyleRuleLayer>>& layerRulesBeforeImportRules() const { return m_layerRulesBeforeImportRules; }
-    const Vector<Ref<StyleRuleImport>>& importRules() const { return m_importRules; }
-    const Vector<Ref<StyleRuleNamespace>>& namespaceRules() const { return m_namespaceRules; }
-    const Vector<Ref<StyleRuleBase>>& childRules() const { return m_childRules; }
+    const Vector<Ref<StyleRuleLayer>>& layerRulesBeforeImportRules() const LIFETIME_BOUND { return m_layerRulesBeforeImportRules; }
+    const Vector<Ref<StyleRuleImport>>& importRules() const LIFETIME_BOUND { return m_importRules; }
+    const Vector<Ref<StyleRuleNamespace>>& namespaceRules() const LIFETIME_BOUND { return m_namespaceRules; }
+    const Vector<Ref<StyleRuleBase>>& childRules() const LIFETIME_BOUND { return m_childRules; }
 
     void notifyLoadedSheet(const CachedCSSStyleSheet*);
     
@@ -123,7 +123,7 @@ public:
     // this style sheet. This property probably isn't useful for much except
     // the JavaScript binding (which needs to use this value for security).
     String originalURL() const { return m_originalURL; }
-    const URL& baseURL() const { return m_parserContext.baseURL; }
+    const URL& baseURL() const LIFETIME_BOUND { return m_parserContext.baseURL; }
 
     bool isEmpty() const { return !ruleCount(); }
     unsigned NODELETE ruleCount() const;

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -110,7 +110,7 @@ public:
 
     void dump(TextStream&) const;
 
-    const CSSCalc::Tree& tree() const { return m_tree; }
+    const CSSCalc::Tree& tree() const LIFETIME_BOUND { return m_tree; }
 
 private:
     explicit Value(CSS::Category, CSS::Range, CSSCalc::Tree&&);

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -116,7 +116,7 @@ public:
     static CSSSelectorList parsePageSelector(CSSParserTokenRange, StyleSheetContents*);
 
     bool supportsDeclaration(CSSParserTokenRange&);
-    const CSSParserContext& context() const { return m_context; }
+    const CSSParserContext& context() const LIFETIME_BOUND { return m_context; }
 
     // This function updates the range it's given.
     RefPtr<StyleRuleBase> consumeAtRule(CSSParserTokenRange&, AllowedRules);
@@ -128,7 +128,7 @@ public:
 
     static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(const CSSParserContext&, const String&);
 
-    CSSTokenizer* tokenizer() const { return m_tokenizer.get(); }
+    CSSTokenizer* tokenizer() const LIFETIME_BOUND { return m_tokenizer.get(); }
 
 private:
     struct NestingContext {

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.h
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.h
@@ -49,7 +49,7 @@ public:
     void NODELETE skipCommentsBefore(const CSSParserTokenRange&, bool leaveDirectlyBefore);
     void yieldCommentsBefore(const CSSParserTokenRange&);
 
-    CSSParserObserver& observer() { return m_observer; }
+    CSSParserObserver& observer() LIFETIME_BOUND { return m_observer; }
     void addComment(unsigned startOffset, unsigned endOffset, unsigned tokensBefore)
     {
         CommentPosition position = {startOffset, endOffset, tokensBefore};

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -52,11 +52,11 @@ public:
     ~MutableCSSSelector();
 
     CSSSelector releaseSelector() { return WTF::move(m_selector); }
-    const CSSSelector& selector() const { return m_selector; };
-    CSSSelector& selector() { return m_selector; }
+    const CSSSelector& selector() const LIFETIME_BOUND { return m_selector; };
+    CSSSelector& selector() LIFETIME_BOUND { return m_selector; }
 
     void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector.setValue(value, matchLowerCase); }
-    const AtomString& value() const { return m_selector.value(); }
+    const AtomString& value() const LIFETIME_BOUND { return m_selector.value(); }
 
     void setAttribute(const QualifiedName& value, CSSSelector::AttributeMatchType type) { m_selector.setAttribute(value, type); }
 

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -48,7 +48,7 @@ public:
 
     float effectiveSize();
 
-    const Vector<MQ::MediaQueryResult>& dynamicMediaQueryResults() const { return m_dynamicMediaQueryResults; }
+    const Vector<MQ::MediaQueryResult>& dynamicMediaQueryResults() const LIFETIME_BOUND { return m_dynamicMediaQueryResults; }
 
 private:
     std::optional<float> parse(CSSParserTokenRange, const CSSParserContext&);

--- a/Source/WebCore/css/typedom/CSSKeywordValue.h
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.h
@@ -40,7 +40,7 @@ class CSSKeywordValue final : public CSSStyleValue {
 public:
     static ExceptionOr<Ref<CSSKeywordValue>> create(const String&);
     
-    const String& value() const { return m_value; }
+    const String& value() const LIFETIME_BOUND { return m_value; }
     ExceptionOr<void> setValue(const String&);
     
     CSSStyleValueType styleValueType() const final { return CSSStyleValueType::CSSKeywordValue; }

--- a/Source/WebCore/css/typedom/CSSNumericValue.h
+++ b/Source/WebCore/css/typedom/CSSNumericValue.h
@@ -62,7 +62,7 @@ public:
     ExceptionOr<Ref<CSSUnitValue>> to(CSSUnitType);
     ExceptionOr<Ref<CSSMathSum>> toSum(FixedVector<String>&&);
 
-    const CSSNumericType& type() const { return m_type; }
+    const CSSNumericType& type() const LIFETIME_BOUND { return m_type; }
     
     static ExceptionOr<Ref<CSSNumericValue>> parse(Document&, String&&);
     static Ref<CSSNumericValue> rectifyNumberish(CSSNumberish&&);

--- a/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.h
+++ b/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.h
@@ -43,7 +43,7 @@ public:
     String toString() const;
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const;
 
-    const String& variable() const { return m_variable; }
+    const String& variable() const LIFETIME_BOUND { return m_variable; }
     CSSUnparsedValue* fallback() { return m_fallback.get(); }
     
 private:

--- a/Source/WebCore/css/typedom/color/CSSOMColor.h
+++ b/Source/WebCore/css/typedom/color/CSSOMColor.h
@@ -37,7 +37,7 @@ public:
     std::optional<CSSKeywordish> NODELETE colorSpace() const;
     void NODELETE setColorSpace(std::optional<CSSKeywordish>);
 
-    const CSSNumberish& alpha() const { return m_alpha; }
+    const CSSNumberish& alpha() const LIFETIME_BOUND { return m_alpha; }
     void setAlpha(CSSNumberish alpha) { m_alpha = WTF::move(alpha); }
 
 private:

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.h
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~CSSPerspective();
 
-    const CSSPerspectiveValue& length() const { return m_length; }
+    const CSSPerspectiveValue& length() const LIFETIME_BOUND { return m_length; }
     ExceptionOr<void> setLength(CSSPerspectiveValue);
 
     void serialize(StringBuilder&) const final;


### PR DESCRIPTION
#### d1fa83889ea9462f16a4c001918a129390a1548b
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in CSS
<a href="https://bugs.webkit.org/show_bug.cgi?id=309142">https://bugs.webkit.org/show_bug.cgi?id=309142</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/css/CSSAppleColorFilterValue.h:
* Source/WebCore/css/CSSBasicShapeValue.h:
* Source/WebCore/css/CSSBorderImageSliceValue.h:
* Source/WebCore/css/CSSBorderImageWidthValue.h:
* Source/WebCore/css/CSSBoxShadowPropertyValue.h:
* Source/WebCore/css/CSSColorSchemeValue.h:
* Source/WebCore/css/CSSColorValue.h:
* Source/WebCore/css/CSSCounterStyle.h:
(WebCore::CSSCounterStyle::name const): Deleted.
(WebCore::CSSCounterStyle::negative const): Deleted.
(WebCore::CSSCounterStyle::prefix const): Deleted.
(WebCore::CSSCounterStyle::suffix const): Deleted.
(WebCore::CSSCounterStyle::ranges const): Deleted.
(WebCore::CSSCounterStyle::pad const): Deleted.
(WebCore::CSSCounterStyle::fallbackName const): Deleted.
(WebCore::CSSCounterStyle::symbols const): Deleted.
(WebCore::CSSCounterStyle::additiveSymbols const): Deleted.
(WebCore::CSSCounterStyle::explicitlySetDescriptors const): Deleted.
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSCounterValue.h:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSDynamicRangeLimitValue.h:
* Source/WebCore/css/CSSEasingFunctionValue.h:
* Source/WebCore/css/CSSFilterValue.h:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSFontFeatureValue.h:
* Source/WebCore/css/CSSFontStyleWithAngleValue.h:
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/css/CSSGridTemplateAreasValue.h:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSPaintImageValue.h:
* Source/WebCore/css/CSSPathValue.h:
* Source/WebCore/css/CSSPositionValue.h:
* Source/WebCore/css/CSSProperty.h:
(WebCore::CSSProperty::metadata const): Deleted.
* Source/WebCore/css/CSSRatioValue.h:
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/CSSRectValue.h:
* Source/WebCore/css/CSSRuleList.h:
* Source/WebCore/css/CSSSegmentedFontFace.h:
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::argument const): Deleted.
(WebCore::CSSSelector::integerList const): Deleted.
(WebCore::CSSSelector::stringList const): Deleted.
(WebCore::CSSSelector::langList const): Deleted.
(WebCore::CSSSelector::selectorList const): Deleted.
(WebCore::CSSSelector::selectorList): Deleted.
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSStyleSheetObservableArray.h:
(WebCore::CSSStyleSheetObservableArray::sheets const): Deleted.
* Source/WebCore/css/CSSTextShadowPropertyValue.h:
* Source/WebCore/css/CSSURLValue.h:
* Source/WebCore/css/CSSVariableData.h:
(WebCore::CSSVariableData::context const): Deleted.
(WebCore::CSSVariableData::tokens const): Deleted.
* Source/WebCore/css/DOMMatrixReadOnly.h:
(WebCore::DOMMatrixReadOnly::transformationMatrix const): Deleted.
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryListEvent.h:
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRule::selectorList const): Deleted.
* Source/WebCore/css/StyleRuleFunction.h:
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/parser/CSSParser.h:
(WebCore::CSSParser::context const): Deleted.
(WebCore::CSSParser::tokenizer const): Deleted.
* Source/WebCore/css/parser/CSSParserObserverWrapper.h:
(WebCore::CSSParserObserverWrapper::observer): Deleted.
* Source/WebCore/css/parser/MutableCSSSelector.h:
(WebCore::MutableCSSSelector::selector const): Deleted.
(WebCore::MutableCSSSelector::selector): Deleted.
(WebCore::MutableCSSSelector::value const): Deleted.
* Source/WebCore/css/parser/SizesAttributeParser.h:
(WebCore::SizesAttributeParser::dynamicMediaQueryResults const): Deleted.
* Source/WebCore/css/typedom/CSSKeywordValue.h:
* Source/WebCore/css/typedom/CSSNumericValue.h:
(WebCore::CSSNumericValue::type const): Deleted.
* Source/WebCore/css/typedom/CSSOMVariableReferenceValue.h:
(WebCore::CSSOMVariableReferenceValue::variable const): Deleted.
* Source/WebCore/css/typedom/color/CSSOMColor.h:
* Source/WebCore/css/typedom/transform/CSSPerspective.h:
(WebCore::CSSPerspective::length const): Deleted.

Canonical link: <a href="https://commits.webkit.org/308614@main">https://commits.webkit.org/308614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed070b800f7ba6a6c02ba9f41ab4f2a353986656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156705 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1774e33-2846-4fc6-9bd5-40788b890a4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16347 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94877 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d16eabf-92da-4208-88a6-71d5da3a786a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4144 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159040 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122142 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31356 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132645 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9397 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19855 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->