### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/page

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2069,13 +2069,15 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
     return createElementNS(namespaceURI, qualifiedName, { });
 }
 
-DocumentEventTiming* Document::documentEventTimingFromNavigationTiming()
+std::optional<DocumentEventTiming> Document::documentEventTimingFromNavigationTiming()
 {
     RefPtr window = this->window();
     if (!window)
-        return nullptr;
+        return std::nullopt;
     RefPtr navigationTiming = window->performance().navigationTiming();
-    return navigationTiming ? &navigationTiming->documentEventTiming() : nullptr;
+    if (!navigationTiming)
+        return std::nullopt;
+    return navigationTiming->documentEventTiming();
 }
 
 void Document::setReadyState(ReadyState readyState)
@@ -2088,7 +2090,7 @@ void Document::setReadyState(ReadyState readyState)
         if (!m_eventTiming.domLoading) {
             auto now = MonotonicTime::now();
             m_eventTiming.domLoading = now;
-            if (auto* eventTiming = documentEventTimingFromNavigationTiming())
+            if (auto eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domLoading = now;
             // We do this here instead of in the Document constructor because monotonicTimestamp() is 0 when the Document constructor is running.
             if (!url().isEmpty())
@@ -2100,7 +2102,7 @@ void Document::setReadyState(ReadyState readyState)
         if (!m_eventTiming.domComplete) {
             auto now = MonotonicTime::now();
             m_eventTiming.domComplete = now;
-            if (auto* eventTiming = documentEventTimingFromNavigationTiming())
+            if (auto eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domComplete = now;
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domComplete");
         }
@@ -2109,7 +2111,7 @@ void Document::setReadyState(ReadyState readyState)
         if (!m_eventTiming.domInteractive) {
             auto now = MonotonicTime::now();
             m_eventTiming.domInteractive = now;
-            if (auto* eventTiming = documentEventTimingFromNavigationTiming())
+            if (auto eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domInteractive = now;
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domInteractive");
         }
@@ -8307,7 +8309,7 @@ void Document::finishedParsing()
     if (!m_eventTiming.domContentLoadedEventStart) {
         auto now = MonotonicTime::now();
         m_eventTiming.domContentLoadedEventStart = now;
-        if (auto* eventTiming = documentEventTimingFromNavigationTiming())
+        if (auto eventTiming = documentEventTimingFromNavigationTiming())
             eventTiming->domContentLoadedEventStart = now;
         WTFEmitSignpost(this, NavigationAndPaintTiming, "domContentLoadedEventBegin");
     }
@@ -8323,7 +8325,7 @@ void Document::finishedParsing()
     if (!m_eventTiming.domContentLoadedEventEnd) {
         auto now = MonotonicTime::now();
         m_eventTiming.domContentLoadedEventEnd = now;
-        if (auto* eventTiming = documentEventTimingFromNavigationTiming())
+        if (auto eventTiming = documentEventTimingFromNavigationTiming())
             eventTiming->domContentLoadedEventEnd = now;
         WTFEmitSignpost(this, NavigationAndPaintTiming, "domContentLoadedEventEnd");
     }
@@ -11760,10 +11762,9 @@ NotificationClient* Document::notificationClient()
 
 GraphicsClient* Document::graphicsClient()
 {
-    RefPtr page = this->page();
-    if (!page)
-        return nullptr;
-    return &page->chrome();
+    if (auto* page = this->page())
+        return &page->chrome();
+    return nullptr;
 }
 
 std::optional<PAL::SessionID> Document::sessionID() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2140,7 +2140,7 @@ private:
     void createRenderTree();
     void detachParser();
 
-    DocumentEventTiming* documentEventTimingFromNavigationTiming();
+    std::optional<DocumentEventTiming> documentEventTimingFromNavigationTiming();
 
     // ScriptExecutionContext
     CSSFontSelector* cssFontSelector() final;

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -290,10 +290,9 @@ void ResourceLoader::setDefersLoading(bool defers)
 
 FrameLoader* ResourceLoader::frameLoader() const
 {
-    RefPtr frame = m_frame.get();
-    if (!frame)
-        return nullptr;
-    return &frame->loader();
+    if (m_frame)
+        return &m_frame->loader();
+    return nullptr;
 }
 
 void ResourceLoader::loadDataURL()

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -106,7 +106,7 @@ public:
     String primaryAudioTrackLanguageOverride() const;
 
     void setPreferredAudioCharacteristicsForTesting(const Vector<String>& characteristics) { m_preferredAudioCharacteristicsForTesting = characteristics; }
-    const Vector<String>& preferredAudioCharacteristicsForTesting() const { return m_preferredAudioCharacteristicsForTesting; }
+    const Vector<String>& preferredAudioCharacteristicsForTesting() const LIFETIME_BOUND { return m_preferredAudioCharacteristicsForTesting; }
 
     virtual bool testingMode() const { return m_testingModeCount; }
 

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -108,8 +108,8 @@ public:
     Chrome(Page&, UniqueRef<ChromeClient>&&);
     virtual ~Chrome();
 
-    ChromeClient& client() { return m_client; }
-    const ChromeClient& client() const { return m_client; }
+    ChromeClient& client() LIFETIME_BOUND { return m_client; }
+    const ChromeClient& client() const LIFETIME_BOUND { return m_client; }
 
     // HostWindow methods.
     void invalidateRootView(const IntRect&) override;

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -59,11 +59,11 @@ public:
 
     Type type() const { return m_type; }
 
-    const HitTestResult& hitTestResult() const { return m_hitTestResult; }
+    const HitTestResult& hitTestResult() const LIFETIME_BOUND { return m_hitTestResult; }
     Event* event() const { return m_event.get(); }
 
     void setSelectedText(const String& selectedText) { m_selectedText = selectedText; }
-    const String& selectedText() const { return m_selectedText; }
+    const String& selectedText() const LIFETIME_BOUND { return m_selectedText; }
 
     bool hasEntireImage() const { return m_hasEntireImage; }
     bool allowsFollowingLink() const { return m_allowsFollowingLink; }

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -51,9 +51,9 @@ public:
     ~ContextMenuController();
 
     Page& NODELETE page();
-    ContextMenuClient& client() { return m_client.get(); }
+    ContextMenuClient& client() LIFETIME_BOUND { return m_client.get(); }
 
-    ContextMenu* contextMenu() const { return m_contextMenu.get(); }
+    ContextMenu* contextMenu() const LIFETIME_BOUND { return m_contextMenu.get(); }
     WEBCORE_EXPORT void clearContextMenu();
 
     void handleContextMenuEvent(Event&);
@@ -67,13 +67,13 @@ public:
     WEBCORE_EXPORT void checkOrEnableIfNeeded(ContextMenuItem&) const;
 
     void setContextMenuContext(const ContextMenuContext& context) { m_context = context; }
-    const ContextMenuContext& context() const { return m_context; }
-    const HitTestResult& hitTestResult() const { return m_context.hitTestResult(); }
+    const ContextMenuContext& context() const LIFETIME_BOUND { return m_context; }
+    const HitTestResult& hitTestResult() const LIFETIME_BOUND { return m_context.hitTestResult(); }
 
 #if USE(ACCESSIBILITY_CONTEXT_MENUS)
     void showContextMenuAt(LocalFrame&, const IntPoint& clickPoint);
 #endif
-    
+
 #if ENABLE(SERVICE_CONTROLS)
     void showImageControlsMenu(Event&);
 #endif

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -103,7 +103,7 @@ class DOMWindow : public RefCounted<DOMWindow>, public EventTarget {
 public:
     virtual ~DOMWindow();
 
-    const GlobalWindowIdentifier& identifier() const { return m_identifier; }
+    const GlobalWindowIdentifier& identifier() const LIFETIME_BOUND { return m_identifier; }
     virtual Frame* NODELETE frame() const = 0;
 
     enum class DOMWindowType : bool { Local, Remote };

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -83,9 +83,9 @@ public:
     void setDidInitiateDrag(bool initiated) { m_didInitiateDrag = initiated; }
     bool didInitiateDrag() const { return m_didInitiateDrag; }
     OptionSet<DragOperation> sourceDragOperationMask() const { return m_sourceDragOperationMask; }
-    const URL& draggingImageURL() const { return m_draggingImageURL; }
+    const URL& draggingImageURL() const LIFETIME_BOUND { return m_draggingImageURL; }
     void setDragOffset(const IntPoint& offset) { m_dragOffset = offset; }
-    const IntPoint& dragOffset() const { return m_dragOffset; }
+    const IntPoint& dragOffset() const LIFETIME_BOUND { return m_dragOffset; }
     OptionSet<DragSourceAction> dragSourceAction() const { return m_dragSourceAction; }
     DragHandlingMethod dragHandlingMethod() const { return m_dragHandlingMethod; }
 
@@ -98,8 +98,8 @@ public:
 
     WEBCORE_EXPORT void placeDragCaret(const IntPoint&);
 
-    const Vector<Ref<HTMLImageElement>>& droppedImagePlaceholders() const { return m_droppedImagePlaceholders; }
-    const std::optional<SimpleRange>& droppedImagePlaceholderRange() const { return m_droppedImagePlaceholderRange; }
+    const Vector<Ref<HTMLImageElement>>& droppedImagePlaceholders() const LIFETIME_BOUND { return m_droppedImagePlaceholders; }
+    const std::optional<SimpleRange>& droppedImagePlaceholderRange() const LIFETIME_BOUND { return m_droppedImagePlaceholderRange; }
 
     WEBCORE_EXPORT void finalizeDroppedImagePlaceholder(HTMLImageElement&, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>& imageSizes);
@@ -145,7 +145,7 @@ private:
 #endif
     }
 
-    DragClient& client() const { return *m_client; }
+    DragClient& client() const LIFETIME_BOUND { return *m_client; }
 
     bool tryToUpdateDroppedImagePlaceholders(const DragData&);
     void removeAllDroppedImagePlaceholders();

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -273,7 +273,7 @@ public:
     bool dispatchTouchEvent(const PlatformTouchEvent&, const AtomString&, const EventTargetTouchArrayMap&, float, float);
     WEBCORE_EXPORT bool dispatchSimulatedTouchEvent(IntPoint location);
     Frame* touchEventTargetSubframe() const { return m_touchEventTargetSubframe.get(); }
-    const TouchArray& touches() const { return m_touches; }
+    const TouchArray& touches() const LIFETIME_BOUND { return m_touches; }
 #endif
 
 #if ENABLE(IOS_GESTURE_EVENTS)

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -63,7 +63,7 @@ public:
 
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    const String& url() const;
+    const String& url() const LIFETIME_BOUND;
     bool withCredentials() const;
 
     using State = short;
@@ -134,7 +134,7 @@ private:
     RefPtr<SecurityOrigin> m_eventStreamOrigin;
 };
 
-inline const String& EventSource::url() const
+inline const String& EventSource::url() const LIFETIME_BOUND
 {
     return m_url.string();
 }

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -81,7 +81,7 @@ public:
     const WindowProxy& windowProxy() const { return m_windowProxy; }
 
     DOMWindow* window() const { return virtualWindow(); }
-    FrameTree& tree() const { return m_treeNode; }
+    FrameTree& tree() const LIFETIME_BOUND { return m_treeNode; }
     WEBCORE_EXPORT std::optional<uint64_t> indexInFrameTreeSiblings() const;
     WEBCORE_EXPORT Vector<uint64_t> pathToFrame() const;
     FrameIdentifier frameID() const { return m_frameID; }
@@ -110,7 +110,7 @@ public:
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in FrameInlines.h.
 
     WEBCORE_EXPORT void disconnectOwnerElement();
-    NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
+    NavigationScheduler& navigationScheduler() const LIFETIME_BOUND { return m_navigationScheduler.get(); }
     WEBCORE_EXPORT void takeWindowProxyAndOpenerFrom(Frame&);
 
     virtual void frameDetached() = 0;

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -42,7 +42,7 @@ public:
 
     ~FrameTree();
 
-    const AtomString& specifiedName() const { return m_specifiedName; }
+    const AtomString& specifiedName() const LIFETIME_BOUND { return m_specifiedName; }
     WEBCORE_EXPORT AtomString uniqueName() const;
     WEBCORE_EXPORT void setSpecifiedName(const AtomString&);
     WEBCORE_EXPORT void clearName();

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -172,8 +172,9 @@ IntRect FrameView::scrollableAreaBoundingBox(bool*) const
 
 HostWindow* FrameView::hostWindow() const
 {
-    RefPtr page = frame().page();
-    return page ? &page->chrome() : nullptr;
+    if (auto* page = frame().page())
+        return &page->chrome();
+    return nullptr;
 }
 
 void FrameView::scrollbarStyleChanged(ScrollbarStyle newStyle, bool forceUpdate)

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -57,8 +57,8 @@ public:
     void setTotalStateObjectPayloadLimitOverride(std::optional<uint32_t> limit) { m_totalStateObjectPayloadLimitOverride = limit; }
 
     ExceptionOr<SerializedScriptValue*> state();
-    JSValueInWrappedObject& cachedState();
-    JSValueInWrappedObject& cachedStateForGC() { return m_cachedState; }
+    JSValueInWrappedObject& cachedState() LIFETIME_BOUND;
+    JSValueInWrappedObject& cachedStateForGC() LIFETIME_BOUND { return m_cachedState; }
 
     ExceptionOr<void> back();
     ExceptionOr<void> forward();

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -94,10 +94,10 @@ public:
     ContainerNode* root() const { return m_root.get(); }
     String rootMargin() const;
     String scrollMargin() const;
-    const IntersectionObserverMarginBox& rootMarginBox() const { return m_rootMargin; }
-    const IntersectionObserverMarginBox& scrollMarginBox() const { return m_scrollMargin; }
-    const Vector<double>& thresholds() const { return m_thresholds; }
-    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& observationTargets() const { return m_observationTargets; }
+    const IntersectionObserverMarginBox& rootMarginBox() const LIFETIME_BOUND { return m_rootMargin; }
+    const IntersectionObserverMarginBox& scrollMarginBox() const LIFETIME_BOUND { return m_scrollMargin; }
+    const Vector<double>& thresholds() const LIFETIME_BOUND { return m_thresholds; }
+    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& observationTargets() const LIFETIME_BOUND { return m_observationTargets; }
     bool hasObservationTargets() const { return m_observationTargets.size(); }
     bool isObserving(const Element&) const;
 

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -162,14 +162,14 @@ public:
     WEBCORE_EXPORT RefPtr<const LocalFrame> NODELETE localMainFrame() const;
     WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame();
 
-    inline Editor& editor(); // Defined in LocalFrameInlines.h
-    inline const Editor& editor() const; // Defined in LocalFrameInlines.h
+    inline Editor& editor() LIFETIME_BOUND; // Defined in LocalFrameInlines.h
+    inline const Editor& editor() const LIFETIME_BOUND; // Defined in LocalFrameInlines.h
 
     EventHandler& eventHandler() { return m_eventHandler; }
     const EventHandler& eventHandler() const { return m_eventHandler; }
 
-    const FrameLoader& loader() const { return m_loader.get(); }
-    FrameLoader& loader() { return m_loader.get(); }
+    const FrameLoader& loader() const LIFETIME_BOUND { return m_loader.get(); }
+    FrameLoader& loader() LIFETIME_BOUND { return m_loader.get(); }
 
     inline FrameSelection& selection(); // Defined in LocalFrameInlines.h
     inline const FrameSelection& selection() const; // Defined in LocalFrameInlines.h
@@ -228,8 +228,8 @@ public:
     void deviceOrPageScaleFactorChanged();
 
 #if ENABLE(DATA_DETECTION)
-    DataDetectionResultsStorage* dataDetectionResultsIfExists() const { return m_dataDetectionResults.get(); }
-    WEBCORE_EXPORT DataDetectionResultsStorage& dataDetectionResults();
+    DataDetectionResultsStorage* dataDetectionResultsIfExists() const LIFETIME_BOUND { return m_dataDetectionResults.get(); }
+    WEBCORE_EXPORT DataDetectionResultsStorage& dataDetectionResults() LIFETIME_BOUND;
 #endif
 
 #if PLATFORM(COCOA)
@@ -249,7 +249,7 @@ public:
 #endif // PLATFORM(COCOA)
 
 #if PLATFORM(IOS_FAMILY)
-    const ViewportArguments& viewportArguments() const;
+    const ViewportArguments& viewportArguments() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setViewportArguments(const ViewportArguments&);
 
     WEBCORE_EXPORT Node* deepestNodeAtLocation(const FloatPoint& viewportLocation);
@@ -391,7 +391,7 @@ private:
     void disconnectView() final;
     DOMWindow* NODELETE virtualWindow() const final;
     void reinitializeDocumentSecurityContext() final;
-    FrameLoaderClient& NODELETE loaderClient() final;
+    FrameLoaderClient& NODELETE loaderClient() LIFETIME_BOUND final;
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
 
     WeakHashSet<FrameDestructionObserver> m_destructionObservers;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -348,12 +348,12 @@ public:
     void removeSlowRepaintObject(RenderElement&);
     bool NODELETE hasSlowRepaintObject(const RenderElement& renderer) const;
     bool NODELETE hasSlowRepaintObjects() const;
-    SingleThreadWeakKeyHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
+    SingleThreadWeakKeyHashSet<RenderElement>* slowRepaintObjects() const LIFETIME_BOUND { return m_slowRepaintObjects.get(); }
 
     // Includes fixed- and sticky-position objects.
     void addViewportConstrainedObject(RenderLayerModelObject&);
     void removeViewportConstrainedObject(RenderLayerModelObject&);
-    const SingleThreadWeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
+    const SingleThreadWeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const LIFETIME_BOUND { return m_viewportConstrainedObjects.get(); }
     WEBCORE_EXPORT bool NODELETE hasViewportConstrainedObjects() const;
     bool hasAnchorPositionedViewportConstrainedObjects() const;
     void NODELETE clearCachedHasAnchorPositionedViewportConstrainedObjects();
@@ -580,7 +580,7 @@ public:
     WEBCORE_EXPORT void setTracksRepaints(bool);
     bool isTrackingRepaints() const { return m_isTrackingRepaints; }
     WEBCORE_EXPORT void resetTrackedRepaints();
-    const Vector<FloatRect>& trackedRepaintRects() const { return m_trackedRepaintRects; }
+    const Vector<FloatRect>& trackedRepaintRects() const LIFETIME_BOUND { return m_trackedRepaintRects; }
     String trackedRepaintRectsAsText() const;
 
     WEBCORE_EXPORT void NODELETE startTrackingLayoutUpdates();
@@ -594,11 +594,11 @@ public:
     // Returns whether the scrollable area has just been removed.
     WEBCORE_EXPORT bool removeScrollableArea(ScrollableArea*);
     bool NODELETE containsScrollableArea(ScrollableArea*) const;
-    const ScrollableAreaSet* scrollableAreas() const { return m_scrollableAreas.get(); }
+    const ScrollableAreaSet* scrollableAreas() const LIFETIME_BOUND { return m_scrollableAreas.get(); }
     
     void addScrollableAreaForAnimatedScroll(ScrollableArea*);
     void removeScrollableAreaForAnimatedScroll(ScrollableArea*);
-    const ScrollableAreaSet* scrollableAreasForAnimatedScroll() const { return m_scrollableAreasForAnimatedScroll.get(); }
+    const ScrollableAreaSet* scrollableAreasForAnimatedScroll() const LIFETIME_BOUND { return m_scrollableAreasForAnimatedScroll.get(); }
 
     WEBCORE_EXPORT void addChild(Widget&) final;
     WEBCORE_EXPORT void removeChild(Widget&) final;
@@ -616,7 +616,7 @@ public:
     // LocalFrameView. LocalFrameView::pagination() will return m_pagination if it has been set. Otherwise,
     // it will return Page::pagination() since currently there are no callers that need to
     // distinguish between the two.
-    const Pagination& pagination() const;
+    const Pagination& pagination() const LIFETIME_BOUND;
     void setPagination(const Pagination&);
 
 #if HAVE(RUBBER_BANDING)
@@ -666,7 +666,7 @@ public:
     void didAddWidgetToRenderTree(Widget&);
     void willRemoveWidgetFromRenderTree(Widget&);
 
-    const HashSet<SingleThreadWeakRef<Widget>>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
+    const HashSet<SingleThreadWeakRef<Widget>>& widgetsInRenderTree() const LIFETIME_BOUND { return m_widgetsInRenderTree; }
 
     void notifyAllFramesThatContentAreaWillPaint() const;
 
@@ -732,7 +732,7 @@ public:
     // overflow:hidden scrollable areas can participate in anchoring, so they need their own set.
     void addScrollableAreaForScrollAnchoring(ScrollableArea&);
     void removeScrollableAreaForScrollAnchoring(ScrollableArea&);
-    const ScrollableAreaSet* scrollableAreasForScrollAnchoring() const { return m_anchoringScrollableAreas.get(); }
+    const ScrollableAreaSet* scrollableAreasForScrollAnchoring() const LIFETIME_BOUND { return m_anchoringScrollableAreas.get(); }
 
     void dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
     void queueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -137,7 +137,7 @@ public:
     // Returns true if a pending compositing layer update was done.
     bool updateCompositingLayersAfterLayoutIfNeeded();
 
-    RenderLayoutState* NODELETE layoutState() const PURE_FUNCTION;
+    RenderLayoutState* NODELETE layoutState() const LIFETIME_BOUND PURE_FUNCTION;
     // Returns true if layoutState should be used for its cached offset and clip.
     bool isPaintOffsetCacheEnabled() const { return !m_paintOffsetCacheDisableCount && layoutState(); }
 #ifndef NDEBUG
@@ -153,8 +153,8 @@ public:
 #endif
     using LayoutStateStack = Vector<std::unique_ptr<RenderLayoutState>>;
 
-    UpdateScrollInfoAfterLayoutTransaction& updateScrollInfoAfterLayoutTransaction();
-    UpdateScrollInfoAfterLayoutTransaction* updateScrollInfoAfterLayoutTransactionIfExists() { return m_updateScrollInfoAfterLayoutTransaction.get(); }
+    UpdateScrollInfoAfterLayoutTransaction& updateScrollInfoAfterLayoutTransaction() LIFETIME_BOUND;
+    UpdateScrollInfoAfterLayoutTransaction* updateScrollInfoAfterLayoutTransactionIfExists() LIFETIME_BOUND { return m_updateScrollInfoAfterLayoutTransaction.get(); }
     void setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox&, RenderBlock& container);
     Vector<SingleThreadWeakPtr<RenderBox>> takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock&);
 
@@ -167,8 +167,8 @@ public:
     bool addToDetachedRendererList(RenderPtr<RenderObject>&& renderer) const { return m_detachedRendererList.append(WTF::move(renderer)); }
     void deleteDetachedRenderersNow() const { m_detachedRendererList.clear(); }
 
-    Vector<AnchorScrollAdjuster>& anchorScrollAdjusters() { return m_anchorScrollAdjusters; }
-    const AnchorScrollAdjuster* anchorScrollAdjusterFor(const RenderBox& anchored) const;
+    Vector<AnchorScrollAdjuster>& anchorScrollAdjusters() LIFETIME_BOUND { return m_anchorScrollAdjusters; }
+    const AnchorScrollAdjuster* anchorScrollAdjusterFor(const RenderBox& anchored) const LIFETIME_BOUND;
     AnchorScrollAdjuster::Diff registerAnchorScrollAdjuster(AnchorScrollAdjuster&&);
     void unregisterAnchorScrollAdjusterFor(const RenderBox& anchored);
     void invalidateAnchorDependenciesForScroller(const RenderBox& scroller);

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -76,7 +76,7 @@ public:
 
     DOMWindow* window() { return m_window.get(); }
 
-    const URL& url() const;
+    const URL& url() const LIFETIME_BOUND;
 
 private:
     explicit Location(DOMWindow&);

--- a/Source/WebCore/page/LoginStatus.h
+++ b/Source/WebCore/page/LoginStatus.h
@@ -56,8 +56,8 @@ public:
     WEBCORE_EXPORT bool hasExpired() const;
     WEBCORE_EXPORT WallTime expiry() const;
 
-    const RegistrableDomain& domain() const { return m_domain; }
-    const String& username() const { return m_username; }
+    const RegistrableDomain& domain() const LIFETIME_BOUND { return m_domain; }
+    const String& username() const LIFETIME_BOUND { return m_username; }
     CredentialTokenType tokenType() const { return m_tokenType; }
     AuthenticationType authType() const { return m_authType; }
     WallTime loggedInTime() const { return m_loggedInTime; }

--- a/Source/WebCore/page/MouseEventWithHitTestResults.h
+++ b/Source/WebCore/page/MouseEventWithHitTestResults.h
@@ -31,8 +31,8 @@ class MouseEventWithHitTestResults {
 public:
     MouseEventWithHitTestResults(const PlatformMouseEvent&, const HitTestResult&);
 
-    const PlatformMouseEvent& event() const { return m_event; }
-    const HitTestResult& hitTestResult() const { return m_hitTestResult; }
+    const PlatformMouseEvent& event() const LIFETIME_BOUND { return m_event; }
+    const HitTestResult& hitTestResult() const LIFETIME_BOUND { return m_hitTestResult; }
     LayoutPoint localPoint() const { return m_hitTestResult.localPoint(); }
     Scrollbar* scrollbar() const { return m_hitTestResult.scrollbar(); }
     bool isOverLink() const;

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -102,7 +102,7 @@ public:
     DOMFormData* formData() { return m_formData.get(); }
     String downloadRequest() { return m_downloadRequest; }
     JSC::JSValue info() { return m_info.getValue(); }
-    JSValueInWrappedObject& infoWrapper() { return m_info; }
+    JSValueInWrappedObject& infoWrapper() LIFETIME_BOUND { return m_info; }
     Element* sourceElement() { return m_sourceElement.get(); }
 
     ExceptionOr<void> intercept(Document&, NavigationInterceptOptions&&);
@@ -113,7 +113,7 @@ public:
 
     void finish(Document&, InterceptionHandlersDidFulfill, FocusDidChange);
 
-    Vector<Ref<NavigationInterceptHandler>>& handlers() { return m_handlers; }
+    Vector<Ref<NavigationInterceptHandler>>& handlers() LIFETIME_BOUND { return m_handlers; }
 
 private:
     NavigateEvent(const AtomString& type, Init&&, EventIsTrusted, AbortController*);

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -131,7 +131,7 @@ public:
         RefPtr<DOMPromise> finished;
     };
 
-    const Vector<Ref<NavigationHistoryEntry>>& entries() const;
+    const Vector<Ref<NavigationHistoryEntry>>& entries() const LIFETIME_BOUND;
     NavigationHistoryEntry* currentEntry() const;
     NavigationTransition* transition() { return m_transition.get(); };
     NavigationActivation* activation() { return m_activation.get(); };
@@ -233,7 +233,7 @@ public:
     };
 
     // Testing support
-    RateLimiter& rateLimiterForTesting() { return m_rateLimiter; }
+    RateLimiter& rateLimiterForTesting() LIFETIME_BOUND { return m_rateLimiter; }
 
     NavigateEvent* ongoingNavigateEvent() { return m_ongoingNavigateEvent.get(); } // This may get called on a GC thread.
     bool hasInterceptedOngoingNavigateEvent() const { return m_ongoingNavigateEvent && m_ongoingNavigateEvent->wasIntercepted(); }

--- a/Source/WebCore/page/NavigationDestination.h
+++ b/Source/WebCore/page/NavigationDestination.h
@@ -44,7 +44,7 @@ public:
 
     ~NavigationDestination();
 
-    const URL& url() const { return m_url; };
+    const URL& url() const LIFETIME_BOUND { return m_url; };
     String key() const { return m_entry ? m_entry->key() : String(); };
     String id() const { return m_entry ? m_entry->id() : String(); };
     int64_t index() const { return m_entry ? m_entry->index() : -1; };

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -56,7 +56,7 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    const String& url() const;
+    const String& url() const LIFETIME_BOUND;
     String key() const;
     String id() const;
     uint64_t index() const;

--- a/Source/WebCore/page/OriginAccessEntry.h
+++ b/Source/WebCore/page/OriginAccessEntry.h
@@ -52,8 +52,8 @@ public:
     OriginAccessEntry(const String& protocol, const String& host, SubdomainSetting, IPAddressSetting);
     bool matchesOrigin(const SecurityOrigin&) const;
 
-    const String& protocol() const { return m_protocol; }
-    const String& host() const { return m_host; }
+    const String& protocol() const LIFETIME_BOUND { return m_protocol; }
+    const String& host() const LIFETIME_BOUND { return m_host; }
     SubdomainSetting subdomainSettings() const { return m_subdomainSettings; }
     IPAddressSetting ipAddressSettings() const { return m_ipAddressSettings; }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -405,7 +405,7 @@ public:
 
     WEBCORE_EXPORT void reloadExecutionContextsForOrigin(const ClientOrigin&, std::optional<FrameIdentifier> triggeringFrame) const;
 
-    const ViewportArguments* overrideViewportArguments() const { return m_overrideViewportArguments.get(); }
+    const ViewportArguments* overrideViewportArguments() const LIFETIME_BOUND { return m_overrideViewportArguments.get(); }
     WEBCORE_EXPORT void setOverrideViewportArguments(const std::optional<ViewportArguments>&);
 
     static void refreshPlugins(bool reload);
@@ -424,7 +424,7 @@ public:
 
     Frame& mainFrame() const { return m_mainFrame.get(); }
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
-    WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const;
+    WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const LIFETIME_BOUND;
     SecurityOrigin& mainFrameOrigin() const;
     WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
 
@@ -454,14 +454,14 @@ public:
     bool openedByDOMWithOpener() const { return m_openedByDOMWithOpener; }
     void setOpenedByDOMWithOpener(bool value) { m_openedByDOMWithOpener = value; }
 
-    const RegistrableDomain& openedByScriptDomain() const { return m_openedByScriptDomain; }
+    const RegistrableDomain& openedByScriptDomain() const LIFETIME_BOUND { return m_openedByScriptDomain; }
     void setOpenedByScriptDomain(RegistrableDomain&& domain) { m_openedByScriptDomain = WTF::move(domain); }
 
     WEBCORE_EXPORT void goToItem(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
     void goToItemForNavigationAPI(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, LocalFrame& triggeringFrame, NavigationAPIMethodTracker*);
 
     WEBCORE_EXPORT void setGroupName(const String&);
-    WEBCORE_EXPORT const String& NODELETE groupName() const;
+    WEBCORE_EXPORT const String& NODELETE groupName() const LIFETIME_BOUND;
 
     WEBCORE_EXPORT PageGroup& group();
 
@@ -481,29 +481,29 @@ public:
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const;
 
-    Chrome& chrome() { return m_chrome.get(); }
-    const Chrome& chrome() const { return m_chrome.get(); }
-    CryptoClient& cryptoClient() { return m_cryptoClient.get(); }
-    const CryptoClient& cryptoClient() const { return m_cryptoClient.get(); }
-    DocumentSyncClient& documentSyncClient() { return m_documentSyncClient.get(); }
-    const DocumentSyncClient& documentSyncClient() const { return m_documentSyncClient.get(); }
-    DragCaretController& dragCaretController() { return m_dragCaretController.get(); }
-    const DragCaretController& dragCaretController() const { return m_dragCaretController.get(); }
+    Chrome& chrome() LIFETIME_BOUND { return m_chrome.get(); }
+    const Chrome& chrome() const LIFETIME_BOUND { return m_chrome.get(); }
+    CryptoClient& cryptoClient() LIFETIME_BOUND { return m_cryptoClient.get(); }
+    const CryptoClient& cryptoClient() const LIFETIME_BOUND { return m_cryptoClient.get(); }
+    DocumentSyncClient& documentSyncClient() LIFETIME_BOUND { return m_documentSyncClient.get(); }
+    const DocumentSyncClient& documentSyncClient() const LIFETIME_BOUND { return m_documentSyncClient.get(); }
+    DragCaretController& dragCaretController() LIFETIME_BOUND { return m_dragCaretController.get(); }
+    const DragCaretController& dragCaretController() const LIFETIME_BOUND { return m_dragCaretController.get(); }
 #if ENABLE(DRAG_SUPPORT)
-    DragController& dragController() { return m_dragController.get(); }
-    const DragController& dragController() const { return m_dragController.get(); }
+    DragController& dragController() LIFETIME_BOUND { return m_dragController.get(); }
+    const DragController& dragController() const LIFETIME_BOUND { return m_dragController.get(); }
 #endif
     FocusController& focusController() const { return m_focusController; }
 #if ENABLE(CONTEXT_MENUS)
-    ContextMenuController& contextMenuController() { return m_contextMenuController.get(); }
-    const ContextMenuController& contextMenuController() const { return m_contextMenuController.get(); }
+    ContextMenuController& contextMenuController() LIFETIME_BOUND { return m_contextMenuController.get(); }
+    const ContextMenuController& contextMenuController() const LIFETIME_BOUND { return m_contextMenuController.get(); }
 #endif
     PageInspectorController& inspectorController() { return m_inspectorController.get(); }
-    PointerCaptureController& pointerCaptureController() { return m_pointerCaptureController.get(); }
+    PointerCaptureController& pointerCaptureController() LIFETIME_BOUND { return m_pointerCaptureController.get(); }
 #if ENABLE(POINTER_LOCK)
-    PointerLockController& pointerLockController() { return m_pointerLockController.get(); }
+    PointerLockController& pointerLockController() LIFETIME_BOUND { return m_pointerLockController.get(); }
 #endif
-    WebRTCProvider& webRTCProvider() { return m_webRTCProvider.get(); }
+    WebRTCProvider& webRTCProvider() LIFETIME_BOUND { return m_webRTCProvider.get(); }
     RTCController& rtcController() { return m_rtcController.get(); }
     WEBCORE_EXPORT void disableICECandidateFiltering();
     WEBCORE_EXPORT void enableICECandidateFiltering();
@@ -512,9 +512,9 @@ public:
     void didChangeMainDocument(Document* newDocument);
     void mainFrameDidChangeToNonInitialEmptyDocument();
 
-    PerformanceMonitor* performanceMonitor() { return m_performanceMonitor.get(); }
+    PerformanceMonitor* performanceMonitor() LIFETIME_BOUND { return m_performanceMonitor.get(); }
 
-    ValidationMessageClient* validationMessageClient() const { return m_validationMessageClient.get(); }
+    ValidationMessageClient* validationMessageClient() const LIFETIME_BOUND { return m_validationMessageClient.get(); }
     void updateValidationBubbleStateIfNeeded();
     void scheduleValidationMessageUpdate(ValidatedFormListedElement&, HTMLElement&);
 
@@ -587,12 +587,12 @@ public:
     void platformInitialize();
     WEBCORE_EXPORT void addSchedulePair(Ref<WTF::SchedulePair>&&);
     WEBCORE_EXPORT void removeSchedulePair(Ref<WTF::SchedulePair>&&);
-    WTF::SchedulePairHashSet* scheduledRunLoopPairs() { return m_scheduledRunLoopPairs.get(); }
+    WTF::SchedulePairHashSet* scheduledRunLoopPairs() LIFETIME_BOUND { return m_scheduledRunLoopPairs.get(); }
 
     std::unique_ptr<WTF::SchedulePairHashSet> m_scheduledRunLoopPairs;
 #endif
 
-    WEBCORE_EXPORT const VisibleSelection& selection() const;
+    WEBCORE_EXPORT const VisibleSelection& selection() const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setDefersLoading(bool);
     bool defersLoading() const { return m_defersLoading; }
@@ -652,21 +652,21 @@ public:
     WEBCORE_EXPORT std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond(OptionSet<PreferredRenderingUpdateOption> = allPreferredRenderingUpdateOptions) const;
     WEBCORE_EXPORT Seconds preferredRenderingUpdateInterval() const;
 
-    const FloatBoxExtent& contentInsets() const { return m_contentInsets; }
+    const FloatBoxExtent& contentInsets() const LIFETIME_BOUND { return m_contentInsets; }
     void setContentInsets(const FloatBoxExtent& insets) { m_contentInsets = insets; }
 
-    const FloatBoxExtent& unobscuredSafeAreaInsets() const { return m_unobscuredSafeAreaInsets; }
+    const FloatBoxExtent& unobscuredSafeAreaInsets() const LIFETIME_BOUND { return m_unobscuredSafeAreaInsets; }
     WEBCORE_EXPORT void setUnobscuredSafeAreaInsets(const FloatBoxExtent&);
 
 #if PLATFORM(IOS_FAMILY)
     bool enclosedInScrollableAncestorView() const { return m_enclosedInScrollableAncestorView; }
     void setEnclosedInScrollableAncestorView(bool f) { m_enclosedInScrollableAncestorView = f; }
 
-    const FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
+    const FloatBoxExtent& obscuredInsets() const LIFETIME_BOUND { return m_obscuredInsets; }
     WEBCORE_EXPORT void setObscuredInsets(const FloatBoxExtent&);
 #endif
 
-    const FloatBoxExtent& obscuredContentInsets() const { return m_obscuredContentInsets; }
+    const FloatBoxExtent& obscuredContentInsets() const LIFETIME_BOUND { return m_obscuredContentInsets; }
     WEBCORE_EXPORT void setObscuredContentInsets(const FloatBoxExtent&);
 
 #if ENABLE(BANNER_VIEW_OVERLAYS)
@@ -690,7 +690,7 @@ public:
 
     OptionSet<FilterRenderingMode> preferredFilterRenderingModes(const GraphicsContext&) const;
 
-    const FloatBoxExtent& fullscreenInsets() const { return m_fullscreenInsets; }
+    const FloatBoxExtent& fullscreenInsets() const LIFETIME_BOUND { return m_fullscreenInsets; }
     WEBCORE_EXPORT void setFullscreenInsets(const FloatBoxExtent&);
 
     const Seconds fullscreenAutoHideDuration() const { return m_fullscreenAutoHideDuration; }
@@ -719,7 +719,7 @@ public:
     // and FrameView::pagination() is set only by CSS. Page::pagination() will affect all
     // FrameViews in the back/forward cache, but FrameView::pagination() only affects the current
     // FrameView.
-    const Pagination& pagination() const { return m_pagination; }
+    const Pagination& pagination() const LIFETIME_BOUND { return m_pagination; }
     WEBCORE_EXPORT void setPagination(const Pagination&);
 
     WEBCORE_EXPORT unsigned pageCount() const;
@@ -729,16 +729,16 @@ public:
 
     WEBCORE_EXPORT void logMediaDiagnosticMessage(const RefPtr<FormData>&) const;
 
-    PerformanceLoggingClient* performanceLoggingClient() const { return m_performanceLoggingClient.get(); }
+    PerformanceLoggingClient* performanceLoggingClient() const LIFETIME_BOUND { return m_performanceLoggingClient.get(); }
 
-    WheelEventDeltaFilter* wheelEventDeltaFilter() { return m_recentWheelEventDeltaFilter.get(); }
-    PageOverlayController& pageOverlayController() { return m_pageOverlayController; }
+    WheelEventDeltaFilter* wheelEventDeltaFilter() LIFETIME_BOUND { return m_recentWheelEventDeltaFilter.get(); }
+    PageOverlayController& pageOverlayController() LIFETIME_BOUND { return m_pageOverlayController; }
 
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
-    ServicesOverlayController& servicesOverlayController() { return m_servicesOverlayController.get(); }
+    ServicesOverlayController& servicesOverlayController() LIFETIME_BOUND { return m_servicesOverlayController.get(); }
 #endif
-    ImageOverlayController& imageOverlayController();
-    ImageOverlayController* imageOverlayControllerIfExists() { return m_imageOverlayController.get(); }
+    ImageOverlayController& imageOverlayController() LIFETIME_BOUND;
+    ImageOverlayController* imageOverlayControllerIfExists() LIFETIME_BOUND { return m_imageOverlayController.get(); }
 
 #if ENABLE(IMAGE_ANALYSIS)
     WEBCORE_EXPORT ImageAnalysisQueue& imageAnalysisQueue();
@@ -746,8 +746,8 @@ public:
 #endif
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
-    ScrollLatchingController& scrollLatchingController();
-    ScrollLatchingController* scrollLatchingControllerIfExists() { return m_scrollLatchingController.get(); }
+    ScrollLatchingController& scrollLatchingController() LIFETIME_BOUND;
+    ScrollLatchingController* scrollLatchingControllerIfExists() LIFETIME_BOUND { return m_scrollLatchingController.get(); }
 #endif // ENABLE(WHEEL_EVENT_LATCHING)
 
 #if ENABLE(APPLE_PAY)
@@ -766,12 +766,12 @@ public:
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    AuthenticatorCoordinator& authenticatorCoordinator() { return m_authenticatorCoordinator.get(); }
+    AuthenticatorCoordinator& authenticatorCoordinator() LIFETIME_BOUND { return m_authenticatorCoordinator.get(); }
     CredentialRequestCoordinator& credentialRequestCoordinator() { return m_credentialRequestCoordinator.get(); }
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
-    const std::optional<ApplicationManifest>& applicationManifest() const { return m_applicationManifest; }
+    const std::optional<ApplicationManifest>& applicationManifest() const LIFETIME_BOUND { return m_applicationManifest; }
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
@@ -857,7 +857,7 @@ public:
 #endif
 
     void userStyleSheetLocationChanged();
-    const String& userStyleSheet() const;
+    const String& userStyleSheet() const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void userAgentChanged();
 
@@ -868,7 +868,7 @@ public:
 #endif
 
     void setDebugger(JSC::Debugger*);
-    JSC::Debugger* debugger() const { return m_debugger; }
+    JSC::Debugger* debugger() const LIFETIME_BOUND { return m_debugger; }
 
     WEBCORE_EXPORT void invalidateStylesForAllLinks();
     WEBCORE_EXPORT void invalidateStylesForLink(SharedStringHash);
@@ -879,7 +879,7 @@ public:
     double NODELETE customHTMLTokenizerTimeDelay() const;
 
     WEBCORE_EXPORT void setCORSDisablingPatterns(Vector<UserContentURLPattern>&&);
-    const Vector<UserContentURLPattern>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
+    const Vector<UserContentURLPattern>& corsDisablingPatterns() const LIFETIME_BOUND { return m_corsDisablingPatterns; }
     WEBCORE_EXPORT void addCORSDisablingPatternForTesting(UserContentURLPattern&&);
 
     WEBCORE_EXPORT void setMemoryCacheClientCallsEnabled(bool);
@@ -919,7 +919,7 @@ public:
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
     WEBCORE_EXPORT void updateFixedContainerEdges(EnumSet<BoxSide>);
-    const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdgesAndElements.first; }
+    const FixedContainerEdges& fixedContainerEdges() const LIFETIME_BOUND { return m_fixedContainerEdgesAndElements.first; }
     Element* NODELETE lastFixedContainer(BoxSide) const;
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
@@ -1125,7 +1125,7 @@ public:
     WEBCORE_EXPORT void NODELETE applicationWillEnterForeground();
     WEBCORE_EXPORT void applicationDidBecomeActive();
 
-    PerformanceLogging& performanceLogging() const { return m_performanceLogging; }
+    PerformanceLogging& performanceLogging() const LIFETIME_BOUND { return m_performanceLogging; }
 
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
 
@@ -1156,7 +1156,7 @@ public:
 
     bool shouldDisableCorsForRequestTo(const URL&) const;
     bool shouldAssumeSameSiteForRequestTo(const URL& url) const { return shouldDisableCorsForRequestTo(url); }
-    const HashSet<String>& maskedURLSchemes() const { return m_maskedURLSchemes; }
+    const HashSet<String>& maskedURLSchemes() const LIFETIME_BOUND { return m_maskedURLSchemes; }
 
     WEBCORE_EXPORT void injectUserStyleSheet(UserStyleSheet&);
     WEBCORE_EXPORT void removeInjectedUserStyleSheet(UserStyleSheet&);
@@ -1195,7 +1195,7 @@ public:
     void updateScreenSupportedContentsFormats();
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    AttachmentElementClient* attachmentElementClient() { return m_attachmentElementClient.get(); }
+    AttachmentElementClient* attachmentElementClient() LIFETIME_BOUND { return m_attachmentElementClient.get(); }
 #endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -1226,7 +1226,7 @@ public:
     void NODELETE willBeginScrolling();
     void NODELETE didFinishScrolling();
 
-    const HashSet<WeakRef<LocalFrame>>& rootFrames() const { return m_rootFrames; }
+    const HashSet<WeakRef<LocalFrame>>& rootFrames() const LIFETIME_BOUND { return m_rootFrames; }
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
     WEBCORE_EXPORT void removeRootFrame(LocalFrame&);
 
@@ -1241,7 +1241,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT void setSceneIdentifier(String&&);
 #endif
-    WEBCORE_EXPORT const String& NODELETE sceneIdentifier() const;
+    WEBCORE_EXPORT const String& NODELETE sceneIdentifier() const LIFETIME_BOUND;
 
     std::optional<std::pair<uint16_t, uint16_t>> NODELETE portsForUpgradingInsecureSchemeForTesting() const;
     WEBCORE_EXPORT void NODELETE setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
@@ -1307,7 +1307,7 @@ public:
 #endif
 
     void setLastAuthentication(LoginStatusAuthenticationType);
-    const LoginStatus* lastAuthentication() const { return m_lastAuthentication.get(); }
+    const LoginStatus* lastAuthentication() const LIFETIME_BOUND { return m_lastAuthentication.get(); }
 
 #if ENABLE(FULLSCREEN_API)
     WEBCORE_EXPORT bool NODELETE isDocumentFullscreenEnabled() const;
@@ -1335,12 +1335,12 @@ public:
     ProcessID presentingApplicationPID() const;
 
 #if HAVE(AUDIT_TOKEN)
-    const std::optional<audit_token_t>& NODELETE presentingApplicationAuditToken() const;
+    const std::optional<audit_token_t>& NODELETE presentingApplicationAuditToken() const LIFETIME_BOUND;
     WEBCORE_EXPORT void NODELETE setPresentingApplicationAuditToken(std::optional<audit_token_t>);
 #endif
 
 #if PLATFORM(COCOA)
-    const String& presentingApplicationBundleIdentifier() const;
+    const String& presentingApplicationBundleIdentifier() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setPresentingApplicationBundleIdentifier(String&&);
 #endif
 
@@ -1382,8 +1382,8 @@ public:
 #endif
 
 #if ENABLE(THREADED_ANIMATIONS)
-    AcceleratedTimelinesUpdater* acceleratedTimelinesUpdater() const { return m_acceleratedTimelinesUpdater.get(); }
-    AcceleratedTimelinesUpdater& ensureAcceleratedTimelinesUpdater();
+    AcceleratedTimelinesUpdater* acceleratedTimelinesUpdater() const LIFETIME_BOUND { return m_acceleratedTimelinesUpdater.get(); }
+    AcceleratedTimelinesUpdater& ensureAcceleratedTimelinesUpdater() LIFETIME_BOUND;
 #endif
 
     void syncLocalFrameInfoToRemote();
@@ -1436,8 +1436,8 @@ private:
     void scheduleRenderingUpdateInternal();
     void prioritizeVisibleResources();
 
-    RenderingUpdateScheduler& renderingUpdateScheduler();
-    RenderingUpdateScheduler* NODELETE existingRenderingUpdateScheduler();
+    RenderingUpdateScheduler& renderingUpdateScheduler() LIFETIME_BOUND;
+    RenderingUpdateScheduler* NODELETE existingRenderingUpdateScheduler() LIFETIME_BOUND;
 
     WheelEventTestMonitor& ensureWheelEventTestMonitor();
 

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -50,12 +50,12 @@ public:
 
     WEBCORE_EXPORT static PageGroup* pageGroup(const String& groupName);
 
-    const WeakHashSet<Page>& pages() const { return m_pages; }
+    const WeakHashSet<Page>& pages() const LIFETIME_BOUND { return m_pages; }
 
     void addPage(Page&);
     void removePage(Page&);
 
-    const String& name() { return m_name; }
+    const String& name() LIFETIME_BOUND { return m_name; }
     unsigned identifier() { return m_identifier; }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -78,7 +78,7 @@ public:
     WEBCORE_EXPORT static Ref<PageOverlay> create(PageOverlayClient&, OverlayType = OverlayType::View, AlwaysTileOverlayLayer = AlwaysTileOverlayLayer::No);
     WEBCORE_EXPORT ~PageOverlay();
 
-    WEBCORE_EXPORT PageOverlayController* NODELETE controller() const;
+    WEBCORE_EXPORT PageOverlayController* NODELETE controller() const LIFETIME_BOUND;
 
     typedef uint64_t PageOverlayID;
     PageOverlayID pageOverlayID() const { return m_pageOverlayID; }
@@ -102,7 +102,7 @@ public:
 
     WEBCORE_EXPORT void clear();
 
-    PageOverlayClient& client() const { return m_client; }
+    PageOverlayClient& client() const LIFETIME_BOUND { return m_client; }
 
     enum class FadeMode : bool { DoNotFade, Fade };
 
@@ -115,7 +115,7 @@ public:
 
     WEBCORE_EXPORT IntSize viewToOverlayOffset() const;
 
-    const Color& backgroundColor() const { return m_backgroundColor; }
+    const Color& backgroundColor() const LIFETIME_BOUND { return m_backgroundColor; }
     void setBackgroundColor(const Color&);
 
     void setShouldIgnoreMouseEventsOutsideBounds(bool flag) { m_shouldIgnoreMouseEventsOutsideBounds = flag; }

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -52,7 +52,7 @@ public:
     GraphicsLayer& layerWithDocumentOverlays();
     GraphicsLayer& layerWithViewOverlays();
 
-    const Vector<Ref<PageOverlay>>& pageOverlays() const { return m_pageOverlays; }
+    const Vector<Ref<PageOverlay>>& pageOverlays() const LIFETIME_BOUND { return m_pageOverlays; }
 
     WEBCORE_EXPORT void installPageOverlay(PageOverlay&, PageOverlay::FadeMode);
     WEBCORE_EXPORT void uninstallPageOverlay(PageOverlay&, PageOverlay::FadeMode);

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -92,7 +92,7 @@ public:
 
     PerformanceNavigation& navigation();
     PerformanceTiming& timing();
-    EventCounts& eventCounts();
+    EventCounts& eventCounts() LIFETIME_BOUND;
 
     uint64_t interactionCount();
 

--- a/Source/WebCore/page/PerformanceEntry.h
+++ b/Source/WebCore/page/PerformanceEntry.h
@@ -42,7 +42,7 @@ class PerformanceEntry : public RefCounted<PerformanceEntry> {
 public:
     virtual ~PerformanceEntry();
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
     virtual double startTime() const { return m_startTime; }
     virtual double duration() const { return m_duration; }
 

--- a/Source/WebCore/page/PerformanceNavigationTiming.h
+++ b/Source/WebCore/page/PerformanceNavigationTiming.h
@@ -68,8 +68,8 @@ public:
     double NODELETE startTime() const final;
     double duration() const final;
 
-    DocumentEventTiming& documentEventTiming() { return m_documentEventTiming; }
-    DocumentLoadTiming& documentLoadTiming() { return m_documentLoadTiming; }
+    DocumentEventTiming& documentEventTiming() LIFETIME_BOUND { return m_documentEventTiming; }
+    DocumentLoadTiming& documentLoadTiming() LIFETIME_BOUND { return m_documentLoadTiming; }
     void documentLoadFinished(const NetworkLoadMetrics&);
 
 private:

--- a/Source/WebCore/page/PerformanceObserverEntryList.h
+++ b/Source/WebCore/page/PerformanceObserverEntryList.h
@@ -39,7 +39,7 @@ class PerformanceObserverEntryList : public RefCounted<PerformanceObserverEntryL
 public:
     static Ref<PerformanceObserverEntryList> create(Vector<Ref<PerformanceEntry>>&& entries);
 
-    const Vector<Ref<PerformanceEntry>>& getEntries() const { return m_entries; }
+    const Vector<Ref<PerformanceEntry>>& getEntries() const LIFETIME_BOUND { return m_entries; }
     Vector<Ref<PerformanceEntry>> getEntriesByType(const String& entryType) const;
     Vector<Ref<PerformanceEntry>> getEntriesByName(const String& name, const String& entryType) const;
 

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -46,9 +46,9 @@ class PerformanceResourceTiming : public PerformanceEntry {
 public:
     static Ref<PerformanceResourceTiming> create(MonotonicTime timeOrigin, ResourceTiming&&);
 
-    const String& initiatorType() const { return m_resourceTiming.initiatorType(); }
+    const String& initiatorType() const LIFETIME_BOUND { return m_resourceTiming.initiatorType(); }
     String deliveryType() const { return m_resourceTiming.deliveryType(); }
-    const String& NODELETE nextHopProtocol() const;
+    const String& NODELETE nextHopProtocol() const LIFETIME_BOUND;
 
     double workerStart() const;
     double redirectStart() const;
@@ -69,11 +69,11 @@ public:
     uint64_t NODELETE decodedBodySize() const;
     double workerRouterEvaluationStart() const;
     double workerCacheLookupStart() const;
-    const String& NODELETE workerMatchedRouterSource() const;
-    const String& NODELETE workerFinalRouterSource() const;
+    const String& NODELETE workerMatchedRouterSource() const LIFETIME_BOUND;
+    const String& NODELETE workerFinalRouterSource() const LIFETIME_BOUND;
 
-    const Vector<Ref<PerformanceServerTiming>>& serverTiming() const { return m_serverTiming; }
-    ResourceTiming& resourceTiming() { return m_resourceTiming; }
+    const Vector<Ref<PerformanceServerTiming>>& serverTiming() const LIFETIME_BOUND { return m_serverTiming; }
+    ResourceTiming& resourceTiming() LIFETIME_BOUND { return m_resourceTiming; }
 
     Type performanceEntryType() const override { return Type::Resource; }
     ASCIILiteral entryType() const override { return "resource"_s; }

--- a/Source/WebCore/page/PerformanceServerTiming.h
+++ b/Source/WebCore/page/PerformanceServerTiming.h
@@ -36,9 +36,9 @@ public:
     static Ref<PerformanceServerTiming> create(String&& name, double duration, String&& description);
     ~PerformanceServerTiming();
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
     double duration() const { return m_duration; }
-    const String& description() const { return m_description; }
+    const String& description() const LIFETIME_BOUND { return m_description; }
 
 private:
     PerformanceServerTiming(String&& name, double duration, String&& description);

--- a/Source/WebCore/page/PrintContext.h
+++ b/Source/WebCore/page/PrintContext.h
@@ -60,8 +60,8 @@ public:
 
     // These are only valid after page rects are computed.
     size_t pageCount() const { return m_pageRects.size(); }
-    const IntRect& pageRect(size_t pageNumber) const { return m_pageRects[pageNumber]; }
-    const Vector<IntRect>& pageRects() const { return m_pageRects; }
+    const IntRect& pageRect(size_t pageNumber) const LIFETIME_BOUND { return m_pageRects[pageNumber]; }
+    const Vector<IntRect>& pageRects() const LIFETIME_BOUND { return m_pageRects; }
     WEBCORE_EXPORT FloatBoxExtent computedPageMargin(FloatBoxExtent printMargin);
     WEBCORE_EXPORT FloatSize computedPageSize(FloatSize pageSize, FloatBoxExtent printMargin);
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -178,7 +178,7 @@ public:
     void triggerOptionalStorageAccessIframeQuirk(const URL& frameURL, CompletionHandler<void()>&&) const;
     StorageAccessResult triggerOptionalStorageAccessQuirk(Element&, const PlatformMouseEvent&, const AtomString& eventType, int, Element*, bool isParentProcessAFullWebBrowser, IsSyntheticClick) const;
     void setSubFrameDomainsForStorageAccessQuirk(Vector<RegistrableDomain>&& domains) { m_subFrameDomainsForStorageAccessQuirk = WTF::move(domains); }
-    const Vector<RegistrableDomain>& subFrameDomainsForStorageAccessQuirk() const { return m_subFrameDomainsForStorageAccessQuirk; }
+    const Vector<RegistrableDomain>& subFrameDomainsForStorageAccessQuirk() const LIFETIME_BOUND { return m_subFrameDomainsForStorageAccessQuirk; }
 
     bool needsVP9FullRangeFlagQuirk() const;
 

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -58,8 +58,8 @@ public:
 
     RemoteDOMWindow& NODELETE window() const;
 
-    const RemoteFrameClient& client() const { return m_client.get(); }
-    RemoteFrameClient& client() { return m_client.get(); }
+    const RemoteFrameClient& client() const LIFETIME_BOUND { return m_client.get(); }
+    RemoteFrameClient& client() LIFETIME_BOUND { return m_client.get(); }
 
     RemoteFrameView* view() const { return m_view.get(); }
     WEBCORE_EXPORT void setView(RefPtr<RemoteFrameView>&&);
@@ -112,7 +112,7 @@ private:
     FrameView* NODELETE virtualView() const final;
     void disconnectView() final;
     DOMWindow* NODELETE virtualWindow() const final;
-    FrameLoaderClient& NODELETE loaderClient() final;
+    FrameLoaderClient& NODELETE loaderClient() LIFETIME_BOUND final;
     void reinitializeDocumentSecurityContext() final { }
 
     const Ref<RemoteDOMWindow> m_window;

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -76,9 +76,9 @@ public:
 
     void resetObservationSize(Element&);
 
-    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& activeObservationTargets() const WTF_REQUIRES_LOCK(m_observationTargetsLock) { return m_activeObservationTargets; }
-    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& targetsWaitingForFirstObservation() const WTF_REQUIRES_LOCK(m_observationTargetsLock) { return m_targetsWaitingForFirstObservation; }
-    Lock& observationTargetsLock() WTF_RETURNS_LOCK(m_observationTargetsLock) { return m_observationTargetsLock; }
+    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& activeObservationTargets() const LIFETIME_BOUND WTF_REQUIRES_LOCK(m_observationTargetsLock) { return m_activeObservationTargets; }
+    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& targetsWaitingForFirstObservation() const LIFETIME_BOUND WTF_REQUIRES_LOCK(m_observationTargetsLock) { return m_targetsWaitingForFirstObservation; }
+    Lock& observationTargetsLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_observationTargetsLock) { return m_observationTargetsLock; }
 
     ResizeObserverCallback* callbackConcurrently();
     bool isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor&) const;

--- a/Source/WebCore/page/ResizeObserverEntry.h
+++ b/Source/WebCore/page/ResizeObserverEntry.h
@@ -48,8 +48,8 @@ public:
     Element& target() const { return m_target; }
     DOMRectReadOnly& contentRect() const { return m_contentRect; }
 
-    const Vector<Ref<ResizeObserverSize>>& borderBoxSize() const { return m_borderBoxSizes; }
-    const Vector<Ref<ResizeObserverSize>>& contentBoxSize() const { return m_contentBoxSizes; }
+    const Vector<Ref<ResizeObserverSize>>& borderBoxSize() const LIFETIME_BOUND { return m_borderBoxSizes; }
+    const Vector<Ref<ResizeObserverSize>>& contentBoxSize() const LIFETIME_BOUND { return m_contentBoxSizes; }
 
 private:
     ResizeObserverEntry(Ref<Element>&& target, const FloatRect& contentRect, FloatSize borderBoxSize, FloatSize contentBoxSize)

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -73,9 +73,9 @@ public:
     void setDomainFromDOM(const String& newDomain);
     bool domainWasSetInDOM() const { return m_domainWasSetInDOM; }
 
-    const String& protocol() const { return m_data.protocol(); }
-    const String& host() const { return m_data.host(); }
-    const String& domain() const { return m_domain; }
+    const String& protocol() const LIFETIME_BOUND { return m_data.protocol(); }
+    const String& host() const LIFETIME_BOUND { return m_data.host(); }
+    const String& domain() const LIFETIME_BOUND { return m_domain; }
     std::optional<uint16_t> port() const { return m_data.port(); }
 
     static bool shouldIgnoreHost(const URL&);
@@ -203,7 +203,7 @@ public:
     WEBCORE_EXPORT static bool isLocalHostOrLoopbackIPAddress(StringView);
     WEBCORE_EXPORT static bool isLocalhostAddress(StringView);
 
-    const SecurityOriginData& data() const { return m_data; }
+    const SecurityOriginData& data() const LIFETIME_BOUND { return m_data; }
 
     // This method checks that the scheme for this origin is an HTTP-family
     // scheme, e.g. HTTP and HTTPS.

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -78,7 +78,7 @@ public:
     // FIXME <rdar://9018386>: We should be sending more state across the wire than just the protocol,
     // host, and port.
 
-    const String& protocol() const
+    const String& protocol() const LIFETIME_BOUND
     {
         return switchOn(m_data, [] (const Tuple& tuple) -> const String& {
             return tuple.protocol;
@@ -86,7 +86,7 @@ public:
             return emptyString();
         });
     }
-    const String& host() const
+    const String& host() const LIFETIME_BOUND
     {
         return switchOn(m_data, [] (const Tuple& tuple) -> const String&  {
             return tuple.host;
@@ -160,7 +160,7 @@ public:
 
     WEBCORE_EXPORT static bool shouldTreatAsOpaqueOrigin(const URL&);
     
-    const Variant<Tuple, ProcessQualified<OpaqueOriginIdentifier>>& data() const { return m_data; }
+    const Variant<Tuple, ProcessQualified<OpaqueOriginIdentifier>>& data() const LIFETIME_BOUND { return m_data; }
 private:
     Variant<Tuple, ProcessQualified<OpaqueOriginIdentifier>> m_data;
 };

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -73,32 +73,32 @@ public:
     static const unsigned defaultMaximumHTMLParserDOMTreeDepth = 512;
     static const unsigned defaultMaximumRenderTreeDepth = 512;
 
-    virtual FontGenericFamilies& fontGenericFamilies() = 0;
-    virtual const FontGenericFamilies& fontGenericFamilies() const = 0;
+    virtual FontGenericFamilies& fontGenericFamilies() LIFETIME_BOUND = 0;
+    virtual const FontGenericFamilies& fontGenericFamilies() const LIFETIME_BOUND = 0;
 
     WEBCORE_EXPORT void setStandardFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& standardFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& standardFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setFixedFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& fixedFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& fixedFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setSerifFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& serifFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& serifFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setSansSerifFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& sansSerifFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& sansSerifFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setCursiveFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& cursiveFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& cursiveFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setFantasyFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& fantasyFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& fantasyFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setPictographFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& pictographFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& pictographFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setMathFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
-    WEBCORE_EXPORT const String& mathFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    WEBCORE_EXPORT const String& mathFontFamily(UScriptCode = USCRIPT_COMMON) const LIFETIME_BOUND;
 
     WEBCORE_EXPORT void setMinimumDOMTimerInterval(Seconds); // Initialized to DOMTimer::defaultMinimumInterval().
     Seconds minimumDOMTimerInterval() const { return m_minimumDOMTimerInterval; }
@@ -111,27 +111,27 @@ public:
 
     WEBCORE_EXPORT void setMediaContentTypesRequiringHardwareSupport(const Vector<ContentType>&);
     WEBCORE_EXPORT void setMediaContentTypesRequiringHardwareSupport(const String&);
-    const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const { return m_mediaContentTypesRequiringHardwareSupport; }
+    const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const LIFETIME_BOUND { return m_mediaContentTypesRequiringHardwareSupport; }
 
     void setAllowedMediaContainerTypes(std::optional<Vector<String>>&& types) { m_allowedMediaContainerTypes = WTF::move(types); }
     WEBCORE_EXPORT void setAllowedMediaContainerTypes(const String&);
-    const std::optional<Vector<String>>& allowedMediaContainerTypes() const { return m_allowedMediaContainerTypes; }
+    const std::optional<Vector<String>>& allowedMediaContainerTypes() const LIFETIME_BOUND { return m_allowedMediaContainerTypes; }
 
     void setAllowedMediaCodecTypes(std::optional<Vector<String>>&& types) { m_allowedMediaCodecTypes = WTF::move(types); }
     WEBCORE_EXPORT void setAllowedMediaCodecTypes(const String&);
-    const std::optional<Vector<String>>& allowedMediaCodecTypes() const { return m_allowedMediaCodecTypes; }
+    const std::optional<Vector<String>>& allowedMediaCodecTypes() const LIFETIME_BOUND { return m_allowedMediaCodecTypes; }
 
     void setAllowedMediaVideoCodecIDs(std::optional<Vector<FourCC>>&& types) { m_allowedMediaVideoCodecIDs = WTF::move(types); }
     WEBCORE_EXPORT void setAllowedMediaVideoCodecIDs(const String&);
-    const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const { return m_allowedMediaVideoCodecIDs; }
+    const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const LIFETIME_BOUND { return m_allowedMediaVideoCodecIDs; }
 
     void setAllowedMediaAudioCodecIDs(std::optional<Vector<FourCC>>&& types) { m_allowedMediaAudioCodecIDs = WTF::move(types); }
     WEBCORE_EXPORT void setAllowedMediaAudioCodecIDs(const String&);
-    const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const { return m_allowedMediaAudioCodecIDs; }
+    const std::optional<Vector<FourCC>>& allowedMediaAudioCodecIDs() const LIFETIME_BOUND { return m_allowedMediaAudioCodecIDs; }
 
     void setAllowedMediaCaptionFormatTypes(std::optional<Vector<FourCC>>&& types) { m_allowedMediaCaptionFormatTypes = WTF::move(types); }
     WEBCORE_EXPORT void setAllowedMediaCaptionFormatTypes(const String&);
-    const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const { return m_allowedMediaCaptionFormatTypes; }
+    const std::optional<Vector<FourCC>>& allowedMediaCaptionFormatTypes() const LIFETIME_BOUND { return m_allowedMediaCaptionFormatTypes; }
 
     WEBCORE_EXPORT void resetToConsistentState();
 

--- a/Source/WebCore/page/ShadowRealmGlobalScope.h
+++ b/Source/WebCore/page/ShadowRealmGlobalScope.h
@@ -46,7 +46,7 @@ public:
     ~ShadowRealmGlobalScope();
 
     ShadowRealmGlobalScope& self();
-    ScriptModuleLoader& moduleLoader();
+    ScriptModuleLoader& moduleLoader() LIFETIME_BOUND;
     JSShadowRealmGlobalScopeBase* wrapper();
 
 protected:

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -170,7 +170,7 @@ public:
     FloatRect contentImageWithoutSelectionRectInRootViewCoordinates() const { return m_data.contentImageWithoutSelectionRectInRootViewCoordinates; }
     void setContentImageWithoutSelectionRectInRootViewCoordinates(FloatRect contentImageWithoutSelectionRectInRootViewCoordinates) { m_data.contentImageWithoutSelectionRectInRootViewCoordinates = contentImageWithoutSelectionRectInRootViewCoordinates; }
 
-    const Vector<FloatRect>& textRectsInBoundingRectCoordinates() const { return m_data.textRectsInBoundingRectCoordinates; }
+    const Vector<FloatRect>& textRectsInBoundingRectCoordinates() const LIFETIME_BOUND { return m_data.textRectsInBoundingRectCoordinates; }
 
     float contentImageScaleFactor() const { return m_data.contentImageScaleFactor; }
     void setContentImageScaleFactor(float contentImageScaleFactor) { m_data.contentImageScaleFactor = contentImageScaleFactor; }

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -59,7 +59,7 @@ public:
     UndoManager* NODELETE undoManager() const;
     void setUndoManager(UndoManager*);
 
-    const String& label() const { return m_label; }
+    const String& label() const LIFETIME_BOUND { return m_label; }
     VoidCallback& undoHandler() const { return m_undoHandler.get(); }
     VoidCallback& redoHandler() const { return m_redoHandler.get(); }
 

--- a/Source/WebCore/page/UserContentController.h
+++ b/Source/WebCore/page/UserContentController.h
@@ -58,7 +58,7 @@ private:
     bool hasBuffersForWorld(const DOMWrapperWorld&) const override { return false; }
     WebKitBuffer* buffer(const DOMWrapperWorld&, const String&) const override { return nullptr; }
 #if ENABLE(CONTENT_EXTENSIONS)
-    const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const override { return m_contentExtensionBackend; }
+    const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const LIFETIME_BOUND override { return m_contentExtensionBackend; }
 #endif
 
     UserScriptMap m_userScripts;

--- a/Source/WebCore/page/UserContentURLPattern.h
+++ b/Source/WebCore/page/UserContentURLPattern.h
@@ -62,9 +62,9 @@ public:
         return matchesScheme(test) && matchesHost(test) && matchesPath(test);
     }
 
-    const String& scheme() const { return m_scheme; }
-    const String& host() const { return m_host; }
-    const String& path() const { return m_path; }
+    const String& scheme() const LIFETIME_BOUND { return m_scheme; }
+    const String& host() const LIFETIME_BOUND { return m_host; }
+    const String& path() const LIFETIME_BOUND { return m_path; }
 
     bool matchAllHosts() const { return m_matchSubdomains && m_host.isEmpty(); }
     bool matchSubdomains() const { return m_matchSubdomains; }

--- a/Source/WebCore/page/UserScript.h
+++ b/Source/WebCore/page/UserScript.h
@@ -38,10 +38,10 @@ class UserScript {
 public:
     WEBCORE_EXPORT UserScript(String&& source, URL&& = { }, Vector<String>&& allowlist = { }, Vector<String>&& blocklist = { }, UserScriptInjectionTime = UserScriptInjectionTime::DocumentStart, UserContentInjectedFrames = UserContentInjectedFrames::InjectInAllFrames, UserContentMatchParentFrame = UserContentMatchParentFrame::Never);
 
-    const String& source() const { return m_source; }
-    const URL& url() const { return m_url; }
-    const Vector<String>& allowlist() const { return m_allowlist; }
-    const Vector<String>& blocklist() const { return m_blocklist; }
+    const String& source() const LIFETIME_BOUND { return m_source; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
+    const Vector<String>& allowlist() const LIFETIME_BOUND { return m_allowlist; }
+    const Vector<String>& blocklist() const LIFETIME_BOUND { return m_blocklist; }
     UserScriptInjectionTime injectionTime() const { return m_injectionTime; }
     UserContentInjectedFrames injectedFrames() const { return m_injectedFrames; }
     UserContentMatchParentFrame matchParentFrame() const { return m_matchParentFrame; }

--- a/Source/WebCore/page/UserStyleSheet.h
+++ b/Source/WebCore/page/UserStyleSheet.h
@@ -45,10 +45,10 @@ public:
 
     WEBCORE_EXPORT UserStyleSheet(const String&, const URL&, Vector<String>&& = { }, Vector<String>&& = { }, UserContentInjectedFrames = UserContentInjectedFrames::InjectInAllFrames, UserContentMatchParentFrame = UserContentMatchParentFrame::Never, UserStyleLevel = UserStyleLevel::User, std::optional<PageIdentifier> = std::nullopt);
 
-    const String& source() const { return m_source; }
-    const URL& url() const { return m_url; }
-    const Vector<String>& allowlist() const { return m_allowlist; }
-    const Vector<String>& blocklist() const { return m_blocklist; }
+    const String& source() const LIFETIME_BOUND { return m_source; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
+    const Vector<String>& allowlist() const LIFETIME_BOUND { return m_allowlist; }
+    const Vector<String>& blocklist() const LIFETIME_BOUND { return m_blocklist; }
     UserContentInjectedFrames injectedFrames() const { return m_injectedFrames; }
     UserContentMatchParentFrame matchParentFrame() const { return m_matchParentFrame; }
     UserStyleLevel level() const { return m_level; }

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -69,21 +69,21 @@ public:
 
     WEBCORE_EXPORT ViewportConfiguration();
 
-    const Parameters& defaultConfiguration() const { return m_defaultConfiguration; }
+    const Parameters& defaultConfiguration() const LIFETIME_BOUND { return m_defaultConfiguration; }
     WEBCORE_EXPORT void setDefaultConfiguration(const Parameters&);
 
-    const IntSize& contentsSize() const { return m_contentSize; }
+    const IntSize& contentsSize() const LIFETIME_BOUND { return m_contentSize; }
     WEBCORE_EXPORT bool setContentsSize(const IntSize&);
 
-    const FloatSize& viewLayoutSize() const { return m_viewLayoutSize; }
+    const FloatSize& viewLayoutSize() const LIFETIME_BOUND { return m_viewLayoutSize; }
 
-    const FloatSize& minimumLayoutSize() const { return m_minimumLayoutSize; }
+    const FloatSize& minimumLayoutSize() const LIFETIME_BOUND { return m_minimumLayoutSize; }
     WEBCORE_EXPORT bool setViewLayoutSize(const FloatSize&, std::optional<double>&& scaleFactor = std::nullopt, std::optional<double>&& effectiveWidth = std::nullopt);
 
-    const OptionSet<DisabledAdaptations>& disabledAdaptations() const { return m_disabledAdaptations; }
+    const OptionSet<DisabledAdaptations>& disabledAdaptations() const LIFETIME_BOUND { return m_disabledAdaptations; }
     WEBCORE_EXPORT bool setDisabledAdaptations(const OptionSet<DisabledAdaptations>&);
 
-    const ViewportArguments& viewportArguments() const { return m_viewportArguments; }
+    const ViewportArguments& viewportArguments() const LIFETIME_BOUND { return m_viewportArguments; }
     WEBCORE_EXPORT bool setViewportArguments(const ViewportArguments&);
 
     WEBCORE_EXPORT bool setCanIgnoreScalingConstraints(bool);

--- a/Source/WebCore/page/WebKitSerializedNode.h
+++ b/Source/WebCore/page/WebKitSerializedNode.h
@@ -35,7 +35,7 @@ class WebKitSerializedNode : public RefCounted<WebKitSerializedNode> {
 public:
     static Ref<WebKitSerializedNode> create(const Node& node, bool deep) { return adoptRef(*new WebKitSerializedNode(node, deep)); }
 
-    const SerializedNode& serializedNode() const { return m_serializedNode; }
+    const SerializedNode& serializedNode() const LIFETIME_BOUND { return m_serializedNode; }
 
 private:
     WebKitSerializedNode(const Node&, bool);

--- a/Source/WebCore/page/csp/CSPViolationReportBody.h
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.h
@@ -45,14 +45,14 @@ public:
     WEBCORE_EXPORT static Ref<CSPViolationReportBody> create(Init&&);
     WEBCORE_EXPORT static Ref<CSPViolationReportBody> create(String&& documentURL, String&& referrer, String&& blockedURL, String&& effectiveDirective, String&& originalPolicy, String&& sourceFile, String&& sample, SecurityPolicyViolationEventDisposition, unsigned short statusCode, uint64_t lineNumber, uint64_t columnNumber);
 
-    const String& type() const final;
-    const String& documentURL() const { return m_documentURL; }
-    const String& referrer() const { return m_referrer; }
-    const String& blockedURL() const { return m_blockedURL; }
-    const String& effectiveDirective() const { return m_effectiveDirective; }
-    const String& originalPolicy() const { return m_originalPolicy; }
-    const String& sourceFile() const { return m_sourceFile; }
-    const String& sample() const { return m_sample; }
+    const String& type() const LIFETIME_BOUND final;
+    const String& documentURL() const LIFETIME_BOUND { return m_documentURL; }
+    const String& referrer() const LIFETIME_BOUND { return m_referrer; }
+    const String& blockedURL() const LIFETIME_BOUND { return m_blockedURL; }
+    const String& effectiveDirective() const LIFETIME_BOUND { return m_effectiveDirective; }
+    const String& originalPolicy() const LIFETIME_BOUND { return m_originalPolicy; }
+    const String& sourceFile() const LIFETIME_BOUND { return m_sourceFile; }
+    const String& sample() const LIFETIME_BOUND { return m_sample; }
     SecurityPolicyViolationEventDisposition disposition() const { return m_disposition; }
     unsigned short statusCode() const { return m_statusCode; }
     uint64_t lineNumber() const { return m_lineNumber; }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -228,7 +228,7 @@ public:
     }
 
     // Used by ContentSecurityPolicySource
-    const String& selfProtocol() const { return m_selfSourceProtocol; };
+    const String& selfProtocol() const LIFETIME_BOUND { return m_selfSourceProtocol; };
 
     void setUpgradeInsecureRequests(bool);
     bool upgradeInsecureRequests() const { return m_upgradeInsecureRequests; }
@@ -250,11 +250,11 @@ public:
 
     bool isHeaderDelivered() const { return m_isHeaderDelivered; }
 
-    const String& evalErrorMessage() const { return m_lastPolicyEvalDisabledErrorMessage; }
-    const String& webAssemblyErrorMessage() const { return m_lastPolicyWebAssemblyDisabledErrorMessage; }
+    const String& evalErrorMessage() const LIFETIME_BOUND { return m_lastPolicyEvalDisabledErrorMessage; }
+    const String& webAssemblyErrorMessage() const LIFETIME_BOUND { return m_lastPolicyWebAssemblyDisabledErrorMessage; }
 
     ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_contentSecurityPolicyModeForExtension; }
-    const HashAlgorithmSetCollection& hashesToReport();
+    const HashAlgorithmSetCollection& hashesToReport() LIFETIME_BOUND;
 
     void setIsReportingToConsoleEnabled(bool value) { m_isReportingToConsoleEnabled = value; }
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirective.h
@@ -46,11 +46,11 @@ public:
 
     virtual ~ContentSecurityPolicyDirective() = 0;
 
-    const String& name() const { return m_name; }
-    const String& text() const { return m_text; }
-    virtual const String& nameForReporting() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
+    const String& text() const LIFETIME_BOUND { return m_text; }
+    virtual const String& nameForReporting() const LIFETIME_BOUND { return m_name; }
 
-    const ContentSecurityPolicyDirectiveList& directiveList() const { return m_directiveList; }
+    const ContentSecurityPolicyDirectiveList& directiveList() const LIFETIME_BOUND { return m_directiveList; }
 
     bool NODELETE isDefaultSrc() const;
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -44,55 +44,55 @@ public:
     static std::unique_ptr<ContentSecurityPolicyDirectiveList> create(ContentSecurityPolicy&, const String&, ContentSecurityPolicyHeaderType, ContentSecurityPolicy::PolicyFrom);
     ContentSecurityPolicyDirectiveList(ContentSecurityPolicy&, ContentSecurityPolicyHeaderType);
 
-    const String& header() const { return m_header; }
+    const String& header() const LIFETIME_BOUND { return m_header; }
     ContentSecurityPolicyHeaderType headerType() const { return m_headerType; }
 
-    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeEval() const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForInlineJavascriptURL(const Vector<ContentSecurityPolicyHash>&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForInlineEventHandlers(const Vector<ContentSecurityPolicyHash>&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeInlineScriptElement(const String&, const Vector<ContentSecurityPolicyHash>&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForNonParserInsertedScripts(const String&, const Vector<ContentSecurityPolicyHash>&, const Vector<ResourceCryptographicDigest>&, const URL&, ParserInserted) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeInlineStyleElement(const String&, const Vector<ContentSecurityPolicyHash>&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeInlineStyleAttribute(const String&, const Vector<ContentSecurityPolicyHash>&) const;
+    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeEval() const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForInlineJavascriptURL(const Vector<ContentSecurityPolicyHash>&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForInlineEventHandlers(const Vector<ContentSecurityPolicyHash>&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeInlineScriptElement(const String&, const Vector<ContentSecurityPolicyHash>&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForNonParserInsertedScripts(const String&, const Vector<ContentSecurityPolicyHash>&, const Vector<ResourceCryptographicDigest>&, const URL&, ParserInserted) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeInlineStyleElement(const String&, const Vector<ContentSecurityPolicyHash>&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForUnsafeInlineStyleAttribute(const String&, const Vector<ContentSecurityPolicyHash>&) const LIFETIME_BOUND;
 
-    const ContentSecurityPolicyDirective* violatedDirectiveForScriptNonce(const String&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForStyleNonce(const String&) const;
+    const ContentSecurityPolicyDirective* violatedDirectiveForScriptNonce(const String&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForStyleNonce(const String&) const LIFETIME_BOUND;
 
-    const ContentSecurityPolicyDirective* violatedDirectiveForBaseURI(const URL&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForChildContext(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForConnectSource(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForFont(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForFormAction(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForFrame(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForFrameAncestor(const LocalFrame&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForFrameAncestorOrigins(const Vector<Ref<SecurityOrigin>>&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForImage(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForPrefetch(const URL&, bool didReceiveRedirectResponse) const;
+    const ContentSecurityPolicyDirective* violatedDirectiveForBaseURI(const URL&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForChildContext(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForConnectSource(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForFont(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForFormAction(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForFrame(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForFrameAncestor(const LocalFrame&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForFrameAncestorOrigins(const Vector<Ref<SecurityOrigin>>&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForImage(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForPrefetch(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
 #if ENABLE(APPLICATION_MANIFEST)
-    const ContentSecurityPolicyDirective* violatedDirectiveForManifest(const URL&, bool didReceiveRedirectResponse) const;
+    const ContentSecurityPolicyDirective* violatedDirectiveForManifest(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
 #endif
-    const ContentSecurityPolicyDirective* violatedDirectiveForMedia(const URL&, bool didReceiveRedirectResponse) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForObjectSource(const URL&, bool didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForPluginType(const String& type, const String& typeAttribute) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForScript(const URL&, bool didReceiveRedirectResponse, const Vector<ResourceCryptographicDigest>&, const String&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForStyle(const URL&, bool didReceiveRedirectResponse, const String&) const;
-    const ContentSecurityPolicyDirective* violatedDirectiveForWorker(const URL&, bool didReceiveRedirectResponse);
-    const ContentSecurityPolicyDirective* violatedDirectiveForTrustedTypesPolicy(const String&, bool isDuplicate, AllowTrustedTypePolicy&) const;
+    const ContentSecurityPolicyDirective* violatedDirectiveForMedia(const URL&, bool didReceiveRedirectResponse) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForObjectSource(const URL&, bool didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForPluginType(const String& type, const String& typeAttribute) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForScript(const URL&, bool didReceiveRedirectResponse, const Vector<ResourceCryptographicDigest>&, const String&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForStyle(const URL&, bool didReceiveRedirectResponse, const String&) const LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForWorker(const URL&, bool didReceiveRedirectResponse) LIFETIME_BOUND;
+    const ContentSecurityPolicyDirective* violatedDirectiveForTrustedTypesPolicy(const String&, bool isDuplicate, AllowTrustedTypePolicy&) const LIFETIME_BOUND;
 
-    const ContentSecurityPolicyDirective* defaultSrc() const { return m_defaultSrc.get(); }
+    const ContentSecurityPolicyDirective* defaultSrc() const LIFETIME_BOUND { return m_defaultSrc.get(); }
 
     bool hasBlockAllMixedContentDirective() const { return m_hasBlockAllMixedContentDirective; }
     bool hasFrameAncestorsDirective() const { return !!m_frameAncestors; }
     bool requiresTrustedTypesForScript() const { return m_requireTrustedTypesForScript; }
     bool trustedEvalEnabled() const { return m_trustedEvalEnabled; }
 
-    const String& evalDisabledErrorMessage() const { return m_evalDisabledErrorMessage; }
-    const String& webAssemblyDisabledErrorMessage() const { return m_webAssemblyDisabledErrorMessage; }
+    const String& evalDisabledErrorMessage() const LIFETIME_BOUND { return m_evalDisabledErrorMessage; }
+    const String& webAssemblyDisabledErrorMessage() const LIFETIME_BOUND { return m_webAssemblyDisabledErrorMessage; }
     bool isReportOnly() const { return m_reportOnly; }
     bool shouldReportSample(const String&) const;
     HashAlgorithmSet reportHash() const;
-    const Vector<String>& reportToTokens() const { return m_reportToTokens; }
-    const Vector<String>& reportURIs() const { return m_reportURIs; }
+    const Vector<String>& reportToTokens() const LIFETIME_BOUND { return m_reportToTokens; }
+    const Vector<String>& reportURIs() const LIFETIME_BOUND { return m_reportURIs; }
 
     // FIXME: Remove this once we teach ContentSecurityPolicyDirectiveList how to log an arbitrary console message.
     const ContentSecurityPolicy& policy() const { return m_policy; }
@@ -115,7 +115,7 @@ private:
     void setUpgradeInsecureRequests(ParsedDirective&&);
     void setBlockAllMixedContentEnabled(ParsedDirective&&);
 
-    const ContentSecurityPolicySourceListDirective* hashReportDirectiveForScript() const;
+    const ContentSecurityPolicySourceListDirective* hashReportDirectiveForScript() const LIFETIME_BOUND;
 
     template <class CSPDirectiveType>
     void setCSPDirective(ParsedDirective&&, std::unique_ptr<CSPDirectiveType>&);

--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
@@ -55,7 +55,7 @@ public:
 
     void addPolicyHeadersTo(ResourceResponse&) const;
 
-    const Vector<std::pair<String, ContentSecurityPolicyHeaderType>>& headers() const { return m_headers; }
+    const Vector<std::pair<String, ContentSecurityPolicyHeaderType>>& headers() const LIFETIME_BOUND { return m_headers; }
     void setHeaders(Vector<std::pair<String, ContentSecurityPolicyHeaderType>>&& headers) { m_headers = WTF::move(headers); }
     int httpStatusCode() const { return m_httpStatusCode; }
     void setHTTPStatusCode(int httpStatusCode) { m_httpStatusCode = httpStatusCode; }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
@@ -56,7 +56,7 @@ public:
     OptionSet<ContentSecurityPolicyHashAlgorithm> hashAlgorithmsUsed() const { return m_sourceList.hashAlgorithmsUsed(); }
 
     void setNameForReporting(const String& name) { m_nameForReporting = name; }
-    const String& nameForReporting() const final { return !m_nameForReporting.isEmpty() ? m_nameForReporting : name(); }
+    const String& nameForReporting() const LIFETIME_BOUND final { return !m_nameForReporting.isEmpty() ? m_nameForReporting : name(); }
 
 private:
     String m_nameForReporting;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -99,7 +99,7 @@ protected:
     WEBCORE_EXPORT AsyncScrollingCoordinator(Page*);
 
     void setScrollingTree(Ref<ScrollingTree>&& scrollingTree) { m_scrollingTree = WTF::move(scrollingTree); }
-    const SmallMap<FrameIdentifier, UniqueRef<ScrollingStateTree>>& scrollingStateTrees() const { return m_scrollingStateTrees; }
+    const SmallMap<FrameIdentifier, UniqueRef<ScrollingStateTree>>& scrollingStateTrees() const LIFETIME_BOUND { return m_scrollingStateTrees; }
 
     RefPtr<ScrollingTree> releaseScrollingTree() { return WTF::move(m_scrollingTree); }
 

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -82,10 +82,10 @@ public:
 
     WEBCORE_EXPORT FloatPoint viewportRelativeLayerPosition(const FloatRect& viewportRect) const;
 
-    const FloatRect& viewportRectAtLastLayout() const { return m_viewportRectAtLastLayout; }
+    const FloatRect& viewportRectAtLastLayout() const LIFETIME_BOUND { return m_viewportRectAtLastLayout; }
     void setViewportRectAtLastLayout(const FloatRect& rect) { m_viewportRectAtLastLayout = rect; }
 
-    const FloatPoint& layerPositionAtLastLayout() const { return m_layerPositionAtLastLayout; }
+    const FloatPoint& layerPositionAtLastLayout() const LIFETIME_BOUND { return m_layerPositionAtLastLayout; }
     void setLayerPositionAtLastLayout(FloatPoint position) { m_layerPositionAtLastLayout = position; }
 
     friend bool operator==(const ViewportConstraints&, const ViewportConstraints&) = default;
@@ -147,7 +147,7 @@ public:
 
     FloatSize computeStickyOffset(const FloatRect& constrainingRect) const;
 
-    const FloatSize& anchorLayerOffsetAtLastLayout() const { return m_anchorLayerOffsetAtLastLayout; }
+    const FloatSize& anchorLayerOffsetAtLastLayout() const LIFETIME_BOUND { return m_anchorLayerOffsetAtLastLayout; }
     void setAnchorLayerOffsetAtLastLayout(FloatSize offset) { m_anchorLayerOffsetAtLastLayout = offset; }
 
     const FloatSize stickyOffsetAtLastLayout() const { return m_stickyOffsetAtLastLayout; }

--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.h
@@ -46,7 +46,7 @@ public:
     virtual ~ScrollingStateFixedNode();
 
     WEBCORE_EXPORT void updateConstraints(const FixedPositionViewportConstraints&);
-    const FixedPositionViewportConstraints& viewportConstraints() const { return m_constraints; }
+    const FixedPositionViewportConstraints& viewportConstraints() const LIFETIME_BOUND { return m_constraints; }
 
 private:
     WEBCORE_EXPORT ScrollingStateFixedNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, FixedPositionViewportConstraints&&);

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -51,7 +51,7 @@ public:
     float frameScaleFactor() const { return m_frameScaleFactor; }
     WEBCORE_EXPORT void setFrameScaleFactor(float);
 
-    const EventTrackingRegions& eventTrackingRegions() const { return m_eventTrackingRegions; }
+    const EventTrackingRegions& eventTrackingRegions() const LIFETIME_BOUND { return m_eventTrackingRegions; }
     WEBCORE_EXPORT void setEventTrackingRegions(const EventTrackingRegions&);
 
     ScrollBehaviorForFixedElements scrollBehaviorForFixedElements() const { return m_behaviorForFixed; }
@@ -88,29 +88,29 @@ public:
     WEBCORE_EXPORT void setBannerViewHeight(float);
 #endif
 
-    const LayerRepresentation& rootContentsLayer() const { return m_rootContentsLayer; }
+    const LayerRepresentation& rootContentsLayer() const LIFETIME_BOUND { return m_rootContentsLayer; }
     WEBCORE_EXPORT void setRootContentsLayer(const LayerRepresentation&);
 
     // This is a layer moved in the opposite direction to scrolling, for example for background-attachment:fixed
-    const LayerRepresentation& counterScrollingLayer() const { return m_counterScrollingLayer; }
+    const LayerRepresentation& counterScrollingLayer() const LIFETIME_BOUND { return m_counterScrollingLayer; }
     WEBCORE_EXPORT void setCounterScrollingLayer(const LayerRepresentation&);
 
     // This is a clipping layer that will scroll with the page for all y-delta scroll values between 0
     // and obscuredInset().top. Once the y-deltas get beyond the content inset point, this layer no longer
     // needs to move. If the obscuredInset().top is 0, this layer does not need to move at all. This is
     // only used on the Mac.
-    const LayerRepresentation& insetClipLayer() const { return m_insetClipLayer; }
+    const LayerRepresentation& insetClipLayer() const LIFETIME_BOUND { return m_insetClipLayer; }
     WEBCORE_EXPORT void setInsetClipLayer(const LayerRepresentation&);
 
-    const LayerRepresentation& contentShadowLayer() const { return m_contentShadowLayer; }
+    const LayerRepresentation& contentShadowLayer() const LIFETIME_BOUND { return m_contentShadowLayer; }
     WEBCORE_EXPORT void setContentShadowLayer(const LayerRepresentation&);
 
     // The header and footer layers scroll vertically with the page, they should remain fixed when scrolling horizontally.
-    const LayerRepresentation& headerLayer() const { return m_headerLayer; }
+    const LayerRepresentation& headerLayer() const LIFETIME_BOUND { return m_headerLayer; }
     WEBCORE_EXPORT void setHeaderLayer(const LayerRepresentation&);
 
     // The header and footer layers scroll vertically with the page, they should remain fixed when scrolling horizontally.
-    const LayerRepresentation& footerLayer() const { return m_footerLayer; }
+    const LayerRepresentation& footerLayer() const LIFETIME_BOUND { return m_footerLayer; }
     WEBCORE_EXPORT void setFooterLayer(const LayerRepresentation&);
 
     // True when the visual viewport is smaller than the layout viewport, indicating that panning should be possible.

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -313,7 +313,7 @@ public:
     
     virtual void reconcileLayerPositionForViewportRect(const LayoutRect& /*viewportRect*/, ScrollingLayerPositionAction) { }
 
-    const LayerRepresentation& layer() const { return m_layer; }
+    const LayerRepresentation& layer() const LIFETIME_BOUND { return m_layer; }
     WEBCORE_EXPORT void setLayer(const LayerRepresentation&);
 
     bool isAttachedToScrollingStateTree() const { return !!m_scrollingStateTree; }
@@ -330,8 +330,8 @@ public:
     void setParent(RefPtr<ScrollingStateNode>&& parent) { m_parent = parent; }
     std::optional<ScrollingNodeID> parentNodeID() const;
 
-    Vector<Ref<ScrollingStateNode>>& children() { return m_children; }
-    const Vector<Ref<ScrollingStateNode>>& children() const { return m_children; }
+    Vector<Ref<ScrollingStateNode>>& children() LIFETIME_BOUND { return m_children; }
+    const Vector<Ref<ScrollingStateNode>>& children() const LIFETIME_BOUND { return m_children; }
     Vector<Ref<ScrollingStateNode>> takeChildren() { return std::exchange(m_children, { }); }
     WEBCORE_EXPORT void setChildren(Vector<Ref<ScrollingStateNode>>&&);
     void traverse(NOESCAPE const Function<void(ScrollingStateNode&)>&);

--- a/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h
@@ -47,11 +47,11 @@ public:
     virtual ~ScrollingStatePositionedNode();
 
     // These are the overflow scrolling nodes whose scroll position affects the layers in this node.
-    const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const { return m_relatedOverflowScrollingNodes; }
+    const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const LIFETIME_BOUND { return m_relatedOverflowScrollingNodes; }
     WEBCORE_EXPORT void setRelatedOverflowScrollingNodes(Vector<ScrollingNodeID>&&);
 
     WEBCORE_EXPORT void updateConstraints(const AbsolutePositionConstraints&);
-    const AbsolutePositionConstraints& layoutConstraints() const { return m_constraints; }
+    const AbsolutePositionConstraints& layoutConstraints() const LIFETIME_BOUND { return m_constraints; }
 
 private:
     WEBCORE_EXPORT ScrollingStatePositionedNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, Vector<ScrollingNodeID>&&, AbsolutePositionConstraints&&);

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -72,22 +72,22 @@ class ScrollingStateScrollingNode : public ScrollingStateNode {
 public:
     virtual ~ScrollingStateScrollingNode();
 
-    const FloatSize& scrollableAreaSize() const { return m_scrollableAreaSize; }
+    const FloatSize& scrollableAreaSize() const LIFETIME_BOUND { return m_scrollableAreaSize; }
     WEBCORE_EXPORT void setScrollableAreaSize(const FloatSize&);
 
-    const FloatSize& totalContentsSize() const { return m_totalContentsSize; }
+    const FloatSize& totalContentsSize() const LIFETIME_BOUND { return m_totalContentsSize; }
     WEBCORE_EXPORT void setTotalContentsSize(const FloatSize&);
 
-    const FloatSize& reachableContentsSize() const { return m_reachableContentsSize; }
+    const FloatSize& reachableContentsSize() const LIFETIME_BOUND { return m_reachableContentsSize; }
     WEBCORE_EXPORT void setReachableContentsSize(const FloatSize&);
 
-    const FloatPoint& scrollPosition() const { return m_scrollPosition; }
+    const FloatPoint& scrollPosition() const LIFETIME_BOUND { return m_scrollPosition; }
     WEBCORE_EXPORT void setScrollPosition(const FloatPoint&);
 
-    const IntPoint& scrollOrigin() const { return m_scrollOrigin; }
+    const IntPoint& scrollOrigin() const LIFETIME_BOUND { return m_scrollOrigin; }
     WEBCORE_EXPORT void setScrollOrigin(const IntPoint&);
 
-    const FloatScrollSnapOffsetsInfo& snapOffsetsInfo() const { return m_snapOffsetsInfo; }
+    const FloatScrollSnapOffsetsInfo& snapOffsetsInfo() const LIFETIME_BOUND { return m_snapOffsetsInfo; }
     WEBCORE_EXPORT void setSnapOffsetsInfo(const FloatScrollSnapOffsetsInfo& newOffsetsInfo);
 
     std::optional<unsigned> currentHorizontalSnapPointIndex() const { return m_currentHorizontalSnapPointIndex; }
@@ -96,7 +96,7 @@ public:
     std::optional<unsigned> currentVerticalSnapPointIndex() const { return m_currentVerticalSnapPointIndex; }
     WEBCORE_EXPORT void setCurrentVerticalSnapPointIndex(std::optional<unsigned>);
 
-    const ScrollableAreaParameters& scrollableAreaParameters() const { return m_scrollableAreaParameters; }
+    const ScrollableAreaParameters& scrollableAreaParameters() const LIFETIME_BOUND { return m_scrollableAreaParameters; }
     WEBCORE_EXPORT void setScrollableAreaParameters(const ScrollableAreaParameters& params);
 
 #if ENABLE(SCROLLING_THREAD)
@@ -105,10 +105,10 @@ public:
     bool hasSynchronousScrollingReasons() const { return !m_synchronousScrollingReasons.isEmpty(); }
 #endif
 
-    const RequestedKeyboardScrollData& keyboardScrollData() const { return m_keyboardScrollData; }
+    const RequestedKeyboardScrollData& keyboardScrollData() const LIFETIME_BOUND { return m_keyboardScrollData; }
     WEBCORE_EXPORT void setKeyboardScrollData(const RequestedKeyboardScrollData&);
 
-    const ScrollRequestData& requestedScrollData() const { return m_requestedScrollData; }
+    const ScrollRequestData& requestedScrollData() const LIFETIME_BOUND { return m_requestedScrollData; }
 
     WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&);
 
@@ -117,17 +117,17 @@ public:
     bool isMonitoringWheelEvents() const { return m_isMonitoringWheelEvents; }
     WEBCORE_EXPORT void setIsMonitoringWheelEvents(bool);
 
-    const LayerRepresentation& scrollContainerLayer() const { return m_scrollContainerLayer; }
+    const LayerRepresentation& scrollContainerLayer() const LIFETIME_BOUND { return m_scrollContainerLayer; }
     WEBCORE_EXPORT void setScrollContainerLayer(const LayerRepresentation&);
 
     // This is a layer with the contents that move.
-    const LayerRepresentation& scrolledContentsLayer() const { return m_scrolledContentsLayer; }
+    const LayerRepresentation& scrolledContentsLayer() const LIFETIME_BOUND { return m_scrolledContentsLayer; }
     WEBCORE_EXPORT void setScrolledContentsLayer(const LayerRepresentation&);
 
-    const LayerRepresentation& horizontalScrollbarLayer() const { return m_horizontalScrollbarLayer; }
+    const LayerRepresentation& horizontalScrollbarLayer() const LIFETIME_BOUND { return m_horizontalScrollbarLayer; }
     WEBCORE_EXPORT void setHorizontalScrollbarLayer(const LayerRepresentation&);
 
-    const LayerRepresentation& verticalScrollbarLayer() const { return m_verticalScrollbarLayer; }
+    const LayerRepresentation& verticalScrollbarLayer() const LIFETIME_BOUND { return m_verticalScrollbarLayer; }
     WEBCORE_EXPORT void setVerticalScrollbarLayer(const LayerRepresentation&);
 
 #if PLATFORM(MAC)
@@ -143,7 +143,7 @@ public:
     ScrollbarEnabledState scrollbarEnabledState() const { return m_scrollbarEnabledState; }
     WEBCORE_EXPORT void setScrollbarEnabledState(ScrollbarOrientation, bool);
 
-    const std::optional<ScrollbarColor>& scrollbarColor() const { return m_scrollbarColor; }
+    const std::optional<ScrollbarColor>& scrollbarColor() const LIFETIME_BOUND { return m_scrollbarColor; }
     WEBCORE_EXPORT void setScrollbarColor(std::optional<ScrollbarColor>);
 
     void setScrollerImpsFromScrollbars(Scrollbar* verticalScrollbar, Scrollbar* horizontalScrollbar);
@@ -152,7 +152,7 @@ public:
     bool mouseIsOverContentArea() const { return m_mouseIsOverContentArea; }
 
     WEBCORE_EXPORT void setMouseMovedInContentArea(const MouseLocationState&);
-    const MouseLocationState& mouseLocationState() const { return m_mouseLocationState; }
+    const MouseLocationState& mouseLocationState() const LIFETIME_BOUND { return m_mouseLocationState; }
 
     WEBCORE_EXPORT void setScrollbarLayoutDirection(UserInterfaceLayoutDirection);
     UserInterfaceLayoutDirection scrollbarLayoutDirection() const { return m_scrollbarLayoutDirection; }

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
@@ -46,9 +46,9 @@ public:
     virtual ~ScrollingStateStickyNode();
 
     WEBCORE_EXPORT void updateConstraints(const StickyPositionViewportConstraints&);
-    const StickyPositionViewportConstraints& viewportConstraints() const { return m_constraints; }
+    const StickyPositionViewportConstraints& viewportConstraints() const LIFETIME_BOUND { return m_constraints; }
 
-    const LayerRepresentation& viewportAnchorLayer() const { return m_viewportAnchorLayer; }
+    const LayerRepresentation& viewportAnchorLayer() const LIFETIME_BOUND { return m_viewportAnchorLayer; }
     WEBCORE_EXPORT void setViewportAnchorLayer(const LayerRepresentation&);
 
 private:

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -76,7 +76,7 @@ public:
     unsigned scrollingNodeCount() const { return m_scrollingNodeCount; }
 
     using StateNodeMap = HashMap<ScrollingNodeID, Ref<ScrollingStateNode>>;
-    const StateNodeMap& nodeMap() const { return m_stateNodeMap; }
+    const StateNodeMap& nodeMap() const LIFETIME_BOUND { return m_stateNodeMap; }
 
     LayerRepresentation::Type preferredLayerRepresentation() const { return m_preferredLayerRepresentation; }
     void setPreferredLayerRepresentation(LayerRepresentation::Type representation) { m_preferredLayerRepresentation = representation; }

--- a/Source/WebCore/page/scrolling/ScrollingThread.h
+++ b/Source/WebCore/page/scrolling/ScrollingThread.h
@@ -57,7 +57,7 @@ private:
 
     ScrollingThread();
 
-    RunLoop& runLoop() { return m_runLoop; }
+    RunLoop& runLoop() LIFETIME_BOUND { return m_runLoop; }
 
     const Ref<RunLoop> m_runLoop;
 };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -217,10 +217,10 @@ public:
     // A map of overflow scrolling nodes to positioned nodes which need to be updated
     // when the scroller changes, but are not descendants.
     using RelatedNodesMap = HashMap<ScrollingNodeID, Vector<ScrollingNodeID>>;
-    RelatedNodesMap& overflowRelatedNodes() { return m_overflowRelatedNodesMap; }
+    RelatedNodesMap& overflowRelatedNodes() LIFETIME_BOUND { return m_overflowRelatedNodesMap; }
 
-    HashSet<Ref<ScrollingTreeOverflowScrollProxyNode>>& activeOverflowScrollProxyNodes() { return m_activeOverflowScrollProxyNodes; }
-    HashSet<Ref<ScrollingTreePositionedNode>>& activePositionedNodes() { return m_activePositionedNodes; }
+    HashSet<Ref<ScrollingTreeOverflowScrollProxyNode>>& activeOverflowScrollProxyNodes() LIFETIME_BOUND { return m_activeOverflowScrollProxyNodes; }
+    HashSet<Ref<ScrollingTreePositionedNode>>& activePositionedNodes() LIFETIME_BOUND { return m_activePositionedNodes; }
 
     WEBCORE_EXPORT String scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { });
 
@@ -237,7 +237,7 @@ public:
 
     virtual bool isScrollingSynchronizedWithMainThread() WTF_REQUIRES_LOCK(m_treeLock) { return true; }
 
-    Lock& treeLock() WTF_RETURNS_LOCK(m_treeLock) { return m_treeLock; }
+    Lock& treeLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_treeLock) { return m_treeLock; }
 
     WEBCORE_EXPORT void windowScreenDidChange(PlatformDisplayID, std::optional<FramesPerSecond> nominalFramesPerSecond);
     PlatformDisplayID displayID();

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
@@ -46,7 +46,7 @@ public:
 protected:
     ScrollingTreeFixedNode(ScrollingTree&, ScrollingNodeID);
 
-    const ViewportConstraints& constraints() const final { return m_constraints; }
+    const ViewportConstraints& constraints() const LIFETIME_BOUND final { return m_constraints; }
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -85,7 +85,7 @@ public:
 
     WEBCORE_EXPORT bool isRootNode() const;
 
-    const Vector<Ref<ScrollingTreeNode>>& children() const { return m_children; }
+    const Vector<Ref<ScrollingTreeNode>>& children() const LIFETIME_BOUND { return m_children; }
 
     void appendChild(Ref<ScrollingTreeNode>&&);
     void removeChild(ScrollingTreeNode&);

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -55,12 +55,12 @@ bool ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const Scrol
         m_overflowScrollingNodeID = overflowProxyStateNode->overflowScrollingNode();
 
     if (m_overflowScrollingNodeID) {
-        auto& relatedNodes = scrollingTree()->overflowRelatedNodes();
-        relatedNodes.ensure(*m_overflowScrollingNodeID, [] {
+        RefPtr scrollingTree = this->scrollingTree();
+        scrollingTree->overflowRelatedNodes().ensure(*m_overflowScrollingNodeID, [] {
             return Vector<ScrollingNodeID>();
         }).iterator->value.append(scrollingNodeID());
 
-        scrollingTree()->activeOverflowScrollProxyNodes().add(*this);
+        scrollingTree->activeOverflowScrollProxyNodes().add(*this);
     }
     
     return true;

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h
@@ -39,7 +39,7 @@ class ScrollingTreePositionedNode : public ScrollingTreeNode {
 public:
     virtual ~ScrollingTreePositionedNode();
 
-    const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const { return m_relatedOverflowScrollingNodes; }
+    const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const LIFETIME_BOUND { return m_relatedOverflowScrollingNodes; }
 
     FloatSize scrollDeltaSinceLastCommit() const;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -77,7 +77,7 @@ public:
     FloatPoint lastCommittedScrollPosition() const { return m_lastCommittedScrollPosition; }
     FloatSize scrollDeltaSinceLastCommit() const { return m_currentScrollPosition - m_lastCommittedScrollPosition; }
 
-    const IntPoint& scrollOrigin() const { return m_scrollOrigin; }
+    const IntPoint& scrollOrigin() const LIFETIME_BOUND { return m_scrollOrigin; }
 
     RectEdges<bool> edgePinnedState() const;
 
@@ -116,8 +116,8 @@ public:
     bool hasNonRepaintSynchronousScrollingReasons() const { return !(m_synchronousScrollingReasons - SynchronousScrollingReason::HasSlowRepaintObjects).isEmpty(); }
 #endif
 
-    const FloatSize& scrollableAreaSize() const { return m_scrollableAreaSize; }
-    const FloatSize& totalContentsSize() const { return m_totalContentsSize; }
+    const FloatSize& scrollableAreaSize() const LIFETIME_BOUND { return m_scrollableAreaSize; }
+    const FloatSize& totalContentsSize() const LIFETIME_BOUND { return m_totalContentsSize; }
 
     NativeScrollbarVisibility horizontalNativeScrollbarVisibility() const { return m_scrollableAreaParameters.horizontalNativeScrollbarVisibility; }
     NativeScrollbarVisibility verticalNativeScrollbarVisibility() const { return m_scrollableAreaParameters.verticalNativeScrollbarVisibility; }
@@ -125,7 +125,7 @@ public:
     bool canHaveVerticalScrollbar() const { return m_scrollableAreaParameters.verticalScrollbarMode != ScrollbarMode::AlwaysOff; }
     bool canHaveScrollbars() const { return m_scrollableAreaParameters.horizontalScrollbarMode != ScrollbarMode::AlwaysOff || m_scrollableAreaParameters.verticalScrollbarMode != ScrollbarMode::AlwaysOff; }
 
-    const FloatScrollSnapOffsetsInfo& snapOffsetsInfo() const;
+    const FloatScrollSnapOffsetsInfo& snapOffsetsInfo() const LIFETIME_BOUND;
     std::optional<unsigned> currentHorizontalSnapPointIndex() const;
     std::optional<unsigned> currentVerticalSnapPointIndex() const;
     void setCurrentHorizontalSnapPointIndex(std::optional<unsigned>);
@@ -135,8 +135,8 @@ public:
     
     bool scrolledSinceLastCommit() const { return m_scrolledSinceLastCommit; }
 
-    const LayerRepresentation& scrollContainerLayer() const { return m_scrollContainerLayer; }
-    const LayerRepresentation& scrolledContentsLayer() const { return m_scrolledContentsLayer; }
+    const LayerRepresentation& scrollContainerLayer() const LIFETIME_BOUND { return m_scrollContainerLayer; }
+    const LayerRepresentation& scrolledContentsLayer() const LIFETIME_BOUND { return m_scrolledContentsLayer; }
     
     OverscrollBehavior horizontalOverscrollBehavior() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior; }
     OverscrollBehavior verticalOverscrollBehavior() const { return m_scrollableAreaParameters.verticalOverscrollBehavior; }
@@ -180,14 +180,14 @@ protected:
 
     void applyLayerPositions() override;
 
-    const FloatSize& reachableContentsSize() const { return m_reachableContentsSize; }
+    const FloatSize& reachableContentsSize() const LIFETIME_BOUND { return m_reachableContentsSize; }
     
     bool isLatchedNode() const;
 
     // If the totalContentsSize changes in the middle of a rubber-band, we still want to use the old totalContentsSize for the sake of
     // computing the stretchAmount(). Using the old value will keep the animation smooth. When there is no rubber-band in progress at
     // all, m_totalContentsSizeForRubberBand should be equivalent to m_totalContentsSize.
-    const FloatSize& totalContentsSizeForRubberBand() const { return m_totalContentsSizeForRubberBand; }
+    const FloatSize& totalContentsSizeForRubberBand() const LIFETIME_BOUND { return m_totalContentsSizeForRubberBand; }
     void setTotalContentsSizeForRubberBand(const FloatSize& totalContentsSizeForRubberBand) { m_totalContentsSizeForRubberBand = totalContentsSizeForRubberBand; }
 
     ScrollElasticity horizontalScrollElasticity() const { return m_scrollableAreaParameters.horizontalScrollElasticity; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -59,7 +59,7 @@ protected:
 
     virtual FloatPoint layerTopLeft() const = 0;
     virtual bool hasViewportClippingLayer() const { return false; }
-    const ViewportConstraints& constraints() const final { return m_constraints; }
+    const ViewportConstraints& constraints() const LIFETIME_BOUND final { return m_constraints; }
 
     bool isCurrentlySticking(const FloatRect& constrainingRect) const;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.h
@@ -41,7 +41,7 @@ protected:
     ScrollingTreeViewportConstrainedNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 
     virtual ~ScrollingTreeViewportConstrainedNode();
-    virtual const ViewportConstraints& constraints() const = 0;
+    virtual const ViewportConstraints& constraints() const LIFETIME_BOUND = 0;
     virtual ScrollingPlatformLayer* layer() const = 0;
 
     FloatPoint computeLayerPosition() const;

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -65,7 +65,7 @@ public:
     void willStartRenderingUpdate();
     virtual void didCompleteRenderingUpdate();
 
-    Lock& treeLock() WTF_RETURNS_LOCK(m_treeLock) { return m_treeLock; }
+    Lock& treeLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_treeLock) { return m_treeLock; }
 
     bool scrollAnimatorEnabled() const { return m_scrollAnimatorEnabled; }
     void removePendingScrollAnimationForNode(ScrollingNodeID) WTF_REQUIRES_LOCK(m_treeLock) final;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -95,7 +95,7 @@ public:
     double knobAlpha();
     double trackAlpha();
     bool hasScrollerImp();
-    RecursiveLock& scrollerImpLock() const { return m_scrollerImpLock; }
+    RecursiveLock& scrollerImpLock() const LIFETIME_BOUND { return m_scrollerImpLock; }
 
 private:
     int m_minimumKnobLength { 0 };


### PR DESCRIPTION
#### cf994a7e92ba1e6f0fd32f5eaf94b96b10c658b3
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=309153">https://bugs.webkit.org/show_bug.cgi?id=309153</a>

Reviewed by Geoffrey Garen and Anne van Kesteren.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::documentEventTimingFromNavigationTiming):
(WebCore::Document::setReadyState):
(WebCore::Document::finishedParsing):
(WebCore::Document::graphicsClient):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::frameLoader const):
* Source/WebCore/page/CaptionUserPreferences.h:
(WebCore::CaptionUserPreferences::preferredAudioCharacteristicsForTesting const): Deleted.
* Source/WebCore/page/Chrome.h:
(WebCore::Chrome::client): Deleted.
(WebCore::Chrome::client const): Deleted.
* Source/WebCore/page/ContextMenuContext.h:
(WebCore::ContextMenuContext::hitTestResult const): Deleted.
(WebCore::ContextMenuContext::selectedText const): Deleted.
* Source/WebCore/page/ContextMenuController.h:
(WebCore::ContextMenuController::client): Deleted.
(WebCore::ContextMenuController::contextMenu const): Deleted.
(WebCore::ContextMenuController::context const): Deleted.
(WebCore::ContextMenuController::hitTestResult const): Deleted.
* Source/WebCore/page/DOMWindow.h:
(WebCore::DOMWindow::identifier const): Deleted.
* Source/WebCore/page/DragController.h:
(WebCore::DragController::draggingImageURL const): Deleted.
(WebCore::DragController::dragOffset const): Deleted.
(WebCore::DragController::droppedImagePlaceholders const): Deleted.
(WebCore::DragController::droppedImagePlaceholderRange const): Deleted.
(WebCore::DragController::client const): Deleted.
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/EventSource.h:
(WebCore::EventSource::url const): Deleted.
* Source/WebCore/page/Frame.h:
(WebCore::Frame::tree const): Deleted.
(WebCore::Frame::navigationScheduler const): Deleted.
* Source/WebCore/page/FrameTree.h:
(WebCore::FrameTree::specifiedName const): Deleted.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::hostWindow const):
* Source/WebCore/page/History.h:
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::rootMarginBox const): Deleted.
(WebCore::IntersectionObserver::scrollMarginBox const): Deleted.
(WebCore::IntersectionObserver::thresholds const): Deleted.
(WebCore::IntersectionObserver::observationTargets const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Location.h:
* Source/WebCore/page/LoginStatus.h:
(WebCore::LoginStatus::domain const): Deleted.
(WebCore::LoginStatus::username const): Deleted.
* Source/WebCore/page/MouseEventWithHitTestResults.h:
(WebCore::MouseEventWithHitTestResults::event const): Deleted.
(WebCore::MouseEventWithHitTestResults::hitTestResult const): Deleted.
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationDestination.h:
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/OriginAccessEntry.h:
(WebCore::OriginAccessEntry::protocol const): Deleted.
(WebCore::OriginAccessEntry::host const): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::overrideViewportArguments const): Deleted.
(WebCore::Page::openedByScriptDomain const): Deleted.
(WebCore::Page::chrome): Deleted.
(WebCore::Page::chrome const): Deleted.
(WebCore::Page::cryptoClient): Deleted.
(WebCore::Page::cryptoClient const): Deleted.
(WebCore::Page::documentSyncClient): Deleted.
(WebCore::Page::documentSyncClient const): Deleted.
(WebCore::Page::dragCaretController): Deleted.
(WebCore::Page::dragCaretController const): Deleted.
(WebCore::Page::dragController): Deleted.
(WebCore::Page::dragController const): Deleted.
(WebCore::Page::contextMenuController): Deleted.
(WebCore::Page::contextMenuController const): Deleted.
(WebCore::Page::pointerCaptureController): Deleted.
(WebCore::Page::pointerLockController): Deleted.
(WebCore::Page::webRTCProvider): Deleted.
(WebCore::Page::performanceMonitor): Deleted.
(WebCore::Page::validationMessageClient const): Deleted.
(WebCore::Page::scheduledRunLoopPairs): Deleted.
(WebCore::Page::contentInsets const): Deleted.
(WebCore::Page::unobscuredSafeAreaInsets const): Deleted.
(WebCore::Page::obscuredInsets const): Deleted.
(WebCore::Page::obscuredContentInsets const): Deleted.
(WebCore::Page::fullscreenInsets const): Deleted.
(WebCore::Page::pagination const): Deleted.
(WebCore::Page::performanceLoggingClient const): Deleted.
(WebCore::Page::wheelEventDeltaFilter): Deleted.
(WebCore::Page::pageOverlayController): Deleted.
(WebCore::Page::servicesOverlayController): Deleted.
(WebCore::Page::imageOverlayControllerIfExists): Deleted.
(WebCore::Page::scrollLatchingControllerIfExists): Deleted.
(WebCore::Page::authenticatorCoordinator): Deleted.
(WebCore::Page::applicationManifest const): Deleted.
(WebCore::Page::debugger const): Deleted.
(WebCore::Page::corsDisablingPatterns const): Deleted.
(WebCore::Page::fixedContainerEdges const): Deleted.
(WebCore::Page::performanceLogging const): Deleted.
(WebCore::Page::maskedURLSchemes const): Deleted.
(WebCore::Page::attachmentElementClient): Deleted.
(WebCore::Page::rootFrames const): Deleted.
(WebCore::Page::lastAuthentication const): Deleted.
(WebCore::Page::acceleratedTimelinesUpdater const): Deleted.
* Source/WebCore/page/PageGroup.h:
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceEntry.h:
(WebCore::PerformanceEntry::name const): Deleted.
* Source/WebCore/page/PerformanceNavigationTiming.h:
* Source/WebCore/page/PerformanceObserverEntryList.h:
(WebCore::PerformanceObserverEntryList::getEntries const): Deleted.
* Source/WebCore/page/PerformanceResourceTiming.h:
(WebCore::PerformanceResourceTiming::initiatorType const): Deleted.
(WebCore::PerformanceResourceTiming::serverTiming const): Deleted.
(WebCore::PerformanceResourceTiming::resourceTiming): Deleted.
* Source/WebCore/page/PerformanceServerTiming.h:
(WebCore::PerformanceServerTiming::name const): Deleted.
(WebCore::PerformanceServerTiming::description const): Deleted.
* Source/WebCore/page/PrintContext.h:
(WebCore::PrintContext::pageRect const): Deleted.
(WebCore::PrintContext::pageRects const): Deleted.
* Source/WebCore/page/Quirks.h:
(WebCore::Quirks::subFrameDomainsForStorageAccessQuirk const): Deleted.
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/ResizeObserver.h:
(WebCore::ResizeObserver::WTF_REQUIRES_LOCK):
(WebCore::ResizeObserver::WTF_RETURNS_LOCK):
* Source/WebCore/page/ResizeObserverEntry.h:
(WebCore::ResizeObserverEntry::borderBoxSize const): Deleted.
(WebCore::ResizeObserverEntry::contentBoxSize const): Deleted.
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::SecurityOrigin::protocol const): Deleted.
(WebCore::SecurityOrigin::host const): Deleted.
(WebCore::SecurityOrigin::domain const): Deleted.
(WebCore::SecurityOrigin::data const): Deleted.
* Source/WebCore/page/SecurityOriginData.h:
(WebCore::SecurityOriginData::protocol const): Deleted.
(WebCore::SecurityOriginData::host const): Deleted.
(WebCore::SecurityOriginData::data const): Deleted.
* Source/WebCore/page/SettingsBase.h:
(WebCore::SettingsBase::mediaContentTypesRequiringHardwareSupport const): Deleted.
(WebCore::SettingsBase::allowedMediaContainerTypes const): Deleted.
(WebCore::SettingsBase::allowedMediaCodecTypes const): Deleted.
(WebCore::SettingsBase::allowedMediaVideoCodecIDs const): Deleted.
(WebCore::SettingsBase::allowedMediaAudioCodecIDs const): Deleted.
(WebCore::SettingsBase::allowedMediaCaptionFormatTypes const): Deleted.
* Source/WebCore/page/ShadowRealmGlobalScope.h:
* Source/WebCore/page/TextIndicator.h:
(WebCore::TextIndicator::textRectsInBoundingRectCoordinates const): Deleted.
* Source/WebCore/page/UndoItem.h:
(WebCore::UndoItem::label const): Deleted.
* Source/WebCore/page/UserContentController.h:
* Source/WebCore/page/UserContentURLPattern.h:
(WebCore::UserContentURLPattern::scheme const): Deleted.
(WebCore::UserContentURLPattern::host const): Deleted.
(WebCore::UserContentURLPattern::path const): Deleted.
* Source/WebCore/page/UserScript.h:
(WebCore::UserScript::source const): Deleted.
(WebCore::UserScript::url const): Deleted.
(WebCore::UserScript::allowlist const): Deleted.
(WebCore::UserScript::blocklist const): Deleted.
* Source/WebCore/page/UserStyleSheet.h:
(WebCore::UserStyleSheet::source const): Deleted.
(WebCore::UserStyleSheet::url const): Deleted.
(WebCore::UserStyleSheet::allowlist const): Deleted.
(WebCore::UserStyleSheet::blocklist const): Deleted.
* Source/WebCore/page/ViewportConfiguration.h:
(WebCore::ViewportConfiguration::defaultConfiguration const): Deleted.
(WebCore::ViewportConfiguration::contentsSize const): Deleted.
(WebCore::ViewportConfiguration::viewLayoutSize const): Deleted.
(WebCore::ViewportConfiguration::minimumLayoutSize const): Deleted.
(WebCore::ViewportConfiguration::disabledAdaptations const): Deleted.
(WebCore::ViewportConfiguration::viewportArguments const): Deleted.
* Source/WebCore/page/WebKitSerializedNode.h:
(WebCore::WebKitSerializedNode::serializedNode const): Deleted.
* Source/WebCore/page/csp/CSPViolationReportBody.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirective.h:
(WebCore::ContentSecurityPolicyDirective::name const): Deleted.
(WebCore::ContentSecurityPolicyDirective::text const): Deleted.
(WebCore::ContentSecurityPolicyDirective::nameForReporting const): Deleted.
(WebCore::ContentSecurityPolicyDirective::directiveList const): Deleted.
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
(WebCore::ContentSecurityPolicyDirectiveList::header const): Deleted.
(WebCore::ContentSecurityPolicyDirectiveList::defaultSrc const): Deleted.
(WebCore::ContentSecurityPolicyDirectiveList::evalDisabledErrorMessage const): Deleted.
(WebCore::ContentSecurityPolicyDirectiveList::webAssemblyDisabledErrorMessage const): Deleted.
(WebCore::ContentSecurityPolicyDirectiveList::reportToTokens const): Deleted.
(WebCore::ContentSecurityPolicyDirectiveList::reportURIs const): Deleted.
* Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h:
(WebCore::ContentSecurityPolicyResponseHeaders::headers const): Deleted.
* Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
(WebCore::AsyncScrollingCoordinator::scrollingStateTrees const): Deleted.
* Source/WebCore/page/scrolling/ScrollingConstraints.h:
(WebCore::ViewportConstraints::viewportRectAtLastLayout const): Deleted.
(WebCore::ViewportConstraints::layerPositionAtLastLayout const): Deleted.
(WebCore::StickyPositionViewportConstraints::anchorLayerOffsetAtLastLayout const): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateFixedNode.h:
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::layer const): Deleted.
(WebCore::ScrollingStateNode::children): Deleted.
(WebCore::ScrollingStateNode::children const): Deleted.
* Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::scrollableAreaSize const): Deleted.
(WebCore::ScrollingStateScrollingNode::totalContentsSize const): Deleted.
(WebCore::ScrollingStateScrollingNode::reachableContentsSize const): Deleted.
(WebCore::ScrollingStateScrollingNode::scrollPosition const): Deleted.
(WebCore::ScrollingStateScrollingNode::scrollOrigin const): Deleted.
(WebCore::ScrollingStateScrollingNode::snapOffsetsInfo const): Deleted.
(WebCore::ScrollingStateScrollingNode::scrollableAreaParameters const): Deleted.
(WebCore::ScrollingStateScrollingNode::keyboardScrollData const): Deleted.
(WebCore::ScrollingStateScrollingNode::requestedScrollData const): Deleted.
(WebCore::ScrollingStateScrollingNode::scrollContainerLayer const): Deleted.
(WebCore::ScrollingStateScrollingNode::scrolledContentsLayer const): Deleted.
(WebCore::ScrollingStateScrollingNode::horizontalScrollbarLayer const): Deleted.
(WebCore::ScrollingStateScrollingNode::verticalScrollbarLayer const): Deleted.
(WebCore::ScrollingStateScrollingNode::scrollbarColor const): Deleted.
(WebCore::ScrollingStateScrollingNode::mouseLocationState const): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/ScrollingThread.h:
(WebCore::ScrollingThread::runLoop): Deleted.
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::WTF_RETURNS_LOCK):
(WebCore::ScrollingTree::overflowRelatedNodes): Deleted.
(WebCore::ScrollingTree::activeOverflowScrollProxyNodes): Deleted.
(WebCore::ScrollingTree::activePositionedNodes): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::children const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp:
(WebCore::ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h:
(WebCore::ScrollingTreePositionedNode::relatedOverflowScrollingNodes const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeViewportConstrainedNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
(WebCore::ThreadedScrollingTree::WTF_RETURNS_LOCK):
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:

Canonical link: <a href="https://commits.webkit.org/308683@main">https://commits.webkit.org/308683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b21d93132ac59545d45d1812e872d04d1af3e2fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148053 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101466 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114141 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81387 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44980ca2-6192-4b41-8a88-80032984dee7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94907 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/015903c9-4f1b-4e46-a052-3cbdb36e810f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13314 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4173 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159069 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122167 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122381 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31903 "Failed to checkout and rebase branch from PR 59879") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76688 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17831 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9418 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19940 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->