### PR TITLE
[AppKit Gestures] Clicks in text Mail compose window to move insertion point not always going through

### DIFF
--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -43,6 +43,7 @@ namespace WebCore {
 
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
+enum class MouseEventInputSource : uint8_t;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 enum class AttachmentAssociatedElementType : uint8_t;
@@ -210,7 +211,7 @@ public:
 
     virtual bool performTwoStepDrop(DocumentFragment&, const SimpleRange& destination, bool isMove) = 0;
 
-    virtual bool shouldAllowSingleClickToChangeSelection(Node&, const VisibleSelection&) const { return true; }
+    virtual bool shouldAllowSingleClickToChangeSelection(Node&, const VisibleSelection&, MouseEventInputSource) const { return true; }
 
     virtual void willChangeSelectionForAccessibility() { }
     virtual void didChangeSelectionForAccessibility() { }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -793,7 +793,7 @@ bool EventHandler::handleMousePressEventSingleClick(const MouseEventWithHitTestR
     VisibleSelection newSelection = frame->selection().selection();
     TextGranularity granularity = TextGranularity::CharacterGranularity;
 
-    if (!frame->editor().client()->shouldAllowSingleClickToChangeSelection(*targetNode, newSelection))
+    if (!frame->editor().client()->shouldAllowSingleClickToChangeSelection(*targetNode, newSelection, event.event().inputSource()))
         return true;
 
     if (extendSelection && newSelection.isCaretOrRange()) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -509,10 +509,10 @@ void WebEditorClient::subFrameScrollPositionChanged()
 
 #if PLATFORM(COCOA)
 
-bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
+bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource inputSource) const
 {
     RefPtr page = m_page.get();
-    return page && page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection);
+    return page && page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection, inputSource);
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -193,7 +193,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    bool shouldAllowSingleClickToChangeSelection(WebCore::Node&, const WebCore::VisibleSelection&) const final;
+    bool shouldAllowSingleClickToChangeSelection(WebCore::Node&, const WebCore::VisibleSelection&, WebCore::MouseEventInputSource) const final;
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2276,7 +2276,7 @@ bool WebPage::isSpeaking() const
     return result;
 }
 
-bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection)
+bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource inputSource)
 {
 #if !PLATFORM(MAC) || HAVE(APPKIT_GESTURES_SUPPORT)
 #if HAVE(APPKIT_GESTURES_SUPPORT)
@@ -2287,7 +2287,7 @@ bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode,
     if (RefPtr editableRoot = newSelection.rootEditableElement(); editableRoot && editableRoot == targetNode.rootEditableElement()) {
         // FIXME: This logic should be made consistent for both macOS and iOS.
 #if PLATFORM(MAC)
-        return false;
+        return inputSource != WebCore::MouseEventInputSource::Automation;
 #else
         // Text interaction gestures will handle selection in the case where we are already editing the node. In the case where we're
         // just starting to focus an editable element by tapping on it, only change the selection if we weren't already showing an

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1078,7 +1078,7 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection);
+    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource);
     void selectWithGesture(const WebCore::IntPoint&, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
     void updateFocusBeforeSelectingTextAtLocation(const WebCore::IntPoint&);
     WebCore::VisiblePosition visiblePositionInFocusedNodeForPoint(const WebCore::LocalFrame&, const WebCore::IntPoint&, bool isInteractingWithFocusedElement);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -189,7 +189,7 @@ private:
     void registerUndoOrRedoStep(WebCore::UndoStep&, bool isRedo);
 
 #if PLATFORM(IOS_FAMILY)
-    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const;
+    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource) const;
 #endif
 
     WebView *m_webView;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -1297,7 +1297,7 @@ void WebEditorClient::requestExtendedCheckingOfString(TextCheckingRequest& reque
 }
 
 #if PLATFORM(IOS_FAMILY)
-bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
+bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection, WebCore::MouseEventInputSource) const
 {
     // The text selection assistant will handle selection in the case where we are already editing the node
     auto* editableRoot = newSelection.rootEditableElement();

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		07DEB44A2E7A079400066C32 /* Foundation+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04492CF139BF00B453A6 /* Foundation+Extras.swift */; };
 		07DF05182E0531AD00007A1B /* WebPageNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DF05172E0531AD00007A1B /* WebPageNavigationTests.swift */; };
 		07E499911F9E56DF002F1EF3 /* GetUserMediaReprompt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */; };
+		07EFC6202F576F610079E8EB /* AppKitGestures.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07EFC6182F576F560079E8EB /* AppKitGestures.mm */; };
+		07EFC6232F5771050079E8EB /* AppKitGesturesSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EFC6222F5771010079E8EB /* AppKitGesturesSupport.swift */; };
 		07FAA74D2CE95E3200128360 /* WebPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74C2CE95E3200128360 /* WebPageTests.swift */; };
 		0DE559ED2A6B0AAF009AA320 /* WKWebViewResize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */; };
 		0E404A8C2166DE0A008271BA /* InjectedBundleNodeHandleIsSelectElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0E404A8A2166DDF8008271BA /* InjectedBundleNodeHandleIsSelectElement.mm */; };
@@ -2541,6 +2543,9 @@
 		07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetUserMediaReprompt.mm; sourceTree = "<group>"; };
 		07EDEFAC1EB9400C00D43292 /* UserMediaDisabled.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaDisabled.mm; sourceTree = "<group>"; };
 		07EF76D42540FC060053ED53 /* MediaMutedState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaMutedState.mm; sourceTree = "<group>"; };
+		07EFC6182F576F560079E8EB /* AppKitGestures.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppKitGestures.mm; sourceTree = "<group>"; };
+		07EFC6212F5770200079E8EB /* AppKitGesturesSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitGesturesSupport.h; sourceTree = "<group>"; };
+		07EFC6222F5771010079E8EB /* AppKitGesturesSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitGesturesSupport.swift; sourceTree = "<group>"; };
 		07F4E92D20AF58D3002E3803 /* UserMediaSimulateFailedSandbox.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaSimulateFailedSandbox.mm; sourceTree = "<group>"; };
 		07F7696C2CA8BAC500FF004B /* IOSMouseEventTestHarness.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IOSMouseEventTestHarness.h; sourceTree = "<group>"; };
 		07F7696D2CA8BAC500FF004B /* IOSMouseEventTestHarness.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = IOSMouseEventTestHarness.mm; sourceTree = "<group>"; };
@@ -4882,6 +4887,9 @@
 				A1EB6C302D5582530096D4F8 /* AllowInlinePlaybackInDesktopClassBrowsing.mm */,
 				A1DF74301C41B65800A2F4D0 /* AlwaysRevalidatedURLSchemes.mm */,
 				2DE71AFD1D49C0BD00904094 /* AnimatedResize.mm */,
+				07EFC6182F576F560079E8EB /* AppKitGestures.mm */,
+				07EFC6212F5770200079E8EB /* AppKitGesturesSupport.h */,
+				07EFC6222F5771010079E8EB /* AppKitGesturesSupport.swift */,
 				A1798B8122431D65000764BD /* ApplePay.mm */,
 				E5D2146E2D58002C007DB350 /* AppleVisualEffectTests.mm */,
 				63F668201F97C3AA0032EE51 /* ApplicationManifest.mm */,
@@ -7861,6 +7869,8 @@
 				712E4BC125DDC52A0007201C /* AnimationFrameRate.cpp in Sources */,
 				57152B5E21CC2045000C37CA /* ApduTest.cpp in Sources */,
 				071B91922F57F81800E4ACAB /* AppKit+Extras.swift in Sources */,
+				07EFC6202F576F610079E8EB /* AppKitGestures.mm in Sources */,
+				07EFC6232F5771050079E8EB /* AppKitGesturesSupport.swift in Sources */,
 				6354F4D11F7C3AB500D89DF3 /* ApplicationManifestParser.cpp in Sources */,
 				F46C45C427D42A2F00ECED2C /* ApplicationStateTracking.mm in Sources */,
 				DF6580942722168900B3F1C1 /* ASN1Utilities.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGestures.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGestures.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "../../TestPDFDocument.h"
-#import "../WTF/cocoa/SwiftCxxInteropTestbed.h"
-#import "../WebKitCocoa/AppKitGesturesSupport.h"
-#import "../WebKitCocoa/SmartListsSupport.h"
-#import "TestWKWebView.h"
-#import "UIKitSPIForTesting.h"
+#import "config.h"
+
+#import <wtf/Platform.h>
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+
+#import "AppKitGesturesSupport.h"
+#import "TestCocoa.h"
+
+SWIFT_TEST(AppKitGestures, ClickingChangesSelection);
+
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "../../TestPDFDocument.h"
-#import "../WTF/cocoa/SwiftCxxInteropTestbed.h"
-#import "../WebKitCocoa/AppKitGesturesSupport.h"
-#import "../WebKitCocoa/SmartListsSupport.h"
-#import "TestWKWebView.h"
-#import "UIKitSPIForTesting.h"
+#pragma once
+
+#import <wtf/Platform.h>
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_UI_ACTOR
+@interface AppKitGesturesSupport : NSObject
+
++ (void)testClickingChangesSelectionWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(NSError * _Nullable))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.swift
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)
+
+import Foundation
+import WebKit
+import SwiftUI
+
+@objc
+@implementation
+extension AppKitGesturesSupport {
+    class func testClickingChangesSelection() async throws {
+        let page = WebPage()
+
+        let html = """
+            <div id="div" contenteditable style="font-size: 30px;">Here's to the crazy ones.</div>
+            """
+
+        try await page.load(html: html).wait()
+
+        let contentSize = NSSize(width: 800, height: 600)
+
+        let window = NSWindow(size: contentSize) {
+            WebView(page)
+        }
+
+        window.setFrameOrigin(.zero)
+        window.makeKeyAndOrderFront(nil)
+
+        let selectCrazy = """
+            const textNode = document.getElementById("div").firstChild
+
+            const range = document.createRange();
+            range.setStart(textNode, 14);
+            range.setEnd(textNode, 19);
+
+            let selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            """
+
+        try await page.callJavaScript(selectCrazy)
+
+        let getSelectionBounds = """
+            const selection = window.getSelection();
+
+            const range = selection.getRangeAt(0);
+            return range.getBoundingClientRect().toJSON();
+            """
+
+        let crazyBoundsDictionary = try await Testing.require(page.callJavaScript(getSelectionBounds) as? [String: Int])
+        let crazyBoundsInViewportCoordinates = CGRect(
+            x: crazyBoundsDictionary["x", default: 0],
+            y: crazyBoundsDictionary["y", default: 0],
+            width: crazyBoundsDictionary["width", default: 0],
+            height: crazyBoundsDictionary["height", default: 0],
+        )
+
+        let crazyBoundsInAppKitCoordinates = CGRect(
+            x: crazyBoundsInViewportCoordinates.minX,
+            y: contentSize.height - crazyBoundsInViewportCoordinates.maxY,
+            width: crazyBoundsInViewportCoordinates.width,
+            height: crazyBoundsInViewportCoordinates.height,
+        )
+
+        let middleOfCrazy = CGPoint(x: crazyBoundsInAppKitCoordinates.midX, y: crazyBoundsInAppKitCoordinates.midY)
+
+        let moveSelectionToStart = """
+            const textNode = document.getElementById("div").firstChild
+
+            const range = document.createRange();
+            range.setStart(textNode, 0);
+            range.setEnd(textNode, 0);
+
+            let selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            """
+
+        try await page.callJavaScript(moveSelectionToStart)
+
+        page.click(at: middleOfCrazy)
+
+        try await Testing.waitUntil {
+            let selection = try await page.callJavaScript("return window.getSelection().focusOffset") as? Int
+            return selection != 0
+        }
+
+        let selection = try await page.callJavaScript("return window.getSelection().focusOffset") as? Int
+        let expected = "Here's to the cra".count
+        try Testing.expect(selection, toEqual: expected)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)

--- a/Tools/TestWebKitAPI/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/WebPage+Extras.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI
+#if ENABLE_SWIFTUI && compiler(>=6.2)
 
 import Foundation
 @_spi(Testing) @_spi(CrossImportOverlay) import WebKit
@@ -114,4 +114,4 @@ extension WebPage {
     #endif // os(macOS)
 }
 
-#endif // ENABLE_SWIFTUI
+#endif // ENABLE_SWIFTUI && compiler(>=6.2)


### PR DESCRIPTION
#### bf8388916cc3498f921f27882682bd2948ecab48
<pre>
[AppKit Gestures] Clicks in text Mail compose window to move insertion point not always going through
<a href="https://bugs.webkit.org/show_bug.cgi?id=309143">https://bugs.webkit.org/show_bug.cgi?id=309143</a>
<a href="https://rdar.apple.com/171626443">rdar://171626443</a>

Reviewed by Abrar Rahman Protyasha.

The logic that was recently changed in `WebPage::shouldAllowSingleClickToChangeSelection` for macOS should have only been applied
for Automation-type mouse events.

Fix by reverting to prior correct behavior for mouse events that are not Automation.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebKit Swift/TestWebKitAPIBundle-Bridging-Header.h
       Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGestures.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.h
       Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.swift

* Source/WebCore/page/EditorClient.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEventSingleClick):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::shouldAllowSingleClickToChangeSelection const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::shouldAllowSingleClickToChangeSelection):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(WebEditorClient::shouldAllowSingleClickToChangeSelection const):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit Swift/TestWebKitAPIBundle-Bridging-Header.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGestures.mm: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.h: Copied from Tools/TestWebKitAPI/Tests/WebKit Swift/TestWebKitAPIBundle-Bridging-Header.h.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppKitGesturesSupport.swift: Added.
(AppKitGesturesSupport.testClickingChangesSelection):

Canonical link: <a href="https://commits.webkit.org/308681@main">https://commits.webkit.org/308681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2928bb8b3ef82e2325dcc2a9c0571ae685a72c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148209 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156892 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/588b4eb6-aa36-4d93-836d-01a821dcaac4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114257 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a329ffd1-b53c-4840-bcb3-434d5bda56d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95028 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ca2e659-511d-4884-9605-274da67057bb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4329 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159225 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122509 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/32746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76853 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9546 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20310 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20041 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20187 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->