### PR TITLE
[WIP] Get rid of WeakOrStrongPtr type

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -386,10 +386,8 @@ WebProcessPool::~WebProcessPool()
     while (!m_processes.isEmpty()) {
         auto& process = m_processes.first();
 
-        ASSERT(process->isPrewarmed());
-        // We need to be the only one holding a reference to the pre-warmed process so that it gets destroyed.
-        // WebProcessProxies currently always expect to have a WebProcessPool.
-        ASSERT(process->hasOneRef());
+        ASSERT(!process->pageCount());
+        ASSERT(!process->provisionalPageCount());
 
         process->shutDown();
     }
@@ -1361,6 +1359,7 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
         if (!process) {
             auto enableWebAssemblyDebugger = protect(pageConfiguration->preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
             process = WebProcessProxy::create(*this, protect(pageConfiguration->websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Shared, WebProcessProxy::ShouldLaunchProcess::No, enableWebAssemblyDebugger);
+            process->markAsDummyProcessProxy();
             m_dummyProcessProxies.add(pageConfiguration->websiteDataStore().sessionID(), *process);
             m_processes.append(*process);
         }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -315,7 +315,7 @@ WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* 
     : AuxiliaryProcessProxy(processPool.shouldTakeUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
     , processPool.alwaysRunsAtBackgroundPriority() ? AlwaysRunsAtBackgroundPriority::Yes : AlwaysRunsAtBackgroundPriority::No)
     , m_backgroundResponsivenessTimer(makeUniqueRef<BackgroundProcessResponsivenessTimer>(*this))
-    , m_processPool(processPool, isPrewarmed == IsPrewarmed::Yes ? IsWeak::Yes : IsWeak::No)
+    , m_processPool(processPool)
 #if HAVE(DISPLAY_LINK)
     , m_displayLinkClient(makeUniqueRef<DisplayLinkProcessProxyClient>())
 #endif
@@ -383,7 +383,7 @@ WebProcessProxy::~WebProcessProxy()
     WebPasteboardProxy::singleton().removeWebProcessProxy(*this);
 
 #if HAVE(DISPLAY_LINK)
-    if (RefPtr<WebProcessPool> processPool = m_processPool.get())
+    if (RefPtr processPool = m_processPool)
         processPool->displayLinks().stopDisplayLinks(m_displayLinkClient.get());
 #endif
 
@@ -443,14 +443,7 @@ void WebProcessProxy::setIsInProcessCache(bool value, WillShutDown willShutDown)
     // the process via a background activity long enough to process the IPC if necessary.
     sendWithAsyncReply(Messages::WebProcess::SetIsInProcessCache(m_isInProcessCache), []() { });
 
-    if (m_isInProcessCache) {
-        // WebProcessProxy objects normally keep the process pool alive but we do not want this to be the case
-        // for cached processes or it would leak the pool.
-        m_processPool.setIsWeak(IsWeak::Yes);
-    } else {
-        RELEASE_ASSERT(m_processPool);
-        m_processPool.setIsWeak(IsWeak::No);
-    }
+    RELEASE_ASSERT(m_isInProcessCache || m_processPool);
 
     updateRuntimeStatistics();
 }
@@ -471,11 +464,6 @@ void WebProcessProxy::setWebsiteDataStore(WebsiteDataStore& dataStore)
     // Delay construction of the WebLockRegistryProxy until the WebProcessProxy has a data store since the data store holds the
     // LocalWebLockRegistry.
     lazyInitialize(m_webLockRegistry, makeUniqueWithoutRefCountedCheck<WebLockRegistryProxy>(*this));
-}
-
-bool WebProcessProxy::isDummyProcessProxy() const
-{
-    return m_websiteDataStore && protect(processPool())->dummyProcessProxy(m_websiteDataStore->sessionID()) == this;
 }
 
 void WebProcessProxy::updateRegistrationWithDataStore()
@@ -761,7 +749,8 @@ void WebProcessProxy::shutDown()
         routingArbitrator->processDidTerminate();
 #endif
 
-    Ref<WebProcessPool> { processPool() }->disconnectProcess(*this);
+    if (RefPtr processPool = m_processPool)
+        processPool->disconnectProcess(*this);
 }
 
 WebPageProxy* WebProcessProxy::webPage(WebPageProxyIdentifier pageID)
@@ -899,7 +888,6 @@ void WebProcessProxy::markIsNoLongerInPrewarmedPool()
 
     m_isPrewarmed = false;
     RELEASE_ASSERT(m_processPool);
-    m_processPool.setIsWeak(IsWeak::No);
 
     send(Messages::WebProcess::MarkIsNoLongerPrewarmed(), 0);
 
@@ -1638,14 +1626,15 @@ void WebProcessProxy::maybeShutDown()
 {
     if (isDummyProcessProxy() && m_pageMap.isEmpty()) {
         ASSERT(state() == State::Terminated);
-        protect(processPool())->disconnectProcess(*this);
+        if (RefPtr processPool = m_processPool)
+            processPool->disconnectProcess(*this);
         return;
     }
 
     if (state() == State::Terminated || !canTerminateAuxiliaryProcess())
         return;
 
-    if (canBeAddedToWebProcessCache() && protect(processPool())->webProcessCache().addProcessIfPossible(*this))
+    if (canBeAddedToWebProcessCache() && m_processPool && protect(m_processPool)->webProcessCache().addProcessIfPossible(*this))
         return;
 
     shutDown();
@@ -2126,7 +2115,7 @@ void WebProcessProxy::memoryPressureStatusChanged(SystemMemoryPressureStatus sta
     m_memoryPressureStatus = status;
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    if (RefPtr pool = m_processPool.get())
+    if (RefPtr pool = m_processPool)
         pool->memoryPressureStatusChangedForProcess(*this, status);
 #endif
 }
@@ -3013,7 +3002,7 @@ void WebProcessProxy::updateRuntimeStatistics()
     m_throttleStateForStatistics = newState;
     m_throttleStateForStatisticsTimestamp = newTimestamp;
 
-    if (RefPtr pool = m_processPool.get()) {
+    if (RefPtr pool = m_processPool) {
         if (pool->webProcessStateUpdatesForPageClientEnabled()) {
             for (Ref page : mainPages())
                 page->processDidUpdateThrottleState();
@@ -3126,7 +3115,7 @@ const WebCore::ProcessIdentity& WebProcessProxy::processIdentity()
 #if ENABLE(CONTENT_EXTENSIONS)
 void WebProcessProxy::requestResourceMonitorRuleLists(bool forTesting)
 {
-    if (RefPtr processPool = m_processPool.get()) {
+    if (RefPtr processPool = m_processPool) {
         m_resourceMonitorRuleListRequestedBySomePage = true;
 
         if (RefPtr ruleList = processPool->cachedResourceMonitorRuleList(forTesting))

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -298,7 +298,8 @@ public:
     bool isStandaloneSharedWorkerProcess() const { return isRunningSharedWorkers() && !pageCount(); }
     bool isRunningWorkers() const { return m_sharedWorkerInformation || m_serviceWorkerInformation; }
 
-    bool isDummyProcessProxy() const;
+    void markAsDummyProcessProxy() { m_isDummyProcessProxy = true; }
+    bool isDummyProcessProxy() const { return m_isDummyProcessProxy; }
 
     void didCreateWebPageInProcess(WebCore::PageIdentifier);
 
@@ -755,41 +756,9 @@ private:
     void sendMessageToInspector(WebCore::ServiceWorkerIdentifier, String&& message);
 #endif
 
-    enum class IsWeak : bool { No, Yes };
-    template<typename T> class WeakOrStrongPtr {
-    public:
-        WeakOrStrongPtr(T& object, IsWeak isWeak)
-            : m_isWeak(isWeak)
-            , m_weakObject(object)
-        {
-            updateStrongReference();
-        }
-
-        void setIsWeak(IsWeak isWeak)
-        {
-            m_isWeak = isWeak;
-            updateStrongReference();
-        }
-
-        T* get() const { return m_weakObject.get(); }
-        T* operator->() const { return m_weakObject.get(); }
-        T& operator*() const { return *m_weakObject; }
-        explicit operator bool() const { return !!m_weakObject; }
-
-    private:
-        void updateStrongReference()
-        {
-            m_strongObject = m_isWeak == IsWeak::Yes ? nullptr : m_weakObject.get();
-        }
-
-        IsWeak m_isWeak;
-        WeakPtr<T> m_weakObject;
-        RefPtr<T> m_strongObject;
-    };
-
     const UniqueRef<BackgroundProcessResponsivenessTimer> m_backgroundResponsivenessTimer;
     
-    WeakOrStrongPtr<WebProcessPool> m_processPool; // Pre-warmed and cached processes do not hold a strong reference to their pool.
+    WeakPtr<WebProcessPool> m_processPool; // The WebPageProxy objects are keeping the processPool alive via m_configuration.
 
     bool m_mayHaveUniversalFileReadSandboxExtension { false }; // True if a read extension for "/" was ever granted - we don't track whether WebProcess still has it.
     HashSet<String> m_localPathsWithAssumedReadAccess;
@@ -937,6 +906,7 @@ private:
 #endif
 
     bool m_isEligibleForWebProcessCache { true };
+    bool m_isDummyProcessProxy { false };
 
     HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
 


### PR DESCRIPTION
#### 10826e8cda77f0d313f1aa4ba1088c5efa4345af
<pre>
[WIP] Get rid of WeakOrStrongPtr type
<a href="https://bugs.webkit.org/show_bug.cgi?id=309148">https://bugs.webkit.org/show_bug.cgi?id=309148</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::~WebProcessPool):
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::WebProcessProxy):
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::setIsInProcessCache):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::markIsNoLongerInPrewarmedPool):
(WebKit::WebProcessProxy::maybeShutDown):
(WebKit::WebProcessProxy::memoryPressureStatusChanged):
(WebKit::WebProcessProxy::updateRuntimeStatistics):
(WebKit::WebProcessProxy::requestResourceMonitorRuleLists):
(WebKit::WebProcessProxy::isDummyProcessProxy const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10826e8cda77f0d313f1aa4ba1088c5efa4345af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101460 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/925e2dcf-e131-444f-b3fc-f890cbc1e730) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114132 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81383 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c45cb74-b2ff-46bd-b345-4b4c17578b69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16367 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132954 "Found 3 new API test failures: TestWebKitAPI.ElementFullscreen.RemoveFullscreenElementFromDOM, TestWebKitAPI.WKWebViewMacEditingTests.DoNotCrashWhenCallingTextInputClientMethodsWhileDeallocatingView, TestWebKitAPI.SOAuthorizationRedirect.InterceptionFailedWith307PUT (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94898 "Found 3 new API test failures: WPE/TestWebKitWebView:/webkit/WebKitWebView/close-quickly, WPE/TestWebKitWebView:/webkit/WebKitWebView/ephemeral, WPE/TestAutomationSession:/webkit/WebKitAutomationSession/request-session (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07fa3b61-7c2d-4e05-8d17-c0d2fe856cfc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15507 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13309 "Found 5 new API test failures: TestWebKitAPI.WKWebViewMacEditingTests.DoNotCrashWhenCallingTextInputClientMethodsWhileDeallocatingView, TestWebKitAPI.WKWebExtensionAPITabs.RemoveMultipleTabs, TestWebKitAPI.WKWebExtensionAPITabs.Remove, TestWebKitAPI.WKWebExtensionAPIWindows.RemovedEvent, TestWebKitAPI.WKWebExtensionAPITabs.ReplacedEvent (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4167 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125111 "Found 3 new API test failures: TestWebKitAPI.WKWebsiteDataStore.RemoveDataStoreWithIdentifier, TestWebKitAPI.WKWebsiteDataStore.RemoveSessionWithIdentifierFromNetworkProcess, TestWebKitAPI.SOAuthorizationRedirect.InterceptionFailedWith307PUT (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159063 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122163 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17247 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122377 "Found 2 new API test failures: WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly, WebKitGTK/TestAutomationSession:/webkit/WebKitAutomationSession/request-session (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76682 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9413 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83907 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19878 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->