### PR TITLE
[Swift in WebKit] Make it easier to use Swift in tests in TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/AppKit+Extras.swift
+++ b/Tools/TestWebKitAPI/AppKit+Extras.swift
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(macOS)
+
+import AppKit
+import Foundation
+import SwiftUI
+
+extension NSWindow {
+    /// Create a new NSWindow with the specified size, containing a SwiftUI view.
+    ///
+    /// - Parameters:
+    ///   - size: The content size for the window.
+    ///   - rootView: The root view for the window.
+    public convenience init(size: NSSize, @ViewBuilder rootView: () -> some View) {
+        let viewController = NSHostingController(rootView: rootView())
+        self.init(contentViewController: viewController)
+        setContentSize(size)
+        layoutIfNeeded()
+    }
+}
+
+#endif // os(macOS)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		0714677A2DFE8DEA00F77867 /* WebPageTransferableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */; };
 		07180F612F1ACD26000CA4F9 /* small-video-test-now-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07180F5F2F1ACD25000CA4F9 /* small-video-test-now-playing.html */; };
 		07180F622F1ACD26000CA4F9 /* small-video-with-silent-audio.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07180F602F1ACD26000CA4F9 /* small-video-with-silent-audio.mp4 */; };
+		071B91902F57F11300E4ACAB /* Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071B91882F57F10700E4ACAB /* Testing.swift */; };
+		071B91922F57F81800E4ACAB /* AppKit+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071B91912F57F80E00E4ACAB /* AppKit+Extras.swift */; };
 		07275CBC2D01398C002315A5 /* _WebKit_SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */; };
 		073310B52E6E4EFC0048CF1E /* SmartLists.mm in Sources */ = {isa = PBXBuildFile; fileRef = 073310AD2E6E4E800048CF1E /* SmartLists.mm */; };
 		074E87E52CF920A20059E469 /* Bundle+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E42CF920A20059E469 /* Bundle+Extras.swift */; };
@@ -2489,6 +2491,8 @@
 		071467792DFE8DEA00F77867 /* WebPageTransferableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageTransferableTests.swift; sourceTree = "<group>"; };
 		07180F5F2F1ACD25000CA4F9 /* small-video-test-now-playing.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "small-video-test-now-playing.html"; path = "Tests/WebKitCocoa/small-video-test-now-playing.html"; sourceTree = "<group>"; };
 		07180F602F1ACD26000CA4F9 /* small-video-with-silent-audio.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; name = "small-video-with-silent-audio.mp4"; path = "Tests/WebKitCocoa/small-video-with-silent-audio.mp4"; sourceTree = "<group>"; };
+		071B91882F57F10700E4ACAB /* Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Testing.swift; sourceTree = "<group>"; };
+		071B91912F57F80E00E4ACAB /* AppKit+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppKit+Extras.swift"; sourceTree = "<group>"; };
 		0721D4582838295400A95853 /* start-offset.ts */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.typescript; path = "start-offset.ts"; sourceTree = "<group>"; };
 		07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = _WebKit_SwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		073310AD2E6E4E800048CF1E /* SmartLists.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SmartLists.mm; sourceTree = "<group>"; };
@@ -4717,6 +4721,7 @@
 				A121EEB52CA734D600DB8BB8 /* app */,
 				A17C582F2C9B3EAE009DD0B5 /* TestBundle */,
 				A13EBB441B87332B00097110 /* WebProcessPlugIn */,
+				071B91912F57F80E00E4ACAB /* AppKit+Extras.swift */,
 				F4A74B9229DDD9F100CB5288 /* CGImagePixelReader.cpp */,
 				F4A74B9129DDD9F100CB5288 /* CGImagePixelReader.h */,
 				F44A530F21B8976900DBB99C /* ClassMethodSwizzler.h */,
@@ -4758,6 +4763,7 @@
 				DF6BC46F2534E120008F63CC /* TestDownloadDelegate.mm */,
 				CDD99F3E2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.h */,
 				CDD99F3F2EA2F3E8003FAFB8 /* TestElementFullscreenDelegate.mm */,
+				071B91882F57F10700E4ACAB /* Testing.swift */,
 				99C607F426FD5A1E00A0953F /* TestInspectorURLSchemeHandler.h */,
 				99C607F526FD5A1F00A0953F /* TestInspectorURLSchemeHandler.mm */,
 				5C72E8CD244FFCE300381EB7 /* TestLegacyDownloadDelegate.h */,
@@ -7854,6 +7860,7 @@
 				48124A272925A0C100EED506 /* AnimationControl.mm in Sources */,
 				712E4BC125DDC52A0007201C /* AnimationFrameRate.cpp in Sources */,
 				57152B5E21CC2045000C37CA /* ApduTest.cpp in Sources */,
+				071B91922F57F81800E4ACAB /* AppKit+Extras.swift in Sources */,
 				6354F4D11F7C3AB500D89DF3 /* ApplicationManifestParser.cpp in Sources */,
 				F46C45C427D42A2F00ECED2C /* ApplicationStateTracking.mm in Sources */,
 				DF6580942722168900B3F1C1 /* ASN1Utilities.cpp in Sources */,
@@ -8208,6 +8215,7 @@
 				F4E0A2B82122847400AF7C7F /* TestFilePromiseReceiver.mm in Sources */,
 				F4F5BB5221667BAA002D06B9 /* TestFontOptions.mm in Sources */,
 				7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */,
+				071B91902F57F11300E4ACAB /* Testing.swift in Sources */,
 				F45E15762112CE6200307E82 /* TestInputDelegate.mm in Sources */,
 				F45D3891215A7B4B002A2979 /* TestInspectorBar.mm in Sources */,
 				A17C48592C98FA3F0023F3C7 /* TestNSBundleExtras.m in Sources */,

--- a/Tools/TestWebKitAPI/Testing.swift
+++ b/Tools/TestWebKitAPI/Testing.swift
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+#if compiler(>=6.2)
+
+/// A set of facilities to mimic basic Swift Testing support, until Swift Testing can be directly used.
+public enum Testing {
+    /// The cause of a test failure.
+    public struct Error: Swift.Error {
+        /// A descriptive message of why the error occurred.
+        public let message: Swift.String
+
+        /// The name of the function where the error occurred.
+        public let function: StaticString
+
+        /// The line number in the file where the error occurred.
+        public let line: Int
+
+        init(_ message: Swift.String, function: StaticString = #function, line: Int = #line) {
+            self.message = message
+            self.function = function
+            self.line = line
+        }
+    }
+
+    /// Unwrap an optional value or, if it is `nil`, fail and throw an error.
+    ///
+    /// - Parameters:
+    ///   - optionalValue: The optional value to be unwrapped.
+    ///   - comment: A comment describing the expectation.
+    ///   - function: The function of the source location where this is called.
+    ///   - line: The line number of the source location where this is called.
+    /// - Returns: The unwrapped value of `optionalValue`.
+    /// - Throws: An Error if the value is `nil`
+    public static func require<T>(
+        _ optionalValue: T?,
+        _ comment: @autoclosure () -> Swift.String? = nil,
+        function: StaticString = #function,
+        line: Int = #line,
+    ) throws(Error) -> T {
+        guard let optionalValue else {
+            let resolvedComment = comment()
+            throw Error("Found nil value of type \(T.self) : \(resolvedComment ?? "")", function: function, line: line)
+        }
+
+        return optionalValue
+    }
+
+    /// Check that an expectation has passed after a condition has been evaluated.
+    ///
+    /// If the equality condition evaluates to false, an Error is thrown.
+    ///
+    /// - Parameters:
+    ///   - actualValue: The actual value to compare.
+    ///   - expectedValue: The expected value to compare.
+    ///   - comment: A comment describing the expectation.
+    ///   - function: The function of the source location where this is called.
+    ///   - line: The line number of the source location where this is called.
+    /// - Throws: An error if the values are not equal.
+    public static func expect<T>(
+        _ actualValue: T?,
+        toEqual expectedValue: T?,
+        _ comment: @autoclosure () -> Swift.String? = nil,
+        function: StaticString = #function,
+        line: Int = #line,
+    ) throws(Error) where T: Equatable {
+        guard actualValue == expectedValue else {
+            let resolvedComment = comment()
+            throw Error(
+                "Expected \(Swift.String(describing: actualValue)) to equal \(Swift.String(describing: expectedValue)) : \(resolvedComment ?? "")",
+                function: function,
+                line: line
+            )
+        }
+    }
+
+    /// Repeatedly invokes a condition until it evaluates to true or until a timeout has been reached.
+    ///
+    /// - Parameters:
+    ///   - timeout: The timeout to wait until before exiting this function and throwing an Error.
+    ///   - interval: The duration to wait between consecutive evaluations of the condition
+    ///   - function: The function of the source location where this is called.
+    ///   - line: The line number of the source location where this is called.
+    ///   - condition: The predicate condition to evaluate.
+    /// - Throws: An Error if the condition throws an Error, or if the timeout duration is reached.
+    public nonisolated(nonsending) static func waitUntil(
+        timeout: Duration = .seconds(10),
+        interval: Duration = .milliseconds(100),
+        function: StaticString = #function,
+        line: Int = #line,
+        condition: () async throws -> Bool,
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if try await condition() {
+                return
+            }
+            try await Task.sleep(for: interval)
+        }
+        throw Error("Timed out.", function: function, line: line)
+    }
+}
+
+#endif // compiler(>=6.2)

--- a/Tools/TestWebKitAPI/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/WebPage+Extras.swift
@@ -29,6 +29,10 @@ import WebKit_Private.WKPreferencesPrivate
 import WebKit_Private.WKWebViewPrivateForTesting
 import WebKit_Private.WKWebViewPrivate
 
+#if os(macOS)
+private import Carbon
+#endif
+
 extension WebPage {
     enum EditCommand: String {
         case deleteBackward = "DeleteBackward"
@@ -67,6 +71,47 @@ extension WebPage {
         let success = await backingWebView._executeEditCommand(command.rawValue, argument: argument)
         assert(success)
     }
+
+    #if os(macOS)
+    func click(at location: NSPoint) {
+        guard let window = unsafe backingWebView.window else {
+            preconditionFailure("Could not create NSEvent because there is no NSWindow.")
+        }
+
+        let timestamp = GetCurrentEventTime()
+
+        let mouseDown = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: location,
+            modifierFlags: [],
+            timestamp: timestamp,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )
+
+        let mouseUp = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: location,
+            modifierFlags: [],
+            timestamp: timestamp,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        )
+
+        guard let mouseDown, let mouseUp else {
+            preconditionFailure("Could not create NSEvent.")
+        }
+
+        backingWebView.mouseDown(with: mouseDown)
+        backingWebView.mouseUp(with: mouseUp)
+    }
+    #endif // os(macOS)
 }
 
 #endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoa.h
@@ -27,6 +27,7 @@
 
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import <wtf/text/TextStream.h>
 
 namespace TestWebKitAPI {
 namespace Util {
@@ -67,3 +68,40 @@ constexpr CGFloat redColorComponents[4] = { 1, 0, 0, 1 };
 constexpr CGFloat blueColorComponents[4] = { 0, 0, 1, 1 };
 
 #endif
+
+/**
+ A testing hook to be able to easily write a full test in Swift and run it using the existing gtest infrastructure.
+
+ To write a Swift test:
+
+ 1. Use this macro to define a new test, such as:
+
+ ```
+ SWIFT_TEST(AppKitGestures, ClickingChangesSelection);
+ ```
+
+ 2. Create an Objective-C interface named "{Suite}Support" and declare class methods for each test of the form:
+
+ ```
+ + (void)test{Name}WithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(NSError * _Nullable))completionHandler;
+ ```
+
+ 3. Add an `@objc @implementation` Swift implementation for the interface type, and implement each method.
+
+ 4. Use the convenience testing functions in the `Testing` type to write expectations and throw errors.
+
+ */
+#define SWIFT_TEST(Suite, Name) \
+TEST(Suite, Name) \
+{ \
+    __block bool done = false; \
+    [Suite##Support test##Name##WithCompletionHandler:^(NSError *error) { \
+        if (error) { \
+            TextStream errorMessage; \
+            errorMessage << error; \
+            EXPECT_NULL(error) << errorMessage.release().utf8().data(); \
+        } \
+        done = true; \
+    }]; \
+    TestWebKitAPI::Util::run(&done); \
+}


### PR DESCRIPTION
#### 5f03fc642065a4940e249adc253b34e8513fbe84
<pre>
[Swift in WebKit] Make it easier to use Swift in tests in TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=309178">https://bugs.webkit.org/show_bug.cgi?id=309178</a>
<a href="https://rdar.apple.com/171735698">rdar://171735698</a>

Reviewed by Abrar Rahman Protyasha.

Bring up generic testing infrastructure support to more easily write Swift tests, until such time when the Swift Testing framework
is fully supported.

* Tools/TestWebKitAPI/AppKit+Extras.swift: Added.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Testing.swift: Added.
* Tools/TestWebKitAPI/WebPage+Extras.swift:
(click(at:)):
* Tools/TestWebKitAPI/cocoa/TestCocoa.h:

Canonical link: <a href="https://commits.webkit.org/308668@main">https://commits.webkit.org/308668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac674a40edcaf623ee24cea683502c333fd5e1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156840 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4835060-d3ba-48d9-a328-7a0862c8d079) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114216 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d395e51e-0054-4ac6-946c-04a82c156b06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151117 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94983 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e8a2981-0b43-47a5-9e1b-d198bb9c3e7f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4277 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159173 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122247 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20641 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122466 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/31383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132749 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22827 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9496 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20135 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->