### PR TITLE
[Site Isolation] Fix ProcessSwap.NumberOfPrewarmedProcesses

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5491,6 +5491,11 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     return _page->pageLoadState().networkRequestsInProgress();
 }
 
+- (BOOL)_usesBackForwardCache
+{
+    return _page->shouldUseBackForwardCache();
+}
+
 static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingProgressEvents events)
 {
     OptionSet<WebCore::LayoutMilestone> milestones;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -267,6 +267,7 @@ for this property.
 @property (nonatomic, copy, setter=_setCORSDisablingPatterns:) NSArray<NSString *> *_corsDisablingPatterns WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
 @property (nonatomic, readonly) BOOL _networkRequestsInProgress;
+@property (nonatomic, readonly) BOOL _usesBackForwardCache;
 
 @property (nonatomic, readonly, getter=_isShowingNavigationGestureSnapshot) BOOL _showingNavigationGestureSnapshot;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2967,6 +2967,8 @@ public:
     bool hasShownSafeBrowsingWarningAfterLastLoadCommit() const { return m_hasShownSafeBrowsingWarningAfterLastLoadCommit; }
 #endif
 
+    bool shouldUseBackForwardCache() const;
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -2978,7 +2980,6 @@ private:
     void removeAllMessageReceivers();
 
     void notifyProcessPoolToPrewarm();
-    bool shouldUseBackForwardCache() const;
 
     bool attachmentElementEnabled();
     bool modelElementEnabled();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -4133,7 +4133,9 @@ TEST(ProcessSwap, NumberOfPrewarmedProcesses)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(2u, [processPool _webProcessCount]);
+    // Site Isolation has 2 prewarmed processes while PSON only has 1.
+    auto expectedCount = isSiteIsolationEnabled(webView.get()) ? 3u : 2u;
+    EXPECT_EQ(expectedCount, [processPool _webProcessCount]);
     EXPECT_EQ(1u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
     EXPECT_TRUE([processPool _hasPrewarmedWebProcess]);
 
@@ -4142,8 +4144,13 @@ TEST(ProcessSwap, NumberOfPrewarmedProcesses)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(3u, [processPool _webProcessCount]);
-    EXPECT_EQ(2u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
+    // Site Isolation has 2 prewarmed processes while PSON only has 1.
+    expectedCount = isSiteIsolationEnabled(webView.get()) ? 4u : 3u;
+    EXPECT_EQ(expectedCount, [processPool _webProcessCount]);
+
+    // If page cache is disabled, process for www.webkit.org will enter process cache (cached).
+    expectedCount = webView.get()._usesBackForwardCache ? 2u : 1u;
+    EXPECT_EQ(expectedCount, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
     EXPECT_TRUE([processPool _hasPrewarmedWebProcess]);
 }
 


### PR DESCRIPTION
#### 3394794bd55d7d52d66c25445c41e0141e04b94b
<pre>
[Site Isolation] Fix ProcessSwap.NumberOfPrewarmedProcesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=309175">https://bugs.webkit.org/show_bug.cgi?id=309175</a>
<a href="https://rdar.apple.com/171732734">rdar://171732734</a>

Reviewed by NOBODY (OOPS!).

In current implementation, we prewarm 1 more process under Site Isolation (see <a href="https://commits.webkit.org/300594@main">300594@main</a>); so the test&apos;s expectation
needs to be updated under Site Isolation. Also, the test sets the expectation for active process (i.e. process not in
process cache or prewarmed) based on the assumption page cache is enabled, but it does not specifically turn it on. So
this patch also updates expectation for when page cache is disabled (which is the current case under Site Isolation).

A new testing-only SPI is introduced to check whether `WKWebView` actually enables page cache (which is computed based
on a few settings).

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _usesBackForwardCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, NumberOfPrewarmedProcesses)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3394794bd55d7d52d66c25445c41e0141e04b94b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101524 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0765dcf-c0ff-4d14-873a-6d35f62042e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114185 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81414 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62314250-fbb2-4e69-a1fe-358b586f97ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16422 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133012 "Found 1 new API test failure: TestWebKitAPI.ScrollingCoordinatorTests.ScrollingTreeAfterDetachReattach (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94952 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04b56f49-5852-4355-b1c0-0c14f72d2f8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15559 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13358 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4231 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159127 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122215 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132723 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76751 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9474 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83971 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19942 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20089 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->