### PR TITLE
[Site Isolation] prepareForProvisionalLoadInProcess should guard against cancellation during network process's handling

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt
@@ -2,6 +2,7 @@ CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/ins
 CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 
 == Running test suite: SiteIsolation.Target
 -- Running test case: SiteIsolation.Target.SameOriginIframe
@@ -33,4 +34,16 @@ CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/ins
 {"event":"target-manager-target-removed","target":8,"type":"frame","isProvisional":false}
 {"event":"target-manager-provisional-target-committed","target":9,"type":"frame","isProvisional":false}
 {"event":"console-manager-message-added","target":9,"message":"Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html"}
+
+-- Running test case: SiteIsolation.Target.ProvisionalFrameCancelledByRemoval
+{"event":"target-manager-target-added","target":10,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":11,"type":"frame","isProvisional":true}
+{"event":"target-manager-target-removed","target":10,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-removed","target":11,"type":"frame","isProvisional":true}
+
+-- Running test case: SiteIsolation.Target.ProvisionalFrameCancelledByNavigation
+{"event":"target-manager-target-added","target":12,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":13,"type":"frame","isProvisional":true}
+{"event":"target-manager-target-removed","target":13,"type":"frame","isProvisional":true}
+{"event":"console-manager-message-added","target":12,"message":"Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html"}
 

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target.html
@@ -113,8 +113,7 @@
             },
         });
 
-        // FIXME <https://webkit.org/b/309172>: Fix timing around cancelling provisional loading and LoadRequest.
-        /* suite.addTestCase({
+        suite.addTestCase({
             name: "SiteIsolation.Target.ProvisionalFrameCancelledByRemoval",
             description: "Removing cross-origin iframe before loading completes destroys both targets.",
             test(resolve) {
@@ -128,7 +127,7 @@
             test(resolve) {
                 runCallbackCountingTest(resolve, 4, `addAndNavigateAwayIframe();`);
             },
-        }); */
+        });
 
         suite.runTestCasesAndFinish();
     }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -535,7 +535,7 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, String&&
 #endif
 }
 
-void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process, API::Navigation& navigation, BrowsingContextGroup& group, std::optional<SecurityOriginData> effectiveOrigin, CompletionHandler<void(WebCore::PageIdentifier)>&& completionHandler)
+void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process, API::Navigation& navigation, BrowsingContextGroup& group, std::optional<SecurityOriginData> effectiveOrigin, CompletionHandler<void(std::optional<WebCore::PageIdentifier>)>&& completionHandler)
 {
     if (isMainFrame())
         return completionHandler(*webPageIDInCurrentProcess());
@@ -556,7 +556,14 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     if (RefPtr provisionalFrame = m_provisionalFrame)
         page->inspectorController().didCreateProvisionalFrame(*provisionalFrame);
 
-    protect(protect(page->websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
+    protect(protect(page->websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [weakProvisionalFrame = WeakPtr { m_provisionalFrame }, pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
+        RefPtr provisionalFrame = weakProvisionalFrame.get();
+        if (!provisionalFrame || !protect(provisionalFrame->frame())->isConnected()) {
+            // Provisional loading was cancelled while network process was handling this message.
+            completionHandler(std::nullopt);
+            return;
+        }
+
         completionHandler(pageID);
     });
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -216,7 +216,7 @@ public:
     bool isConnected() const;
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
     ProcessID NODELETE processID() const;
-    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, std::optional<WebCore::SecurityOriginData>, CompletionHandler<void(WebCore::PageIdentifier)>&&);
+    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, std::optional<WebCore::SecurityOriginData>, CompletionHandler<void(std::optional<WebCore::PageIdentifier>)>&&);
 
     void commitProvisionalFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, String&& proxyName, WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, WebCore::DocumentSecurityPolicy&&, const UserData&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5647,8 +5647,9 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
             loadParameters = WTF::move(loadParameters),
             newProcess = newProcess.copyRef(),
             preventProcessShutdownScope = newProcess->shutdownPreventingScope()
-        ] (PageIdentifier pageID) mutable {
-            newProcess->send(Messages::WebPage::LoadRequest(WTF::move(loadParameters)), pageID);
+        ](std::optional<PageIdentifier> pageID) mutable {
+            if (pageID)
+                newProcess->send(Messages::WebPage::LoadRequest(WTF::move(loadParameters)), *pageID);
         });
         return;
     }


### PR DESCRIPTION
#### 077e5cdf8cb0b5248b6b783a83f164d8c893b037
<pre>
[Site Isolation] prepareForProvisionalLoadInProcess should guard against cancellation during network process&apos;s handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=309172">https://bugs.webkit.org/show_bug.cgi?id=309172</a>

Reviewed by BJ Burg.

When frame.prepareForProvisionalLoadInProcess completes, it&apos;s possible
for provisional loading to be cancelled in the meantime. Sending
WebPage::LoadRequest for that cancelled frame results in an assertion
failure as the frame is already unregistered in that web process.

When provisional loading is cancelled, the ProvisionalFrameProxy will
either be destroyed or disconnected from parent frame. Use that info
as a guard to only optionally report back the pageID as the loading
destination.

The two test cases in target.html involving cancelling provisional
loading should now progress.

(This assertion failure only occurred intermittently in that inspector
testing environment and under debug+asan build. I could not repro it
with a standalone JS test. Thus, no new tests.)

* LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/target/target.html:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):

Canonical link: <a href="https://commits.webkit.org/308729@main">https://commits.webkit.org/308729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b688c978f99290b15a7c2ead1fc0c8d347151906

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101576 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccd8515d-3e3f-4153-acc7-4d6aca9aa00f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81435 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/590945b8-5946-468d-9658-1666720f3789) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05e9f1bb-9b04-472b-82a5-05a7db5d9f90) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15593 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13394 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159179 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122264 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76807 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22857 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9512 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84064 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19994 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20141 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->