### PR TITLE
Payment Request: reject with InvalidStateError when document is not fully active

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1269,6 +1269,8 @@ webkit.org/b/253126 imported/w3c/web-platform-tests/screen-wake-lock/wakelock-en
 webkit.org/b/253126 imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-permissions-policy.https.html [ Skip ]
 webkit.org/b/253126 imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-permissions-policy.https.html [ Skip ]
 webkit.org/b/253126 imported/w3c/web-platform-tests/screen-wake-lock/wakelock-supported-by-permissions-policy.html [ Skip ]
+webkit.org/b/253126 imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub.html [ Skip ]
+webkit.org/b/253126 imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative.html [ Skip ]
 
 webkit.org/b/182292 imported/w3c/web-platform-tests/css/cssom-view/scrollingElement-quirks-dynamic-001.html [ ImageOnlyFailure ]
 webkit.org/b/182292 imported/w3c/web-platform-tests/css/cssom-view/scrollingElement-quirks-dynamic-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/http/tests/paymentrequest/page-cache-created-payment-response.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/page-cache-created-payment-response.https-expected.txt
@@ -9,8 +9,8 @@ pagehide - entering cache
 pageshow - from cache
 PASS Page did enter and was restored from the back/forward cache
 Testing that PaymentResponse is now in the Closed state.
-PASS response.complete() rejected promise  with AbortError: The operation was aborted..
-PASS response.retry() rejected promise  with AbortError: The operation was aborted..
+PASS response.complete() rejected promise  with InvalidStateError: The payment response object is closed..
+PASS response.retry() rejected promise  with InvalidStateError: The payment response object is closed..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/paymentrequest/page-cache-created-payment-response.https.html
+++ b/LayoutTests/http/tests/paymentrequest/page-cache-created-payment-response.https.html
@@ -18,8 +18,8 @@ window.addEventListener('pageshow', async function(event) {
     testPassed('Page did enter and was restored from the back/forward cache');
 
     debug('Testing that PaymentResponse is now in the Closed state.');
-    await shouldRejectWithErrorName('response.complete()', 'AbortError');
-    await shouldRejectWithErrorName('response.retry()', 'AbortError');
+    await shouldRejectWithErrorName('response.complete()', 'InvalidStateError');
+    await shouldRejectWithErrorName('response.retry()', 'InvalidStateError');
 
     finishJSTest();
 }, false);

--- a/LayoutTests/http/tests/paymentrequest/page-cache-retried-payment-response.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/page-cache-retried-payment-response.https-expected.txt
@@ -11,8 +11,8 @@ PASS Page did enter and was restored from the back/forward cache
 Testing that the promise returned by retry() was rejected with "AbortError".
 PASS retryPromise rejected promise  with AbortError: The operation was aborted..
 Testing that PaymentResponse is now in the Closed state.
-PASS response.complete() rejected promise  with AbortError: The operation was aborted..
-PASS response.retry() rejected promise  with AbortError: The operation was aborted..
+PASS response.complete() rejected promise  with InvalidStateError: The payment response object is closed..
+PASS response.retry() rejected promise  with InvalidStateError: The payment response object is closed..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/paymentrequest/page-cache-retried-payment-response.https.html
+++ b/LayoutTests/http/tests/paymentrequest/page-cache-retried-payment-response.https.html
@@ -21,8 +21,8 @@ window.addEventListener('pageshow', async function(event) {
     await shouldRejectWithErrorName('retryPromise', 'AbortError');
 
     debug('Testing that PaymentResponse is now in the Closed state.');
-    await shouldRejectWithErrorName('response.complete()', 'AbortError');
-    await shouldRejectWithErrorName('response.retry()', 'AbortError');
+    await shouldRejectWithErrorName('response.complete()', 'InvalidStateError');
+    await shouldRejectWithErrorName('response.retry()', 'InvalidStateError');
 
     finishJSTest();
 }, false);

--- a/LayoutTests/http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html
+++ b/LayoutTests/http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html
@@ -66,10 +66,10 @@ function methodNotFullyActive(text, methodName, ...args) {
     const promise = response[methodName](...args);
     await promise_rejects_dom(
       t,
-      "AbortError",
+      "InvalidStateError",
       iframeDOMException,
       promise,
-      "Inactive document, so must throw AbortError"
+      "Inactive document, so must throw InvalidStateError"
     );
     // We are done, so clean up.
     iframe.remove();
@@ -105,7 +105,7 @@ function methodBecomesNotFullyActive(text, methodName, ...args) {
       "AbortError",
       iframeDOMException,
       promise,
-      "Inactive document, so must throw AbortError"
+      "Document became inactive, so must throw AbortError"
     );
     // We are done, so clean up.
     iframe.remove();

--- a/LayoutTests/http/tests/paymentrequest/rejects_if_not_active.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/rejects_if_not_active.https-expected.txt
@@ -2,4 +2,6 @@
 PASS PaymentRequest.show() aborts if the document is not active
 PASS PaymentRequest.show() aborts if the document is active, but not fully active
 PASS If a payment request is showing, but its document is navigated away (so no longer fully active), the payment request aborts.
+PASS PaymentRequest.canMakePayment() rejects if the document is not active
+PASS PaymentRequest.canMakePayment() rejects if the document is active, but not fully active
 

--- a/LayoutTests/http/tests/paymentrequest/rejects_if_not_active.https.html
+++ b/LayoutTests/http/tests/paymentrequest/rejects_if_not_active.https.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <link rel="help" href="https://w3c.github.io/payment-request/#show()-method">
-<title>PaymentRequest show() rejects if doc is not fully active</title>
+<link rel="help" href="https://w3c.github.io/payment-request/#canmakepayment-method">
+<title>PaymentRequest methods reject if doc is not fully active</title>
 <script src="/js-test-resources/ui-helper.js"></script>
 <script src="/resources/payment-request.js"></script>
 <script src="/resources/testharness.js"></script>
@@ -74,10 +75,10 @@ promise_test(async t => {
   // So, call .show(), and make sure it rejects appropriately.
   await promise_rejects_dom(
     t,
-    "AbortError",
+    "InvalidStateError",
     firstCtor,
     request1.show(),
-    "Inactive document, so must throw AbortError"
+    "Inactive document, so must throw InvalidStateError"
   );
 
   // request2 has an active document tho, so confirm it's working as expected:
@@ -141,10 +142,10 @@ promise_test(async t => {
   // So, call request.show() and make sure it rejects appropriately.
   await promise_rejects_dom(
     t,
-    "AbortError",
+    "InvalidStateError",
     requestWindow.DOMException,
     request.show(),
-    "Active, but not fully active, so must throw AbortError"
+    "Active, but not fully active, so must throw InvalidStateError"
   );
 
   // We are done, so clean up.
@@ -183,4 +184,92 @@ promise_test(async t => {
   // We are done, so clean up.
   iframe.remove();
 }, "If a payment request is showing, but its document is navigated away (so no longer fully active), the payment request aborts.");
+
+promise_test(async t => {
+  // Check that PaymentRequests can be constructed.
+  new PaymentRequest(validMethods, validDetails);
+  const iframe = document.createElement("iframe");
+  iframe.allowPaymentRequest = true;
+  document.body.appendChild(iframe);
+
+  // We first go to page1.html, grab a PaymentRequest instance.
+  const request1 = await getLoadedPaymentRequest(
+    iframe,
+    "resources/page1.html"
+  );
+  const firstCtor = iframe.contentWindow.DOMException;
+
+  // We navigate the iframe again, putting request1's document into an inactive state.
+  const request2 = await getLoadedPaymentRequest(
+    iframe,
+    "resources/page2.html"
+  );
+
+  // Now, request1's relevant global object's document is no longer active.
+  // So, call .canMakePayment(), and make sure it rejects appropriately.
+  await promise_rejects_dom(
+    t,
+    "InvalidStateError",
+    firstCtor,
+    request1.canMakePayment(),
+    "Inactive document, so must throw InvalidStateError"
+  );
+
+  // request2 has an active document, so confirm it's working as expected:
+  const result = await request2.canMakePayment();
+  assert_true(typeof result === "boolean", "canMakePayment() should return a boolean");
+
+  // We are done, so clean up.
+  iframe.remove();
+}, "PaymentRequest.canMakePayment() rejects if the document is not active");
+
+promise_test(async t => {
+  // check that PaymentRequests can be constructed (smoke test).
+  new PaymentRequest(validMethods, validDetails);
+
+  // We nest two iframes and wait for them to load.
+  const outerIframe = document.createElement("iframe");
+  outerIframe.allowPaymentRequest = true;
+  document.body.appendChild(outerIframe);
+  // Load the outer iframe (we don't care about the awaited request)
+  await getLoadedPaymentRequest(
+    outerIframe,
+    "resources/page1.html"
+  );
+
+  // Now we create the inner iframe
+  const innerIframe = outerIframe.contentDocument.createElement("iframe");
+  innerIframe.allowPaymentRequest = true;
+
+  // nest them
+  outerIframe.contentDocument.body.appendChild(innerIframe);
+
+  // load innerIframe, and get the PaymentRequest instance
+  const request = await getLoadedPaymentRequest(
+    innerIframe,
+    "resources/page2.html"
+  );
+  const requestWindow = innerIframe.contentWindow;
+
+  // Navigate the outer iframe to a new location.
+  // Wait for the load event to fire.
+  await new Promise(resolve => {
+    outerIframe.addEventListener("load", resolve);
+    outerIframe.src = "resources/page2.html";
+  });
+  // Now, request's relevant global object's document is still active
+  // (it is the active document of the inner iframe), but is not fully active
+  // (since the parent of the inner iframe is itself no longer active).
+  // So, call request.canMakePayment() and make sure it rejects appropriately.
+  await promise_rejects_dom(
+    t,
+    "InvalidStateError",
+    requestWindow.DOMException,
+    request.canMakePayment(),
+    "Active, but not fully active, so must throw InvalidStateError"
+  );
+
+  // We are done, so clean up.
+  outerIframe.remove();
+}, "PaymentRequest.canMakePayment() rejects if the document is active, but not fully active");
 </script>

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -12873,6 +12873,8 @@
         "web-platform-tests/mimesniff/sniffing/support/rss.html",
         "web-platform-tests/page-lifecycle/set-composited-layer-position-ref.html",
         "web-platform-tests/payment-request/show-method-postmessage-iframe.html",
+        "web-platform-tests/permissions-policy/resources/permissions-policy-payment-extension.html",
+        "web-platform-tests/permissions-policy/resources/permissions-policy-payment.html",
         "web-platform-tests/permissions/feature-policy-permissions-query.html",
         "web-platform-tests/quirks/body-fills-html-quirk-ref.html",
         "web-platform-tests/quirks/body-fills-html-quirk-ref2.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL PaymentRequest.show() aborts if the document is not active. promise_rejects_dom: Inactive document, so must throw InvalidStateError function "function() { throw e; }" threw object "AbortError: The operation was aborted." that is not a DOMException InvalidStateError: property "code" is equal to 20, expected 11
-FAIL PaymentRequest.show() aborts if the document is active, but not fully active. promise_rejects_dom: Active, but not fully active, so must throw InvalidStateError function "function() { throw e; }" threw object "AbortError: The operation was aborted." that is not a DOMException InvalidStateError: property "code" is equal to 20, expected 11
+PASS PaymentRequest.show() aborts if the document is not active.
+PASS PaymentRequest.show() aborts if the document is active, but not fully active.
 PASS PaymentRequest.canMakePayment() rejects if the document is not active.
 PASS PaymentRequest.canMakePayment() rejects if the document is active, but not fully active.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy.https.sub-expected.txt
@@ -1,6 +1,6 @@
 
 PASS permissions policy header "payment=*" allows Payment Request API the top-level document.
 PASS permissions policy header "payment=*" allows Payment Request API same-origin iframes.
-PASS permissions policy header "payment=*" disallows Payment Request API cross-origin iframes.
+PASS Payment Request API is disabled in cross-origin iframe if allow="payment" is not set and permissions policy header "payment=*".
 PASS permissions policy header "payment=*" allow="payment" allows Payment Request in cross-origin iframes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html
@@ -48,7 +48,7 @@
         expect_feature_available: expect_feature_unavailable_default,
         is_promise_test: true,
       });
-    }, `${header} disallows Payment Request API cross-origin iframes.`);
+    }, `Payment Request API is disabled in cross-origin iframe if allow="payment" is not set and ${header}.`);
 
     promise_test(async (test) => {
       return test_feature_availability({

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-disabled-by-permissions-policy.https.sub-expected.txt
@@ -4,5 +4,5 @@ FAIL permissions policy header "payment=()" disallows Payment Request API in top
         new PaymentRequest(supportedInstruments, details);
       }" did not throw
 FAIL permissions policy header "payment=()" disallows Payment Request API in same-origin iframes. assert_false: PaymentRequest() expected false got true
-PASS permissions policy header "payment=()" disallows Payment Request API in cross-origin iframes.
+FAIL permissions policy header "payment=()" disallows Payment Request API in cross-origin iframes. assert_false: PaymentRequest() expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
@@ -40,6 +40,7 @@
         test,
         src: cross_origin_src,
         expect_feature_available: expect_feature_unavailable_default,
+        feature_name: "payment",
         is_promise_test: true,
       });
     }, `${header} disallows Payment Request API in cross-origin iframes.`);

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub-expected.txt
@@ -1,0 +1,7 @@
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT WebAuthn "payment" extension is not supported in cross-origin iframe without allow="payment" attribute Test timed out
+NOTRUN WebAuthn "payment" extension can be enabled in cross-origin iframe using allow="payment" attribute
+

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<body>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+  <script src=/resources/testdriver.js></script>
+  <script src=/resources/testdriver-vendor.js></script>
+  <script src=/permissions-policy/resources/permissions-policy.js></script>
+  <script>
+    'use strict';
+    var same_origin_src = '/permissions-policy/resources/permissions-policy-payment-extension.html';
+    var cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
+      same_origin_src;
+    var feature_name = 'WebAuthn "payment" extension';
+    var header = 'allow="payment" attribute';
+
+    promise_test(t => {
+      return test_feature_availability_with_post_message_result(
+          t, cross_origin_src, "NotSupportedError");
+    }, feature_name + ' is not supported in cross-origin iframe without ' + header);
+
+    promise_test(t => {
+      return test_feature_availability_with_post_message_result(
+          t, cross_origin_src, 'OK', 'payment');
+    }, feature_name + ' can be enabled in cross-origin iframe using ' + header);
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL document.featurePolicy.features should advertise payment. undefined is not an object (evaluating 'document.permissionsPolicy.features')
+FAIL document.featurePolicy.features should advertise payment. undefined is not an object (evaluating 'document.featurePolicy.features')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative.html
@@ -6,6 +6,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 test(() => {
-    assert_in_array('payment', document.permissionsPolicy.features());
+    assert_in_array('payment', document.featurePolicy.features());
 }, 'document.featurePolicy.features should advertise payment.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy-payment-extension.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy-payment-extension.html
@@ -1,0 +1,62 @@
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/webauthn/helpers.js"></script>
+<script>
+'use strict';
+
+const textEncoder = new TextEncoder();
+let authenticatorArgs = {
+  protocol: 'ctap2_1',
+  transport: 'internal',
+  hasResidentKey: true,
+  hasUserVerification: true,
+  isUserVerified: true,
+};
+
+window.onload = async function() {
+  test_driver.set_test_context(parent);
+  const authenticator = await window.test_driver.add_virtual_authenticator(authenticatorArgs);
+  let enabled = true;
+  let name = `OK`;
+  try {
+    const publicKey = {
+      rp: {
+        id: window.location.hostname,
+        name: 'Joe',
+      },
+      user: {
+        name: 'user@domain',
+        id: Uint8Array.from('id', c => c.charCodeAt(0)),
+        displayName: 'User',
+      },
+      challenge: textEncoder.encode('Enrollment challenge'),
+      pubKeyCredParams: [{
+        type: 'public-key',
+        alg: -7, // ECDSA, not supported on Windows.
+      }, {
+        type: 'public-key',
+        alg: -257, // RSA, supported on Windows.
+      }],
+      authenticatorSelection: {
+        userVerification: 'required',
+        residentKey: 'required',
+        authenticatorAttachment: 'platform',
+      },
+      extensions: {
+        payment: {
+          isPayment: true,
+        },
+      }
+    };
+    await window.test_driver.bless('user activation');
+    await navigator.credentials.create({
+      publicKey
+    });
+  } catch (e) {
+    enabled = false;
+    name = e.name;
+  }
+  await window.test_driver.remove_virtual_authenticator(authenticator);
+  parent.postMessage({ type: 'availability-result', enabled, name }, '*');
+}
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4052,9 +4052,6 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-textarea-border-top-width-001.html [ Pass ]
 
 # These tests are flaky due to "Blocked access to external URL" messages because we don't support WPT domains.
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ Failure Pass ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ Failure Pass ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ Failure Pass ]
 
 # Close Watcher tests rely on sending escape keys from test_driver which doesn't work on iOS webkit.org/b/274832
 webkit.org/b/274832 imported/w3c/web-platform-tests/close-watcher/esc-key [ Skip ]
@@ -4521,7 +4518,6 @@ webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
 webkit.org/b/254044 http/tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
-webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
 
 # Test times out:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/only-observe-firstInput.html [ Skip ]
@@ -7117,7 +7113,6 @@ webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgba-rgba-unsign
 webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
 
-webkit.org/b/269086 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html [ Pass Failure ]
 
 webkit.org/b/269760 mathml/presentation/scripts-underover.html [ Failure ]
 
@@ -7683,9 +7678,6 @@ media/remove-video-best-media-element-in-main-frame-crash.html [ Pass Timeout ]
 
 # webkit.org/b/278343 [ iOS iPhone Debug ] editing/inserting/insert-composition-whitespace.html is a constant crash
 [ Debug ] editing/inserting/insert-composition-whitespace.html [ Crash ]
-
-# webkit.org/b/278346 REGRESSION(281587@main - 281612@main): [ iOS Debug ] http/tests/paymentrequest/payment-response-reference-cycle-leak.https.html is a constant crash
-[ Debug ] http/tests/paymentrequest/payment-response-reference-cycle-leak.https.html [ Crash ]
 
 # webkit.org/b/278349 [ iOS ] imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-block-in-inline-start-001.html is a flaky image failure
 imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-block-in-inline-start-001.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -88,7 +88,6 @@ http/tests/ssl/applepay [ Pass ]
 fast/visual-viewport/rubberbanding-viewport-rects.html [ Pass ]
 fast/visual-viewport/rubberbanding-viewport-rects-header-footer.html  [ Pass ]
 
-
 http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https.html [ Skip ]
 http/tests/paymentrequest/paymentrequest-isDelegatedRequest.https.html [ Skip ]
 http/tests/paymentrequest [ Pass ]
@@ -1390,7 +1389,6 @@ http/wpt/service-workers/push-console-messages-showNotification-sync.https.html 
 webkit.org/b/242164 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]
 
 webkit.org/b/242138 imported/w3c/web-platform-tests/css/css-transforms/huge-length-tiny-scale.html [ Pass Crash ImageOnlyFailure ]
-
 
 # Cocoa ports run WPT tests over localhost so the URL is treated as secure even though not HTTPs.
 imported/w3c/web-platform-tests/clear-site-data/navigation-insecure.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1919,13 +1919,6 @@ webkit.org/b/246356 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 webkit.org/b/246356 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-default-feature-policy.https.sub.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute.https.sub.html [ Pass Failure ]
 
-# These tests are flaky due to "Blocked access to external URL" messages because we don't support WPT domains.
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html [ Failure Pass ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ Failure Pass ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub.html [ Failure Pass ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ Failure Pass ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ Failure Pass ]
-
 webkit.org/b/245092 webaudio/offlineaudiocontext-gc.html [ Pass Failure ]
 
 webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-streams/construct-byob-request.any.worker.html [ Pass Failure ]
@@ -1972,7 +1965,6 @@ webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
 webkit.org/b/254044 http/tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
-webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
 
 webkit.org/b/237415 webgl/1.0.x/conformance/rendering/clipping-wide-points.html [ Pass Failure ]
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -375,7 +375,12 @@ void PaymentRequest::show(Document& document, RefPtr<DOMPromise>&& detailsPromis
 {
     RefPtr frame = document.frame();
     if (!frame) {
-        promise.reject(Exception { ExceptionCode::AbortError });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Document does not have a frame."_s });
+        return;
+    }
+
+    if (!document.isFullyActive()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Document is not fully active."_s });
         return;
     }
 
@@ -527,6 +532,11 @@ void PaymentRequest::canMakePayment(Document& document, CanMakePaymentPromise&& 
 {
     if (m_state != State::Created) {
         promise.reject(Exception { ExceptionCode::InvalidStateError });
+        return;
+    }
+
+    if (!document.isFullyActive()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Document is not fully active."_s });
         return;
     }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
@@ -70,14 +70,19 @@ void PaymentResponse::setDetailsFunction(DetailsFunction&& detailsFunction)
 
 void PaymentResponse::complete(Document& document, std::optional<PaymentComplete>&& result, std::optional<PaymentCompleteDetails>&& details, DOMPromiseDeferred<void>&& promise)
 {
+    if (!document.isFullyActive()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Document is not fully active."_s });
+        return;
+    }
+
     if (m_state == State::Stopped) {
-        promise.reject(Exception { ExceptionCode::AbortError });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The payment response object is closed."_s });
         return;
     }
 
     RefPtr request = m_request.get();
     if (!request) {
-        promise.reject(Exception { ExceptionCode::AbortError });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The payment response object is closed."_s });
         return;
     }
 
@@ -109,16 +114,21 @@ void PaymentResponse::complete(Document& document, std::optional<PaymentComplete
     promise.settle(WTF::move(exception));
 }
 
-void PaymentResponse::retry(PaymentValidationErrors&& errors, DOMPromiseDeferred<void>&& promise)
+void PaymentResponse::retry(const Document& document, PaymentValidationErrors&& errors, DOMPromiseDeferred<void>&& promise)
 {
+    if (!document.isFullyActive()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Document is not fully active."_s });
+        return;
+    }
+
     if (m_state == State::Stopped) {
-        promise.reject(Exception { ExceptionCode::AbortError });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The payment response object is closed."_s });
         return;
     }
 
     RefPtr request = m_request.get();
     if (!request) {
-        promise.reject(Exception { ExceptionCode::AbortError });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The payment response object is closed."_s });
         return;
     }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -94,7 +94,7 @@ public:
     void setPayerPhone(const String& payerPhone) { m_payerPhone = payerPhone; }
 
     void complete(Document&, std::optional<PaymentComplete>&&, std::optional<PaymentCompleteDetails>&&, DOMPromiseDeferred<void>&&);
-    void retry(PaymentValidationErrors&&, DOMPromiseDeferred<void>&&);
+    void retry(const Document&, PaymentValidationErrors&&, DOMPromiseDeferred<void>&&);
     void abortWithException(Exception&&);
     bool hasRetryPromise() const { return !!m_retryPromise; }
     void settleRetryPromise(ExceptionOr<void>&& = { });

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.idl
@@ -42,8 +42,8 @@
     readonly attribute DOMString? payerEmail;
     readonly attribute DOMString? payerPhone;
 
-    [CallWith=CurrentDocument, NewObject] Promise<undefined> complete(optional PaymentComplete result = "unknown", optional PaymentCompleteDetails details = {});
-    [NewObject] Promise<undefined> retry(optional PaymentValidationErrors errorFields = {});
+    [CallWith=RelevantDocument, NewObject] Promise<undefined> complete(optional PaymentComplete result = "unknown", optional PaymentCompleteDetails details = {});
+    [CallWith=RelevantDocument, NewObject] Promise<undefined> retry(optional PaymentValidationErrors errorFields = {});
 
     attribute EventHandler onpayerdetailchange;
 };


### PR DESCRIPTION
#### ccf55ec022ef118bb4dbea8e5cab4676a7915a5b
<pre>
Payment Request: reject with InvalidStateError when document is not fully active
<a href="https://rdar.apple.com/171593464">rdar://171593464</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309027">https://bugs.webkit.org/show_bug.cgi?id=309027</a>

Reviewed by Abrar Rahman Protyasha and Anne van Kesteren.

Uses InvalidStateError for when the API is called from a detached document,
and AbortError if script itself destroyed the script execution context/document.

Spec change:
<a href="https://github.com/w3c/payment-request/pull/1056">https://github.com/w3c/payment-request/pull/1056</a>

Upstream WPT commit: <a href="https://github.com/web-platform-tests/wpt/commit/05fdf811f9ca0a3d95f0eb54cb9a0680c58104ec">https://github.com/web-platform-tests/wpt/commit/05fdf811f9ca0a3d95f0eb54cb9a0680c58104ec</a>

Test: imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https.html

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/paymentrequest/page-cache-created-payment-response.https-expected.txt:
* LayoutTests/http/tests/paymentrequest/page-cache-created-payment-response.https.html:
* LayoutTests/http/tests/paymentrequest/page-cache-retried-payment-response.https-expected.txt:
* LayoutTests/http/tests/paymentrequest/page-cache-retried-payment-response.https.html:
* LayoutTests/http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html:
* LayoutTests/http/tests/paymentrequest/rejects_if_not_active.https-expected.txt:
* LayoutTests/http/tests/paymentrequest/rejects_if_not_active.https.html:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-extension-allowed-by-permissions-policy-attribute.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-supported-by-permissions-policy.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy-payment-extension.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::show):
(WebCore::PaymentRequest::canMakePayment):
* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
(WebCore::PaymentResponse::complete):
(WebCore::PaymentResponse::retry):
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.idl:

Canonical link: <a href="https://commits.webkit.org/309150@main">https://commits.webkit.org/309150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0ac96a6fd107176ba68733aa65329fada63c487

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103005 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75898c49-6e77-439d-9d3a-c33a929e909a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96119 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6120 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123410 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33590 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78315 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10701 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85522 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->