### PR TITLE
[JSC] String#replace should not do surrogate-aware advancement for non-unicode regexps

### DIFF
--- a/JSTests/stress/string-replace-regexp-empty-match-advance-index.js
+++ b/JSTests/stress/string-replace-regexp-empty-match-advance-index.js
@@ -1,0 +1,90 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+let s = "\uD800\uDC00";
+
+class SlowRegExp extends RegExp {}
+
+{
+    let fast_g  = s.replace(/(?:)/g,  "X");
+    let fast_gu = s.replace(/(?:)/gu, "X");
+    let slow_g  = s.replace(new SlowRegExp("(?:)", "g"),  "X");
+    let slow_gu = s.replace(new SlowRegExp("(?:)", "gu"), "X");
+
+    shouldBe(slow_g,  "X\uD800X\uDC00X");
+    shouldBe(slow_gu, "X\uD800\uDC00X");
+
+    shouldBe(fast_g,  slow_g);
+    shouldBe(fast_gu, slow_gu);
+
+    shouldBe(fast_g.length,  5);
+    shouldBe(fast_gu.length, 4);
+}
+
+{
+    let fast_g  = s.replace(/(?:)/g,  "[$&]");
+    let fast_gu = s.replace(/(?:)/gu, "[$&]");
+    let slow_g  = s.replace(new SlowRegExp("(?:)", "g"),  "[$&]");
+    let slow_gu = s.replace(new SlowRegExp("(?:)", "gu"), "[$&]");
+
+    shouldBe(fast_g,  slow_g);
+    shouldBe(fast_gu, slow_gu);
+    shouldBe(fast_g,  "[]\uD800[]\uDC00[]");
+    shouldBe(fast_gu, "[]\uD800\uDC00[]");
+}
+
+{
+    function collectOffsets(re) {
+        let offsets = [];
+        s.replace(re, function(match, offset) { offsets.push(offset); return ""; });
+        return offsets.join(",");
+    }
+
+    shouldBe(collectOffsets(/(?:)/g),  "0,1,2");
+    shouldBe(collectOffsets(/(?:)/gu), "0,2");
+    shouldBe(collectOffsets(new SlowRegExp("(?:)", "g")),  "0,1,2");
+    shouldBe(collectOffsets(new SlowRegExp("(?:)", "gu")), "0,2");
+}
+
+{
+    shouldBe(s.replaceAll(/(?:)/g,  "X"), "X\uD800X\uDC00X");
+    shouldBe(s.replaceAll(/(?:)/gu, "X"), "X\uD800\uDC00X");
+}
+
+{
+    let fast_g  = s.replace(/a*/g,  "_");
+    let fast_gu = s.replace(/a*/gu, "_");
+    let slow_g  = s.replace(new SlowRegExp("a*", "g"),  "_");
+    let slow_gu = s.replace(new SlowRegExp("a*", "gu"), "_");
+
+    shouldBe(fast_g,  slow_g);
+    shouldBe(fast_gu, slow_gu);
+    shouldBe(fast_g,  "_\uD800_\uDC00_");
+    shouldBe(fast_gu, "_\uD800\uDC00_");
+}
+
+{
+    let fast_gv = s.replace(/(?:)/gv, "X");
+    let slow_gv = s.replace(new SlowRegExp("(?:)", "gv"), "X");
+    shouldBe(fast_gv, slow_gv);
+    shouldBe(fast_gv, "X\uD800\uDC00X");
+}
+
+{
+    let s2 = "\uD800\uDC00\uD801\uDC01";
+    let fast_g  = s2.replace(/(?:)/g,  "|");
+    let fast_gu = s2.replace(/(?:)/gu, "|");
+
+    shouldBe(fast_g,  "|\uD800|\uDC00|\uD801|\uDC01|");
+    shouldBe(fast_gu, "|\uD800\uDC00|\uD801\uDC01|");
+    shouldBe(fast_g,  s2.replace(new SlowRegExp("(?:)", "g"),  "|"));
+    shouldBe(fast_gu, s2.replace(new SlowRegExp("(?:)", "gu"), "|"));
+}
+
+{
+    let s3 = "\uD800x";
+    shouldBe(s3.replace(/(?:)/g,  "_"), "_\uD800_x_");
+    shouldBe(s3.replace(/(?:)/gu, "_"), "_\uD800_x_");
+}

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -777,7 +777,7 @@ ALWAYS_INLINE JSCellButterfly* addToRegExpSearchCache(VM& vm, JSGlobalObject* gl
             startPosition++;
             if (startPosition > source.length())
                 break;
-            if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
+            if (regExp->eitherUnicode() && U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
                 startPosition++;
                 if (startPosition > source.length())
                     break;
@@ -1186,7 +1186,7 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearchNoBackreferences(VM
             startPosition++;
             if (startPosition > sourceLen)
                 break;
-            if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
+            if (regExp->eitherUnicode() && U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
                 startPosition++;
                 if (startPosition > sourceLen)
                     break;
@@ -1243,7 +1243,7 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
             startPosition++;
             if (startPosition > sourceLen)
                 break;
-            if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
+            if (regExp->eitherUnicode() && U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
                 startPosition++;
                 if (startPosition > sourceLen)
                     break;
@@ -1438,7 +1438,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
                 startPosition++;
                 if (startPosition > sourceLen)
                     break;
-                if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
+                if (regExp->eitherUnicode() && U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
                     startPosition++;
                     if (startPosition > sourceLen)
                         break;
@@ -1523,7 +1523,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
                 startPosition++;
                 if (startPosition > sourceLen)
                     break;
-                if (U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
+                if (regExp->eitherUnicode() && U16_IS_LEAD(source[startPosition - 1]) && U16_IS_TRAIL(source[startPosition])) {
                     startPosition++;
                     if (startPosition > sourceLen)
                         break;


### PR DESCRIPTION
#### 13f7de0a8f9494c5db1193a5a826553637a56fcf
<pre>
[JSC] String#replace should not do surrogate-aware advancement for non-unicode regexps
<a href="https://bugs.webkit.org/show_bug.cgi?id=309146">https://bugs.webkit.org/show_bug.cgi?id=309146</a>

Reviewed by Yusuke Suzuki.

Per ECMA-262 AdvanceStringIndex[1], empty-match advancement must be
exactly +1 code unit when the regexp has neither &apos;u&apos; nor &apos;v&apos; flag.
The C++ fast path was unconditionally skipping over surrogate pairs:

    &quot;\uD800\uDC00&quot;.replace(/(?:)/g, &quot;X&quot;)
    Spec:  &quot;X\uD800X\uDC00X&quot; (3 matches)
    JSC:   &quot;X\uD800\uDC00X&quot;  (2 matches)

The JS builtin slow path (RegExpPrototype.js) was already correct.

[1]: <a href="https://tc39.es/ecma262/#sec-advancestringindex">https://tc39.es/ecma262/#sec-advancestringindex</a>

Test: JSTests/stress/string-replace-regexp-empty-match-advance-index.js

* JSTests/stress/string-replace-regexp-empty-match-advance-index.js: Added.
(shouldBe):
(SlowRegExp):
(shouldBe.collectOffsets):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::addToRegExpSearchCache):
(JSC::replaceAllWithStringUsingRegExpSearchNoBackreferences):
(JSC::replaceAllWithStringUsingRegExpSearch):
(JSC::replaceUsingRegExpSearch):

Canonical link: <a href="https://commits.webkit.org/308626@main">https://commits.webkit.org/308626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0046063713adf4565b3eca80145302ce00e278a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114127 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15499 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13304 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4162 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140009 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159058 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8829 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2192 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122157 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122371 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31366 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76677 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17819 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9407 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83902 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45959 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->