### PR TITLE
Fix flaky KeyboardEventTests.UserTextInputEvent test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
@@ -28,7 +28,6 @@
 #if PLATFORM(MAC)
 
 #import "PlatformUtilities.h"
-#import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContentWorldPrivate.h>
@@ -148,11 +147,7 @@ TEST(KeyboardEventTests, TerminateWebContentProcessDuringKeyEventHandling)
 }
 
 // FIXME when rdar://168322007 is resolved.
-#if PLATFORM(MAC)
-TEST(KeyboardEventTests, DISABLED_UserTextInputEvent)
-#else
 TEST(KeyboardEventTests, UserTextInputEvent)
-#endif
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView addToTestWindow];
@@ -160,32 +155,56 @@ TEST(KeyboardEventTests, UserTextInputEvent)
     RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
     configuration.get().allowAutofill = YES;
     RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
-    NSString *pageWorldJS = @"window.addEventListener('webkitusertextinput', () => alert('fail') )";
-    NSString *autofillWorldJS = @"window.addEventListener('webkitusertextinput', (e) => { setTimeout(() => alert('pass ' + e.target.id), 50)})";
+
+    __block RetainPtr<NSString> lastMessage;
+    __block bool receivedMessage = false;
+    RetainPtr messageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [messageHandler setDidReceiveScriptMessage:^(NSString *body) {
+        lastMessage = body;
+        receivedMessage = true;
+    }];
+
+    RetainPtr<WKUserContentController> userContentController = [webView configuration].userContentController;
+    [userContentController addScriptMessageHandler:messageHandler.get() contentWorld:autofillWorld.get() name:@"testHandler"];
+    [userContentController addScriptMessageHandler:messageHandler.get() contentWorld:WKContentWorld.pageWorld name:@"testHandler"];
+
+    NSString *pageWorldJS = @"window.addEventListener('webkitusertextinput', () => webkit.messageHandlers.testHandler.postMessage('fail'))";
+    NSString *autofillWorldJS = @"window.addEventListener('webkitusertextinput', (e) => { setTimeout(() => webkit.messageHandlers.testHandler.postMessage('pass ' + e.target.id), 50) })";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
     RetainPtr autofillWorldScript = adoptNS([[WKUserScript alloc] initWithSource:autofillWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES inContentWorld:autofillWorld.get()]);
-    RetainPtr<WKUserContentController> userContentController = [webView configuration].userContentController;
     [userContentController addUserScript:pageWorldScript.get()];
     [userContentController addUserScript:autofillWorldScript.get()];
 
     [webView synchronouslyLoadHTMLString:@"<input id='input' type='text'><textarea id='textarea'></textarea>"];
 
     [webView objectByEvaluatingJavaScript:@"input.focus()"];
+    [webView waitForNextPresentationUpdate];
+    receivedMessage = false;
     [webView typeCharacter:'a'];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass input");
+    Util::run(&receivedMessage);
+    EXPECT_WK_STREQ(lastMessage.get(), "pass input");
 
     [webView objectByEvaluatingJavaScript:@"textarea.focus()"];
+    [webView waitForNextPresentationUpdate];
+    receivedMessage = false;
     [webView typeCharacter:'c'];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass textarea");
+    Util::run(&receivedMessage);
+    EXPECT_WK_STREQ(lastMessage.get(), "pass textarea");
 
     // Untrusted input changes should not cause webkitusertextinput to fire.
-    [webView objectByEvaluatingJavaScript:@"window.addEventListener('input', (e) => { setTimeout(() => alert('input without webkitusertextinput ' + e.target.id), 50)})"];
+    [webView objectByEvaluatingJavaScript:@"window.addEventListener('webkitusertextinput', () => webkit.messageHandlers.testHandler.postMessage('fail'))" inFrame:nil inContentWorld:autofillWorld.get()];
+    NSString *inputListenerJS = @"window.addEventListener('input', (e) => { setTimeout(() => webkit.messageHandlers.testHandler.postMessage('input without webkitusertextinput ' + e.target.id), 50) })";
+    [webView objectByEvaluatingJavaScript:inputListenerJS];
 
-    [webView objectByEvaluatingJavaScript:@"input.value += 'c'; input.dispatchEvent(new InputEvent('input', { data: 'c', inputType: 'insertText', bubbles: true }));"];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "input without webkitusertextinput input");
+    receivedMessage = false;
+    [webView evaluateJavaScript:@"input.value += 'c'; input.dispatchEvent(new InputEvent('input', { data: 'c', inputType: 'insertText', bubbles: true }));" completionHandler:nil];
+    Util::run(&receivedMessage);
+    EXPECT_WK_STREQ(lastMessage.get(), "input without webkitusertextinput input");
 
-    [webView objectByEvaluatingJavaScript:@"textarea.value += 'c'; textarea.dispatchEvent(new InputEvent('input', { data: 'c', inputType: 'insertText', bubbles: true }));"];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "input without webkitusertextinput textarea");
+    receivedMessage = false;
+    [webView evaluateJavaScript:@"textarea.value += 'c'; textarea.dispatchEvent(new InputEvent('input', { data: 'c', inputType: 'insertText', bubbles: true }));" completionHandler:nil];
+    Util::run(&receivedMessage);
+    EXPECT_WK_STREQ(lastMessage.get(), "input without webkitusertextinput textarea");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2b5877a6cf7e7b4f80545b587561246082433129
<pre>
Fix flaky KeyboardEventTests.UserTextInputEvent test
<a href="https://bugs.webkit.org/show_bug.cgi?id=305665">https://bugs.webkit.org/show_bug.cgi?id=305665</a>
<a href="https://rdar.apple.com/168322007">rdar://168322007</a>

Reviewed by Sihui Liu.

This test can be flaky for a couple of reasons:

1. At the time that `-objectByEvaluatingJavaScript:` returns from executing `focus()` from WebProcess,
   it&apos;s possible that the logic that updates the first responder in UIProcess still hasn&apos;t
   completed. Then, the subsequent call to `-typeCharacter:` ends up typing into nothing rather than
   typing into the text field. Work around this by inserting a `-waitForNextPresentationUpdate`.

2. When dispatching the fake input event, it&apos;s possible that `objectByEvaluatingJavaScript` spins
   the run loop enough to handle an alert before we execute `_test_waitForAlert`. Fix this by using
   a message handler rather than using `_test_waitForAlert`, which dynamically adds and removes a
   UIDelegate to the web view.

* Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm:
(TestWebKitAPI::TEST(KeyboardEventTests, UserTextInputEvent)):

Canonical link: <a href="https://commits.webkit.org/308682@main">https://commits.webkit.org/308682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/235c741fb374fcb5ff4b52025734fae294867d45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156883 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01db514e-beeb-4b51-a257-b88906c82102) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64e3a2b0-c3af-4bbf-94f4-0adc55b88f86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95019 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6674bcdf-d8f5-4ae2-984d-6c49afed9848) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4320 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159216 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122281 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122500 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/32737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76844 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9539 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20301 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20032 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->