### PR TITLE
Support Multiple Crash Log Paths

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/crashlogs.py
+++ b/Tools/Scripts/webkitpy/common/system/crashlogs.py
@@ -47,7 +47,10 @@ class CrashLogs(object):
 
     def __init__(self, host, crash_log_directory, crash_logs_to_skip=[]):
         self._host = host
-        self._crash_log_directory = crash_log_directory
+        if isinstance(crash_log_directory, (list, tuple, set)):
+            self._crash_log_directories = list(crash_log_directory)
+        else:
+            self._crash_log_directories = [crash_log_directory]
         self._crash_logs_to_skip = crash_logs_to_skip
 
     def find_newest_log(self, process_name, pid=None, include_errors=False, newer_than=None):
@@ -95,7 +98,9 @@ class CrashLogs(object):
             return (basename.startswith(process_name + '_') and (basename.endswith('.crash')) or
                     (process_name in basename and basename.endswith('.ips')))
 
-        logs = self._host.filesystem.files_under(self._crash_log_directory, file_filter=is_crash_log)
+        logs = []
+        for directory in self._crash_log_directories:
+            logs.extend(self._host.filesystem.files_under(directory, file_filter=is_crash_log))
         errors = ''
         for path in reversed(sorted(logs)):
             try:
@@ -120,7 +125,9 @@ class CrashLogs(object):
                 return False
             return basename.startswith("CrashLog")
 
-        logs = self._host.filesystem.files_under(self._crash_log_directory, file_filter=is_crash_log)
+        logs = []
+        for directory in self._crash_log_directories:
+            logs.extend(self._host.filesystem.files_under(directory, file_filter=is_crash_log))
         errors = u''
         for path in reversed(sorted(logs)):
             try:
@@ -156,7 +163,9 @@ class CrashLogs(object):
                 return False
             return basename.endswith('.crash') or basename.endswith('.ips')
 
-        logs = self._host.filesystem.files_under(self._crash_log_directory, file_filter=is_crash_log)
+        logs = []
+        for directory in self._crash_log_directories:
+            logs.extend(self._host.filesystem.files_under(directory, file_filter=is_crash_log))
         errors = ''
         crash_logs = {}
         for path in reversed(sorted(logs)):

--- a/Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py
@@ -432,3 +432,27 @@ class CrashLogsTest(unittest.TestCase):
         crash_report = crash_report.replace("Date/Time", "")
         crash_timestamp = crash_logs.get_timestamp_from_log(crash_report)
         self.assertIsNone(crash_timestamp)
+
+    def test_find_log_darwin_multiple_directories(self):
+        if not SystemHost.get_default().platform.is_mac():
+            return
+
+        files = {}
+        files['/Users/mock/Library/Logs/DiagnosticReports/DumpRenderTree_2011-06-13-150719_quadzen.crash'] = \
+            string_utils.encode(make_mock_crash_report_darwin('DumpRenderTree', 28530))
+        files['/Library/Logs/CrashboardArchive/DumpRenderTree_2011-06-13-150720_quadzen.ips'] = \
+            string_utils.encode(make_mock_ips_crash_report_darwin('DumpRenderTree', 28529))
+
+        filesystem = MockFileSystem(files)
+        crash_logs = CrashLogs(
+            MockSystemHost(filesystem=filesystem),
+            ['/Users/mock/Library/Logs/DiagnosticReports', '/Library/Logs/CrashboardArchive'],
+        )
+
+        all_logs = crash_logs.find_all_logs()
+        self.assertEqual(len(all_logs), 2)
+
+        log = crash_logs.find_newest_log("DumpRenderTree", 28529)
+        self.assertIsNotNone(log)
+        log = crash_logs.find_newest_log("DumpRenderTree", 28530)
+        self.assertIsNotNone(log)

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -86,7 +86,13 @@ class ApplePort(Port):
         self.supports_localhost_aliases = True
 
     def setup_test_run(self, device_type=None):
-        self._crash_logs_to_skip_for_host[self.host] = self.host.filesystem.files_under(self.path_to_crash_logs())
+        files_to_skip = []
+        for directory in self.crash_log_directories():
+            files_to_skip.extend(self.host.filesystem.files_under(directory))
+        self._crash_logs_to_skip_for_host[self.host] = files_to_skip
+
+    def crash_log_directories(self):
+        return [self.path_to_crash_logs()]
 
     def default_timeout_ms(self):
         if self.get_option('guard_malloc'):

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -133,6 +133,13 @@ class DarwinPort(ApplePort):
             return diagnositc_reports_directory
         return self.host.filesystem.join(log_directory, 'CrashReporter')
 
+    def crash_log_directories(self):
+        directories = [self.path_to_crash_logs()]
+        crashboard_archive = '/Library/Logs/CrashboardArchive'
+        if self.host.filesystem.exists(crashboard_archive):
+            directories.append(crashboard_archive)
+        return directories
+
     def _merge_crash_logs(self, logs, new_logs, crashed_processes):
         for test, crash_log in new_logs.items():
             try:
@@ -150,7 +157,7 @@ class DarwinPort(ApplePort):
         return logs
 
     def _look_for_all_crash_logs_in_log_dir(self, newer_than):
-        crash_log = CrashLogs(self.host, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(self.host, []))
+        crash_log = CrashLogs(self.host, self.crash_log_directories(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(self.host, []))
         return crash_log.find_all_logs(newer_than=newer_than)
 
     def _get_crash_log(self, name, pid, stdout, stderr, newer_than, time_fn=None, sleep_fn=None, wait_for_log=True, target_host=None):
@@ -160,7 +167,7 @@ class DarwinPort(ApplePort):
         time_fn = time_fn or time.time
         sleep_fn = sleep_fn or time.sleep
         crash_log = ''
-        crash_logs = CrashLogs(target_host or self.host, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(target_host or self.host, []))
+        crash_logs = CrashLogs(target_host or self.host, self.crash_log_directories(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(target_host or self.host, []))
         now = time_fn()
         deadline = now + 5 * int(self.get_option('child_processes', 1))
         while not crash_log and now <= deadline:

--- a/Tools/Scripts/webkitpy/port/darwin_testcase.py
+++ b/Tools/Scripts/webkitpy/port/darwin_testcase.py
@@ -107,6 +107,20 @@ class DarwinTest(port_testcase.PortTestCase):
         port = self.make_port(host)
         self.assertEqual(port.path_to_crash_logs(), '/Users/mock/Library/Logs/DiagnosticReports')
 
+    def test_crash_log_directories(self):
+        port = self.make_port()
+        self.assertEqual(port.crash_log_directories(), ['/Users/mock/Library/Logs/CrashReporter'])
+
+        host = MockSystemHost(filesystem=MockFileSystem(files={
+            '/Users/mock/Library/Logs/DiagnosticReports/crashlog.crash': None,
+            '/Library/Logs/CrashboardArchive/somefile.ips': None,
+        }))
+        port = self.make_port(host)
+        self.assertEqual(port.crash_log_directories(), [
+            '/Users/mock/Library/Logs/DiagnosticReports',
+            '/Library/Logs/CrashboardArchive',
+        ])
+
     def test_tailspin(self):
 
         def logging_run_command(args):

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -50,6 +50,11 @@ class IOSDeviceTest(ios_testcase.IOSTest):
         with self.assertRaises(RuntimeError):
             port.path_to_crash_logs()
 
+    def test_crash_log_directories(self):
+        port = self.make_port()
+        with self.assertRaises(RuntimeError):
+            port.crash_log_directories()
+
     def test_tailspin(self):
         def logging_run_command(args):
             print(args)


### PR DESCRIPTION
#### 03d721925ecd222385786eb32efa33296377ced3
<pre>
Support Multiple Crash Log Paths
<a href="https://rdar.apple.com/171726958">rdar://171726958</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309168">https://bugs.webkit.org/show_bug.cgi?id=309168</a>

Reviewed by Jonathan Bedard.

Support Multiple Crash Log Paths

* Tools/Scripts/webkitpy/common/system/crashlogs.py:
(CrashLogs.__init__):
(CrashLogs._find_newest_log_darwin):
(CrashLogs._find_newest_log_win):
(CrashLogs._find_all_logs_darwin):
* Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py:
* Tools/Scripts/webkitpy/port/apple.py:
(ApplePort.setup_test_run):
(ApplePort):
(ApplePort.crash_log_directories):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.crash_log_directories):
(DarwinPort._look_for_all_crash_logs_in_log_dir):
(DarwinPort._get_crash_log):
* Tools/Scripts/webkitpy/port/darwin_testcase.py:
(DarwinTest.test_crash_log_directories):
* Tools/Scripts/webkitpy/port/ios_device_unittest.py:
(IOSDeviceTest.test_crash_log_directories):

Canonical link: <a href="https://commits.webkit.org/308658@main">https://commits.webkit.org/308658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceac12a63845039091bf0b9f42c07bc539b737d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101511 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e692179-1f38-40e3-8c07-03320d970d20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81405 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3604ad56-26cd-402b-8746-7dcf09d3eaaa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94942 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/173f4b64-d31f-41af-9bb1-afe1b9257627) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147419 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15552 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13349 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4218 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159114 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122207 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76738 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9460 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20199 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19929 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20076 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19985 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->