### PR TITLE
Fix flaky timeout in WKUserContentController.DidAssociateFormControlsFromShadowTree

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
@@ -1306,12 +1306,7 @@ TEST(WKUserContentController, DidAssociateFormControls)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLInputElement]");
 }
 
-// FIXME when webkit.org/b/304021 is resolved.
-#if PLATFORM(MAC)
-TEST(WKUserContentController, DISABLED_DidAssociateFormControlsFromShadowTree)
-#else
 TEST(WKUserContentController, DidAssociateFormControlsFromShadowTree)
-#endif
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
     RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
@@ -1337,8 +1332,7 @@ TEST(WKUserContentController, DidAssociateFormControlsFromShadowTree)
         "}"
         "</script>"
         "<button onclick='addPasswordFieldToForm()'>Add Password Field</button>";
-    [webView synchronouslyLoadHTMLString:html];
-
+    [webView loadHTMLString:html baseURL:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLFormElement]");
     [webView evaluateJavaScript:@"addPasswordFieldToForm()" completionHandler:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLInputElement]");


### PR DESCRIPTION
#### d50f0985bd87cea71d151d419d375df3322dad31
<pre>
Fix flaky timeout in WKUserContentController.DidAssociateFormControlsFromShadowTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=304021">https://bugs.webkit.org/show_bug.cgi?id=304021</a>
<a href="https://rdar.apple.com/problem/166325413">rdar://problem/166325413</a>

Reviewed by Per Arne Vollan.

This test is flaky because it uses `synchronouslyLoadHTMLString:`. Loading the HTML will cause the
`webkitassociateformcontrols` event to be fired, and a 50 ms timer to be scheduled which creates an
alert. Then we spin the run loop until the load completion handler fires. If the timer fires as part
of the run loop spin, then the alert drops on the floor before we can run `_test_waitForAlert`,
which causes the test times out.

To fix this, use `loadHTMLString:baseURL:` instead, since that doesn&apos;t spin the run loop before
`_test_waitForAlert`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, DidAssociateFormControlsFromShadowTree)):

Canonical link: <a href="https://commits.webkit.org/308664@main">https://commits.webkit.org/308664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9833b99fc024176e1ca3ea231a11b7fb3c6991aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156793 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8492adc-b1cf-4a0f-b9f3-31a8203a1e03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114181 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0509289-400b-465a-baa6-f084d6798dbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94948 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf319b09-2704-42c1-a1c5-366e05a0a62a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15556 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4230 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159126 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122213 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122428 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31382 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76750 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9477 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20211 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19941 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20088 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->