### PR TITLE
Sites resolving to loopback addresses should not have Enhanced Security enabled

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3420,4 +3420,19 @@ void NetworkProcess::isEnhancedSecurityLink(const URL& url, CompletionHandler<vo
 }
 #endif
 
+void NetworkProcess::doesHostResolveToLoopbackAddress(const String& hostname, CompletionHandler<void(bool)>&& completionHandler)
+{
+    static uint64_t nextIdentifier { 0 };
+    WebCore::resolveDNS(hostname, ++nextIdentifier, [completionHandler = WTF::move(completionHandler)](WebCore::DNSAddressesOrError&& result) mutable {
+        if (!result.has_value()) {
+            completionHandler(false);
+            return;
+        }
+        bool resolvesToLoopback = std::ranges::all_of(*result, [](const WebCore::IPAddress& address) {
+            return address.isLoopback();
+        });
+        completionHandler(resolvesToLoopback);
+    });
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -236,6 +236,7 @@ public:
     void findPendingDownloadLocation(NetworkDataTask&, ResponseCompletionHandler&&, const WebCore::ResourceResponse&);
 
     void prefetchDNS(const String&);
+    void doesHostResolveToLoopbackAddress(const String& hostname, CompletionHandler<void(bool)>&&);
 
     void addWebsiteDataStore(WebsiteDataStoreParameters&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -299,4 +299,6 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if HAVE(ENHANCED_SECURITY_LINKS)
     IsEnhancedSecurityLink(URL url) -> (bool isEnhancedSecurityLink)
 #endif
+
+    DoesHostResolveToLoopbackAddress(String hostname) -> (bool resolvesToLoopbackAddress)
 }

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -204,6 +204,9 @@ public:
     void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }
     bool isEnhancedSecurityLinkForCurrentSite() const { return m_isEnhancedSecurityLinkForCurrentSite; }
 
+    void setDoesCurrentSiteResolveToLoopbackAddress(bool value) { m_doesCurrentSiteResolveToLoopbackAddress = value; }
+    bool doesCurrentSiteResolveToLoopbackAddress() const { return m_doesCurrentSiteResolveToLoopbackAddress; }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -237,6 +240,7 @@ private:
     bool m_hadSafeBrowsingWarning : 1 { false };
     bool m_hasStorageForCurrentSite : 1 { false };
     bool m_isEnhancedSecurityLinkForCurrentSite : 1 { false };
+    bool m_doesCurrentSiteResolveToLoopbackAddress : 1 { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;
     MonotonicTime m_requestStart { MonotonicTime::now() };

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -176,7 +176,8 @@ bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigatio
     auto currentRequestURL = navigation.currentRequest().url();
 
     if (currentRequestURL.protocolIs("http"_s)
-        && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())) {
+        && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())
+        && !navigation.doesCurrentSiteResolveToLoopbackAddress()) {
         enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
         return true;
     }

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
@@ -35,19 +35,10 @@
 
 namespace WebKit {
 
-WebFramePolicyListenerProxy::WebFramePolicyListenerProxy(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
-    : m_reply(WTF::move(reply))
+WebFramePolicyListenerProxy::WebFramePolicyListenerProxy(Reply&& reply, OptionSet<PolicyListenerCheck> checks)
+    : m_requiredChecks(checks | PolicyListenerCheck::PolicyDecision)
+    , m_reply(WTF::move(reply))
 {
-    if (expectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::No)
-        didReceiveSafeBrowsingResults({ });
-    if (expectAppBoundDomainResult == ShouldExpectAppBoundDomainResult::No)
-        didReceiveAppBoundDomainResult({ });
-    if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::No)
-        didReceiveInitialLinkDecorationFilteringData();
-    if (shouldWaitForSiteHasStorageCheck == ShouldWaitForSiteHasStorageCheck::No)
-        didReceiveSiteHasStorageResults();
-    if (shouldWaitForEnhancedSecurityLinkCheck == ShouldWaitForEnhancedSecurityLinkCheck::No)
-        didReceiveEnhancedSecurityLinkResults();
 }
 
 WebFramePolicyListenerProxy::~WebFramePolicyListenerProxy() = default;
@@ -55,73 +46,75 @@ WebFramePolicyListenerProxy::~WebFramePolicyListenerProxy() = default;
 void WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult(std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain)
 {
     ASSERT(RunLoop::isMain());
-
-    if (m_policyResult && m_safeBrowsingWarning && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
-        if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
-    } else
-        m_isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
+    ASSERT(!m_completedChecks.contains(PolicyListenerCheck::AppBoundDomainResult));
+    m_isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
+    m_completedChecks.add(PolicyListenerCheck::AppBoundDomainResult);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
 }
 
 void WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults(RefPtr<BrowsingWarning>&& safeBrowsingWarning)
 {
     ASSERT(isMainRunLoop());
-    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
-        if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
-    } else if (!m_safeBrowsingWarning)
+    if (!m_safeBrowsingWarning)
         m_safeBrowsingWarning = WTF::move(safeBrowsingWarning);
+    m_completedChecks.add(PolicyListenerCheck::SafeBrowsingResult);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
 }
 
 void WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData()
 {
     ASSERT(RunLoop::isMain());
-    ASSERT(!m_doneWaitingForLinkDecorationFilteringData);
-
-    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_safeBrowsingWarning && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
-        if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
-        return;
-    }
-
-    m_doneWaitingForLinkDecorationFilteringData = true;
+    ASSERT(!m_completedChecks.contains(PolicyListenerCheck::LinkDecorationFiltering));
+    m_completedChecks.add(PolicyListenerCheck::LinkDecorationFiltering);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
 }
 
 void WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults()
 {
     ASSERT(RunLoop::isMain());
-    ASSERT(!m_doneWaitingForSiteHasStorage);
-
-    if (m_policyResult && m_safeBrowsingWarning && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForEnhancedSecurityLink) {
-        if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
-        return;
-    }
-
-    m_doneWaitingForSiteHasStorage = true;
+    ASSERT(!m_completedChecks.contains(PolicyListenerCheck::SiteHasStorage));
+    m_completedChecks.add(PolicyListenerCheck::SiteHasStorage);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
 }
 
 void WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults()
 {
     ASSERT(RunLoop::isMain());
-    ASSERT(!m_doneWaitingForEnhancedSecurityLink);
+    ASSERT(!m_completedChecks.contains(PolicyListenerCheck::EnhancedSecurityLink));
+    m_completedChecks.add(PolicyListenerCheck::EnhancedSecurityLink);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
+}
 
-    if (m_policyResult && m_safeBrowsingWarning && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage) {
-        if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+void WebFramePolicyListenerProxy::didReceiveDNSResolutionResults()
+{
+    ASSERT(RunLoop::isMain());
+    if (m_completedChecks.contains(PolicyListenerCheck::DNSResolution))
         return;
-    }
+    m_completedChecks.add(PolicyListenerCheck::DNSResolution);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
+}
 
-    m_doneWaitingForEnhancedSecurityLink = true;
+void WebFramePolicyListenerProxy::fireReply()
+{
+    ASSERT(m_policyResult);
+    if (m_reply)
+        m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
 }
 
 void WebFramePolicyListenerProxy::use(API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient)
 {
-    if (m_safeBrowsingWarning && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
-        if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, policies, processSwapRequestedByClient, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
-    } else if (!m_policyResult)
-        m_policyResult = {{ policies, processSwapRequestedByClient }};
+    if (m_completedChecks.contains(PolicyListenerCheck::PolicyDecision))
+        return;
+    m_policyResult = { { policies, processSwapRequestedByClient } };
+    m_completedChecks.add(PolicyListenerCheck::PolicyDecision);
+    if (m_completedChecks == m_requiredChecks)
+        fireReply();
 }
 
 void WebFramePolicyListenerProxy::download()

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
@@ -29,6 +29,7 @@
 #include "PolicyDecision.h"
 #include <WebCore/FrameLoaderTypes.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
 namespace API {
@@ -40,43 +41,50 @@ namespace WebKit {
 class BrowsingWarning;
 
 enum class ProcessSwapRequestedByClient : bool { No, Yes };
-enum class ShouldExpectSafeBrowsingResult : bool { No, Yes };
-enum class ShouldExpectAppBoundDomainResult : bool { No, Yes };
-enum class ShouldWaitForInitialLinkDecorationFilteringData : bool { No, Yes };
-enum class ShouldWaitForSiteHasStorageCheck : bool { No, Yes };
-enum class ShouldWaitForEnhancedSecurityLinkCheck : bool { No, Yes };
 enum class WasNavigationIntercepted : bool { No, Yes };
+
+enum class PolicyListenerCheck : uint8_t {
+    PolicyDecision          = 1 << 0,
+    SafeBrowsingResult      = 1 << 1,
+    AppBoundDomainResult    = 1 << 2,
+    LinkDecorationFiltering = 1 << 3,
+    SiteHasStorage          = 1 << 4,
+    EnhancedSecurityLink    = 1 << 5,
+    DNSResolution           = 1 << 6,
+};
 
 class WebFramePolicyListenerProxy : public API::ObjectImpl<API::Object::Type::FramePolicyListener>, public CanMakeWeakPtr<WebFramePolicyListenerProxy> {
 public:
 
     using Reply = CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>;
-    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
+    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, OptionSet<PolicyListenerCheck> checks)
     {
-        return adoptRef(*new WebFramePolicyListenerProxy(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck));
+        return adoptRef(*new WebFramePolicyListenerProxy(WTF::move(reply), checks));
     }
     ~WebFramePolicyListenerProxy();
 
     void use(API::WebsitePolicies* = nullptr, ProcessSwapRequestedByClient = ProcessSwapRequestedByClient::No);
     void download();
     void ignore(WasNavigationIntercepted = WasNavigationIntercepted::No);
-    
+
     void didReceiveSafeBrowsingResults(RefPtr<BrowsingWarning>&&);
     void didReceiveAppBoundDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveManagedDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveInitialLinkDecorationFilteringData();
     void didReceiveSiteHasStorageResults();
     void didReceiveEnhancedSecurityLinkResults();
+    void didReceiveDNSResolutionResults();
 
 private:
-    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
+    WebFramePolicyListenerProxy(Reply&&, OptionSet<PolicyListenerCheck>);
+
+    void fireReply();
 
     std::optional<std::pair<RefPtr<API::WebsitePolicies>, ProcessSwapRequestedByClient>> m_policyResult;
     std::optional<RefPtr<BrowsingWarning>> m_safeBrowsingWarning;
-    std::optional<std::optional<NavigatingToAppBoundDomain>> m_isNavigatingToAppBoundDomain;
-    bool m_doneWaitingForSiteHasStorage { false };
-    bool m_doneWaitingForEnhancedSecurityLink { false };
-    bool m_doneWaitingForLinkDecorationFilteringData { false };
+    std::optional<NavigatingToAppBoundDomain> m_isNavigatingToAppBoundDomain;
+    OptionSet<PolicyListenerCheck> m_requiredChecks;
+    OptionSet<PolicyListenerCheck> m_completedChecks;
     Reply m_reply;
 };
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -364,7 +364,7 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTF::move(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, OptionSet<PolicyListenerCheck> checks)
 {
     if (RefPtr previousListener = m_activeListener)
         previousListener->ignore();
@@ -374,7 +374,7 @@ WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionH
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
         m_activeListener = nullptr;
-    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck);
+    }, checks);
     return *m_activeListener;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -29,6 +29,7 @@
 #include "FrameLoadState.h"
 #include "MessageReceiver.h"
 #include "ProvisionalFrameCreationParameters.h"
+#include "WebFramePolicyListenerProxy.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/DocumentSecurityPolicy.h>
 #include <WebCore/FrameLoaderTypes.h>
@@ -114,11 +115,6 @@ enum class CanWrap : bool { No, Yes };
 enum class DidWrap : bool { No, Yes };
 enum class IsMainFrame : bool { No, Yes };
 enum class NavigatingToAppBoundDomain : bool;
-enum class ShouldExpectSafeBrowsingResult : bool;
-enum class ShouldExpectAppBoundDomainResult : bool;
-enum class ShouldWaitForInitialLinkDecorationFilteringData : bool;
-enum class ShouldWaitForSiteHasStorageCheck : bool;
-enum class ShouldWaitForEnhancedSecurityLinkCheck : bool;
 enum class ProcessSwapRequestedByClient : bool;
 enum class WasNavigationIntercepted : bool;
 
@@ -198,7 +194,7 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, OptionSet<PolicyListenerCheck>);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTF::move(contentFilterUnblockHandler); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -494,6 +494,8 @@ static constexpr Seconds tryCloseTimeoutDelay = 50_ms;
 static constexpr Seconds audibleActivityClearDelay = 10_s;
 #endif
 
+static constexpr Seconds loopbackDnsResolutionCheckTimeout = 1_s;
+
 #if PLATFORM(COCOA)
 static WorkQueue& sharedFileQueueSingleton()
 {
@@ -8624,29 +8626,27 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     }
 #endif
 
-    ShouldExpectSafeBrowsingResult shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::Yes;
-    if (!protect(preferences())->safeBrowsingEnabled())
-        shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::No;
+    bool expectSafeBrowsing = protect(preferences())->safeBrowsingEnabled();
 
-    ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck = ShouldWaitForSiteHasStorageCheck::Yes;
-    if (!frame.isMainFrame() || !protect(preferences())->enhancedSecurityHeuristicsEnabled())
-        shouldWaitForSiteHasStorageCheck = ShouldWaitForSiteHasStorageCheck::No;
-
-    ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLink = ShouldWaitForEnhancedSecurityLinkCheck::No;
+    OptionSet<PolicyListenerCheck> listenerChecks;
+    if (frame.isMainFrame() && protect(preferences())->enhancedSecurityHeuristicsEnabled())
+        listenerChecks.add(PolicyListenerCheck::SiteHasStorage);
 #if HAVE(ENHANCED_SECURITY_LINKS)
     if (frame.isMainFrame() && protect(preferences())->enhancedSecurityHeuristicsEnabled() && protect(preferences())->enhancedSecurityLinksEnabled())
-        shouldWaitForEnhancedSecurityLink = ShouldWaitForEnhancedSecurityLinkCheck::Yes;
+        listenerChecks.add(PolicyListenerCheck::EnhancedSecurityLink);
 #endif
-
-    ShouldExpectAppBoundDomainResult shouldExpectAppBoundDomainResult = ShouldExpectAppBoundDomainResult::No;
+    if (frame.isMainFrame()
+        && protect(preferences())->enhancedSecurityHeuristicsEnabled()
+        && request.url().protocolIs("http"_s)
+        && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(request.url().host())
+        && !URL::hostIsIPAddress(request.url().host().toString()))
+        listenerChecks.add(PolicyListenerCheck::DNSResolution);
 #if ENABLE(APP_BOUND_DOMAINS)
-    shouldExpectAppBoundDomainResult = ShouldExpectAppBoundDomainResult::Yes;
+    listenerChecks.add(PolicyListenerCheck::AppBoundDomainResult);
 #endif
-
-    auto shouldWaitForInitialLinkDecorationFilteringData = ShouldWaitForInitialLinkDecorationFilteringData::No;
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     if (LinkDecorationFilteringController::sharedSingleton().cachedListData().isEmpty())
-        shouldWaitForInitialLinkDecorationFilteringData = ShouldWaitForInitialLinkDecorationFilteringData::Yes;
+        listenerChecks.add(PolicyListenerCheck::LinkDecorationFiltering);
     else if (m_needsInitialLinkDecorationFilteringData)
         sendCachedLinkDecorationFilteringData();
 #endif
@@ -8665,7 +8665,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         frameInfo,
         protectedPageClient = protect(pageClient())
 #if HAVE(SAFE_BROWSING)
-        , shouldExpectSafeBrowsingResult
+        , expectSafeBrowsing
 #endif
     ] (PolicyAction policyAction, API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain> isAppBoundDomain, WasNavigationIntercepted wasNavigationIntercepted) mutable {
         WEBPAGEPROXY_RELEASE_LOG(Loading, "decidePolicyForNavigationAction: listener called: frameID=%" PRIu64 ", isMainFrame=%d, navigationID=%" PRIu64  ", policyAction=%" PUBLIC_LOG_STRING ", isAppBoundDomain=%d, wasNavigationIntercepted=%d", frame->frameID().toUInt64(), frame->isMainFrame(), navigation ? navigation->navigationID().toUInt64() : 0, toString(policyAction).characters(), !!isAppBoundDomain, wasNavigationIntercepted == WasNavigationIntercepted::Yes);
@@ -8776,22 +8776,24 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
             return;
         }
 #if HAVE(SAFE_BROWSING)
-        if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
+        if (expectSafeBrowsing)
             protectedThis->completeSafeBrowsingCheckForModals(true);
 #endif
         completionHandlerWrapper(policyAction);
 
-    }, ShouldExpectSafeBrowsingResult::No, shouldExpectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLink);
-    if (shouldExpectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::Yes)
+    }, listenerChecks);
+    if (expectSafeBrowsing)
         beginSafeBrowsingCheck(request.url(), *navigation, frame.isMainFrame());
-    if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::Yes)
+    if (listenerChecks.contains(PolicyListenerCheck::LinkDecorationFiltering))
         waitForInitialLinkDecorationFilteringData(listener);
-    if (shouldWaitForSiteHasStorageCheck == ShouldWaitForSiteHasStorageCheck::Yes)
+    if (listenerChecks.contains(PolicyListenerCheck::SiteHasStorage))
         beginSiteHasStorageCheck(request.url(), *navigation, listener);
 #if HAVE(ENHANCED_SECURITY_LINKS)
-    if (shouldWaitForEnhancedSecurityLink == ShouldWaitForEnhancedSecurityLinkCheck::Yes)
+    if (listenerChecks.contains(PolicyListenerCheck::EnhancedSecurityLink))
         beginEnhancedSecurityLinkCheck(request.url(), *navigation, listener);
 #endif
+    if (listenerChecks.contains(PolicyListenerCheck::DNSResolution))
+        beginDNSResolutionCheck(request.url(), *navigation, listener);
 #if ENABLE(APP_BOUND_DOMAINS)
     bool shouldSendSecurityOriginData = !frame.isMainFrame() && shouldTreatURLProtocolAsAppBound(request.url(), websiteDataStore().configuration().enableInAppBrowserPrivacyForTesting());
     auto host = shouldSendSecurityOriginData ? frameInfo.securityOrigin.host() : request.url().host();
@@ -8956,7 +8958,7 @@ void WebPageProxy::decidePolicyForNewWindowAction(IPC::Connection& connection, N
         RELEASE_ASSERT(processSwapRequestedByClient == ProcessSwapRequestedByClient::No);
 
         receivedPolicyDecision(policyAction, nullptr, std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
-    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
+    }, { });
 
     if (m_policyClient)
         m_policyClient->decidePolicyForNewWindowAction(*this, *frame, navigationAction.get(), request, frameName, WTF::move(listener));
@@ -8990,11 +8992,11 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         m_openedMainFrameName = { };
     }
 
-    auto expectSafeBrowsing = ShouldExpectSafeBrowsingResult::No;
+    OptionSet<PolicyListenerCheck> listenerChecks;
     MonotonicTime requestStart;
 
     if (navigation && navigation->safeBrowsingCheckOngoing()) {
-        expectSafeBrowsing = ShouldExpectSafeBrowsingResult::Yes;
+        listenerChecks.add(PolicyListenerCheck::SafeBrowsingResult);
         requestStart = navigation->requestStart();
     }
 
@@ -9101,8 +9103,8 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
-    if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
+    }, listenerChecks);
+    if (listenerChecks.contains(PolicyListenerCheck::SafeBrowsingResult) && navigation) {
         Seconds timeout = (MonotonicTime::now() - requestStart) * 1.5 + 0.25_s;
         RunLoop::mainSingleton().dispatchAfter(timeout, [listener, navigation] mutable {
             listener->didReceiveSafeBrowsingResults({ });
@@ -17007,6 +17009,25 @@ void WebPageProxy::beginEnhancedSecurityLinkCheck(const URL& url, API::Navigatio
         networkProcess->sendWithAsyncReply(Messages::NetworkProcess::IsEnhancedSecurityLink(url), WTF::move(completionHandler));
 }
 #endif
+
+void WebPageProxy::beginDNSResolutionCheck(const URL& url, API::Navigation& navigation, WebFramePolicyListenerProxy& listener)
+{
+    auto completionHandler = [navigation = protect(navigation), url, listener = protect(listener)] (bool resolvesToLoopbackAddress) {
+        if (url == navigation->currentRequest().url()) {
+            navigation->setDoesCurrentSiteResolveToLoopbackAddress(resolvesToLoopbackAddress);
+            listener->didReceiveDNSResolutionResults();
+        }
+    };
+
+    if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists())
+        networkProcess->sendWithAsyncReply(Messages::NetworkProcess::DoesHostResolveToLoopbackAddress(url.host().toString()), WTF::move(completionHandler));
+    else
+        listener.didReceiveDNSResolutionResults();
+
+    RunLoop::mainSingleton().dispatchAfter(loopbackDnsResolutionCheckTimeout, [listener = protect(listener)] () mutable {
+        listener->didReceiveDNSResolutionResults();
+    });
+}
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 void WebPageProxy::pauseAllAnimations(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3656,6 +3656,7 @@ private:
 
     void beginSiteHasStorageCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
     void beginEnhancedSecurityLinkCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
+    void beginDNSResolutionCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
 
     Ref<BrowsingContextGroup> browsingContextGroupForNavigation(WebFrameProxy&, API::Navigation&, WebsiteDataStore&, ProcessSwapRequestedByClient);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -327,6 +327,25 @@ static void runHttpLocalhostLoad(bool useSiteIsolation)
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLocalhostLoad)
 
+#if ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
+
+static void runHttpDomainResolvingToLoopbackLoad(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "/"_s, { "<script>alert('insecure-page')</script>"_s } },
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, nullptr, useSiteIsolation);
+
+    auto urlString = [NSString stringWithFormat:@"http://web-platform.test:%d/", plaintextServer.port()];
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, urlString, {
+        { "insecure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpDomainResolvingToLoopbackLoad)
+
+#endif // ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
+
 // MARK: - Frame Tests
 
 static void runHttpEmbeddingHttpIframe(bool useSiteIsolation)


### PR DESCRIPTION
#### e7a49944abc3fb5243f4934b4bb7a8dcc4d5d527
<pre>
Sites resolving to loopback addresses should not have Enhanced Security enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309067">https://bugs.webkit.org/show_bug.cgi?id=309067</a>
<a href="https://rdar.apple.com/171616437">rdar://171616437</a>

Reviewed by NOBODY (OOPS!).

In the Enhanced Security HTTP implementation we want to prevent opting local sites
into using Enhanced Security. We currently have checks against the navigation site
for localhost-like sites or loopback IP addresses.

However, it could be the case that hosts overrides or similar are used to associate
a site with the loopback IP address. In this case, we should also not opt into
Enhanced Security.

We do so by adding another parallel check and performing a very short-timeout DNS
resolve attempt against the site. If this is mapped via the hosts mechanism or
similar, this should resolve quickly and allow us to not opt-in to Enhanced Security.
Local DNS cache should also assist here.

To prevent too many DNS requests being sent off, we only perform this when ES
heuristics are enabled, for the main frame, and when this is a HTTP URL.

Tests added:

  * EnhancedSecurityPolicies.HttpDomainResolvingToLoopbackLoad

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::doesHostResolveToLoopbackAddress):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::setDoesCurrentSiteResolveToLoopbackAddress):
(API::Navigation::doesCurrentSiteResolveToLoopbackAddress const):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::EnhancedSecurityTracking::enableIfRequired):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp:
(WebKit::WebFramePolicyListenerProxy::WebFramePolicyListenerProxy):
(WebKit::WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult):
(WebKit::WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData):
(WebKit::WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveDNSResolutionResults):
(WebKit::WebFramePolicyListenerProxy::fireReply):
(WebKit::WebFramePolicyListenerProxy::use):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h:
(WebKit::WebFramePolicyListenerProxy::create):
(): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setUpPolicyListenerProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::beginDNSResolutionCheck):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(runHttpDomainResolvingToLoopbackLoad):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7a49944abc3fb5243f4934b4bb7a8dcc4d5d527

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156987 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101732 "Failed to checkout and rebase branch from PR 59897") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62cb4832-4a43-4f3e-b7d7-ae77bafb34b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114340 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/101732 "Failed to checkout and rebase branch from PR 59897") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e93d881-3772-4b76-a8bb-36a79e9175c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16578 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133161 "Found 2 new API test failures: TestWebKitAPI.EnhancedSecurityPolicies.HttpDomainResolvingToLoopbackLoad, TestWebKitAPI.EnhancedSecurityPolicies.HttpDomainResolvingToLoopbackLoadWithSiteIsolation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95110 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5873da4-48a1-445d-ba52-078bd742868e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15691 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13497 "Found 2 new API test failures: TestWebKitAPI.EnhancedSecurityPolicies.HttpDomainResolvingToLoopbackLoad, TestWebKitAPI.EnhancedSecurityPolicies.HttpDomainResolvingToLoopbackLoadWithSiteIsolation (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4424 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2455 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122373 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122592 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76948 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18003 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9629 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20405 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84190 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->