### PR TITLE
[Site Isolation] Support cross-site process swap for UIProcess-driven back/forward child frame navigation

### DIFF
--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
@@ -65,7 +65,7 @@ window.onmessage = (event) => dispatchMessage(event.data, {
                 sendMessageToPopup("navigate-to-other");
             } else if (page2ShowCount == 2) {
                 testPassed("Page2 displayed twice.");
-                sendMessageToPopup("back2");
+                sendMessageToPopup("back");
             }
         }
     },
@@ -73,7 +73,7 @@ window.onmessage = (event) => dispatchMessage(event.data, {
         load: () => debug("Other page loaded"),
         pageshow: ({arg}) => {
             debug("Other page displayed.");
-            sendMessageToPopup("back1");
+            sendMessageToPopup("back");
         }
     },
 });

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-other.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-other.html
@@ -11,7 +11,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
-        back1: () => history.back(),
+        back: () => history.back(),
     },
 });
 

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
@@ -13,8 +13,9 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
         'navigate-to-page2': () => navigateIframeTo("back-iframe-2.html"),
+        'navigate-to-page2-cross-site-iframe': () => navigateIframeTo(crossSiteUrl("back-iframe-2.html")),
         'navigate-to-other': () => navigateTo("back-iframe-other.html"),
-        back2: () => history.back(),
+        back: () => history.back(),
     },
     page1: () => forwardMessageToOpener(event.data),
     page2: () => forwardMessageToOpener(event.data),

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has a same-site iframe with page1 loaded initially.
+Navigate iframe to cross-site page2.
+Navigate main frame to other (same-site).
+Go back. (back-iframe-popup.html with iframe showing cross-site page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
@@ -6,7 +6,7 @@
 <script src="/navigation/resources/navigation-utils.js"></script>
 <script>
 
-description("Nested iframe history navigation works correctly with same-site iframe when back/forward cache is disabled.");
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
 jsTestIsAsync = true;
 
 const page = "opener";
@@ -41,8 +41,8 @@ window.onmessage = (event) => dispatchMessage(event.data, {
             page1ShowCount++;
             if (page1ShowCount == 1) {
                 debug("Page1 displayed first time.");
-                sendMessageToPopup("navigate-to-page2");
-            } else if (page1ShowCount == 2) {
+                sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else {
                 testFailed("Page1 should be displayed only once.");
                 finishJSTest();
             }
@@ -83,10 +83,10 @@ window.onmessage = (event) => dispatchMessage(event.data, {
 </head>
 <body>
 <ul>
-    <li>Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.</li>
-    <li>Navigate iframe to page2.</li>
-    <li>Navigate main frame to other.</li>
-    <li>Go back. (back-iframe-popup.html with iframe showing page2)</li>
+    <li>Open a new window with back-iframe-popup.html. It has a same-site iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to cross-site page2.</li>
+    <li>Navigate main frame to other (same-site).</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
 </ul>
 <p>... and ensures the nested iframe content is correctly restored to page2.</p>
 </body>

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -204,6 +204,9 @@ public:
     void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }
     bool isEnhancedSecurityLinkForCurrentSite() const { return m_isEnhancedSecurityLinkForCurrentSite; }
 
+    WebKit::FrameState* backForwardFrameState() const { return m_backForwardFrameState.get(); }
+    void setBackForwardFrameState(RefPtr<WebKit::FrameState>&& frameState) { m_backForwardFrameState = WTF::move(frameState); }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -243,6 +246,7 @@ private:
     RefPtr<WebKit::BrowsingWarning> m_safeBrowsingWarning;
     ListHashSet<size_t> m_ongoingSafeBrowsingChecks;
     RefPtr<WebKit::FrameProcess> m_pendingSharedProcess;
+    RefPtr<WebKit::FrameState> m_backForwardFrameState;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5613,10 +5613,49 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
     Ref preferences = m_preferences;
     if (preferences->siteIsolationEnabled() && (!frame.isMainFrame() || newProcess->coreProcessIdentifier() == frame.process().coreProcessIdentifier())) {
+        // about:blank frames should inherit the origin of the which originated navigation.
+        // If the two frames share origins, they should share the same process.
+        //
+        // From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
+        //
+        // If url matches about:blank or is about:srcdoc, then:
+        //     Set documentState's origin to initiatorOriginSnapshot.
+        //     Set documentState's about base URL to initiatorBaseURLSnapshot.
+        std::optional<SecurityOriginData> originator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo() ? std::make_optional(navigation.originatingFrameInfo()->securityOrigin) : std::nullopt;
+
+        auto shouldTreatAsContinuingLoad = navigation.currentRequestIsRedirect() ? WebCore::ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted : WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
+
+        // When a child frame's Back/Forward navigation triggers a process swap (Site Isolation),
+        // send GoToBackForwardItem so the new process performs a proper history navigation using
+        // the FrameState stored on the Navigation object.
+        if (RefPtr frameState = navigation.backForwardFrameState()) {
+            // The FrameState from the BackForwardList may contain an old frameID from a
+            // previous incarnation of this child frame. Update it to the current frameID
+            // so the new process can find the correct frame to navigate.
+            frameState->frameID = frame.frameID();
+
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: Sending GoToBackForwardItem for child frame to new process, URL=%" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
+            auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(navigation.currentRequest().url());
+            frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
+                navigationID = navigation.navigationID(),
+                frameState = WTF::move(frameState),
+                shouldTreatAsContinuingLoad,
+                lastNavigationWasAppInitiated = m_lastNavigationWasAppInitiated,
+                publicSuffix = WTF::move(publicSuffix),
+                newProcess = newProcess.copyRef(),
+                preventProcessShutdownScope = newProcess->shutdownPreventingScope()
+            ] (std::optional<PageIdentifier> pageID) mutable {
+                if (pageID)
+                    newProcess->send(Messages::WebPage::GoToBackForwardItem({ navigationID, frameState.releaseNonNull(), FrameLoadType::IndexedBackForward, shouldTreatAsContinuingLoad, std::nullopt, lastNavigationWasAppInitiated, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), *pageID);
+            });
+            return;
+        }
+
         // FIXME: Add more parameters as appropriate. <rdar://116200985>
         LoadParameters loadParameters;
         loadParameters.request = navigation.currentRequest();
-        loadParameters.shouldTreatAsContinuingLoad = navigation.currentRequestIsRedirect() ? WebCore::ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted : WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
+        loadParameters.shouldTreatAsContinuingLoad = shouldTreatAsContinuingLoad;
         loadParameters.frameIdentifier = frame.frameID();
         loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
         loadParameters.navigationID = navigation.navigationID();
@@ -5631,17 +5670,6 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
         if (navigation.isInitialFrameSrcLoad())
             frame.setIsPendingInitialHistoryItem(true);
-
-        // about:blank frames should inherit the origin of the which originated navigation.
-        // If the two frames share origins, they should share the same process.
-        //
-        // From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
-        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
-        //
-        // If url matches about:blank or is about:srcdoc, then:
-        //     Set documentState's origin to initiatorOriginSnapshot.
-        //     Set documentState's about base URL to initiatorBaseURLSnapshot.
-        std::optional<SecurityOriginData> originator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo() ? std::make_optional(navigation.originatingFrameInfo()->securityOrigin) : std::nullopt;
 
         frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
             loadParameters = WTF::move(loadParameters),
@@ -8517,12 +8545,11 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
     }
 
-    // Wrap completionHandler to include FrameState in response.
     auto completionHandler = [
         originalCompletionHandler = WTF::move(originalCompletionHandler),
-        frameStateForBackForwardNavigation = WTF::move(frameStateForBackForwardNavigation)
+        frameStateForBackForwardNavigation
     ](PolicyDecision&& policyDecision) mutable {
-        if (frameStateForBackForwardNavigation && (policyDecision.policyAction == PolicyAction::Use))
+        if (frameStateForBackForwardNavigation && policyDecision.policyAction == PolicyAction::Use)
             policyDecision.backForwardFrameState = WTF::move(frameStateForBackForwardNavigation);
         originalCompletionHandler(WTF::move(policyDecision));
     };
@@ -8579,6 +8606,10 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         if (!navigation)
             navigation = m_navigationState->createLoadRequestNavigation(process->coreProcessIdentifier(), ResourceRequest(request), protect(backForwardList().currentItem()));
     }
+
+    // Store frameState on navigation for Site Isolation process swap.
+    if (frameStateForBackForwardNavigation && navigation)
+        navigation->setBackForwardFrameState(frameStateForBackForwardNavigation->copy());
 
     if (!checkURLReceivedFromCurrentOrPreviousWebProcess(process, request.url())) {
         WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "Ignoring request to load this main resource because it is outside the sandbox");


### PR DESCRIPTION
#### 95087ee3081bee456f186e4d69df2348c77cbf6b
<pre>
[Site Isolation] Support cross-site process swap for UIProcess-driven back/forward child frame navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=309110">https://bugs.webkit.org/show_bug.cgi?id=309110</a>
<a href="https://rdar.apple.com/171032434">rdar://171032434</a>

Reviewed by Charlie Wolfe.

This is a follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=308562">https://bugs.webkit.org/show_bug.cgi?id=308562</a> which routed
same-site child frame back/forward navigations through UIProcess when
UseUIProcessForBackForwardItemLoading is enabled.

When a child frame&apos;s back/forward navigation requires a cross-site process swap, send
GoToBackForwardItem with the child frame&apos;s FrameState to the new process so it can perform
a proper history navigation with full state restoration instead of a plain LoadRequest.

In decidePolicyForNavigationAction, the FrameState found for back/forward child frame
navigations is now stored on the Navigation object in addition to the PolicyDecision.
This allows continueNavigationInNewProcess to retrieve it when a process swap is needed.
The two consumers are mutually exclusive: the completionHandler sets it on PolicyDecision
for same-site navigations (PolicyAction::Use), while the Navigation object carries it for
cross-site process swaps (PolicyAction::LoadWillContinueInAnotherProcess).

Test: http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html:
* LayoutTests/http/tests/navigation/resources/back-iframe-other.html:
* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html:
* LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html: Copied from LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html.
* LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::backForwardFrameState const):
(API::Navigation::setBackForwardFrameState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/308761@main">https://commits.webkit.org/308761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/320070e1b9687d1743f8136bc4965eed40edb9f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148417 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/21103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/21008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/157101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159434 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/21008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33348 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/14699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->