### PR TITLE
Web Inspector: JavaScriptRuntimeCompletionProvider doesn't handle null propertyNames from callFunctionOn

### DIFF
--- a/LayoutTests/inspector/console/js-completions-expected.txt
+++ b/LayoutTests/inspector/console/js-completions-expected.txt
@@ -13,6 +13,9 @@ PASS: Completions should still contain myVariable before cache is cleared.
 PASS: Completions should change after cache is cleared.
 PASS: Completions should not contain myVariable after it's deleted by code run in console.
 
+-- Running test case: console.jsCompletions.revokedProxy
+PASS: Completions for a revoked proxy should return an empty array and should not crash.
+
 -- Running test case: console.jsCompletions.completionOrdering
 Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""}:
 [

--- a/LayoutTests/inspector/console/js-completions.html
+++ b/LayoutTests/inspector/console/js-completions.html
@@ -66,6 +66,18 @@ function test()
     });
 
     suite.addTestCase({
+        name: "console.jsCompletions.revokedProxy",
+        description: "Test that completions handle objects that throw when accessing properties.",
+        async test() {
+            await InspectorTest.evaluateInPage(`revokedProxy = Proxy.revocable({}, {}); revokedProxy.revoke(); revokedProxy = revokedProxy.proxy;`);
+            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+
+            let completions = await generateJSCompletions({baseString: "revokedProxy.", prefix: ""});
+            InspectorTest.expectShallowEqual(completions, [], "Completions for a revoked proxy should return an empty array and should not crash.");
+        }
+    });
+
+    suite.addTestCase({
         name: "console.jsCompletions.completionOrdering",
         description: "Test that the JavaScript completions are ordered correctly.",
         async test() {

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -260,7 +260,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
 
         function receivedObjectPropertyNames(propertyNames)
         {
-            receivedPropertyNames.call(this, Object.keys(propertyNames));
+            receivedPropertyNames.call(this, propertyNames ? Object.keys(propertyNames) : null);
         }
 
         function receivedArrayPropertyNames(propertyNames)


### PR DESCRIPTION
#### 23fcca439970c347c6c96604fcdfc2db8d1e24a3
<pre>
Web Inspector: JavaScriptRuntimeCompletionProvider doesn&apos;t handle null propertyNames from callFunctionOn
<a href="https://bugs.webkit.org/show_bug.cgi?id=309085">https://bugs.webkit.org/show_bug.cgi?id=309085</a>
<a href="https://rdar.apple.com/171639265">rdar://171639265</a>

Reviewed by Devin Rousso and BJ Burg.

receivedObjectPropertyNames calls Object.keys(propertyNames) without a null check,
unlike receivedPropertyNamesFromEvaluate and receivedArrayPropertyNames which already
guard against null.

* LayoutTests/inspector/console/js-completions-expected.txt:
* LayoutTests/inspector/console/js-completions.html:
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.receivedArrayPropertyNames): Deleted.

Canonical link: <a href="https://commits.webkit.org/308703@main">https://commits.webkit.org/308703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb0ac136052edcacd9cc4642d8030873f862809f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101573 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/094f43bc-9e82-439e-aa0b-fe088b09c101) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114218 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81432 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db1b082c-2f14-4f5f-a1b1-03cbc0d2df24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94985 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1017e43f-6837-4351-9ec8-e25ad2645b86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15592 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13391 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159176 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122249 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33308 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132763 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76804 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9510 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84020 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19991 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20047 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->