### PR TITLE
[Testing/EWS only] Add extra release asserts

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -396,8 +396,9 @@ void MarkedBlock::Handle::removeFromDirectory()
 
 void MarkedBlock::Handle::didAddToDirectory(BlockDirectory* directory, unsigned index)
 {
-    ASSERT(m_index == std::numeric_limits<unsigned>::max());
-    ASSERT(!m_directory);
+    RELEASE_ASSERT(m_index == std::numeric_limits<unsigned>::max());
+    RELEASE_ASSERT(WTF::opaque(!m_directory));
+    RELEASE_ASSERT(WTF::opaque(directory));
     
     RELEASE_ASSERT(directory->subspace()->alignedMemoryAllocator() == m_alignedMemoryAllocator);
     
@@ -433,21 +434,19 @@ void MarkedBlock::Handle::didAddToDirectory(BlockDirectory* directory, unsigned 
 
 void MarkedBlock::Handle::didRemoveFromDirectory()
 {
-    ASSERT(m_index != std::numeric_limits<unsigned>::max());
-    ASSERT(m_directory);
+    RELEASE_ASSERT(m_index != std::numeric_limits<unsigned>::max());
+    RELEASE_ASSERT(m_directory);
     
     m_index = std::numeric_limits<unsigned>::max();
     m_directory = nullptr;
     blockHeader().m_subspace = nullptr;
 }
 
-#if ASSERT_ENABLED
 void MarkedBlock::assertValidCell(VM& vm, HeapCell* cell) const
 {
     RELEASE_ASSERT(&vm == &this->vm());
     RELEASE_ASSERT(const_cast<MarkedBlock*>(this)->handle().cellAlign(cell) == cell);
 }
-#endif // ASSERT_ENABLED
 
 void MarkedBlock::Handle::dumpState(PrintStream& out)
 {

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -378,11 +378,7 @@ public:
 
     bool hasAnyMarked() const;
     void noteMarked();
-#if ASSERT_ENABLED
     void assertValidCell(VM&, HeapCell*) const;
-#else
-    void assertValidCell(VM&, HeapCell*) const { }
-#endif
         
     WeakSet& weakSet();
 

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -295,14 +295,11 @@ void PreciseAllocation::dump(PrintStream& out) const
     out.print(RawPointer(this), ":(cell at ", RawPointer(cell()), " with size ", m_cellSize, " and attributes ", m_attributes, ")");
 }
 
-#if ASSERT_ENABLED
 void PreciseAllocation::assertValidCell(VM& vm, HeapCell* cell) const
 {
-    ASSERT(&vm == &this->vm());
-    ASSERT(cell == this->cell());
-    ASSERT(m_hasValidCell);
+    RELEASE_ASSERT(&vm == &this->vm());
+    RELEASE_ASSERT(cell == this->cell());
+    RELEASE_ASSERT(m_hasValidCell);
 }
-#endif
 
 } // namespace JSC
-

--- a/Source/JavaScriptCore/heap/PreciseAllocation.h
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.h
@@ -140,11 +140,7 @@ public:
     
     void noteMarked() { }
     
-#if ASSERT_ENABLED
     void assertValidCell(VM&, HeapCell*) const;
-#else
-    void assertValidCell(VM&, HeapCell*) const { }
-#endif
     
     void sweep();
     

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -83,9 +83,7 @@ static void validate(JSCell* cell)
 SlotVisitor::SlotVisitor(JSC::Heap& heap, CString codeName)
     : Base(heap, codeName, heap.m_opaqueRoots)
     , m_markingVersion(MarkedSpace::initialVersion)
-#if ASSERT_ENABLED
     , m_isCheckingForDefaultMarkViolation(false)
-#endif
 {
 }
 
@@ -144,7 +142,7 @@ void SlotVisitor::appendJSCellOrAuxiliary(HeapCell* heapCell)
     if (!heapCell)
         return;
     
-    ASSERT(!m_isCheckingForDefaultMarkViolation);
+    RELEASE_ASSERT(!m_isCheckingForDefaultMarkViolation);
     
     auto validateCell = [&] (JSCell* jsCell) {
         StructureID structureID = jsCell->structureID();
@@ -240,7 +238,7 @@ void SlotVisitor::appendHiddenSlow(JSCell* cell, Dependency dependency)
 
 ALWAYS_INLINE void SlotVisitor::appendHiddenSlowImpl(JSCell* cell, Dependency dependency)
 {
-    ASSERT(!m_isCheckingForDefaultMarkViolation);
+    RELEASE_ASSERT(!m_isCheckingForDefaultMarkViolation);
 
 #if ENABLE(GC_VALIDATION)
     validate(cell);
@@ -279,14 +277,13 @@ void SlotVisitor::appendToMarkStack(JSCell* cell)
 template<typename ContainerType>
 ALWAYS_INLINE void SlotVisitor::appendToMarkStack(ContainerType& container, JSCell* cell)
 {
-    ASSERT(m_heap.isMarked(cell));
-#if CPU(X86_64)
+    RELEASE_ASSERT(m_heap.isMarked(cell));
     if (Options::dumpZappedCellCrashData()) [[unlikely]] {
         if (cell->isZapped()) [[unlikely]]
             reportZappedCellAndCrash(m_heap, cell);
     }
-#endif
-    ASSERT(!cell->isZapped());
+
+    RELEASE_ASSERT(!cell->isZapped());
 
     container.noteMarked();
     
@@ -300,7 +297,7 @@ void SlotVisitor::markAuxiliary(const void* base)
 {
     HeapCell* cell = std::bit_cast<HeapCell*>(base);
     
-    ASSERT(cell->heap() == heap());
+    RELEASE_ASSERT(cell->heap() == heap());
     
     if (Heap::testAndSetMarked(m_markingVersion, cell))
         return;
@@ -349,7 +346,7 @@ private:
 
 ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
 {
-    ASSERT(m_heap.isMarked(cell));
+    RELEASE_ASSERT(m_heap.isMarked(cell));
     
     SetCurrentCellScope currentCellScope(*this, cell);
     
@@ -385,7 +382,6 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
     default:
         // FIXME: This could be so much better.
         // https://bugs.webkit.org/show_bug.cgi?id=162462
-#if CPU(X86_64)
         if (Options::dumpZappedCellCrashData()) [[unlikely]] {
             Structure* structure = cell->structure();
             if (structure) [[likely]] {
@@ -395,7 +391,6 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
             }
             reportZappedCellAndCrash(m_heap, const_cast<JSCell*>(cell));
         }
-#endif
         cell->methodTable()->visitChildren(const_cast<JSCell*>(cell), *this);
         break;
     }

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -65,7 +65,6 @@ public:
 
     class DefaultMarkingViolationAssertionScope {
     public:
-#if ASSERT_ENABLED
         DefaultMarkingViolationAssertionScope(SlotVisitor& visitor)
             : m_visitor(visitor)
         {
@@ -81,9 +80,6 @@ public:
     private:
         SlotVisitor& m_visitor;
         bool m_wasCheckingForDefaultMarkViolation;
-#else
-        DefaultMarkingViolationAssertionScope(SlotVisitor&) { }
-#endif
     };
 
     SlotVisitor(Heap&, CString codeName);
@@ -240,9 +236,7 @@ private:
     
     // Put padding here to mitigate false sharing between multiple SlotVisitors.
     char padding[64];
-#if ASSERT_ENABLED
     bool m_isCheckingForDefaultMarkViolation { false };
-#endif
 };
 
 class ParallelModeEnabler {

--- a/Source/JavaScriptCore/runtime/JSCell.cpp
+++ b/Source/JavaScriptCore/runtime/JSCell.cpp
@@ -276,7 +276,6 @@ void JSCellLock::unlockSlow()
     IndexingTypeLockAlgorithm::unlockSlow(*lock);
 }
 
-#if CPU(X86_64)
 NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void reportZappedCellAndCrash(Heap& heap, const JSCell* cell)
 {
     MarkedBlock::Handle* foundBlockHandle = nullptr;
@@ -353,7 +352,6 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void reportZappedCellAndCras
 
     CRASH_WITH_INFO(cellAddress, headerWord, zapReasonAndMore, subspaceHash, cellSize, foundBlock, variousState);
 }
-#endif // CPU(X86_64)
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -324,8 +324,6 @@ inline auto subspaceForConcurrently(VM& vm)
     return Type::template subspaceFor<Type, SubspaceAccess::Concurrently>(vm);
 }
 
-#if CPU(X86_64)
 JS_EXPORT_PRIVATE NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void reportZappedCellAndCrash(Heap&, const JSCell*);
-#endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -59,14 +59,14 @@ namespace JSC {
 inline JSCell::JSCell(CreatingEarlyCellTag)
     : m_cellState(CellState::DefinitelyWhite)
 {
-    ASSERT(!isCompilationThread());
+    RELEASE_ASSERT(!isCompilationThread());
 }
 
 inline JSCell::JSCell(VM&, Structure* structure)
     : JSCell(CreatingWellDefinedBuiltinCell, structure->id(), structure->typeInfoBlob())
 {
-    ASSERT(!isCompilationThread());
-    ASSERT(m_cellState == CellState::DefinitelyWhite);
+    RELEASE_ASSERT(!isCompilationThread());
+    RELEASE_ASSERT(m_cellState == CellState::DefinitelyWhite);
 
     // Note that in the constructor initializer list above, we are only using values
     // inside structure but not necessarily the structure pointer itself. All these
@@ -103,18 +103,18 @@ inline void JSCell::finishCreation(VM& vm)
     // to make sure that none of our stores sink below here.
     vm.mutatorFence();
 #if ENABLE(GC_VALIDATION)
-    ASSERT(vm.isInitializingObject());
+    RELEASE_ASSERT(vm.isInitializingObject());
     vm.setInitializingObjectClass(0);
 #else
     UNUSED_PARAM(vm);
 #endif
-    ASSERT(m_structureID);
+    RELEASE_ASSERT(m_structureID);
 }
 
 inline void JSCell::finishCreation(VM& vm, Structure* structure, CreatingEarlyCellTag)
 {
 #if ENABLE(GC_VALIDATION)
-    ASSERT(vm.isInitializingObject());
+    RELEASE_ASSERT(vm.isInitializingObject());
     vm.setInitializingObjectClass(0);
     if (structure) {
 #endif
@@ -128,7 +128,7 @@ inline void JSCell::finishCreation(VM& vm, Structure* structure, CreatingEarlyCe
     UNUSED_PARAM(vm);
 #endif
     // Very first set of allocations won't have a real structure.
-    ASSERT(m_structureID || !vm.structureStructure);
+    RELEASE_ASSERT(m_structureID || !vm.structureStructure);
 }
 
 inline JSType JSCell::type() const
@@ -189,15 +189,15 @@ inline Allocator allocatorForConcurrently(VM& vm, size_t allocationSize, Allocat
 template<typename T, AllocationFailureMode failureMode>
 ALWAYS_INLINE void* tryAllocateCellHelper(VM& vm, size_t size, GCDeferralContext* deferralContext)
 {
-    ASSERT(deferralContext || vm.heap.isDeferred() || !AssertNoGC::isInEffectOnCurrentThread());
-    ASSERT(size >= sizeof(T));
+    RELEASE_ASSERT(deferralContext || vm.heap.isDeferred() || !AssertNoGC::isInEffectOnCurrentThread());
+    RELEASE_ASSERT(size >= sizeof(T));
     JSCell* result = static_cast<JSCell*>(subspaceFor<T>(vm)->allocate(vm, WTF::roundUpToMultipleOf<T::atomSize>(size), deferralContext, failureMode));
     if constexpr (failureMode == AllocationFailureMode::ReturnNull) {
         if (!result)
             return nullptr;
     }
 #if ENABLE(GC_VALIDATION)
-    ASSERT(!vm.isInitializingObject());
+    RELEASE_ASSERT(!vm.isInitializingObject());
     vm.setInitializingObjectClass(T::info());
 #endif
     result->clearStructure();
@@ -317,8 +317,8 @@ inline bool JSCell::isAPIValueWrapper() const
 
 ALWAYS_INLINE void JSCell::setStructure(VM& vm, Structure* structure)
 {
-    ASSERT(structure->classInfoForCells() == this->structure()->classInfoForCells());
-    ASSERT(!this->structure()
+    RELEASE_ASSERT(structure->classInfoForCells() == this->structure()->classInfoForCells());
+    RELEASE_ASSERT(!this->structure()
         || this->structure()->transitionWatchpointSetHasBeenInvalidated()
         || structure->id().decode() == structure);
     m_structureID = structure->id();
@@ -326,7 +326,7 @@ ALWAYS_INLINE void JSCell::setStructure(VM& vm, Structure* structure)
     m_type = structure->typeInfo().type();
     IndexingType newIndexingType = structure->indexingModeIncludingHistory();
     if (m_indexingTypeAndMisc != newIndexingType) {
-        ASSERT(!(newIndexingType & ~AllArrayTypesAndHistory));
+        RELEASE_ASSERT(!(newIndexingType & ~AllArrayTypesAndHistory));
         for (;;) {
             IndexingType oldValue = m_indexingTypeAndMisc;
             IndexingType newValue = (oldValue & ~AllArrayTypesAndHistory) | structure->indexingModeIncludingHistory();
@@ -340,10 +340,8 @@ ALWAYS_INLINE void JSCell::setStructure(VM& vm, Structure* structure)
 inline const MethodTable* JSCell::methodTable() const
 {
     Structure* structure = this->structure();
-#if ASSERT_ENABLED
     if (Structure* rootStructure = structure->structure())
-        ASSERT(rootStructure == rootStructure->structure());
-#endif
+        RELEASE_ASSERT(rootStructure == rootStructure->structure());
     return &structure->classInfoForCells()->methodTable;
 }
 
@@ -379,7 +377,7 @@ ALWAYS_INLINE const ClassInfo* JSCell::classInfo() const
     // may have been swept already (and we're probably being called from this object's destructor).
     // This can only be verified for the mutator thread since other threads might be querying JSCells
     // that are not being swept by the mutator.
-    ASSERT_IMPLIES(vm().currentThreadIsHoldingAPILock(), vm().heap.mutatorState() != MutatorState::Sweeping);
+    RELEASE_ASSERT_IMPLIES(vm().currentThreadIsHoldingAPILock(), vm().heap.mutatorState() != MutatorState::Sweeping);
     return structure()->classInfoForCells();
 }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -202,8 +202,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, verboseFTLFailure, false, Normal, nullptr) \
     v(Bool, testTheFTL, false, Normal, nullptr) \
     v(Bool, verboseSanitizeStack, false, Normal, nullptr) \
-    v(Bool, useGenerationalGC, true, Normal, nullptr) \
-    v(Bool, useConcurrentGC, true, Normal, nullptr) \
+    v(Bool, useGenerationalGC, false, Normal, nullptr) \
+    v(Bool, useConcurrentGC, false, Normal, nullptr) \
     v(Bool, collectContinuously, false, Normal, nullptr) \
     v(Double, collectContinuouslyPeriodMS, 1, Normal, nullptr) \
     v(Bool, forceFencedBarrier, false, Normal, nullptr) \
@@ -237,13 +237,13 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, gcIncrementBytes, 10000, Normal, nullptr) \
     v(Double, gcIncrementMaxBytes, 100000, Normal, nullptr) \
     v(Double, gcIncrementScale, 0, Normal, nullptr) \
-    v(Bool, scribbleFreeCells, false, Normal, nullptr) \
+    v(Bool, scribbleFreeCells, true, Normal, nullptr) \
     v(Double, sizeClassProgression, 1.4, Normal, nullptr) \
     v(Unsigned, preciseAllocationCutoff, 100000, Normal, nullptr) \
     v(Bool, dumpSizeClasses, false, Normal, nullptr) \
-    v(Bool, stealEmptyBlocksFromOtherAllocators, true, Normal, nullptr) \
+    v(Bool, stealEmptyBlocksFromOtherAllocators, false, Normal, nullptr) \
     v(Bool, eagerlyUpdateTopCallFrame, false, Normal, nullptr) \
-    v(Bool, dumpZappedCellCrashData, false, Normal, nullptr) \
+    v(Bool, dumpZappedCellCrashData, true, Normal, nullptr) \
     \
     v(Bool, useOSREntryToDFG, true, Normal, nullptr) \
     v(Bool, useOSREntryToFTL, true, Normal, nullptr) \
@@ -282,7 +282,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, logExecutableAllocation, false, Normal, nullptr) \
     v(Unsigned, maxDFGNodesInBasicBlockForPreciseAnalysis, 20000, Normal, "Disable precise but costly analysis and give conservative results if the number of DFG nodes in a block exceeds this threshold"_s) \
     \
-    v(Bool, useConcurrentJIT, true, Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread"_s) \
+    v(Bool, useConcurrentJIT, false, Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread"_s) \
     v(Unsigned, minNumberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, maxNumberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, numberOfBaselineCompilerThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
@@ -410,9 +410,9 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, alwaysHaveABadTime, false, Normal, "debugging option to test HaveABadTime mode"_s) \
     v(Bool, allowDoubleShape, true, Normal, "debugging option to test disabling use of DoubleShape"_s) \
-    v(Bool, useZombieMode, false, Normal, "debugging option to scribble over dead objects with 0xbadbeef0"_s) \
+    v(Bool, useZombieMode, true, Normal, "debugging option to scribble over dead objects with 0xbadbeef0"_s) \
     v(Bool, useImmortalObjects, false, Normal, "debugging option to keep all objects alive forever"_s) \
-    v(Bool, sweepSynchronously, false, Normal, "debugging option to sweep all dead objects synchronously at GC end before resuming mutator"_s) \
+    v(Bool, sweepSynchronously, true, Normal, "debugging option to sweep all dead objects synchronously at GC end before resuming mutator"_s) \
     v(Unsigned, maxSingleAllocationSize, 0, Configurable, "debugging option to limit individual allocations to a max size (0 = limit not set, N = limit size in bytes)"_s) \
     \
     v(GCLogLevel, logGC, GCLogging::None, Normal, "debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)"_s) \

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -544,9 +544,7 @@
 
 #if !defined(ENABLE_SECURITY_ASSERTIONS)
 /* Enable security assertions on all ASAN builds and debug builds. */
-#if ASAN_ENABLED || !defined(NDEBUG)
 #define ENABLE_SECURITY_ASSERTIONS 1
-#endif
 #endif
 
 #if !defined(ENABLE_SEPARATED_WX_HEAP)
@@ -814,7 +812,7 @@
 
 #endif /* !defined(ENABLE_DFG_JIT) && ENABLE(JIT) */
 
-#if ENABLE(DFG_JIT) && ASSERT_ENABLED
+#if ENABLE(DFG_JIT)
 #define ENABLE_DFG_DOES_GC_VALIDATION 1
 #else
 #define ENABLE_DFG_DOES_GC_VALIDATION 0
@@ -1007,9 +1005,7 @@
 #define ENABLE_THREADING_GENERIC 1
 #endif
 
-#if !defined(ENABLE_GC_VALIDATION) && !defined(NDEBUG)
 #define ENABLE_GC_VALIDATION 1
-#endif
 
 #if OS(DARWIN) && ENABLE(JIT) && USE(APPLE_INTERNAL_SDK) && CPU(ARM64E) && HAVE(JIT_CAGE) && !PLATFORM(MAC) && !PLATFORM(MACCATALYST)
 #define ENABLE_JIT_CAGE 1


### PR DESCRIPTION
#### 2d4ab40b31ef02b28376dfdf148e8bb968b3e899
<pre>
[Testing/EWS only] Add extra release asserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=309165">https://bugs.webkit.org/show_bug.cgi?id=309165</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::didAddToDirectory):
(JSC::MarkedBlock::Handle::didRemoveFromDirectory):
(JSC::MarkedBlock::assertValidCell const):
* Source/JavaScriptCore/heap/MarkedBlock.h:
(JSC::MarkedBlock::assertValidCell const): Deleted.
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
(JSC::PreciseAllocation::assertValidCell const):
* Source/JavaScriptCore/heap/PreciseAllocation.h:
(JSC::PreciseAllocation::assertValidCell const): Deleted.
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::appendHiddenSlowImpl):
(JSC::SlotVisitor::appendToMarkStack):
(JSC::SlotVisitor::markAuxiliary):
(JSC::SlotVisitor::visitChildren):
* Source/JavaScriptCore/runtime/JSCell.cpp:
(JSC::reportZappedCellAndCrash):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSCellInlines.h:
(JSC::JSCell::JSCell):
(JSC::JSCell::finishCreation):
(JSC::tryAllocateCellHelper):
(JSC::JSCell::setStructure):
(JSC::JSCell::methodTable const):
(JSC::JSCell::classInfo const):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/PlatformEnable.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b067e90e75f9a377ed2da998aef5f31ae6e88c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101727 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114342 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81474 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16576 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133165 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPITabs.ConnectToSubframe, TestWTF.WTF_CheckedPtrDeathTest.UniquelyOwnedCheckedPtrCheckFailure (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95112 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15689 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13498 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4419 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140266 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125315 "Found 5 new API test failures: TestWTF.WTF_CheckedPtrDeathTest.UniquelyOwnedCheckedPtrCheckFailure, TestWebKitAPI.JavaScriptCore.IncrementalSweeperMainThread, TestWebKitAPI.JavaScriptCore.IncrementalSweeperSecondaryThread, TestWebKitAPI.WebKit.GetUserMediaWithWebThread, TestWebKitAPI.WritingTools.AttributedStringWithWebKitLegacy (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11070 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159315 "") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9086 "Found 3 new JSC stress test failures: exceptionFuzz.yaml/exceptionFuzz/date-format-xparb.js.exception-fuzz, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-aggressive-inline, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2450 "Found 1167 new failures in Modules/mediastream/MediaStream.cpp, dom/Element.cpp, WebProcess/WebCoreSupport/mac/WebDragClientMac.mm, page/TextIndicator.cpp, mac/DOM/DOMInternal.mm, rendering/RenderTable.cpp, dom/DatasetDOMStringMap.cpp, UIProcess/UserMediaPermissionRequestProxy.cpp, rendering/RenderTableSection.cpp, page/IntersectionObserver.cpp ...") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12588 "Found 2 new test failures: accessibility/mac/text-marker-ranges-intersect.html inspector/heap/garbageCollected.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/159315 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17468 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/159315 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76943 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18005 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9633 "Found 2 new test failures: accessibility/mac/text-marker-ranges-intersect.html inspector/heap/garbageCollected.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20400 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84185 "Found 1214 new failures in Modules/mediastream/MediaStream.cpp, dom/Element.cpp, page/TextIndicator.cpp, mac/DOM/DOMInternal.mm, rendering/RenderTable.cpp, dom/DatasetDOMStringMap.cpp, UIProcess/UserMediaPermissionRequestProxy.cpp, rendering/RenderTableSection.cpp, page/IntersectionObserver.cpp, html/HTMLVideoElementCaptionDisplaySettings.cpp ...") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46007 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20132 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20277 "Hash 8b067e90 for PR 59892 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->