### PR TITLE
REGRESSION(306380@main) [Tahoe Debug x86_64] TestWebKitAPI.WebKit.ManagedMSEHasMediaStreamingActivity is flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
@@ -33,17 +33,21 @@
       function load(event)
       {
           source = new ManagedMediaSource();
-          source.addEventListener('sourceopen', sourceopen);
           video.src = URL.createObjectURL(source);
-      }
-
-      function sourceopen(event)
-      {
-          sourceBuffer = source.addSourceBuffer(isMP4Supported() ? 'video/mp4;codecs="avc1.4D4001,mp4a.40.2"' : isWebMVP9Supported() ? 'video/webm;codecs="vp9,opus"' : 'video/webm;codecs="opus"');
       }
 
       function startStreaming(event)
       {
+          if (source.readyState == "open") {
+              loadData();
+              return;
+          }
+          source.addEventListener('sourceopen', loadData);
+      }
+
+      function loadData()
+      {
+          sourceBuffer = source.addSourceBuffer(isMP4Supported() ? 'video/mp4;codecs="avc1.4D4001,mp4a.40.2"' : isWebMVP9Supported() ? 'video/webm;codecs="vp9,opus"' : 'video/webm;codecs="opus"');
           sourceBuffer.addEventListener('updateend', updateend);
           sourceBuffer.appendBuffer(request.response);
       }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
@@ -88,11 +88,7 @@ TEST(WebKit, MSEHasMediaStreamingActivity)
 
 // FIXME when webkit.org/b/306970 is resolved.
 #if ENABLE(MEDIA_SOURCE)
-#if PLATFORM(MAC) && !defined(NDEBUG) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
-TEST(WebKit, DISABLED_ManagedMSEHasMediaStreamingActivity)
-#else
 TEST(WebKit, ManagedMSEHasMediaStreamingActivity)
-#endif
 {
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration preferences] _setManagedMediaSourceEnabled:YES];


### PR DESCRIPTION
#### 8a419b55e545cfc62d6db83c587a3d107611725a
<pre>
REGRESSION(306380@main) [Tahoe Debug x86_64] TestWebKitAPI.WebKit.ManagedMSEHasMediaStreamingActivity is flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=306970">https://bugs.webkit.org/show_bug.cgi?id=306970</a>
<a href="https://rdar.apple.com/169640786">rdar://169640786</a>

Reviewed by Youenn Fablet.

The test was racy. It was possible for `startStreaming()` to be called
before the `sourceopen` event had been fired and the MediaSource&apos;s readyState
to move to the `open` state. Under such condition `sourceopen(event)` wouldn&apos;t
have been called and the sourceBuffer wouldn&apos;t have been created leading to
an exception when attempting to call addEventListener.
We remove this race by ensuring the MediaSource is `open` from within the `startStreaming()`
run.

* Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm:
(TestWebKitAPI::TEST(WebKit, ManagedMSEHasMediaStreamingActivity)): Re-enable test.

Canonical link: <a href="https://commits.webkit.org/308630@main">https://commits.webkit.org/308630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/821e569e82f45b981ae37ad2668b88bb3baba648

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101449 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f579811-7364-4420-8bf1-d690bfd74267) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114123 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81374 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3c5e165-1009-4e5b-91ca-059542025542) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94889 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13301 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159052 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122151 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31368 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132653 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76671 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17815 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9405 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20137 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19867 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20014 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->