### PR TITLE
Autoplay should not proceed before default text tracks finish loading

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/ready-states/autoplay-with-slow-text-tracks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/ready-states/autoplay-with-slow-text-tracks-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL autoplay with slow text tracks TypeError: null is not an object (evaluating 'track.track.cues.length')
+PASS autoplay with slow text tracks
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2615,6 +2615,17 @@ void HTMLMediaElement::textTrackModeChanged(TextTrack& track)
     // Mark this track as "configured" so configureTextTracks won't change the mode again.
     track.setHasBeenConfigured(true);
 
+    // If the track's mode changed from disabled to showing / hidden, and the ready state
+    // hasn't already advanced past HAVE_CURRENT_DATA, add it to the pending text tracks
+    // list so textTracksAreReady() blocks ready state advancement until this track
+    // finishes loading. Don't do this if the ready state has already advanced, as that
+    // would cause a readyState regression and re-fire canplaythrough.
+    if (track.mode() != TextTrack::Mode::Disabled && !m_textTracksWhenResourceSelectionBegan.contains(&track) && m_readyState < HAVE_FUTURE_DATA) {
+        m_textTracksWhenResourceSelectionBegan.append(track);
+        if (RefPtr player = m_player)
+            setReadyState(player->readyState());
+    }
+
     if (track.mode() != TextTrack::Mode::Disabled && trackIsLoaded)
         textTrackAddCues(track, *protect(track.cues()));
 


### PR DESCRIPTION
#### 82cb946ab2b3638c6f69793bf2d6c20e4a7a085e
<pre>
Autoplay should not proceed before default text tracks finish loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=309149">https://bugs.webkit.org/show_bug.cgi?id=309149</a>
<a href="https://rdar.apple.com/171699293">rdar://171699293</a>

Reviewed by Eric Carlson.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The HTML spec (4.8.11.7 Ready states [1]) defines HAVE_FUTURE_DATA as
requiring that &quot;the text tracks are ready&quot;. A media element should
therefore not reach HAVE_FUTURE_DATA (or HAVE_ENOUGH_DATA) and should
not autoplay until all text tracks whose mode was not Disabled when
resource selection began have a readiness state of Loaded or
FailedToLoad.

There is a race between the resource selection task (which captures
m_textTracksWhenResourceSelectionBegan) and the configureTextTracks
task (which sets default tracks to Showing). Because both are queued
tasks, resource selection runs first and sees the default track&apos;s mode
as Disabled, so it is never added to the pending list.
textTracksAreReady() then returns true vacuously and autoplay begins
before the VTT file loads.

Fix this by adding tracks to m_textTracksWhenResourceSelectionBegan in
textTrackModeChanged when their mode transitions from Disabled to
Showing/Hidden, but only while the ready state has not yet reached
HAVE_FUTURE_DATA. This ensures textTracksAreReady() blocks ready state
advancement until the track finishes loading, without causing a
readyState regression when a track is enabled after the media has
already fully loaded (which would otherwise re-fire canplaythrough).

[1] <a href="https://html.spec.whatwg.org/#dom-media-have_future_data">https://html.spec.whatwg.org/#dom-media-have_future_data</a>

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::textTrackModeChanged):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/ready-states/autoplay-with-slow-text-tracks-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/308796@main">https://commits.webkit.org/308796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd12907cdb1d04bb11dbbedc8921018bfe0413fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/559d191d-e65f-4959-8f7c-42d9630a314f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c99f335a-6517-47b7-8d07-d278eb579da4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95227 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37a515b6-1280-41df-8a2a-30ab6ce23378) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13613 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4595 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159492 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2626 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122518 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33374 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133002 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77120 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9762 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84361 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20362 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->