### PR TITLE
version._strip_zeros will return an empty string if the list digit is non zero

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py
@@ -170,6 +170,9 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(str(Version(0, 0, 3)), '0.0.3')
         self.assertEqual(str(Version(0, 3)), '0.3')
         self.assertEqual(str(Version(0)), '0')
+        # Regression: non-zero nano caused parts[:-0] == [] and str() returned ''
+        self.assertEqual(str(Version(623, 2, 7, 10, 3)), '623.2.7.10.3')
+        self.assertEqual(str(Version(1, 0, 0, 0, 1)), '1.0.0.0.1')
 
     def test_representation(self):
         self.assertEqual(repr(Version(1, 2, 3)), 'Version(1, 2, 3)')
@@ -179,6 +182,9 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(repr(Version(0, 0, 3)), 'Version(0, 0, 3)')
         self.assertEqual(repr(Version(0, 3)), 'Version(0, 3)')
         self.assertEqual(repr(Version(0)), 'Version(0)')
+        # Regression: non-zero nano caused parts[:-0] == [] and repr() returned 'Version()'
+        self.assertEqual(repr(Version(623, 2, 7, 10, 3)), 'Version(623, 2, 7, 10, 3)')
+        self.assertEqual(repr(Version(1, 0, 0, 0, 1)), 'Version(1, 0, 0, 0, 1)')
 
     def test_hash(self):
         self.assertEqual(Version(1).__hash__(), Version(1, 0, 0).__hash__())

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py
@@ -140,11 +140,23 @@ class Version(object):
         return True if does_match is None else does_match
 
     def _strip_zeros(self):
+        """Return the version components as a list with trailing zero components removed.
+
+        Iterates from the end of the component list and records how many consecutive
+        zeros appear before the first non-zero value (i), then slices them off.
+
+        Examples:
+            Version(1, 2, 3)       -> [1, 2, 3]   (no trailing zeros)
+            Version(1, 2, 0)       -> [1, 2]       (one trailing zero stripped)
+            Version(1, 2, 0, 0, 0) -> [1, 2]       (three trailing zeros stripped)
+            Version(0, 0, 3)       -> [0, 0, 3]    (leading zeros preserved)
+            Version(1, 0, 0, 0, 3) -> [1, 0, 0, 0, 3]  (no trailing zeros, nano is non-zero)
+        """
         parts = list(self)
         for i, part in enumerate(reversed(parts)):
             if part != 0:
                 break
-        return parts[:-i]
+        return parts[:len(parts) - i]
 
     # 11.2 is in 11, but 11 is not in 11.2
     def __contains__(self, version):


### PR DESCRIPTION
#### fc055c9d0995a2e2b897205c98a58ea611e10d53
<pre>
version._strip_zeros will return an empty string if the list digit is non zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=309187">https://bugs.webkit.org/show_bug.cgi?id=309187</a>
<a href="https://rdar.apple.com/169045226">rdar://169045226</a>

Reviewed by Sam Sneddon.

if the last number in the list is non zero, return the entire list
instead of just an empty list

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/version_unittest.py:
(VersionTestCase.test_string):
(VersionTestCase.test_representation):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/version.py:
(Version._strip_zeros):

Canonical link: <a href="https://commits.webkit.org/309443@main">https://commits.webkit.org/309443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ea8d90b82ef98fe8c28fbe1968144577cc16bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150717 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/23475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159439 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23678 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153677 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97050 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150038 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/7287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161913 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14682 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150117 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/23277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124520 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134922 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23154 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/23265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->