### PR TITLE
Add  addTransceiver sendEncodings rid validation steps

### DIFF
--- a/LayoutTests/fast/mediastream/RTCPeerConnection-addTransceiver-expected.txt
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-addTransceiver-expected.txt
@@ -8,13 +8,13 @@ PASS pc.getTransceivers().length is 0
 *** Test arguments
 *** 'trackOrKind' argument is mandatory
 PASS pc.addTransceiver() threw exception TypeError: Not enough arguments.
-PASS pc.addTransceiver({}) threw exception TypeError: Type error.
+PASS pc.addTransceiver({}) threw exception TypeError: Kind should be audio or video.
 *** Bad type as first argument
-PASS pc.addTransceiver(null) threw exception TypeError: Type error.
-PASS pc.addTransceiver(null, {}) threw exception TypeError: Type error.
-PASS pc.addTransceiver(stream) threw exception TypeError: Type error.
+PASS pc.addTransceiver(null) threw exception TypeError: Kind should be audio or video.
+PASS pc.addTransceiver(null, {}) threw exception TypeError: Kind should be audio or video.
+PASS pc.addTransceiver(stream) threw exception TypeError: Kind should be audio or video.
 *** Bad track kind
-PASS pc.addTransceiver('foo') threw exception TypeError: Type error.
+PASS pc.addTransceiver('foo') threw exception TypeError: Kind should be audio or video.
 *** Bad direction value
 PASS pc.addTransceiver("audio", {"direction": "foo"}) threw exception TypeError: Type error.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver.https-expected.txt
@@ -7,22 +7,8 @@ PASS addTransceiver() with direction inactive should have result transceiver.dir
 PASS addTransceiver() with invalid direction should throw TypeError
 PASS addTransceiver(track) should have result with sender.track be given track
 PASS addTransceiver(track) multiple times should create multiple transceivers
-FAIL addTransceiver("video") with rid containing invalid non-alphanumeric characters should throw TypeError assert_throws_js: function "() =>
-      pc.addTransceiver(kind, {
-        sendEncodings: [{
-          rid: '@Invalid!'
-        }]
-      })" threw object "InvalidAccessError: Invalid RID value provided." ("InvalidAccessError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL addTransceiver("video") with rid longer than 16 characters should throw TypeError assert_throws_js: function "() =>
-      pc.addTransceiver(kind, {
-        sendEncodings: [{
-          rid: 'a'.repeat(17)
-        }]
-      })" threw object "InvalidAccessError: Invalid RID value provided." ("InvalidAccessError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS addTransceiver("video") with rid containing invalid non-alphanumeric characters should throw TypeError
+PASS addTransceiver("video") with rid longer than 16 characters should throw TypeError
 FAIL addTransceiver("video") with duplicate rids should throw TypeError assert_throws_js: function "() =>
       pc.addTransceiver(kind, {
         sendEncodings: [{rid: 'a'}, {rid: 'a'}]
@@ -30,22 +16,8 @@ FAIL addTransceiver("video") with duplicate rids should throw TypeError assert_t
 PASS addTransceiver("video") with valid rid value should succeed
 PASS addTransceiver("video") with multiple rid values should succeed
 PASS addTransceiver("video") with valid sendEncodings should succeed
-FAIL addTransceiver("audio") with rid containing invalid non-alphanumeric characters should throw TypeError assert_throws_js: function "() =>
-      pc.addTransceiver(kind, {
-        sendEncodings: [{
-          rid: '@Invalid!'
-        }]
-      })" threw object "InvalidAccessError: Invalid RID value provided." ("InvalidAccessError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL addTransceiver("audio") with rid longer than 16 characters should throw TypeError assert_throws_js: function "() =>
-      pc.addTransceiver(kind, {
-        sendEncodings: [{
-          rid: 'a'.repeat(17)
-        }]
-      })" threw object "InvalidAccessError: Invalid RID value provided." ("InvalidAccessError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS addTransceiver("audio") with rid containing invalid non-alphanumeric characters should throw TypeError
+PASS addTransceiver("audio") with rid longer than 16 characters should throw TypeError
 FAIL addTransceiver("audio") with duplicate rids should throw TypeError assert_throws_js: function "() =>
       pc.addTransceiver(kind, {
         sendEncodings: [{rid: 'a'}, {rid: 'a'}]

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -218,6 +218,21 @@ static std::optional<Exception> validateSendEncodings(Vector<RTCRtpEncodingParam
     return { };
 }
 
+// https://w3c.github.io/webrtc-pc/#dfn-addtransceiver-sendencodings-validation-steps (partial implementation).
+static std::optional<Exception> validateRTCRtpTransceiverInitSendEncodings(const RTCRtpTransceiverInit& init)
+{
+    for (auto& encoding : init.sendEncodings) {
+        if (encoding.rid.length() > 16)
+            return Exception { ExceptionCode::TypeError, "Rid is too long"_s };
+        bool hasInvalidCharacter = encoding.rid.find([](auto character) {
+            return !isASCIIAlphanumeric(character) && character != '-' && character != '_';
+        }) != notFound;
+        if (hasInvalidCharacter)
+            return Exception { ExceptionCode::TypeError, "Rid contains invalid character(s)"_s };
+    }
+    return { };
+}
+
 ExceptionOr<Ref<RTCRtpTransceiver>> RTCPeerConnection::addTransceiver(AddTransceiverTrackOrKind&& withTrack, RTCRtpTransceiverInit&& init)
 {
     INFO_LOG(LOGIDENTIFIER);
@@ -228,10 +243,13 @@ ExceptionOr<Ref<RTCRtpTransceiver>> RTCPeerConnection::addTransceiver(AddTransce
     if (std::holds_alternative<String>(withTrack)) {
         const String& kind = std::get<String>(withTrack);
         if (kind != "audio"_s && kind != "video"_s)
-            return Exception { ExceptionCode::TypeError };
+            return Exception { ExceptionCode::TypeError, "Kind should be audio or video"_s };
 
         if (isClosed())
-            return Exception { ExceptionCode::InvalidStateError };
+            return Exception { ExceptionCode::InvalidStateError, "RTCPeerConnection is closed"_s };
+
+        if (auto exception = validateRTCRtpTransceiverInitSendEncodings(init))
+            return WTF::move(*exception);
 
         return protect(*m_backend)->addTransceiver(kind, init, PeerConnectionBackend::IgnoreNegotiationNeededFlag::No);
     }


### PR DESCRIPTION
#### 7e3980873b3358448539b47c9dbdf3b533d5f52e
<pre>
Add  addTransceiver sendEncodings rid validation steps
<a href="https://rdar.apple.com/171714959">rdar://171714959</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309159">https://bugs.webkit.org/show_bug.cgi?id=309159</a>

Reviewed by Eric Carlson.

We implement the part  of <a href="https://w3c.github.io/webrtc-pc/#dfn-addtransceiver-sendencodings-validation-steps">https://w3c.github.io/webrtc-pc/#dfn-addtransceiver-sendencodings-validation-steps</a> dedicated to rid validation.
Covered by rebased WPT test.

Canonical link: <a href="https://commits.webkit.org/309124@main">https://commits.webkit.org/309124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17637bf36c6323443312e8e85fac2785f204090b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101490 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81397 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acfb150c-cc33-43e7-933b-7a2f6f8d7219) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94923 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0222ba9b-d2c1-4a91-9971-ad4b61dc7a30) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4197 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159093 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2227 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122188 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33578 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76712 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9441 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83937 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->