### PR TITLE
[WTF] Use simple SIMD pair search

### DIFF
--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2011 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,12 +122,8 @@ public:
             }
         }
         int patternLength = m_pattern.size();
-        if (patternLength < bmMinPatternLength) {
-            if (patternLength == 1) {
-                m_strategy = &singleCharSearch;
-                return;
-            }
-            m_strategy = &linearSearch;
+        if (patternLength == 1) {
+            m_strategy = &singleCharSearch;
             return;
         }
         m_strategy = &initialSearch;
@@ -162,11 +158,11 @@ private:
 
     static int linearSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
 
-    static int initialSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
-
     static int boyerMooreHorspoolSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
 
     static int boyerMooreSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
+
+    static int initialSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
 
     void populateBoyerMooreHorspoolTable();
 
@@ -279,6 +275,92 @@ int AdaptiveStringSearcher<PatternChar, SubjectChar>::linearSearch(AdaptiveStrin
         if (charCompare(pattern.data() + 1, subject.data() + i, patternLength - 1))
             return i - 1;
     }
+    return -1;
+}
+
+//---------------------------------------------------------------------
+// Initial Search Strategy using SIMD pair search with bailout to BMH.
+//---------------------------------------------------------------------
+
+// SIMD pair search for short patterns, which bails out if too much false-positive happens.
+// We will fallback to BMH in this case.
+template <typename PatternChar, typename SubjectChar>
+int AdaptiveStringSearcher<PatternChar, SubjectChar>::initialSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int startIndex)
+{
+    auto pattern = search.m_pattern;
+    const auto* patternPtr = pattern.data();
+    const auto* subjectPtr = subject.data();
+    int patternLength = pattern.size();
+    int subjectLength = subject.size();
+    ASSERT(patternLength >= 2);
+    int maxIndex = subjectLength - patternLength;
+    if (startIndex > maxIndex)
+        return -1;
+
+    auto patternFirst = patternPtr[0];
+    auto patternLast = patternPtr[patternLength - 1];
+    auto searchFirst = static_cast<SubjectChar>(patternFirst);
+    auto searchLast = static_cast<SubjectChar>(patternLast);
+
+    using UnsignedChar = SameSizeUnsignedInteger<SubjectChar>;
+    constexpr int stride = SIMD::stride<UnsignedChar>;
+    auto firstVec = SIMD::splat(static_cast<UnsignedChar>(searchFirst));
+    auto lastVec = SIMD::splat(static_cast<UnsignedChar>(searchLast));
+
+    int i = startIndex;
+    int simdLimit = maxIndex - stride + 1;
+    unsigned failureCount = 0;
+    constexpr unsigned failureThreshold = 16;
+    while (i <= simdLimit) {
+        auto firstBlock = SIMD::load(std::bit_cast<const UnsignedChar*>(subjectPtr + i));
+        auto lastBlock = SIMD::load(std::bit_cast<const UnsignedChar*>(subjectPtr + i + patternLength - 1));
+        auto mask1 = SIMD::equal(firstBlock, firstVec);
+        auto mask2 = SIMD::equal(lastBlock, lastVec);
+        auto candidates = SIMD::bitAnd2(mask1, mask2);
+
+        auto index = SIMD::findFirstNonZeroIndex(candidates);
+        if (!index) {
+            i += stride;
+            continue;
+        }
+
+        int pos = i + static_cast<int>(index.value());
+
+        bool match = true;
+        for (int j = 1; j < patternLength - 1; j++) {
+            if (patternPtr[j] != subjectPtr[pos + j]) {
+                match = false;
+                break;
+            }
+        }
+
+        if (match)
+            return pos;
+
+        i = pos + 1;
+
+        if (++failureCount > failureThreshold) {
+            search.populateBoyerMooreHorspoolTable();
+            search.m_strategy = &boyerMooreHorspoolSearch;
+            return boyerMooreHorspoolSearch(search, subject, i);
+        }
+    }
+
+    while (i <= maxIndex) {
+        if (subjectPtr[i] == searchFirst && subjectPtr[i + patternLength - 1] == searchLast) {
+            bool match = true;
+            for (int j = 1; j < patternLength - 1; j++) {
+                if (patternPtr[j] != subjectPtr[i + j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match)
+                return i;
+        }
+        i++;
+    }
+
     return -1;
 }
 
@@ -472,50 +554,6 @@ void AdaptiveStringSearcher<PatternChar, SubjectChar>::populateBoyerMooreHorspoo
     }
 }
 
-//---------------------------------------------------------------------
-// Linear string search with bailout to BMH.
-//---------------------------------------------------------------------
-
-// Simple linear search for short patterns, which bails out if the string
-// isn't found very early in the subject. Upgrades to BoyerMooreHorspool.
-template <typename PatternChar, typename SubjectChar>
-int AdaptiveStringSearcher<PatternChar, SubjectChar>::initialSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int index)
-{
-    std::span<const PatternChar> pattern = search.m_pattern;
-    const auto* subjectPtr = subject.data();
-    const auto* patternPtr = pattern.data();
-    int patternLength = pattern.size();
-    // Badness is a count of how much work we have done. When we have
-    // done enough work we decide it's probably worth switching to a better
-    // algorithm.
-    int badness = -10 - (patternLength << 2);
-
-    // We know our pattern is at least 2 characters, we cache the first so
-    // the common case of the first character not matching is faster.
-    for (int i = index, n = subject.size() - patternLength; i <= n; i++) {
-        badness++;
-        if (badness <= 0) {
-            i = findFirstCharacter(pattern, subject, i);
-            if (i == -1)
-                return -1;
-            ASSERT(i <= n);
-            int j = 1;
-            do {
-                if (patternPtr[j] != subjectPtr[i + j])
-                    break;
-                j++;
-            } while (j < patternLength);
-            if (j == patternLength)
-                return i;
-            badness += j;
-        } else {
-            search.populateBoyerMooreHorspoolTable();
-            search.m_strategy = &boyerMooreHorspoolSearch;
-            return boyerMooreHorspoolSearch(search, subject, i);
-        }
-    }
-    return -1;
-}
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // Perform a a single stand-alone search.


### PR DESCRIPTION
#### cf507455abeb87f095f6013616fc883b89625297
<pre>
[WTF] Use simple SIMD pair search
<a href="https://bugs.webkit.org/show_bug.cgi?id=309157">https://bugs.webkit.org/show_bug.cgi?id=309157</a>
<a href="https://rdar.apple.com/171707400">rdar://171707400</a>

Reviewed by Yijia Huang.

Boyer-Moore / Boyer-Moore-Horspool algorithms are elegant, but in many
cases, this is a bit hard to be executed on modern CPU due to frequent
table access and non-linear memory access via skipping. On modern CPU,
bulk scanning via SIMD in a predictable manner is simply faster in many
cases. This patch implements SIMD pair search, taking first and last
character from the needle and detecting the range which matches first
and last characters. And strictly checking this range is matching against
the needle.

But SIMD pair search can have drawbacks: if first and last characters are
the ones which can be seen frequently, and the pattern is adversarial,
then it becomes very slow. So when we failed with false-positive SIMD
matching 16 times, we switch to Boyer-Moore-Horspool.

* Source/WTF/wtf/text/AdaptiveStringSearcher.h:
(WTF::AdaptiveStringSearcher::AdaptiveStringSearcher):
(WTF::SubjectChar&gt;::initialSearch):

Canonical link: <a href="https://commits.webkit.org/308755@main">https://commits.webkit.org/308755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ecda492ca77687a9fb7b26c3a1f88a1035d3371

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157053 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff549fef-2334-4946-b75d-0c849a2a5278) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114384 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44f2c7aa-df89-47b3-b85c-e99ef3ed39ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f28a1a4-9e15-4302-8825-18c29ecd2ff2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4489 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140336 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159386 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9156 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2520 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122418 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122639 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132933 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22868 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9678 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20470 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84255 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->