### PR TITLE
[JSC] Implement Quick FTL Tier-Up for proven-stable functions

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2280,6 +2280,11 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
         didDFGJettison(reason);
 #endif
 
+#if ENABLE(FTL_JIT)
+    if (jitType() == JITType::FTLJIT)
+        didFTLJettison(reason);
+#endif
+
     CodeBlock* codeBlock = this; // Placate GCC for use in CODEBLOCK_LOG_EVENT  (does not like this).
     CODEBLOCK_LOG_EVENT(codeBlock, "jettison", ("due to ", reason, ", counting = ", mode == CountReoptimization, ", detail = ", pointerDump(detail)));
 
@@ -2856,6 +2861,31 @@ void CodeBlock::didFailDFGCompilation()
 {
     unlinkedCodeBlock()->setQuickDFGTierUp(TriState::False);
 }
+
+#if ENABLE(FTL_JIT)
+void CodeBlock::didInstallFTLCode()
+{
+    if (!unlinkedCodeBlock()->hasQuickFTLTierUpUpdated() && unlinkedCodeBlock()->isQuickDFGTierUp())
+        unlinkedCodeBlock()->setQuickFTLTierUp(WTF::TriState::True);
+}
+
+void CodeBlock::didFTLJettison(Profiler::JettisonReason reason)
+{
+    if (!Profiler::isSpeculationFailure(reason))
+        return;
+
+    // Only mark as failed if code was already installed and ran (flag = True).
+    // If jettison happens during compilation (flag = Indeterminate), leave it
+    // unchanged - this was environmental (OOM, GC pressure), not a code quality issue.
+    if (unlinkedCodeBlock()->hasQuickFTLTierUpUpdated())
+        unlinkedCodeBlock()->setQuickFTLTierUp(WTF::TriState::False);
+}
+
+void CodeBlock::didFailFTLCompilation()
+{
+    unlinkedCodeBlock()->setQuickFTLTierUp(WTF::TriState::False);
+}
+#endif
 
 #endif
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -763,6 +763,12 @@ public:
     void didDFGJettison(Profiler::JettisonReason);
     void didFailDFGCompilation();
 
+#if ENABLE(FTL_JIT)
+    void didInstallFTLCode();
+    void didFTLJettison(Profiler::JettisonReason);
+    void didFailFTLCompilation();
+#endif
+
 #else // No JIT
     void optimizeAfterWarmUp() { }
     unsigned numberOfDFGCompiles() { return 0; }

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -180,6 +180,11 @@ public:
     void setQuickDFGTierUp(TriState state) { m_quickDFGTierUp = state; }
     TriState quickDFGTierUp() const { return m_quickDFGTierUp; }
 
+    bool hasQuickFTLTierUpUpdated() const { return m_quickFTLTierUp != TriState::Indeterminate; }
+    bool isQuickFTLTierUp() const { return m_quickFTLTierUp == TriState::True; }
+    void setQuickFTLTierUp(TriState state) { m_quickFTLTierUp = state; }
+    TriState quickFTLTierUp() const { return m_quickFTLTierUp; }
+
     // Special registers
     void setThisRegister(VirtualRegister thisRegister) { m_thisRegister = thisRegister; }
     void setScopeRegister(VirtualRegister scopeRegister) { m_scopeRegister = scopeRegister; }
@@ -435,6 +440,8 @@ private:
     bool m_hasCheckpoints : 1;
     LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures { 0 };
     TriState m_quickDFGTierUp : 2 { TriState::Indeterminate };
+    TriState m_quickFTLTierUp : 2 { TriState::Indeterminate };
+
 public:
     ConcurrentJSLock m_lock;
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -327,7 +327,12 @@ void JITCode::optimizeAfterWarmUp(CodeBlock* codeBlock)
     ASSERT(codeBlock->jitType() == JITType::DFGJIT);
     dataLogLnIf(Options::verboseOSR(), *codeBlock, ": FTL-optimizing after warm-up.");
     CodeBlock* baseline = codeBlock->baselineVersion();
-    codeBlock->dfgJITData()->tierUpCounter().setNewThreshold(baseline->adjustedCounterValue(Options::thresholdForFTLOptimizeAfterWarmUp()), baseline);
+    int32_t threshold = Options::thresholdForFTLOptimizeAfterWarmUp();
+    if (baseline->unlinkedCodeBlock()->isQuickFTLTierUp()) {
+        threshold = static_cast<int32_t>(threshold * Options::quickFTLTierUpThresholdFactor());
+        dataLogLnIf(Options::verboseOSR(), *codeBlock, ": Quick FTL tier-up enabled and code is stable, adjustedThreshold=", threshold, ", finalThreshold=", baseline->adjustedCounterValue(threshold));
+    }
+    codeBlock->dfgJITData()->tierUpCounter().setNewThreshold(baseline->adjustedCounterValue(threshold), baseline);
 }
 
 void JITCode::optimizeSoon(CodeBlock* codeBlock)
@@ -357,6 +362,7 @@ void JITCode::setOptimizationThresholdBasedOnCompilationResult(
     case CompilationResult::CompilationFailed:
         dontOptimizeAnytimeSoon(codeBlock);
         codeBlock->baselineVersion()->m_didFailFTLCompilation = true;
+        codeBlock->didFailFTLCompilation();
         return;
     case CompilationResult::CompilationDeferred:
         optimizeAfterWarmUp(codeBlock);

--- a/Source/JavaScriptCore/dfg/DFGToFTLDeferredCompilationCallback.cpp
+++ b/Source/JavaScriptCore/dfg/DFGToFTLDeferredCompilationCallback.cpp
@@ -66,10 +66,12 @@ void ToFTLDeferredCompilationCallback::compilationDidComplete(
             "DFG code block ", profiledDFGCodeBlock, " was jettisoned.");
         return;
     }
-    
-    if (result == CompilationResult::CompilationSuccessful)
+
+    if (result == CompilationResult::CompilationSuccessful) {
         codeBlock->ownerExecutable()->installCode(codeBlock);
-    
+        codeBlock->didInstallFTLCode();
+    }
+
     profiledDFGCodeBlock->jitCode()->dfg()->setOptimizationThresholdBasedOnCompilationResult(
         profiledDFGCodeBlock, result);
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -596,11 +596,6 @@ static void overrideDefaults()
     Options::worklistFTLLoadWeight() = 20;
 #endif
 
-#if PLATFORM(MAC)
-    Options::quickDFGTierUpThresholdFactor() = 0.15;
-    Options::relaxedProfileCoverageFactorForQuickDFGTierUp() = 0.85;
-#endif
-
 #if OS(LINUX) && CPU(ARM)
     Options::maximumFunctionForCallInlineCandidateBytecodeCostForDFG() = 77;
     Options::maximumOptimizationCandidateBytecodeCost() = 42403;

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -176,6 +176,30 @@ private:
     static int32_t computePriorityDeltaOfWorkerThreads(int32_t twoCorePriorityDelta, int32_t multiCorePriorityDelta);
     static constexpr bool jitEnabledByDefault() { return is32Bit() || isAddress64Bit(); }
     static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isX86_64(); }
+    static double defaultQuickDFGTierUpThresholdFactor()
+    {
+#if PLATFORM(MAC)
+        return 0.15;
+#else
+        return 0.2;
+#endif
+    }
+    static double defaultRelaxedProfileCoverageFactorForQuickDFGTierUp()
+    {
+#if PLATFORM(MAC)
+        return 0.85;
+#else
+        return 1.0;
+#endif
+    }
+    static double defaultQuickFTLTierUpThresholdFactor()
+    {
+#if PLATFORM(MAC)
+        return 0.15;
+#else
+        return 1.0;
+#endif
+    }
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -381,8 +381,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, desiredProfileLivenessRate, 0.75, Normal, nullptr) \
     v(Double, desiredProfileFullnessRate, 0.35, Normal, nullptr) \
     \
-    v(Double, quickDFGTierUpThresholdFactor, 0.2, Normal, "Threshold factor for quick DFG tier-up"_s) \
-    v(Double, relaxedProfileCoverageFactorForQuickDFGTierUp, 1.0, Normal, "Profile coverage scaling factor for quick DFG tier-up"_s) \
+    v(Double, quickDFGTierUpThresholdFactor, defaultQuickDFGTierUpThresholdFactor(), Normal, "Threshold factor for quick DFG tier-up"_s) \
+    v(Double, relaxedProfileCoverageFactorForQuickDFGTierUp, defaultRelaxedProfileCoverageFactorForQuickDFGTierUp(), Normal, "Profile coverage scaling factor for quick DFG tier-up"_s) \
+    v(Double, quickFTLTierUpThresholdFactor, defaultQuickFTLTierUpThresholdFactor(), Normal, "Threshold factor for quick FTL tier-up"_s) \
     \
     v(Double, doubleVoteRatioForDoubleFormat, 2, Normal, nullptr) \
     v(Double, structureCheckVoteRatioForHoisting, 1, Normal, nullptr) \


### PR DESCRIPTION
#### 9af814208502a3c1b389f1cb3ba9e53c0caa542d
<pre>
[JSC] Implement Quick FTL Tier-Up for proven-stable functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=309170">https://bugs.webkit.org/show_bug.cgi?id=309170</a>
<a href="https://rdar.apple.com/171728162">rdar://171728162</a>

Reviewed by Dan Hecht, Keith Miller, and Yusuke Suzuki.

This patch extends the Quick DFG Tier-Up mechanism one level higher,
applying the same stability-based acceleration from DFG to FTL.
Functions that have already proven DFG stability (isQuickDFGTierUp())
and successfully installed FTL code are marked as quick FTL tier-up
candidates using a TriState flag on UnlinkedCodeBlock, following the
same state machine as the DFG variant:

- Indeterminate -&gt; True:          didInstallFTLCode() (successful FTL install, only if isQuickDFGTierUp())
- Indeterminate -&gt; False:         didFailFTLCompilation() (compilation failed)
- True -&gt; False:                  didFTLJettison() (post-install speculation failure)
- Indeterminate -&gt; Indeterminate: didFTLJettison() (environmental issue, no penalty)

For functions marked as quick FTL tier-up, DFGJITCode::optimizeAfterWarmUp
applies quickFTLTierUpThresholdFactor to reduce the DFG-to-FTL compilation
threshold. Note that only macOS is currently configured to use quick FTL tier-up.

Canonical link: <a href="https://commits.webkit.org/308663@main">https://commits.webkit.org/308663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe59a826949d6a937062a682750658bf2da5fe8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101515 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114190 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81408 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e2cf743-c3b8-4402-a915-1161d3019313) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c77fc288-1e5f-49c6-8986-e017b5f767b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15557 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13355 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4222 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140069 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159118 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8889 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122224 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31381 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76742 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9467 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179522 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83962 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45967 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19933 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->