### PR TITLE
[visionOS] Upstream `UIScrollView#_associateRelatedLayersForOverlayRegions`

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -295,3 +295,10 @@ selectors = [
 requires = ["ENABLE_EXTENSION_CAPABILITIES"]
 requires-sdk = ["iOS <= 26.*"]
 
+[[temporary-usage]]
+request = "rdar://171730075"
+cleanup = "rdar://171730140"
+selectors = [
+    { name = "_lookToScrollGroupName", class = "UIScrollView" },
+]
+requires = ["PLATFORM_VISION"]

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1406,6 +1406,7 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @interface UIScrollView ()
 @property (nonatomic, setter=_setUseVisionAlternateScrollIndicatorRendering:) BOOL _useVisionAlternateScrollIndicatorRendering;
+@property (readonly) NSString *_lookToScrollGroupName;
 @end
 
 #endif // PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -268,6 +268,27 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 
+- (void)_associateRelatedLayersForOverlayRegions:(const HashSet<WebCore::PlatformLayerIdentifier>&)relatedLayers with:(const WebKit::RemoteLayerTreeHost&)host
+{
+    auto diff = _overlayRegionAssociatedLayers.symmetricDifferenceWith(relatedLayers);
+    if (diff.isEmpty())
+        return;
+
+    _overlayRegionAssociatedLayers = relatedLayers;
+    if (![self respondsToSelector:@selector(_lookToScrollGroupName)])
+        return;
+
+    NSString *groupName = [self _lookToScrollGroupName];
+    for (auto layerID : relatedLayers) {
+        if (auto* layer = host.layerForID(layerID)) {
+            CARemoteEffectGroup *group = [CARemoteEffectGroup groupWithEffects:@[]];
+            group.groupName = groupName;
+            group.matched = YES;
+            [layer setRemoteEffects:@[ group ]];
+        }
+    }
+}
+
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKBaseScrollViewAdditions.mm>)
 #import <WebKitAdditions/WKBaseScrollViewAdditions.mm>
 #else
@@ -308,14 +329,6 @@ constexpr float overlayRegionContentFactor = 1.1;
     _overlayRegionRects = overlayRegions;
 }
 
-- (void)_associateRelatedLayersForOverlayRegions:(const HashSet<WebCore::PlatformLayerIdentifier>&)relatedLayers with:(const WebKit::RemoteLayerTreeHost&)host
-{
-    auto diff = _overlayRegionAssociatedLayers.symmetricDifferenceWith(relatedLayers);
-    if (!diff.size())
-        return;
-
-    _overlayRegionAssociatedLayers = relatedLayers;
-}
 #endif
 
 #endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)


### PR DESCRIPTION
#### 1bfbeba7fd7817df0f399fc43d9cf0d6995510ee
<pre>
[visionOS] Upstream `UIScrollView#_associateRelatedLayersForOverlayRegions`
<a href="https://bugs.webkit.org/show_bug.cgi?id=309183">https://bugs.webkit.org/show_bug.cgi?id=309183</a>
&lt;<a href="https://rdar.apple.com/154670691">rdar://154670691</a>&gt;

Reviewed by Mike Wyrzykowski.

Upstream the code, add the UIKitSPI stub and document the SPI use.

Test: LayoutTests/overlay-region/overflow-with-proxy.html

* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView _associateRelatedLayersForOverlayRegions:with:]):

Canonical link: <a href="https://commits.webkit.org/308690@main">https://commits.webkit.org/308690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2442b08d831338bfdb26dae4d0f07924526f7d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101551 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30afb487-cdec-4f99-9391-442f007fd01d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114202 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81421 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c8994bc-ea25-4170-90d8-8c47ec3217c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94968 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/194e72b3-c114-4825-9566-f65d6e04094b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15571 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13372 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4258 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125172 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159154 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122232 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122450 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76778 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9485 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19969 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20116 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->