### PR TITLE
WKTR: make asyncMouse* events truly async

### DIFF
--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -60,12 +60,20 @@ public:
 
     void mouseDown(unsigned button, WKEventModifiers, WKStringRef pointerType = nullptr);
     void mouseUp(unsigned button, WKEventModifiers, WKStringRef pointerType = nullptr);
+    void mouseMoveTo(double x, double y, WKStringRef pointerType = nullptr);
+
+#if PLATFORM(MAC)
+    enum class EventDispatch : bool { Sync, Async };
+    void mouseDown(unsigned button, WKEventModifiers, EventDispatch, WKStringRef pointerType = nullptr);
+    void mouseUp(unsigned button, WKEventModifiers, EventDispatch, WKStringRef pointerType = nullptr);
+    void mouseMoveTo(double x, double y, EventDispatch, WKStringRef pointerType = nullptr);
+#endif
+
     void mouseForceDown();
     void mouseForceUp();
     void mouseForceChanged(float);
     void mouseForceClick();
     void startAndCancelMouseForceClick();
-    void mouseMoveTo(double x, double y, WKStringRef pointerType = nullptr);
     
     // Legacy wheel events.
     void mouseScrollBy(int x, int y);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2739,8 +2739,12 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         WKArrayAppendItem(array.get(), argument2);
         WKPagePostMessageToInjectedBundle(mainWebView()->page(), toWK("SetMousePosition").get(), array.get());
 
+#if PLATFORM(MAC)
+        m_eventSenderProxy->mouseMoveTo(x, y, EventSenderProxy::EventDispatch::Async, pointerType);
+#else
         m_eventSenderProxy->mouseMoveTo(x, y, pointerType);
         m_eventSenderProxy->waitForPendingMouseEvents();
+#endif
         completionHandler(nullptr);
         return;
     }
@@ -2750,8 +2754,12 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto array = arrayValue(argument2);
         const auto pointerType = stringValue(argument3);
 
+#if PLATFORM(MAC)
+        m_eventSenderProxy->mouseDown(button, parseModifierArray(array), EventSenderProxy::EventDispatch::Async, pointerType);
+#else
         m_eventSenderProxy->mouseDown(button, parseModifierArray(array), pointerType);
         m_eventSenderProxy->waitForPendingMouseEvents();
+#endif
         completionHandler(nullptr);
         return;
     }
@@ -2761,8 +2769,12 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto array = arrayValue(argument2);
         const auto pointerType = stringValue(argument3);
 
+#if PLATFORM(MAC)
+        m_eventSenderProxy->mouseUp(button, parseModifierArray(array), EventSenderProxy::EventDispatch::Async, pointerType);
+#else
         m_eventSenderProxy->mouseUp(button, parseModifierArray(array), pointerType);
         m_eventSenderProxy->waitForPendingMouseEvents();
+#endif
         completionHandler(nullptr);
         return;
     }

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -348,25 +348,42 @@ static NSInteger swizzledEventButtonNumber()
 
 void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType)
 {
+    mouseDown(buttonNumber, modifiers, EventDispatch::Sync, pointerType);
+}
+
+void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifiers, EventDispatch dispatch, WKStringRef pointerType)
+{
     auto button = WebCore::buttonFromShort(static_cast<int16_t>(buttonNumber));
     m_mouseButtonsCurrentlyDown.set(button, true);
     m_lastButtonDown = nsEventButtonNumberFromWebCoreMouseButton(button);
 
     updateClickCountForButton(buttonNumber);
 
-    NSEventType eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Down);
-    NSEvent *event = [NSEvent mouseEventWithType:eventType
-                                        location:NSMakePoint(m_position.x, m_position.y)
-                                   modifierFlags:buildModifierFlags(modifiers)
-                                       timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:m_clickCount 
-                                        pressure:WebCore::ForceAtClick];
+    auto eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Down);
+    RetainPtr event = [NSEvent mouseEventWithType:eventType
+                                         location:NSMakePoint(m_position.x, m_position.y)
+                                    modifierFlags:buildModifierFlags(modifiers)
+                                        timestamp:absoluteTimeForEventTime(currentEventTime())
+                                     windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+                                          context:[NSGraphicsContext currentContext]
+                                      eventNumber:++m_eventNumber
+                                       clickCount:m_clickCount
+                                         pressure:WebCore::ForceAtClick];
 
-    m_targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
-    if (m_targetView) {
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
+    if (!targetView)
+        return;
+
+    if (dispatch == EventDispatch::Async) {
+        if (button == WebCore::MouseButton::Left)
+            m_leftMouseButtonDown = true;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp _setCurrentEvent:event];
+            [targetView mouseDown:event];
+            [NSApp _setCurrentEvent:nil];
+        });
+    } else {
+        m_targetView = WTF::move(targetView);
         auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
         auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
         [NSApp _setCurrentEvent:event];
@@ -379,38 +396,53 @@ void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifie
 
 void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType)
 {
+    mouseUp(buttonNumber, modifiers, EventDispatch::Sync, pointerType);
+}
+
+void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers, EventDispatch dispatch, WKStringRef pointerType)
+{
     auto button = WebCore::buttonFromShort(static_cast<int16_t>(buttonNumber));
     m_mouseButtonsCurrentlyDown.set(button, false);
     m_lastButtonDown = nsEventButtonNumberFromWebCoreMouseButton(button);
 
-    NSEventType eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Up);
-    NSEvent *event = [NSEvent mouseEventWithType:eventType
-                                        location:NSMakePoint(m_position.x, m_position.y)
-                                   modifierFlags:buildModifierFlags(modifiers)
-                                       timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:m_clickCount 
-                                        pressure:0.0];
+    auto eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Up);
+    RetainPtr event = [NSEvent mouseEventWithType:eventType
+                                         location:NSMakePoint(m_position.x, m_position.y)
+                                    modifierFlags:buildModifierFlags(modifiers)
+                                        timestamp:absoluteTimeForEventTime(currentEventTime())
+                                     windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+                                          context:[NSGraphicsContext currentContext]
+                                      eventNumber:++m_eventNumber
+                                       clickCount:m_clickCount
+                                         pressure:0.0];
 
-    m_targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
     // FIXME: Silly hack to teach WKTR to respect capturing mouse events outside the WKView.
-    // The right solution is just to use NSApplication's built-in event sending methods, 
+    // The right solution is just to use NSApplication's built-in event sending methods,
     // instead of rolling our own algorithm for selecting an event target.
-    if (!m_targetView)
-        m_targetView = m_testController->mainWebView()->platformView();
+    if (!targetView)
+        targetView = m_testController->mainWebView()->platformView();
 
-    ASSERT(m_targetView);
-    auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
-    auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
-    [NSApp _setCurrentEvent:event];
-    [m_targetView mouseUp:event];
-    [NSApp _setCurrentEvent:nil];
     if (button == WebCore::MouseButton::Left)
         m_leftMouseButtonDown = false;
     m_clickTime = currentEventTime();
     m_clickPosition = m_position;
+
+    if (dispatch == EventDispatch::Async) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp _setCurrentEvent:event];
+            [targetView mouseUp:event];
+            [NSApp _setCurrentEvent:nil];
+        });
+    } else {
+        m_targetView = WTF::move(targetView);
+        ASSERT(m_targetView);
+        auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
+        auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
+        [NSApp _setCurrentEvent:event];
+        [m_targetView mouseUp:event];
+        [NSApp _setCurrentEvent:nil];
+    }
 }
 
 void EventSenderProxy::sendMouseDownToStartPressureEvents()
@@ -615,30 +647,49 @@ void EventSenderProxy::mouseForceChanged(float force)
 
 void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
 {
-    NSView *view = m_testController->mainWebView()->platformView();
-    NSPoint newMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];
-    bool isDrag = m_leftMouseButtonDown;
-    NSEvent *event = [NSEvent mouseEventWithType:(isDrag ? NSEventTypeLeftMouseDragged : NSEventTypeMouseMoved)
-                                        location:newMousePosition
-                                   modifierFlags:0 
-                                       timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:view.window.windowNumber
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:(m_leftMouseButtonDown ? m_clickCount : 0) 
-                                        pressure:0];
+    mouseMoveTo(x, y, EventDispatch::Sync, pointerType);
+}
 
-    CGEventRef cgEvent = event.CGEvent;
+void EventSenderProxy::mouseMoveTo(double x, double y, EventDispatch dispatch, WKStringRef pointerType)
+{
+    auto *view = m_testController->mainWebView()->platformView();
+    auto newMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];
+    auto isDrag = m_leftMouseButtonDown;
+    RetainPtr event = [NSEvent mouseEventWithType:(isDrag ? NSEventTypeLeftMouseDragged : NSEventTypeMouseMoved)
+                                         location:newMousePosition
+                                    modifierFlags:0
+                                        timestamp:absoluteTimeForEventTime(currentEventTime())
+                                     windowNumber:view.window.windowNumber
+                                          context:[NSGraphicsContext currentContext]
+                                      eventNumber:++m_eventNumber
+                                       clickCount:(m_leftMouseButtonDown ? m_clickCount : 0)
+                                         pressure:0];
+
+    auto cgEvent = event.get().CGEvent;
     CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaX, newMousePosition.x - m_position.x);
     CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaY, -1 * (newMousePosition.y - m_position.y));
     event = [NSEvent eventWithCGEvent:cgEvent];
     m_position.x = newMousePosition.x;
     m_position.y = newMousePosition.y;
 
-    NSPoint windowLocation = event.locationInWindow;
     // Always target drags at the WKWebView to allow for drag-scrolling outside the view.
-    m_targetView = isDrag ? m_testController->mainWebView()->platformView() : [m_testController->mainWebView()->platformView() hitTest:windowLocation];
-    if (m_targetView) {
+    RetainPtr<NSView> targetView = isDrag ? RetainPtr<NSView>(m_testController->mainWebView()->platformView()) : RetainPtr<NSView>([m_testController->mainWebView()->platformView() hitTest:newMousePosition]);
+    if (!targetView) {
+        WTFLogAlways("mouseMoveTo failed to find a target view at %f,%f\n", newMousePosition.x, newMousePosition.y);
+        return;
+    }
+
+    if (dispatch == EventDispatch::Async) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp _setCurrentEvent:event];
+            if (isDrag)
+                [targetView mouseDragged:event];
+            else
+                [checked_objc_cast<WKWebView>(targetView.get()) _simulateMouseMove:event];
+            [NSApp _setCurrentEvent:nil];
+        });
+    } else {
+        m_targetView = WTF::move(targetView);
         auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
         [NSApp _setCurrentEvent:event];
         if (isDrag)
@@ -646,8 +697,7 @@ void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
         else
             [checked_objc_cast<WKWebView>(m_targetView.get()) _simulateMouseMove:event];
         [NSApp _setCurrentEvent:nil];
-    } else
-        WTFLogAlways("mouseMoveTo failed to find a target view at %f,%f\n", windowLocation.x, windowLocation.y);
+    }
 }
 
 void EventSenderProxy::leapForward(int milliseconds)


### PR DESCRIPTION
#### 02c4418dda8b59c87642e1f0de70ebe3ecd706bd
<pre>
WKTR: make asyncMouse* events truly async
<a href="https://bugs.webkit.org/show_bug.cgi?id=309150">https://bugs.webkit.org/show_bug.cgi?id=309150</a>

Reviewed by NOBODY (OOPS!).

Draft to see the fallout.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02c4418dda8b59c87642e1f0de70ebe3ecd706bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148050 "22 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101463 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114135 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81382 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/285d75bd-7aa6-4413-8ccb-b5734b83c3f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bda6c8b-c17e-4a54-aa89-2664a0eabce1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15508 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13311 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4170 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159066 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12357 "Found 60 new test failures: fast/canvas/offscreen-clipped.html fast/css/hover-active-drag.html fast/css/resize-rtl.html fast/events/attribute-listener-deletion-crash.html fast/events/autoscroll-in-overflow-hidden-html.html fast/events/autoscroll-in-textarea.html fast/events/cancel-mousedown-and-drag-to-frame.html fast/events/capture-on-target.html fast/events/check-defocus-event-order-when-triggered-by-mouse-click.html fast/events/click-count.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122165 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17249 "Found 60 new test failures: compositing/iframes/layout-on-compositing-change.html fast/css/hover-active-drag.html fast/css/resize-rtl.html fast/events/attribute-listener-deletion-crash.html fast/events/autoscroll-in-overflow-hidden-html.html fast/events/autoscroll-in-textarea.html fast/events/cancel-mousedown-and-drag-to-frame.html fast/events/capture-on-target.html fast/events/check-defocus-event-order-when-triggered-by-mouse-click.html fast/events/click-count.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122379 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76685 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17823 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9416 "Found 60 new test failures: compositing/iframes/layout-on-compositing-change.html compositing/repaint/foreground-layer-change.html css3/filters/backdrop/backdrop-with-visibility-hidden-2.html fast/css/hover-active-drag.html fast/css/resize-rtl.html fast/events/attribute-listener-deletion-crash.html fast/events/autoscroll-in-overflow-hidden-html.html fast/events/cancel-mousedown-and-drag-to-frame.html fast/events/capture-on-target.html fast/events/check-defocus-event-order-when-triggered-by-mouse-click.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20151 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19881 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->