### PR TITLE
[svg2] comprehensive test cases for parsing path data of the d attribute in path element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/arc-commands-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/arc-commands-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Absolute arc: A 50,50 0 0,1 200,100
+PASS Relative arc: a 50,50 0 0,1 100,0 from (100,150)
+PASS Arc endpoint is correct
+PASS Large arc flag: A 50,50 0 1,1 200,200
+PASS Sweep flag variations: 0 vs 1
+PASS X-axis rotation: A 50,25 45 0,1 200,300
+PASS Multiple arc arguments
+PASS Arc flags without comma: 01 instead of 0,1
+PASS Arc flags with spaces: 0 1 instead of 0,1
+PASS Elliptical arc: A 75,25 (different rx and ry)
+PASS Arc with zero radius becomes line
+PASS Arc with negative radius uses absolute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/arc-commands.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/arc-commands.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Elliptical arc (A/a)</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<svg id="svg" width="400" height="400">
+  <!-- Absolute arc -->
+  <path id="test-A" d="M 100,100 A 50,50 0 0,1 200,100" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Relative arc -->
+  <path id="test-a" d="M 100,150 a 50,50 0 0,1 100,0" fill="none" stroke="blue" stroke-width="2"/>
+</svg>
+
+<script>
+test(function() {
+  const path = document.getElementById('test-A');
+  const length = path.getTotalLength();
+
+  assert_greater_than(length, 0, "A command creates an arc");
+  assert_greater_than(length, 100, "Arc is longer than straight line");
+}, "Absolute arc: A 50,50 0 0,1 200,100");
+
+test(function() {
+  const pathA = document.getElementById('test-A');
+  const patha = document.getElementById('test-a');
+
+  // Both should create similar arcs
+  assert_approx_equals(pathA.getTotalLength(), patha.getTotalLength(), 1,
+    "Relative arc creates same curve as absolute");
+}, "Relative arc: a 50,50 0 0,1 100,0 from (100,150)");
+
+test(function() {
+  const path = document.getElementById('test-A');
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+
+  assert_approx_equals(endPoint.x, 200, 0.5, "Arc ends at specified x");
+  assert_approx_equals(endPoint.y, 100, 0.5, "Arc ends at specified y");
+}, "Arc endpoint is correct");
+
+test(function() {
+  // Test large-arc-flag = 1
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,200 A 50,50 0 1,1 200,200');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 100, "Large arc flag creates larger arc");
+}, "Large arc flag: A 50,50 0 1,1 200,200");
+
+test(function() {
+  // Test sweep-flag variations
+  const svg = document.getElementById('svg');
+  const path0 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path0.setAttribute('d', 'M 100,250 A 50,50 0 0,0 200,250');
+  svg.appendChild(path0);
+
+  const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path1.setAttribute('d', 'M 100,250 A 50,50 0 0,1 200,250');
+  svg.appendChild(path1);
+
+  // Both paths share the same start (100,250) and end (200,250) with r=50.
+  // The chord length (100) equals the diameter (2×50), so both arcs are semicircles
+  // with identical path lengths — comparing lengths would yield near-zero floating-point
+  // noise instead of a meaningful difference.
+  //
+  // The arcs bow in opposite directions:
+  //
+  //       (150, 200)  ← midpoint of sweep=1 arc (bows up)
+  //            ●
+  //   ●─────────────●
+  // (100,250)     (200,250)
+  //            ●
+  //       (150, 300)  ← midpoint of sweep=0 arc (bows down)
+  //
+  // Comparing the midpoint y-coordinates gives a ~100-unit difference on all platforms.
+  const mid0 = path0.getPointAtLength(path0.getTotalLength() / 2);
+  const mid1 = path1.getPointAtLength(path1.getTotalLength() / 2);
+  assert_greater_than(Math.abs(mid0.y - mid1.y), 10,
+    "Different sweep flags create different arcs");
+}, "Sweep flag variations: 0 vs 1");
+
+test(function() {
+  // Test x-axis-rotation
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,300 A 50,25 45 0,1 200,300');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Rotated elliptical arc works");
+}, "X-axis rotation: A 50,25 45 0,1 200,300");
+
+test(function() {
+  // Multiple arc arguments
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,350 A 25,25 0 0,1 100,350 25,25 0 0,1 150,350');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 150, 0.5, "Multiple arcs end at last point");
+}, "Multiple arc arguments");
+
+test(function() {
+  // Flags without comma
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 200,100 A 50,50 0 01 300,100');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Flags without comma separator work");
+}, "Arc flags without comma: 01 instead of 0,1");
+
+test(function() {
+  // Flags with spaces
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 200,150 A 50,50 0 0 1 300,150');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Flags with space separator work");
+}, "Arc flags with spaces: 0 1 instead of 0,1");
+
+test(function() {
+  // Different radii (ellipse)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 200,200 A 75,25 0 0,1 300,200');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Elliptical arc with different radii works");
+}, "Elliptical arc: A 75,25 (different rx and ry)");
+
+test(function() {
+  // Zero radius (should create line)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 200,250 A 0,0 0 0,1 300,250');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_approx_equals(length, 100, 0.5, "Zero radius creates straight line");
+}, "Arc with zero radius becomes line");
+
+test(function() {
+  // Negative radius (should use absolute value)
+  const svg = document.getElementById('svg');
+  const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path1.setAttribute('d', 'M 200,300 A -50,50 0 0,1 300,300');
+  svg.appendChild(path1);
+
+  const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path2.setAttribute('d', 'M 200,300 A 50,50 0 0,1 300,300');
+  svg.appendChild(path2);
+
+  // Negative radius should be treated as absolute value
+  assert_approx_equals(path1.getTotalLength(), path2.getTotalLength(), 0.5,
+    "Negative radius treated as positive");
+}, "Arc with negative radius uses absolute value");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/curveto-commands-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/curveto-commands-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Absolute curveto: C 100,25 150,75 200,50
+PASS Relative curveto: c 50,-25 100,25 150,0 from (50,50)
+PASS Curveto endpoints are correct
+PASS Multiple curveto triplets: C x1,y1 x2,y2 x,y x1,y1 x2,y2 x,y
+PASS Smooth curveto: S 175,200 200,150
+PASS Smooth curveto after C: reflects control point
+PASS Relative smooth curveto: s x2,y2 x,y
+PASS Smooth curveto without preceding curve
+PASS Multiple smooth curveto pairs
+PASS Curveto with space separators (no commas)
+PASS Curveto with all comma separators
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/curveto-commands.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/curveto-commands.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Curveto commands (C/c, S/s)</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<svg id="svg" width="400" height="400">
+  <!-- Cubic Bezier curve -->
+  <path id="test-C" d="M 50,50 C 100,25 150,75 200,50" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Relative cubic Bezier -->
+  <path id="test-c" d="M 50,50 c 50,-25 100,25 150,0" fill="none" stroke="blue" stroke-width="1" stroke-dasharray="2,2"/>
+
+  <!-- Smooth cubic Bezier -->
+  <path id="test-S" d="M 50,150 C 75,100 100,100 125,150 S 175,200 200,150" fill="none" stroke="green" stroke-width="2"/>
+</svg>
+
+<script>
+test(function() {
+  const path = document.getElementById('test-C');
+  const length = path.getTotalLength();
+
+  assert_greater_than(length, 0, "C command creates a curve");
+  assert_greater_than(length, 100, "Curve is longer than straight distance");
+}, "Absolute curveto: C 100,25 150,75 200,50");
+
+test(function() {
+  const pathC = document.getElementById('test-C');
+  const pathc = document.getElementById('test-c');
+
+  // Both should create similar curves
+  assert_approx_equals(pathC.getTotalLength(), pathc.getTotalLength(), 1,
+    "Relative curveto creates same curve as absolute");
+}, "Relative curveto: c 50,-25 100,25 150,0 from (50,50)");
+
+test(function() {
+  const pathC = document.getElementById('test-C');
+  const startPoint = pathC.getPointAtLength(0);
+  const endPoint = pathC.getPointAtLength(pathC.getTotalLength());
+
+  assert_approx_equals(startPoint.x, 50, 0.1, "Curve starts at M point");
+  assert_approx_equals(startPoint.y, 50, 0.1, "Curve starts at M point");
+  assert_approx_equals(endPoint.x, 200, 0.1, "Curve ends at specified point");
+  assert_approx_equals(endPoint.y, 50, 0.1, "Curve ends at specified point");
+}, "Curveto endpoints are correct");
+
+test(function() {
+  // Multiple curve triplets
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,50 C 25,0 50,0 75,50 100,100 125,100 150,50');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 150, 0.5, "Multiple curves end at last point");
+  assert_approx_equals(endPoint.y, 50, 0.5, "Multiple curves end at last point");
+}, "Multiple curveto triplets: C x1,y1 x2,y2 x,y x1,y1 x2,y2 x,y");
+
+test(function() {
+  const path = document.getElementById('test-S');
+  const length = path.getTotalLength();
+
+  assert_greater_than(length, 0, "S command creates a curve");
+}, "Smooth curveto: S 175,200 200,150");
+
+test(function() {
+  // S command reflects previous control point
+  const svg = document.getElementById('svg');
+  const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path1.setAttribute('d', 'M 0,50 C 25,0 50,0 75,50 S 125,100 150,50');
+  svg.appendChild(path1);
+
+  const length = path1.getTotalLength();
+  assert_greater_than(length, 0, "S after C creates smooth curve");
+}, "Smooth curveto after C: reflects control point");
+
+test(function() {
+  // Relative smooth curveto
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 C 75,25 100,75 125,50 s 50,-25 75,0');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Relative s command works");
+}, "Relative smooth curveto: s x2,y2 x,y");
+
+test(function() {
+  // S without preceding curve (uses current point as reflection)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 S 100,25 150,50');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "S without preceding C uses current point");
+}, "Smooth curveto without preceding curve");
+
+test(function() {
+  // Multiple S commands
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,50 C 25,0 50,0 75,50 S 125,100 150,50 175,0 200,50');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 200, 0.5, "Multiple S commands");
+  assert_approx_equals(endPoint.y, 50, 0.5, "Multiple S commands");
+}, "Multiple smooth curveto pairs");
+
+test(function() {
+  // Curveto with minimal spacing (no commas)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50 50 C 75 25 100 75 125 50');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "C command works with space separators only");
+}, "Curveto with space separators (no commas)");
+
+test(function() {
+  // Curveto with all commas
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 C 75,25,100,75,125,50');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "C command works with all comma separators");
+}, "Curveto with all comma separators");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/error-handling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/error-handling-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Error: Invalid command letter 'X' stops rendering
+PASS Error: Incomplete coordinate pair stops rendering
+PASS Error: Odd number of coordinates renders last complete pair
+PASS Error: Incomplete curveto (missing coordinates)
+PASS Error: Invalid arc flag (must be 0 or 1)
+PASS Edge case: Path without initial moveto
+PASS Empty path data string
+PASS Path data value 'none' disables rendering
+PASS Error: Multiple errors - stops at first one
+PASS Error: Incomplete second curveto
+PASS Error: Valid commands after error are ignored
+PASS Error: Invalid command letter (case-sensitive)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/error-handling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/error-handling.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Error handling - invalid commands and parameters</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Test 1: Invalid command letter -->
+  <path id="test1" d="M 10,10 L 50,50 X 100,100" fill="none" stroke="black" stroke-width="2"/>
+  <path id="ref1" d="M 10,10 L 50,50" fill="none" stroke="red" stroke-width="1" stroke-dasharray="2,2"/>
+
+  <!-- Test 2: Incomplete coordinate pair -->
+  <path id="test2" d="M 10,60 L 50,60 L 100" fill="none" stroke="black" stroke-width="2"/>
+  <path id="ref2" d="M 10,60 L 50,60" fill="none" stroke="red" stroke-width="1" stroke-dasharray="2,2"/>
+</svg>
+
+<script>
+test(function() {
+  const testPath = document.getElementById('test1');
+  const refPath = document.getElementById('ref1');
+
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Path with invalid command renders up to error");
+}, "Error: Invalid command letter 'X' stops rendering");
+
+test(function() {
+  const testPath = document.getElementById('test2');
+  const refPath = document.getElementById('ref2');
+
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Path with incomplete coordinate pair renders up to error");
+}, "Error: Incomplete coordinate pair stops rendering");
+
+test(function() {
+  // Odd number of coordinates for L command
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'M 10,110 L 50,110 60,110 70');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 10,110 L 50,110 60,110');
+  svg.appendChild(refPath);
+
+  // Should render up to last complete coordinate pair
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Renders last complete coordinate pair before error");
+}, "Error: Odd number of coordinates renders last complete pair");
+
+test(function() {
+  // Incomplete curveto (needs 6 parameters)
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'M 10,160 L 50,160 C 60,150 70,170');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 10,160 L 50,160');
+  svg.appendChild(refPath);
+
+  // Should render up to L command, not the incomplete C
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Incomplete curveto is not rendered");
+}, "Error: Incomplete curveto (missing coordinates)");
+
+test(function() {
+  // Invalid arc flag (must be 0 or 1)
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'M 10,210 L 50,210 A 25,25 0 2,1 100,210');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 10,210 L 50,210');
+  svg.appendChild(refPath);
+
+  // Should render up to L command, not the arc with invalid flag
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Invalid arc flag stops rendering");
+}, "Error: Invalid arc flag (must be 0 or 1)");
+
+test(function() {
+  // Missing moveto at start
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'L 100,260');
+  svg.appendChild(testPath);
+
+  // Path without initial moveto should render (treats as moveto)
+  const length = testPath.getTotalLength();
+  assert_equals(length, 0, "Path without initial moveto may not render or treats L as M");
+}, "Edge case: Path without initial moveto");
+
+test(function() {
+  // Empty path data
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', '');
+  svg.appendChild(testPath);
+
+  const length = testPath.getTotalLength();
+  assert_equals(length, 0, "Empty path has zero length");
+}, "Empty path data string");
+
+test(function() {
+  // Path data = "none"
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'none');
+  svg.appendChild(testPath);
+
+  const length = testPath.getTotalLength();
+  assert_equals(length, 0, "Path with d='none' has zero length");
+}, "Path data value 'none' disables rendering");
+
+test(function() {
+  // Multiple errors - stops at first
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'M 10,310 L 50,310 X 60,310 Y 70,310');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 10,310 L 50,310');
+  svg.appendChild(refPath);
+
+  // Should stop at first error (X)
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Stops at first error, not subsequent errors");
+}, "Error: Multiple errors - stops at first one");
+
+test(function() {
+  // Partial C command (4 params instead of 6)
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'M 0,0 L 50,50 C 60,40 70,60 80,50 C 90,40 100,60');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 0,0 L 50,50 C 60,40 70,60 80,50');
+  svg.appendChild(refPath);
+
+  // Should render first complete C, not second incomplete C
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Renders up to last complete curveto");
+}, "Error: Incomplete second curveto");
+
+test(function() {
+  // Valid commands after error should not render
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  testPath.setAttribute('d', 'M 10,360 L 50,360 L 60 L 100,360');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 10,360 L 50,360');
+  svg.appendChild(refPath);
+
+  // Should not render L 100,360 even though it's valid
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Commands after error are not rendered");
+}, "Error: Valid commands after error are ignored");
+
+test(function() {
+  // Letter case errors (lowercase where uppercase expected, etc.)
+  const svg = document.getElementById('svg');
+  const testPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  // Using 'x' which is not a valid command
+  testPath.setAttribute('d', 'M 100,10 x 150,10');
+  svg.appendChild(testPath);
+
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 100,10');
+  svg.appendChild(refPath);
+
+  assert_approx_equals(testPath.getTotalLength(), refPath.getTotalLength(), 0.5,
+    "Invalid lowercase command stops rendering");
+}, "Error: Invalid command letter (case-sensitive)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/lineto-commands-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/lineto-commands-expected.txt
@@ -1,0 +1,15 @@
+
+PASS Absolute lineto: L 150,150
+PASS Relative lineto: l 100,100 from (50,50) equals L 150,150
+PASS Horizontal lineto: H 150 from (50,200) creates 100-unit line
+PASS Vertical lineto: V 150 from (200,50) creates 100-unit line
+PASS Multiple lineto coordinates: L 10,0 20,0 30,0
+PASS Multiple horizontal lineto: H 10 20 30
+PASS Multiple vertical lineto: V 10 20 30
+PASS Relative horizontal lineto: h 100 from (50,50)
+PASS Relative vertical lineto: v 100 from (50,50)
+PASS Negative relative lineto: h -50 v -50 from (100,100)
+PASS Combined lineto and closepath: creates square
+PASS Mixed absolute and relative lineto
+PASS Closepath: Z and z are case-insensitive
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/lineto-commands.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/lineto-commands.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Lineto commands (L/l, H/h, V/v)</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Absolute lineto -->
+  <path id="test-L" d="M 50,50 L 150,150" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Relative lineto -->
+  <path id="test-l" d="M 50,50 l 100,100" fill="none" stroke="blue" stroke-width="1"/>
+
+  <!-- Horizontal lineto -->
+  <path id="test-H" d="M 50,200 H 150" fill="none" stroke="green" stroke-width="2"/>
+
+  <!-- Vertical lineto -->
+  <path id="test-V" d="M 200,50 V 150" fill="none" stroke="red" stroke-width="2"/>
+</svg>
+
+<script>
+test(function() {
+  const path = document.getElementById('test-L');
+  const length = path.getTotalLength();
+  const expectedLength = Math.sqrt(100*100 + 100*100); // Diagonal line
+
+  assert_approx_equals(length, expectedLength, 0.5, "L command creates line");
+}, "Absolute lineto: L 150,150");
+
+test(function() {
+  const pathL = document.getElementById('test-L');
+  const pathl = document.getElementById('test-l');
+
+  // Both should have same length (both create same diagonal from (50,50) to (150,150))
+  assert_approx_equals(pathL.getTotalLength(), pathl.getTotalLength(), 0.5,
+    "Relative lineto creates same result as absolute");
+}, "Relative lineto: l 100,100 from (50,50) equals L 150,150");
+
+test(function() {
+  const path = document.getElementById('test-H');
+  const length = path.getTotalLength();
+
+  assert_approx_equals(length, 100, 0.5, "H command creates horizontal line of length 100");
+}, "Horizontal lineto: H 150 from (50,200) creates 100-unit line");
+
+test(function() {
+  const path = document.getElementById('test-V');
+  const length = path.getTotalLength();
+
+  assert_approx_equals(length, 100, 0.5, "V command creates vertical line of length 100");
+}, "Vertical lineto: V 150 from (200,50) creates 100-unit line");
+
+test(function() {
+  // Multiple coordinate pairs after L
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,0 L 10,0 20,0 30,0');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_approx_equals(length, 30, 0.5, "Multiple coordinates create multiple line segments");
+}, "Multiple lineto coordinates: L 10,0 20,0 30,0");
+
+test(function() {
+  // Multiple coordinates after H
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,50 H 10 20 30');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_approx_equals(length, 30, 0.5, "Multiple H coordinates");
+}, "Multiple horizontal lineto: H 10 20 30");
+
+test(function() {
+  // Multiple coordinates after V
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,0 V 10 20 30');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_approx_equals(length, 30, 0.5, "Multiple V coordinates");
+}, "Multiple vertical lineto: V 10 20 30");
+
+test(function() {
+  // Relative horizontal lineto
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 h 100');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 150, 0.5, "h adds to current x");
+  assert_approx_equals(endPoint.y, 50, 0.5, "y remains unchanged");
+}, "Relative horizontal lineto: h 100 from (50,50)");
+
+test(function() {
+  // Relative vertical lineto
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 v 100');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 50, 0.5, "x remains unchanged");
+  assert_approx_equals(endPoint.y, 150, 0.5, "v adds to current y");
+}, "Relative vertical lineto: v 100 from (50,50)");
+
+test(function() {
+  // Negative relative movements
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,100 h -50 v -50');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 50, 0.5, "Negative h moves left");
+  assert_approx_equals(endPoint.y, 50, 0.5, "Negative v moves up");
+}, "Negative relative lineto: h -50 v -50 from (100,100)");
+
+test(function() {
+  // Combined line commands
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 L 100,50 L 100,100 L 50,100 Z');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_approx_equals(length, 200, 0.5, "Square perimeter is 200");
+}, "Combined lineto and closepath: creates square");
+
+test(function() {
+  // Mixed absolute and relative
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,0 L 50,0 l 50,0 L 150,0');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_approx_equals(length, 150, 0.5, "Mixed absolute and relative commands");
+}, "Mixed absolute and relative lineto");
+
+test(function() {
+  // Closepath (Z/z)
+  const svg = document.getElementById('svg');
+  const pathZ = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  pathZ.setAttribute('d', 'M 0,0 L 100,0 L 100,100 Z');
+  svg.appendChild(pathZ);
+
+  const pathz = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  pathz.setAttribute('d', 'M 0,0 L 100,0 L 100,100 z');
+  svg.appendChild(pathz);
+
+  assert_approx_equals(pathZ.getTotalLength(), pathz.getTotalLength(), 0.1,
+    "Z and z are equivalent");
+}, "Closepath: Z and z are case-insensitive");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-absolute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-absolute-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Single moveto: M 100,100
+PASS Single moveto has no path length
+PASS Moveto followed by implicit lineto: M 50,50 150,50
+PASS Moveto with multiple coordinate pairs creates implicit lineto commands
+PASS Multiple coordinate pairs after M become implicit lineto
+PASS Moveto without whitespace: M100,100
+PASS Multiple moveto commands create separate subpaths
+PASS Moveto with comma and spaces: M 100 , 200
+PASS Moveto without comma: M 100 200
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-absolute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-absolute.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Moveto command - absolute (M)</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Single moveto -->
+  <path id="test1" d="M 100,100" fill="red" stroke="none"/>
+
+  <!-- Moveto with subsequent lineto (implicit) -->
+  <path id="test2" d="M 50,50 150,50 150,150 50,150 Z" fill="none" stroke="black" stroke-width="2"/>
+</svg>
+
+<script>
+test(function() {
+  const path = document.getElementById('test1');
+  const point = path.getPointAtLength(0);
+
+  assert_approx_equals(point.x, 100, 0.1, "Moveto x coordinate");
+  assert_approx_equals(point.y, 100, 0.1, "Moveto y coordinate");
+}, "Single moveto: M 100,100");
+
+test(function() {
+  const path = document.getElementById('test1');
+  const length = path.getTotalLength();
+
+  // A single moveto has no length
+  assert_approx_equals(length, 0, 0.1, "Single moveto has zero length");
+}, "Single moveto has no path length");
+
+test(function() {
+  const path = document.getElementById('test2');
+  const startPoint = path.getPointAtLength(0);
+
+  assert_approx_equals(startPoint.x, 50, 0.1, "Path starts at x=50");
+  assert_approx_equals(startPoint.y, 50, 0.1, "Path starts at y=50");
+}, "Moveto followed by implicit lineto: M 50,50 150,50");
+
+test(function() {
+  const path = document.getElementById('test2');
+  const length = path.getTotalLength();
+
+  // Square: 100+100+100+100 = 400
+  assert_approx_equals(length, 400, 0.5, "Closed square has perimeter of 400");
+}, "Moveto with multiple coordinate pairs creates implicit lineto commands");
+
+test(function() {
+  // Multiple coordinate pairs after M
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 10,10 20,20 30,30');
+  svg.appendChild(path);
+
+  const startPoint = path.getPointAtLength(0);
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+
+  assert_approx_equals(startPoint.x, 10, 0.1, "Starts at 10,10");
+  assert_approx_equals(startPoint.y, 10, 0.1, "Starts at 10,10");
+  assert_approx_equals(endPoint.x, 30, 0.1, "Ends at 30,30");
+  assert_approx_equals(endPoint.y, 30, 0.1, "Ends at 30,30");
+}, "Multiple coordinate pairs after M become implicit lineto");
+
+test(function() {
+  // Whitespace variations
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M100,100');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 100, 0.1, "M without whitespace");
+  assert_approx_equals(point.y, 100, 0.1, "M without whitespace");
+}, "Moveto without whitespace: M100,100");
+
+test(function() {
+  // Multiple moveto commands (creates subpaths)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 10,10 L 20,20 M 30,30 L 40,40');
+  svg.appendChild(path);
+
+  // Should have two separate subpaths
+  const startPoint = path.getPointAtLength(0);
+  assert_approx_equals(startPoint.x, 10, 0.1, "First subpath starts at 10,10");
+  assert_approx_equals(startPoint.y, 10, 0.1, "First subpath starts at 10,10");
+
+  // Total length should be sum of both subpaths
+  const length = path.getTotalLength();
+  const expectedLength = Math.sqrt(200) * 2; // Two diagonal lines of equal length
+  assert_approx_equals(length, expectedLength, 0.5, "Two subpaths contribute to total length");
+}, "Multiple moveto commands create separate subpaths");
+
+test(function() {
+  // Moveto with comma in coordinate pair
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100 , 200');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 100, 0.1, "Comma with spaces");
+  assert_approx_equals(point.y, 200, 0.1, "Comma with spaces");
+}, "Moveto with comma and spaces: M 100 , 200");
+
+test(function() {
+  // Moveto without comma
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100 200');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 100, 0.1, "Space separator");
+  assert_approx_equals(point.y, 200, 0.1, "Space separator");
+}, "Moveto without comma: M 100 200");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-relative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-relative-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Initial moveto: 'm 100,100' is treated as absolute 'M 100,100'
+PASS Subsequent moveto is relative: M 50,50 L 100,50 m 0,50
+PASS Relative moveto adds to current position: m 10,10 from (50,0) = (60,10)
+PASS Multiple coordinate pairs after initial 'm': m 10,10 20,20 30,30
+PASS Negative relative moveto: M 100,100 m -50,-50
+PASS Zero relative moveto: m 0,0
+PASS Chained relative moveto: m 5,5 m 5,5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-relative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-relative.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Moveto command - relative (m)</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Initial m is treated as absolute -->
+  <path id="test1" d="m 100,100 L 150,150" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Reference with M -->
+  <path id="ref1" d="M 100,100 L 150,150" fill="none" stroke="red" stroke-width="1" stroke-dasharray="2,2"/>
+</svg>
+
+<script>
+test(function() {
+  const testPath = document.getElementById('test1');
+  const refPath = document.getElementById('ref1');
+
+  const testPoint = testPath.getPointAtLength(0);
+  const refPoint = refPath.getPointAtLength(0);
+
+  assert_approx_equals(testPoint.x, refPoint.x, 0.1, "Initial 'm' treated as absolute");
+  assert_approx_equals(testPoint.y, refPoint.y, 0.1, "Initial 'm' treated as absolute");
+}, "Initial moveto: 'm 100,100' is treated as absolute 'M 100,100'");
+
+test(function() {
+  // Subsequent m is relative
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 L 100,50 m 0,50 L 150,150');
+  svg.appendChild(path);
+
+  // After "m 0,50" from position (100,50), we should be at (100,100)
+  const point = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(point.x, 150, 0.1, "Path ends at specified point");
+  assert_approx_equals(point.y, 150, 0.1, "Path ends at specified point");
+}, "Subsequent moveto is relative: M 50,50 L 100,50 m 0,50");
+
+test(function() {
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,0 L 50,0 m 10,10 L 100,50');
+  svg.appendChild(path);
+
+  // After L 50,0, we're at (50,0)
+  // After m 10,10, we should be at (60,10)
+  // The L 100,50 creates a line from (60,10) to (100,50)
+
+  // Get point at start of second subpath
+  const firstLength = Math.sqrt(50*50); // First line length
+  const pointAfterM = path.getPointAtLength(firstLength + 0.1);
+
+  assert_approx_equals(pointAfterM.x, 60, 1, "After 'm 10,10' from (50,0), x should be 60");
+  assert_approx_equals(pointAfterM.y, 10, 1, "After 'm 10,10' from (50,0), y should be 10");
+}, "Relative moveto adds to current position: m 10,10 from (50,0) = (60,10)");
+
+test(function() {
+  // Multiple coordinate pairs after initial m
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'm 10,10 20,20 30,30');
+  svg.appendChild(path);
+
+  const startPoint = path.getPointAtLength(0);
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+
+  // First m 10,10 is absolute, so starts at (10,10)
+  assert_approx_equals(startPoint.x, 10, 0.1, "Starts at 10,10");
+  assert_approx_equals(startPoint.y, 10, 0.1, "Starts at 10,10");
+
+  // Subsequent pairs are relative lineto: (10,10) + (20,20) = (30,30), then + (30,30) = (60,60)
+  assert_approx_equals(endPoint.x, 60, 0.1, "Ends at 60,60");
+  assert_approx_equals(endPoint.y, 60, 0.1, "Ends at 60,60");
+}, "Multiple coordinate pairs after initial 'm': m 10,10 20,20 30,30");
+
+test(function() {
+  // Negative relative movements
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,100 m -50,-50 L 100,100');
+  svg.appendChild(path);
+
+  const firstLength = 0; // M command has no length
+  const pointAfterM = path.getPointAtLength(0.1);
+
+  // From (100,100), m -50,-50 should move to (50,50)
+  assert_approx_equals(pointAfterM.x, 50, 1, "Negative relative move: x");
+  assert_approx_equals(pointAfterM.y, 50, 1, "Negative relative move: y");
+}, "Negative relative moveto: M 100,100 m -50,-50");
+
+test(function() {
+  // Zero relative movement
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 m 0,0 L 100,100');
+  svg.appendChild(path);
+
+  const pointAfterM = path.getPointAtLength(0.1);
+
+  // m 0,0 doesn't change position, should still be at (50,50)
+  assert_approx_equals(pointAfterM.x, 50, 1, "Zero relative move maintains position");
+  assert_approx_equals(pointAfterM.y, 50, 1, "Zero relative move maintains position");
+}, "Zero relative moveto: m 0,0");
+
+test(function() {
+  // Chained relative moveto commands
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,0 L 10,10 m 5,5 m 5,5 L 30,30');
+  svg.appendChild(path);
+
+  // Start at (0,0), line to (10,10)
+  // m 5,5 moves to (15,15)
+  // m 5,5 moves to (20,20)
+  // Line from (20,20) to (30,30)
+
+  const totalLength = path.getTotalLength();
+  const firstLineLength = Math.sqrt(200); // (0,0) to (10,10)
+  const secondLineLength = Math.sqrt(200); // (20,20) to (30,30)
+
+  assert_approx_equals(totalLength, firstLineLength + secondLineLength, 0.5,
+    "Total length is sum of two lines (moveto commands have no length)");
+}, "Chained relative moveto: m 5,5 m 5,5");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-consecutive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-consecutive-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Number parsing: M 100-200 parses as M 100,-200
+PASS Number parsing: First coordinate is 100, second is -200
+PASS Number parsing: M 50+100 parses as M 50,+100
+PASS Number parsing: M 10-20+30-40 parses as M 10,-20,30,-40 (implicit lineto)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-consecutive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-consecutive.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Number parsing - consecutive numbers without separator</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Test: "100-200" should parse as two coordinates: 100 and -200 -->
+  <path id="test1" d="M 100-200 L 200-100" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Reference: explicitly separated version -->
+  <path id="ref1" d="M 100,-200 L 200,-100" fill="none" stroke="red" stroke-width="1"/>
+</svg>
+
+<script>
+test(function() {
+  const testPath = document.getElementById('test1');
+  const refPath = document.getElementById('ref1');
+
+  // Both paths should have the same total length
+  const testLength = testPath.getTotalLength();
+  const refLength = refPath.getTotalLength();
+
+  assert_approx_equals(testLength, refLength, 0.1,
+    "Path with '100-200' should have same length as '100,-200'");
+}, "Number parsing: M 100-200 parses as M 100,-200");
+
+test(function() {
+  const path = document.getElementById('test1');
+  const point = path.getPointAtLength(0);
+
+  assert_approx_equals(point.x, 100, 0.1, "Start x coordinate should be 100");
+  assert_approx_equals(point.y, -200, 0.1, "Start y coordinate should be -200");
+}, "Number parsing: First coordinate is 100, second is -200");
+
+test(function() {
+  // Test multiple consecutive numbers with signs
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50+100 L 150+200');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 50, 0.1, "50+100 should parse as 50 and +100");
+  assert_approx_equals(point.y, 100, 0.1, "Second coordinate should be 100");
+}, "Number parsing: M 50+100 parses as M 50,+100");
+
+test(function() {
+  // Test chain of signed numbers
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 10-20+30-40');
+  svg.appendChild(path);
+
+  const startPoint = path.getPointAtLength(0);
+  assert_approx_equals(startPoint.x, 10, 0.1, "First coordinate is 10");
+  assert_approx_equals(startPoint.y, -20, 0.1, "Second coordinate is -20");
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 30, 0.1, "Third coordinate is 30");
+  assert_approx_equals(endPoint.y, -40, 0.1, "Fourth coordinate is -40");
+}, "Number parsing: M 10-20+30-40 parses as M 10,-20,30,-40 (implicit lineto)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-decimal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-decimal-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Number parsing: M 0.6.5 parses as M 0.6,0.5
+PASS Number parsing: First coordinate is 0.6, second is 0.5
+PASS Number parsing: L 10.5.6 parses as L 10.5,0.6
+PASS Number parsing: M .5.6 parses as M 0.5,0.6
+PASS Number parsing: M 1.2.3.4.5 parses as M 1.2,0.3,0.4,0.5 (implicit lineto)
+PASS Number parsing: Decimal followed by integer with space
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-decimal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-decimal.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Number parsing - decimal point consumption</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Test: "0.6.5" should parse as two coordinates: 0.6 and 0.5 -->
+  <path id="test1" d="M 0.6.5 L 10.5.6" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Reference: explicitly separated version -->
+  <path id="ref1" d="M 0.6,0.5 L 10.5,0.6" fill="none" stroke="red" stroke-width="1"/>
+</svg>
+
+<script>
+test(function() {
+  const testPath = document.getElementById('test1');
+  const refPath = document.getElementById('ref1');
+
+  const testLength = testPath.getTotalLength();
+  const refLength = refPath.getTotalLength();
+
+  assert_approx_equals(testLength, refLength, 0.1,
+    "Path with '0.6.5' should have same length as '0.6,0.5'");
+}, "Number parsing: M 0.6.5 parses as M 0.6,0.5");
+
+test(function() {
+  const path = document.getElementById('test1');
+  const point = path.getPointAtLength(0);
+
+  assert_approx_equals(point.x, 0.6, 0.01, "Start x coordinate should be 0.6");
+  assert_approx_equals(point.y, 0.5, 0.01, "Start y coordinate should be 0.5");
+}, "Number parsing: First coordinate is 0.6, second is 0.5");
+
+test(function() {
+  const path = document.getElementById('test1');
+  const point = path.getPointAtLength(path.getTotalLength());
+
+  assert_approx_equals(point.x, 10.5, 0.01, "End x coordinate should be 10.5");
+  assert_approx_equals(point.y, 0.6, 0.01, "End y coordinate should be 0.6");
+}, "Number parsing: L 10.5.6 parses as L 10.5,0.6");
+
+test(function() {
+  // Test leading decimal point
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M .5.6 L .7.8');
+  svg.appendChild(path);
+
+  const startPoint = path.getPointAtLength(0);
+  assert_approx_equals(startPoint.x, 0.5, 0.01, "First coordinate is .5 (0.5)");
+  assert_approx_equals(startPoint.y, 0.6, 0.01, "Second coordinate is .6 (0.6)");
+}, "Number parsing: M .5.6 parses as M 0.5,0.6");
+
+test(function() {
+  // Test multiple decimal numbers in sequence
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 1.2.3.4.5');
+  svg.appendChild(path);
+
+  const startPoint = path.getPointAtLength(0);
+  assert_approx_equals(startPoint.x, 1.2, 0.01, "First coordinate is 1.2");
+  assert_approx_equals(startPoint.y, 0.3, 0.01, "Second coordinate is .3");
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 0.4, 0.01, "Third coordinate is .4");
+  assert_approx_equals(endPoint.y, 0.5, 0.01, "Fourth coordinate is .5");
+}, "Number parsing: M 1.2.3.4.5 parses as M 1.2,0.3,0.4,0.5 (implicit lineto)");
+
+test(function() {
+  // Test decimal followed by integer
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0.5 10 L 20 0.3');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 0.5, 0.01, "0.5 followed by space and 10");
+  assert_approx_equals(point.y, 10, 0.01, "Second coordinate is 10");
+}, "Number parsing: Decimal followed by integer with space");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-error-trailing-decimal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-error-trailing-decimal-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Error handling: Path renders up to (not including) trailing decimal error
+PASS Error handling: Path ends at last valid segment before error
+PASS Error handling: First trailing decimal stops rendering
+PASS Error handling: Trailing decimal in first coordinate of pair
+PASS Error handling: Complete valid subpath renders before trailing decimal error
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-error-trailing-decimal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-error-trailing-decimal.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Error - trailing decimal point</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400" xmlns="http://www.w3.org/2000/svg">
+  <!-- Test: "23." is an error - path should render up to this point -->
+  <path id="test1" d="M 10,10 L 50,50 L 23.,100" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Reference: path should only render M 10,10 L 50,50 -->
+  <path id="ref1" d="M 10,10 L 50,50" fill="none" stroke="red" stroke-width="1" stroke-dasharray="2,2"/>
+</svg>
+
+<script>
+test(function() {
+  const testPath = document.getElementById('test1');
+  const refPath = document.getElementById('ref1');
+
+  // Path with error should render same as path without the error command
+  const testLength = testPath.getTotalLength();
+  const refLength = refPath.getTotalLength();
+
+  assert_approx_equals(testLength, refLength, 0.1,
+    "Path with trailing decimal should render only up to the error");
+}, "Error handling: Path renders up to (not including) trailing decimal error");
+
+test(function() {
+  const testPath = document.getElementById('test1');
+  const endPoint = testPath.getPointAtLength(testPath.getTotalLength());
+
+  // Should stop at L 50,50, not continue to the invalid L 23.,100
+  assert_approx_equals(endPoint.x, 50, 0.1, "Path should end at x=50");
+  assert_approx_equals(endPoint.y, 50, 0.1, "Path should end at y=50");
+}, "Error handling: Path ends at last valid segment before error");
+
+test(function() {
+  // Multiple trailing decimals
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,0 L 10,10 L 20.,30.');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  // Should render up to L 10,10
+  assert_approx_equals(endPoint.x, 10, 0.1, "Should stop before first trailing decimal");
+  assert_approx_equals(endPoint.y, 10, 0.1, "Should stop before first trailing decimal");
+}, "Error handling: First trailing decimal stops rendering");
+
+test(function() {
+  // Trailing decimal in middle of coordinate pair
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,0 L 15. 20');
+  svg.appendChild(path);
+
+  const totalLength = path.getTotalLength();
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 0,0');
+  svg.appendChild(path);
+
+  // Should only render M 0,0, not the L command
+  assert_approx_equals(totalLength, 0, 0.1,
+    "Path with trailing decimal in first coordinate should not render the L command");
+}, "Error handling: Trailing decimal in first coordinate of pair");
+
+test(function() {
+  // Valid path followed by error - should render valid part
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,100 L 150,100 L 150,150 L 100,150 Z M 200.,200.');
+  svg.appendChild(path);
+
+  // Should render the complete square (first subpath) before the error
+  const length = path.getTotalLength();
+  const refPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  refPath.setAttribute('d', 'M 100,100 L 150,100 L 150,150 L 100,150 Z');
+  svg.appendChild(refPath);
+  const refLength = refPath.getTotalLength();
+
+  assert_approx_equals(length, refLength, 0.1,
+    "Valid closed path before error should render completely");
+}, "Error handling: Complete valid subpath renders before trailing decimal error");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-exponent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-exponent-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Number parsing: 1e2 equals 100, 2E2 equals 200, 1.5e2 equals 150
+PASS Number parsing: 1e2 = 100
+PASS Number parsing: 2E2 = 200, 1.5e2 = 150
+PASS Number parsing: Positive exponent (e+2)
+PASS Number parsing: Negative exponent (e-1)
+PASS Number parsing: 'e' and 'E' are case-insensitive
+PASS Number parsing: Fractional base with exponent (1.5e2)
+PASS Number parsing: Zero exponent (5e0 = 5)
+PASS Number parsing: Consecutive exponent numbers (1e2-1e2 = 100,-100)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-exponent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-exponent.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Number parsing - scientific notation with exponents</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Test various exponent formats -->
+  <path id="test1" d="M 1e2,1e2 L 2E2,1.5e2" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Reference: explicit decimal values -->
+  <path id="ref1" d="M 100,100 L 200,150" fill="none" stroke="red" stroke-width="1"/>
+</svg>
+
+<script>
+test(function() {
+  const testPath = document.getElementById('test1');
+  const refPath = document.getElementById('ref1');
+
+  const testLength = testPath.getTotalLength();
+  const refLength = refPath.getTotalLength();
+
+  assert_approx_equals(testLength, refLength, 0.1,
+    "Path with exponents should match explicit decimal version");
+}, "Number parsing: 1e2 equals 100, 2E2 equals 200, 1.5e2 equals 150");
+
+test(function() {
+  const path = document.getElementById('test1');
+  const startPoint = path.getPointAtLength(0);
+
+  assert_approx_equals(startPoint.x, 100, 0.1, "1e2 should equal 100");
+  assert_approx_equals(startPoint.y, 100, 0.1, "1e2 should equal 100");
+}, "Number parsing: 1e2 = 100");
+
+test(function() {
+  const path = document.getElementById('test1');
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+
+  assert_approx_equals(endPoint.x, 200, 0.1, "2E2 should equal 200");
+  assert_approx_equals(endPoint.y, 150, 0.1, "1.5e2 should equal 150");
+}, "Number parsing: 2E2 = 200, 1.5e2 = 150");
+
+test(function() {
+  // Test positive exponent
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 1e+2,2e+1');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 100, 0.1, "1e+2 should equal 100");
+  assert_approx_equals(point.y, 20, 0.1, "2e+1 should equal 20");
+}, "Number parsing: Positive exponent (e+2)");
+
+test(function() {
+  // Test negative exponent
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 1e-1,5e-2');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 0.1, 0.001, "1e-1 should equal 0.1");
+  assert_approx_equals(point.y, 0.05, 0.001, "5e-2 should equal 0.05");
+}, "Number parsing: Negative exponent (e-1)");
+
+test(function() {
+  // Test case insensitivity
+  const svg = document.getElementById('svg');
+  const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path1.setAttribute('d', 'M 1e2,1e2');
+  svg.appendChild(path1);
+
+  const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path2.setAttribute('d', 'M 1E2,1E2');
+  svg.appendChild(path2);
+
+  const point1 = path1.getPointAtLength(0);
+  const point2 = path2.getPointAtLength(0);
+
+  assert_approx_equals(point1.x, point2.x, 0.001, "'e' and 'E' should be equivalent");
+  assert_approx_equals(point1.y, point2.y, 0.001, "'e' and 'E' should be equivalent");
+}, "Number parsing: 'e' and 'E' are case-insensitive");
+
+test(function() {
+  // Test fractional base with exponent
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 1.5e2,2.5e1');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 150, 0.1, "1.5e2 should equal 150");
+  assert_approx_equals(point.y, 25, 0.1, "2.5e1 should equal 25");
+}, "Number parsing: Fractional base with exponent (1.5e2)");
+
+test(function() {
+  // Test zero exponent
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 5e0,10e0');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 5, 0.001, "5e0 should equal 5");
+  assert_approx_equals(point.y, 10, 0.001, "10e0 should equal 10");
+}, "Number parsing: Zero exponent (5e0 = 5)");
+
+test(function() {
+  // Test consecutive exponent numbers
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 1e2-1e2');
+  svg.appendChild(path);
+
+  const point = path.getPointAtLength(0);
+  assert_approx_equals(point.x, 100, 0.1, "1e2 should equal 100");
+  assert_approx_equals(point.y, -100, 0.1, "-1e2 should equal -100");
+}, "Number parsing: Consecutive exponent numbers (1e2-1e2 = 100,-100)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/quadratic-bezier-commands-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/quadratic-bezier-commands-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Absolute quadratic bezier: Q 100,25 150,50
+PASS Relative quadratic bezier: q 50,-25 100,0 from (50,50)
+PASS Quadratic bezier endpoints are correct
+PASS Multiple quadratic bezier pairs: Q x1,y1 x,y x1,y1 x,y
+PASS Smooth quadratic bezier: T 150,150
+PASS Smooth quadratic bezier after Q: reflects control point
+PASS Relative smooth quadratic bezier: t x,y
+PASS Smooth quadratic bezier without preceding Q
+PASS Multiple smooth quadratic bezier coordinates
+PASS Chain of T commands: each T reflects previous control point
+PASS Quadratic bezier with space separators (no commas)
+PASS Quadratic bezier with all comma separators
+PASS Smooth quadratic bezier after cubic curve
+PASS Quadratic bezier after smooth quadratic bezier
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/quadratic-bezier-commands.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/quadratic-bezier-commands.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Quadratic Bezier curveto (Q/q, T/t)</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<svg id="svg" width="400" height="400">
+  <!-- Quadratic Bezier curve -->
+  <path id="test-Q" d="M 50,50 Q 100,25 150,50" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Relative quadratic Bezier -->
+  <path id="test-q" d="M 50,50 q 50,-25 100,0" fill="none" stroke="blue" stroke-width="1" stroke-dasharray="2,2"/>
+
+  <!-- Smooth quadratic Bezier -->
+  <path id="test-T" d="M 50,150 Q 75,125 100,150 T 150,150" fill="none" stroke="green" stroke-width="2"/>
+</svg>
+
+<script>
+test(function() {
+  const path = document.getElementById('test-Q');
+  const length = path.getTotalLength();
+
+  assert_greater_than(length, 0, "Q command creates a curve");
+  assert_greater_than(length, 90, "Curve is longer than straight distance");
+}, "Absolute quadratic bezier: Q 100,25 150,50");
+
+test(function() {
+  const pathQ = document.getElementById('test-Q');
+  const pathq = document.getElementById('test-q');
+
+  // Both should create same curve
+  assert_approx_equals(pathQ.getTotalLength(), pathq.getTotalLength(), 1,
+    "Relative quadratic bezier creates same curve as absolute");
+}, "Relative quadratic bezier: q 50,-25 100,0 from (50,50)");
+
+test(function() {
+  const pathQ = document.getElementById('test-Q');
+  const startPoint = pathQ.getPointAtLength(0);
+  const endPoint = pathQ.getPointAtLength(pathQ.getTotalLength());
+
+  assert_approx_equals(startPoint.x, 50, 0.1, "Curve starts at M point");
+  assert_approx_equals(startPoint.y, 50, 0.1, "Curve starts at M point");
+  assert_approx_equals(endPoint.x, 150, 0.1, "Curve ends at specified point");
+  assert_approx_equals(endPoint.y, 50, 0.1, "Curve ends at specified point");
+}, "Quadratic bezier endpoints are correct");
+
+test(function() {
+  // Multiple quadratic bezier pairs
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,50 Q 25,25 50,50 75,75 100,50');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 100, 0.5, "Multiple Q curves end at last point");
+  assert_approx_equals(endPoint.y, 50, 0.5, "Multiple Q curves end at last point");
+}, "Multiple quadratic bezier pairs: Q x1,y1 x,y x1,y1 x,y");
+
+test(function() {
+  const path = document.getElementById('test-T');
+  const length = path.getTotalLength();
+
+  assert_greater_than(length, 0, "T command creates a curve");
+}, "Smooth quadratic bezier: T 150,150");
+
+test(function() {
+  // T command reflects previous control point
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,100 Q 25,75 50,100 T 100,100');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 50, "T after Q creates smooth curve");
+}, "Smooth quadratic bezier after Q: reflects control point");
+
+test(function() {
+  // Relative smooth quadratic bezier
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,50 Q 75,25 100,50 t 50,0');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 50, "Relative t command works");
+}, "Relative smooth quadratic bezier: t x,y");
+
+test(function() {
+  // T without preceding Q (uses current point as reflection)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,200 T 100,200');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "T without preceding Q uses current point");
+}, "Smooth quadratic bezier without preceding Q");
+
+test(function() {
+  // Multiple T commands
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,150 Q 25,125 50,150 T 100,150 150,150');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 150, 0.5, "Multiple T commands");
+  assert_approx_equals(endPoint.y, 150, 0.5, "Multiple T commands");
+}, "Multiple smooth quadratic bezier coordinates");
+
+test(function() {
+  // Chain of T commands
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,200 Q 12.5,187.5 25,200 T 50,200 T 75,200');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 75, 0.5, "Chain of T commands works");
+  assert_approx_equals(endPoint.y, 200, 0.5, "Chain of T commands works");
+}, "Chain of T commands: each T reflects previous control point");
+
+test(function() {
+  // Quadratic bezier with minimal spacing
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50 250 Q 75 225 100 250');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Q command works with space separators only");
+}, "Quadratic bezier with space separators (no commas)");
+
+test(function() {
+  // Quadratic bezier with all commas
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 50,300 Q 75,275,100,300');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "Q command works with all comma separators");
+}, "Quadratic bezier with all comma separators");
+
+test(function() {
+  // T after C (cubic) command
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,250 C 12.5,237.5 25,237.5 37.5,250 T 75,250');
+  svg.appendChild(path);
+
+  const length = path.getTotalLength();
+  assert_greater_than(length, 0, "T after C command works");
+}, "Smooth quadratic bezier after cubic curve");
+
+test(function() {
+  // Q after T
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 0,300 Q 12.5,287.5 25,300 T 50,300 Q 62.5,287.5 75,300');
+  svg.appendChild(path);
+
+  const endPoint = path.getPointAtLength(path.getTotalLength());
+  assert_approx_equals(endPoint.x, 75, 0.5, "Q after T works");
+  assert_approx_equals(endPoint.y, 300, 0.5, "Q after T works");
+}, "Quadratic bezier after smooth quadratic bezier");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/whitespace-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/whitespace-basic-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Whitespace: Space (0x20) as separator
+PASS Whitespace: Tab (0x09) as separator
+PASS Whitespace: Line Feed (0x0A) as separator
+PASS Whitespace: Carriage Return (0x0D) as separator
+PASS Whitespace: Form Feed (0x0C) as separator
+PASS Whitespace: Mixed whitespace characters
+PASS Whitespace: Leading whitespace in path data
+PASS Whitespace: Trailing whitespace in path data
+PASS Whitespace: No whitespace (where optional)
+PASS Whitespace: Multiple consecutive spaces
+PASS Whitespace: Comma with surrounding spaces
+PASS Whitespace: Comma without spaces
+PASS Whitespace: Spaces before comma
+PASS Whitespace: Spaces after comma
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/whitespace-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/whitespace-basic.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG Path Data: Whitespace handling</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/paths.html#PathDataBNF">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg id="svg" width="400" height="400">
+  <!-- Reference path -->
+  <path id="ref" d="M 100,100 L 200,200" fill="none" stroke="red" stroke-width="1"/>
+</svg>
+
+<script>
+test(function() {
+  // Space (0x20)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100 100 L 200 200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Space separator works");
+}, "Whitespace: Space (0x20) as separator");
+
+test(function() {
+  // Tab (0x09)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M\t100\t100\tL\t200\t200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Tab separator works");
+}, "Whitespace: Tab (0x09) as separator");
+
+test(function() {
+  // Line Feed (0x0A)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M\n100\n100\nL\n200\n200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Line feed separator works");
+}, "Whitespace: Line Feed (0x0A) as separator");
+
+test(function() {
+  // Carriage Return (0x0D)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M\r100\r100\rL\r200\r200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Carriage return separator works");
+}, "Whitespace: Carriage Return (0x0D) as separator");
+
+test(function() {
+  // Form Feed (0x0C)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M\x0C100\x0C100\x0CL\x0C200\x0C200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Form feed separator works");
+}, "Whitespace: Form Feed (0x0C) as separator");
+
+test(function() {
+  // Mixed whitespace
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M \t\n\r\x0C 100 \t\n\r\x0C 100 \t\n\r\x0C L \t\n\r\x0C 200 \t\n\r\x0C 200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Mixed whitespace works");
+}, "Whitespace: Mixed whitespace characters");
+
+test(function() {
+  // Leading whitespace
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', '   \t\n\r  M 100,100 L 200,200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Leading whitespace allowed");
+}, "Whitespace: Leading whitespace in path data");
+
+test(function() {
+  // Trailing whitespace
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,100 L 200,200   \t\n\r  ');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Trailing whitespace allowed");
+}, "Whitespace: Trailing whitespace in path data");
+
+test(function() {
+  // No whitespace (where optional)
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M100,100L200,200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Minimal whitespace works");
+}, "Whitespace: No whitespace (where optional)");
+
+test(function() {
+  // Multiple spaces
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M     100     100     L     200     200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Multiple consecutive spaces work");
+}, "Whitespace: Multiple consecutive spaces");
+
+test(function() {
+  // comma_wsp with comma and spaces
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100 , 100 L 200 , 200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Comma with surrounding spaces works");
+}, "Whitespace: Comma with surrounding spaces");
+
+test(function() {
+  // comma_wsp: comma without spaces
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100,100 L 200,200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Comma without spaces works");
+}, "Whitespace: Comma without spaces");
+
+test(function() {
+  // comma_wsp: spaces before comma
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100 ,100 L 200 ,200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Spaces before comma works");
+}, "Whitespace: Spaces before comma");
+
+test(function() {
+  // comma_wsp: spaces after comma
+  const svg = document.getElementById('svg');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M 100, 100 L 200, 200');
+  svg.appendChild(path);
+
+  const refPath = document.getElementById('ref');
+  assert_approx_equals(path.getTotalLength(), refPath.getTotalLength(), 0.1,
+    "Spaces after comma works");
+}, "Whitespace: Spaces after comma");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 9af8ffff919a1a1478b8a43cef821adb49a4e6a1
<pre>
[svg2] comprehensive test cases for parsing path data of the d attribute in path element
<a href="https://bugs.webkit.org/show_bug.cgi?id=308520">https://bugs.webkit.org/show_bug.cgi?id=308520</a>
<a href="https://rdar.apple.com/171586653">rdar://171586653</a>

Reviewed by Anne van Kesteren.

The SVG2 Path Data for the d attribute of the path element is defined in
9.3.2. Specifying path data: the ‘d’ property
<a href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty">https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty</a>

the d attribute takes a string with a specific grammar defined in
9.3.9. The grammar for path data
<a href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF">https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF</a>

and has error handling constraints:
9.5.4. Error handling in path data
<a href="https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling">https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling</a>

This adds a series of tests testing these requirements.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/arc-commands-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/arc-commands.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/curveto-commands-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/curveto-commands.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/error-handling-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/error-handling.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/lineto-commands-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/lineto-commands.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-absolute-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-absolute.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-relative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/moveto-relative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-consecutive-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-consecutive.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-decimal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-edge-case-decimal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-error-trailing-decimal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-error-trailing-decimal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-exponent-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/number-exponent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/quadratic-bezier-commands-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/quadratic-bezier-commands.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/whitespace-basic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/parsing/whitespace-basic.html: Added.

Canonical link: <a href="https://commits.webkit.org/308687@main">https://commits.webkit.org/308687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f75e7cdfeecc348808ffe26022ba0fa27603dbd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03bc6c69-c706-40ca-880e-cea2db1d8310) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9bee5ec-79ba-4c16-b42e-96b9783078aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95050 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b0a623d-2416-4b96-a68a-5b94bd61bd71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4353 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159249 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122313 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76877 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9567 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20334 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20211 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->