### PR TITLE
Unreviewed, reverting 308594@main (6904c3f73213)

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -486,7 +486,7 @@ protected:
     Vector<Vector<IndexType, 0, UnsafeVectorOverflow, 4>, 0, UnsafeVectorOverflow> m_adjacencyList;
     Vector<IndexType, 0, UnsafeVectorOverflow> m_degrees;
 
-    using IndexTypeSet = SmallSet<IndexType, IntHash<IndexType>, WTF::UnsignedWithZeroKeyHashTraits<IndexType>>;
+    using IndexTypeSet = SmallSet<IndexType, IntHash<IndexType>>;
 
     UncheckedKeyHashMap<IndexType, IndexTypeSet, DefaultHash<IndexType>, WTF::UnsignedWithZeroKeyHashTraits<IndexType>> m_biases;
 
@@ -499,7 +499,7 @@ protected:
     Vector<MoveOperands, 0, UnsafeVectorOverflow> m_coalescingCandidates;
 
     // List of every move instruction associated with a Tmp.
-    Vector<SmallSet<unsigned, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>> m_moveList;
+    Vector<SmallSet<unsigned, IntHash<unsigned>>> m_moveList;
 
     // Colors.
     Vector<Reg, 0, UnsafeVectorOverflow> m_coloredTmp;

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -396,7 +396,7 @@ private:
     Vector<std::unique_ptr<BasicBlock>> m_blocks;
     SparseCollection<Special> m_specials;
     std::unique_ptr<CFG> m_cfg;
-    SmallSet<Tmp, DefaultHash<Tmp>, HashTraits<Tmp>, 2> m_fastTmps;
+    SmallSet<Tmp, DefaultHash<Tmp>, 2> m_fastTmps;
     CCallSpecial* m_cCallSpecial { nullptr };
     unsigned m_numGPTmps { 0 };
     unsigned m_numFPTmps { 0 };

--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -29,7 +29,6 @@
 #include <wtf/Assertions.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashFunctions.h>
-#include <wtf/HashTraits.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
@@ -41,9 +40,10 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SmallSet);
 // Functionally, this class is very similar to Variant<Vector<T, SmallArraySize>, HashSet<T>>
 // It is optimized primarily for space, but is also quite fast
 // Its main limitation is that it has no way to remove elements once they have been added to it
-// It uses HashTraits to determine its empty value.
+// Also, instead of being fully parameterized by a HashTrait parameter, it always uses -1 (all ones) as its empty value
+// Relatedly, it can only store objects of up to 64 bit size (but that particular limitation should be fairly easy to lift if needed)
 // Use it whenever you need to store an unbounded but probably small number of unsigned integers or pointers.
-template<typename T, typename Hash = PtrHashBase<T, false /* isSmartPtr */>, typename Traits = HashTraits<T>, unsigned SmallArraySize = 8>
+template<typename T, typename Hash = PtrHashBase<T, false /* isSmartPtr */>, unsigned SmallArraySize = 8>
 class SmallSet {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SmallSet);
     WTF_MAKE_NONCOPYABLE(SmallSet);
@@ -101,7 +101,7 @@ public:
         {
             ++m_index;
             ASSERT(m_index <= m_buffer.size());
-            while (m_index < m_buffer.size() && isEmptyBucket(m_buffer[m_index]))
+            while (m_index < m_buffer.size() && m_buffer[m_index] == emptyValue())
                 ++m_index;
             return *this;
         }
@@ -111,7 +111,7 @@ public:
         bool operator==(const iterator& other) const { ASSERT(m_buffer.data() == other.m_buffer.data()); return m_index == other.m_index; }
 
     private:
-        template<typename U, typename H, typename TR, unsigned S> friend class WTF::SmallSet;
+        template<typename U, typename H, unsigned S> friend class WTF::SmallSet;
         unsigned m_index;
         std::span<T> m_buffer;
     };
@@ -203,9 +203,11 @@ public:
     }
 
 private:
-    static bool isEmptyBucket(const T& value)
+    constexpr static T emptyValue()
     {
-        return isHashTraitsEmptyValue<Traits>(value);
+        if constexpr (std::is_pointer<T>::value)
+            return static_cast<T>(std::bit_cast<void*>(std::numeric_limits<uintptr_t>::max()));
+        return std::numeric_limits<T>::max();
     }
 
     bool equal(const T left, const T right) const
@@ -214,12 +216,14 @@ private:
             return Hash::equal(left, right);
         if (isValidEntry(left) && isValidEntry(right))
             return Hash::equal(left, right);
-        return left == right;
+        return left == right; 
     }
 
-    bool isValidEntry(const T& value) const
+    bool isValidEntry(const T value) const
     {
-        return !isEmptyBucket(value);
+        if constexpr (Hash::safeToCompareToEmptyOrDeleted)
+            return !Hash::equal(value, emptyValue());
+        return value != emptyValue();
     }
 
     inline bool isSmall() const
@@ -231,28 +235,34 @@ private:
     {
         m_size = 0;
         m_capacity = SmallArraySize;
-        initializeBuckets(std::span { m_inline.smallStorage });
+        memsetSpan(std::span { m_inline.smallStorage }, -1);
         ASSERT(isSmall());
-    }
-
-    static void initializeBuckets(std::span<T> span)
-    {
-        if constexpr (Traits::emptyValueIsZero)
-            memsetSpan(span, 0);
-        else {
-            for (auto& entry : span)
-                entry = Traits::emptyValue();
-        }
     }
 
     inline void grow(unsigned size)
     {
+        // We memset the new buffer with -1, so for consistency emptyValue() must return something which is all 1s.
+#if !defined(NDEBUG)
+        if constexpr (std::is_pointer<T>::value)
+            ASSERT(std::bit_cast<intptr_t>(emptyValue()) == -1ll);
+        else if constexpr (sizeof(T) == 8)
+            ASSERT(std::bit_cast<int64_t>(emptyValue()) == -1ll);
+        else if constexpr (sizeof(T) == 4)
+            ASSERT(std::bit_cast<int32_t>(emptyValue()) == -1);
+        else if constexpr (sizeof(T) == 2)
+            ASSERT(std::bit_cast<int16_t>(emptyValue()) == -1);
+        else if constexpr (sizeof(T) == 1)
+            ASSERT(std::bit_cast<int8_t>(emptyValue()) == -1);
+        else
+            RELEASE_ASSERT_NOT_REACHED();
+#endif
+
         size_t allocationSize = sizeof(T) * size;
         auto oldBuffer = buffer();
 
         unsigned oldCapacity = m_capacity;
         auto newBuffer = MallocSpan<T, SmallSetMalloc>::malloc(allocationSize);
-        initializeBuckets(newBuffer.mutableSpan());
+        memsetSpan(newBuffer.mutableSpan(), -1);
         m_capacity = size;
 
         for (unsigned i = 0; i < oldCapacity; i++) {


### PR DESCRIPTION
#### 8364428778a4b77ee6aa4bc22dcc8aa7461addca
<pre>
Unreviewed, reverting 308594@main (6904c3f73213)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309179">https://bugs.webkit.org/show_bug.cgi?id=309179</a>
<a href="https://rdar.apple.com/171735885">rdar://171735885</a>

REGRESSION(308594@main): [macOS iOS] ASSERTION FAILED: isValidEntry(value) in TestWTF.WTF_SmallSet tests

Reverted change:

    [WTF] SmallSet should take HashTraits
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309101">https://bugs.webkit.org/show_bug.cgi?id=309101</a>
    <a href="https://rdar.apple.com/171660307">rdar://171660307</a>
    308594@main (6904c3f73213)

Canonical link: <a href="https://commits.webkit.org/308647@main">https://commits.webkit.org/308647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80620c2a872cbb48b59dcb88ff0ecb7ff49a42f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148120 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/20805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/20710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/156803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151080 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/140087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159136 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/8907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/20710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22815 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/179540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/83980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/179540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->