### PR TITLE
[Skia] Text rendered as much less heavy compared to other browsers

### DIFF
--- a/LayoutTests/fast/snapshot/nested-stacking-context.html
+++ b/LayoutTests/fast/snapshot/nested-stacking-context.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-10000" />
 <style>
 #box {
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/color-inherit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/color-inherit.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-shadow-property">
 <link rel="match" href="color-inherit-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1">
 <div style="position: absolute; top: 24px; left: 24px; color: blue; text-shadow: 3px 3px;">Hello</div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/table-caption.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/table-caption.html
@@ -7,6 +7,7 @@
 <link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
 <link rel="author" href="https://mozilla.org" title="Mozilla">
 <link rel="match" href="table-caption-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3">
 <style>
   table {
     view-transition-name: table;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_timestamp_future.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_timestamp_future.html
@@ -2,6 +2,7 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, bold object transition with timestamp, ::cue(b:future) selector</title>
 <link rel="match" href="bold_timestamp_future-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1">
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_root_selector.html
@@ -2,6 +2,7 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, ::cue(:not(:root)) should not match the root</title>
 <link rel="match" href="not_root_selector-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1">
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/Source/WebCore/platform/graphics/FontRenderOptions.h
+++ b/Source/WebCore/platform/graphics/FontRenderOptions.h
@@ -81,6 +81,12 @@ public:
 #if USE(CAIRO)
     const cairo_font_options_t* fontOptions() const { return m_fontOptions.get(); }
 #elif USE(SKIA)
+    // Custom text settings make text look better at the expense of incorrect blending which is industry standard.
+    static constexpr SkScalar s_textContrast { 0 };
+    static constexpr SkScalar s_textGamma { 1 };
+
+    SkSurfaceProps createSurfaceProps(uint32_t flags = 0) const { return { flags, subpixelOrder(), s_textContrast, s_textGamma }; }
+
     SkFontHinting hinting() const;
     SkFont::Edging antialias() const;
     SkPixelGeometry subpixelOrder() const;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -1154,7 +1154,7 @@ static sk_sp<SkSurface> createAcceleratedSurface(const IntSize& size)
     RELEASE_ASSERT(grContext);
 
     auto imageInfo = SkImageInfo::Make(size.width(), size.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    SkSurfaceProps properties { 0, FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, PlatformDisplay::sharedDisplay().msaaSampleCount(), kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface || !surface->getCanvas())
         return nullptr;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -121,7 +121,7 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
         flags |= SkSurfaceProps::kDynamicMSAA_Flag;
         msaaSampleCount = 1;
     }
-    SkSurfaceProps properties { flags, FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps(flags);
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, msaaSampleCount, kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface || !surface->getCanvas())
         return nullptr;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
         return nullptr;
 
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height(), parameters.colorSpace.platformColorSpace());
-    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
     auto surface = SkSurfaces::Raster(imageInfo, &properties);
     if (!surface || !surface->getCanvas())
         return nullptr;

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -217,7 +217,7 @@ static unsigned initializeMSAASampleCount(GrDirectContext* grContext)
         // knows there are bugs. The only way to know whether our sample count will work is trying to create a
         // surface with that value and check whether it works.
         auto imageInfo = SkImageInfo::Make(512, 512, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-        SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+        SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
         auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, sampleCount, kTopLeft_GrSurfaceOrigin, &properties);
 
         // If the creation of the surface failed, disable MSAA.

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -60,7 +60,7 @@ CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& 
 sk_sp<SkSurface> ShareableBitmap::createSurface()
 {
     ref();
-    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
     auto surface = SkSurfaces::WrapPixels(m_configuration.imageInfo(), mutableSpan().data(), bytesPerRow(), [](void*, void* context) {
         static_cast<ShareableBitmap*>(context)->deref();
     }, this, &properties);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -150,7 +150,7 @@ bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
 
     auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
-    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
     m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);
     return true;
 }
@@ -200,7 +200,7 @@ bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
     unsigned msaaSampleCount = PlatformDisplay::sharedDisplay().msaaSampleCount();
 #endif
 
-    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
     m_surface = SkSurfaces::WrapBackendTexture(PlatformDisplay::sharedDisplay().skiaGrContext(),
         backendTexture,
         kTopLeft_GrSurfaceOrigin,

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -227,7 +227,7 @@ SkSurface* AcceleratedSurface::RenderTargetShareableBuffer::skiaSurface()
         if (!skiaGLContext->makeContextCurrent())
             return nullptr;
 
-        SkSurfaceProps properties { 0, FontRenderOptions::singleton().subpixelOrder() };
+        SkSurfaceProps properties = FontRenderOptions::singleton().createSurfaceProps();
         auto skiaSurface = SkSurfaces::WrapBackendRenderTarget(
             display.skiaGrContext(),
             renderTargetSkia,


### PR DESCRIPTION
#### 4613261563297d30bc988207cc937386893ce5ef
<pre>
[Skia] Text rendered as much less heavy compared to other browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=309152">https://bugs.webkit.org/show_bug.cgi?id=309152</a>

Reviewed by Carlos Garcia Campos.

This change makes all the text rendered by skia look right - i.e.
just like in other browsers - by incorrectly blending in linear color
space despite target being in non-linear color space.

Until this patch, the rendering was done mathematically correct i.e.
the blending was done with respect to target&apos;s color space. However,
historically, many fonts were designed for incorrect blending and hence
they look the most &quot;correct&quot; in such a circumstances.

As skia internally implements so called &quot;gamma hack&quot;, this change
tweaks SkSurfaceProps to properly tune it so that text looks correct.
Despite chromium uses 0.2 for contrast and 1.2 for gamma, this change
chooses 0 for contrast and 1 for gamma, as the results are visually
indistinguishable and yet in some reftests, the differences between
anti-aliased pixels are smaller. So in other words, this change makes
text anti-aliasing more stable (uniform) when it comes to very small,
sub-pixel positioning differences.

No new tests.

Canonical link: <a href="https://commits.webkit.org/308692@main">https://commits.webkit.org/308692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86acd4d9bbe7c8d3d98f3cfdcbf72715af28c180

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156949 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114309 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133129 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4386 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159282 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122341 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132857 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76910 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22849 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9596 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20367 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20244 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->