### PR TITLE
Update Swift BFList to match CPP

### DIFF
--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -147,12 +147,15 @@ private:
     Vector<AtomString> m_documentState;
 } SWIFT_SHARED_REFERENCE(refFrameState, derefFrameState);
 
+// FIXME(rdar://171785683): see if this SWIFT_ESCAPABLE can be avoided
 struct BackForwardListItemState {
     Ref<FrameState> frameState;
     std::optional<WebCore::FrameIdentifier> navigatedFrameID;
 
     bool isEqualForTesting(const BackForwardListItemState&) const;
-};
+} SWIFT_ESCAPABLE;
+
+using VectorBackForwardListItemState = Vector<BackForwardListItemState>;
 
 struct BackForwardListState {
     Vector<BackForwardListItemState> items;

--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -38,9 +38,9 @@ protocol CxxRef {
     func copyRef() -> Self
 }
 
-/// Conform any WTF::Vector<WTF::Ref<T>> to this protocol to get useful extensions and iterators.
-protocol CxxRefVector {
-    associatedtype Element: CxxRef // you only need to specify this in your conformance
+/// Conform any WTF::Vector<T> to this protocol to get useful extensions and iterators.
+protocol CxxVector {
+    associatedtype Element // you only need to specify this in your conformance
     init()
     mutating func append(consuming: Element)
     mutating func reserveCapacity(_ newCapacity: Int)
@@ -49,12 +49,16 @@ protocol CxxRefVector {
     func __atUnsafe(_ index: Int) -> UnsafePointer<Element>
 }
 
-// FIXME(rdar://164119356)): conform to LosslessStringConvertible
+/// Conform any WTF::Vector<WTF::Ref<T>> to this protocol to get useful extensions and iterators.
+protocol CxxRefVector: CxxVector where Element: CxxRef {
+}
+
+// FIXME(rdar://164119356): conform to LosslessStringConvertible
 // when this moves to WTF (requires members to be public)
 extension WTF.String {
     /// Construct a `WTF.String` from a `Swift.String`.
     init(_ string: Swift.String) {
-        // rdar://162517354 prevents us from simply writing
+        // rdar://167712240 prevents us from simply writing
         // self = WTF.String.fromUTF8(swiftString.utf8CString.span);
         // Safety - we are guaranteed to get a valid buffer from the Swift
         // string for the duration that we're using it to construct the WTF::String.
@@ -96,10 +100,10 @@ extension CxxRefVector {
     }
 }
 
-// Iterator for WTF::Vectors of Ref types.
+// Iterator for WTF::Vectors.
 // rdar://169297366 when fixed will conform WTF::Vector directly to Sequence.
 // We can't do that manually since this would require C++ interop types to be public
-struct CxxRefVectorIterator<Vec: CxxRefVector>: Sequence, IteratorProtocol {
+struct CxxVectorIterator<Vec: CxxVector>: Sequence, IteratorProtocol {
     typealias Element = Vec.Element
     var vec: Vec
     var pos: Int
@@ -119,7 +123,7 @@ struct CxxRefVectorIterator<Vec: CxxRefVector>: Sequence, IteratorProtocol {
         // within the vector bounds.
         let item = unsafe vec.__atUnsafe(pos)
         pos += 1
-        return unsafe item.pointee.copyRef()
+        return unsafe item.pointee
     }
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -52,16 +52,33 @@ extension WebKit.BackForwardListItemVector: CxxRefVector {
     typealias Element = WebKit.RefWebBackForwardListItem
 }
 
+extension WebKit.VectorBackForwardListItemState: CxxVector {
+    typealias Element = WebKit.BackForwardListItemState
+}
+
 extension WebKit.WebBackForwardListItem {
     private borrowing func getUrlCopy() -> WTF.String {
         // Safety: we immediately make a copy of the string before
-        // it could be freed or mutated. FIXME(rdar://162695942): remove
+        // it could be freed or mutated. FIXME(rdar://145054011): remove
         // this.
         unsafe __urlUnsafe().pointee
     }
 
     var url: WTF.String {
         getUrlCopy()
+    }
+}
+
+extension WebKit.WebBackForwardListFrameItem {
+    private borrowing func getFrameState() -> WebKit.FrameState {
+        // Safety: FrameState is a SWIFT_SHARED_REFERENCE so this will
+        // result in a reference count increment and no lifetime risk.
+        // FIXME(rdar://168057355): remove this.
+        unsafe __frameStateUnsafe()
+    }
+
+    var frameState: WebKit.FrameState {
+        getFrameState()
     }
 }
 
@@ -540,7 +557,9 @@ final class WebBackForwardList {
                 }
                 continue
             }
-            backForwardListState.items.append(consuming: entry.mainFrameState())
+            backForwardListState.items.append(
+                consuming: WebKit.BackForwardListItemState(frameState: entry.mainFrameState(), navigatedFrameID: entry.navigatedFrameID())
+            )
         }
 
         if backForwardListState.items.isEmpty() {
@@ -556,16 +575,9 @@ final class WebBackForwardList {
     private func setBackForwardItemIdentifiers(frameState: WebKit.FrameState, itemID: WebCore.BackForwardItemIdentifier) {
         frameState.itemID = WebCore.MarkableBackForwardItemIdentifier(itemID)
         frameState.frameItemID = WebCore.MarkableBackForwardFrameItemIdentifier(generateBackForwardFrameItemIdentifier())
-        for child in CxxRefVectorIterator(vec: frameState.children) {
+        for child in CxxVectorIterator(vec: frameState.children) {
             setBackForwardItemIdentifiers(frameState: child.ptr(), itemID: itemID)
         }
-    }
-
-    private func createWebBackForwardListItem(
-        state: WebKit.RefFrameState,
-        pageIdentifier: WebKit.WebPageProxyIdentifier
-    ) -> WebKit.RefWebBackForwardListItem {
-        WebKit.WebBackForwardListItem.create(consuming: state, pageIdentifier, state.ptr().frameID)
     }
 
     func restoreFromState(backForwardListState: WebKit.BackForwardListState) {
@@ -576,11 +588,10 @@ final class WebBackForwardList {
         // FIXME: Enable restoring resourceDirectoryURL.
         entries.removeAll()
         entries.reserveCapacity(backForwardListState.items.size())
-        for item in CxxRefVectorIterator(vec: backForwardListState.items) {
-            let stateCopy = item.ptr().copy()
+        for itemState in CxxVectorIterator(vec: backForwardListState.items) {
+            let stateCopy = itemState.frameState.ptr().copy()
             setBackForwardItemIdentifiers(frameState: stateCopy.ptr(), itemID: generateBackForwardItemIdentifier())
-            // FIXME: navigatedFrameID will always be the main frame ID, causing the restored session state to be sent to an incorrect process when going back or forward with site isolation enabled.
-            let item = createWebBackForwardListItem(state: stateCopy, pageIdentifier: page.identifier())
+            let item = WebKit.WebBackForwardListItem.create(consuming: stateCopy, page.identifier(), itemState.navigatedFrameID)
             entries.append(item.ptr())
         }
 
@@ -693,6 +704,23 @@ final class WebBackForwardList {
         return WebKit.RefPtrWebBackForwardListItem(item)
     }
 
+    func findFrameStateInItem(
+        itemID: WebCore.BackForwardItemIdentifier,
+        parentFrameID: WebCore.FrameIdentifier,
+        childFrameIndex: UInt64
+    ) -> WebKit.FrameState? {
+        guard let targetItem = itemForID(identifier: itemID) else {
+            return nil
+        }
+        guard let parentFrameItem = targetItem.mainFrameItem().childItemForFrameID(parentFrameID) else {
+            return nil
+        }
+        guard let childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex) else {
+            return nil
+        }
+        return childFrameItem.frameState
+    }
+
     func loggingString() -> Swift.String {
         var result =
             "\nWebBackForwardList \(ObjectIdentifier(self)) - \(entries.count) entries, has current index \(currentIndex != nil ? "YES" : "NO") (\(currentIndex ?? 0))\n"
@@ -717,7 +745,7 @@ final class WebBackForwardList {
 
     func setBackForwardItemIdentifier(frameState: WebKit.FrameState, itemID: WebCore.BackForwardItemIdentifier) {
         frameState.itemID = WebCore.MarkableBackForwardItemIdentifier(itemID)
-        for child in CxxRefVectorIterator(vec: frameState.children) {
+        for child in CxxVectorIterator(vec: frameState.children) {
             setBackForwardItemIdentifier(frameState: child.ptr(), itemID: itemID)
         }
     }


### PR DESCRIPTION
#### 9f2eb408669825f865b4055ff06eb9e5e342c51b
<pre>
Update Swift BFList to match CPP
<a href="https://bugs.webkit.org/show_bug.cgi?id=309154">https://bugs.webkit.org/show_bug.cgi?id=309154</a>
<a href="https://rdar.apple.com/171703088">rdar://171703088</a>

Reviewed by Richard Robinson and Sihui Liu.

There have been two recent changes to the C++ Back Forward List for site
isolation work; this updates the Swift equivalent to match.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=308939">https://bugs.webkit.org/show_bug.cgi?id=308939</a>, the C++ Back Forward List
was updated; the description was:

&quot;Preserve navigatedFrameID in session state for correct child frame
back/forward navigation&quot;

In <a href="https://bugs.webkit.org/show_bug.cgi?id=308562">https://bugs.webkit.org/show_bug.cgi?id=308562</a>, it was updated again:

&quot;Route same-site child frame back/forward navigations through UIProcess when
UseUIProcessForBackForwardItemLoading is enabled.&quot;

The Swift version is brought up to date in this PR.

Specifically the changes are:
- mark the new BackForwardListItemState type as escapable, which means
  we are promising Swift that any interior pointers do not refer to
  surrounding objects (vectors etc.) that might contain it.
- broaden the existing CxxRefVectorIterator to work with any
  WTF::Vector where the contents are copyable (which therefore includes
  BackForwardListItemState)
- add the ability to retrieve the FrameState reference from a
  WebBackForwardListFrameItem (this adds an &apos;unsafe&apos;;
  there would be no need for this with the very most recent SDKs)
- make code changes corresponding to the changes in the C++

In the process, update a few unrelated comments to fix rdar numbers
where bugs have been marked as duplicates of other bugs.

Canonical link: <a href="https://commits.webkit.org/308700@main">https://commits.webkit.org/308700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33186f44a08ba12ca7b1e891d84c860f20aa865e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156927 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e1996f9-8e93-40fd-ad4c-f3ddb30f98d7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc9ec822-4ee3-49e5-930c-68e9b2c08c65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95064 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f2c6804-5bb7-44f0-94ba-02f0a5aca16a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13453 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4364 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125258 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159260 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122326 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33312 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132839 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76888 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9579 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84130 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20076 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20222 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->