### PR TITLE
[JSC] Retire ScopeRef

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -501,11 +501,11 @@ static constexpr const Latin1Character singleCharacterEscapeValuesForASCII[128] 
 
 template <typename T>
 Lexer<T>::Lexer(VM& vm, JSParserBuiltinMode builtinMode, JSParserScriptMode scriptMode)
-    : m_positionBeforeLastNewline(0,0,0)
-    , m_isReparsingFunction(false)
-    , m_vm(vm)
+    : m_vm(vm)
     , m_parsingBuiltinFunction(builtinMode == JSParserBuiltinMode::Builtin || Options::exposePrivateIdentifiers())
+    , m_positionBeforeLastNewline(0, 0, 0)
     , m_scriptMode(scriptMode)
+    , m_isReparsingFunction(false)
 {
 }
 

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -33,6 +33,8 @@
 #include <wtf/Vector.h>
 #include <wtf/unicode/CharacterNames.h>
 
+#define CACHE_LINE_ALIGNED alignas(64)
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
@@ -48,7 +50,7 @@ enum class LexerFlags : uint8_t {
 bool isLexerKeyword(const Identifier&);
 
 template <typename T>
-class Lexer {
+class CACHE_LINE_ALIGNED Lexer {
     WTF_MAKE_NONCOPYABLE(Lexer);
     WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(Lexer);
 public:
@@ -211,39 +213,36 @@ private:
 
     static constexpr size_t initialReadBufferCapacity = 32;
 
-    int m_lineNumber;
-    int m_lastLineNumber;
-
-    Vector<Latin1Character> m_buffer8;
-    Vector<char16_t> m_buffer16;
-    Vector<char16_t> m_bufferForRawTemplateString16;
-    bool m_hasLineTerminatorBeforeToken;
-    int m_lastToken;
-
-    const SourceCode* m_source;
-    unsigned m_sourceOffset;
+    // Hot fields, grouped to share a cache line. Depending on sizeof(T),
+    // the line may or may not include m_lastLineNumber.
+    VM& m_vm;
+    IdentifierArena* m_arena;
     const T* m_code;
     const T* m_codeStart;
     const T* m_codeEnd;
-    const T* m_codeStartPlusOffset;
     const T* m_lineStart;
-    JSTextPosition m_positionBeforeLastNewline;
-    JSTokenLocation m_lastTokenLocation;
-    bool m_isReparsingFunction;
+    int m_lineNumber;
+    int m_lastToken;
+    T m_current;
+    bool m_hasLineTerminatorBeforeToken;
     bool m_atLineStart;
+    bool m_parsingBuiltinFunction;
+    int m_lastLineNumber;
+
+    JSTokenLocation m_lastTokenLocation;
+    JSTextPosition m_positionBeforeLastNewline;
+    JSParserScriptMode m_scriptMode;
+    Vector<Latin1Character> m_buffer8;
+    Vector<char16_t> m_buffer16;
+    Vector<char16_t> m_bufferForRawTemplateString16;
+    bool m_isReparsingFunction;
     bool m_error;
     String m_lexErrorMessage;
-
     String m_sourceURLDirective;
     String m_sourceMappingURLDirective;
-
-    T m_current;
-
-    IdentifierArena* m_arena;
-
-    VM& m_vm;
-    bool m_parsingBuiltinFunction;
-    JSParserScriptMode m_scriptMode;
+    const SourceCode* m_source;
+    unsigned m_sourceOffset;
+    const T* m_codeStartPlusOffset;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<typename T>, Lexer<T>);

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -127,19 +127,19 @@ void Parser<LexerType>::logError(bool shouldPrintToken, Args&&... args)
 template <typename LexerType>
 Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibility implementationVisibility, JSParserBuiltinMode builtinMode, LexicallyScopedFeatures lexicallyScopedFeatures, JSParserScriptMode scriptMode, SourceParseMode parseMode, FunctionMode functionMode, SuperBinding superBinding, ConstructorKind constructorKind, DerivedContextType derivedContextType, bool isEvalContext, EvalContextType evalContextType, DebuggerParseData* debuggerParseData, bool isInsideOrdinaryFunction)
     : m_vm(vm)
-    , m_source(&source)
-    , m_hasStackOverflow(false)
     , m_allowsIn(true)
+    , m_immediateParentAllowsFunctionDeclarationInStatement(false)
+    , m_parseMode(parseMode)
     , m_statementDepth(0)
+    , m_scriptMode(scriptMode)
+    , m_source(&source)
+    , m_functionMode(functionMode)
+    , m_superBinding(superBinding)
     , m_implementationVisibility(implementationVisibility)
     , m_parsingBuiltin(builtinMode == JSParserBuiltinMode::Builtin)
-    , m_parseMode(parseMode)
-    , m_functionMode(functionMode)
-    , m_scriptMode(scriptMode)
-    , m_superBinding(superBinding)
-    , m_immediateParentAllowsFunctionDeclarationInStatement(false)
-    , m_debuggerParseData(debuggerParseData)
     , m_isInsideOrdinaryFunction(isInsideOrdinaryFunction)
+    , m_hasStackOverflow(false)
+    , m_debuggerParseData(debuggerParseData)
 {
     m_lexer = makeUnique<LexerType>(vm, builtinMode, scriptMode);
     m_lexer->setCode(source, &m_parserArena);
@@ -149,7 +149,7 @@ Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibi
     m_token.m_endPosition.offset = source.startOffset();
     m_functionCache = vm.addSourceProviderCache(source.provider());
 
-    ScopeRef scope = pushScope();
+    Scope* scope = pushScope();
     scope->setLexicallyScopedFeatures(lexicallyScopedFeatures);
     scope->setSourceParseMode(parseMode);
     scope->setIsEvalContext(isEvalContext);
@@ -173,7 +173,7 @@ Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibi
 
 class Scope::MaybeParseAsGeneratorFunctionForScope {
 public:
-    MaybeParseAsGeneratorFunctionForScope(ScopeRef& scope, bool shouldParseAsGeneratorFunction)
+    MaybeParseAsGeneratorFunctionForScope(Scope* scope, bool shouldParseAsGeneratorFunction)
         : m_scope(scope)
         , m_oldValue(scope->m_isGeneratorFunction)
     {
@@ -186,7 +186,7 @@ public:
     }
 
 private:
-    ScopeRef m_scope;
+    Scope* m_scope;
     bool m_oldValue;
 };
 
@@ -218,7 +218,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
 {
     ASTBuilder context(const_cast<VM&>(m_vm), m_parserArena, const_cast<SourceCode*>(m_source));
     SourceParseMode parseMode = sourceParseMode();
-    ScopeRef scope = currentScope();
+    Scope* scope = currentScope();
     scope->setIsLexicalScope();
 
     bool hasPrivateNames = scope->isEvalContext() && parentScopePrivateNames && parentScopePrivateNames->size();
@@ -366,7 +366,7 @@ template <class TreeBuilder> bool Parser<LexerType>::isArrowFunctionParameters(T
         else {
             SyntaxChecker syntaxChecker(const_cast<VM&>(m_vm), m_lexer.get());
             // We make fake scope, otherwise parseFormalParameters will add variable to current scope that lead to errors
-            AutoPopScopeRef fakeScope(this, pushScope());
+            AutoPopScope fakeScope(this, pushScope());
 
             fakeScope->setSourceParseMode(SourceParseMode::ArrowFunctionMode);
             resetImplementationVisibilityIfNeeded();
@@ -539,7 +539,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
     info.startLine = tokenLine();
 
     {
-        AutoPopScopeRef generatorBodyScope(this, pushScope());
+        AutoPopScope generatorBodyScope(this, pushScope());
 
         generatorBodyScope->setSourceParseMode(SourceParseMode::GeneratorBodyMode);
         resetImplementationVisibilityIfNeeded();
@@ -583,7 +583,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
     bool bodyUsesAwait = false;
     SavePoint bodySavePoint = createSavePoint(context);
     {
-        AutoPopScopeRef asyncFunctionBodyScope(this, pushScope());
+        AutoPopScope asyncFunctionBodyScope(this, pushScope());
 
         asyncFunctionBodyScope->setSourceParseMode(sourceParseMode());
         resetImplementationVisibilityIfNeeded();
@@ -675,7 +675,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGen
     SourceParseMode parseMode = SourceParseMode::AsyncGeneratorBodyMode;
     SetForScope innerParseMode(m_parseMode, parseMode);
     {
-        AutoPopScopeRef asyncFunctionBodyScope(this, pushScope());
+        AutoPopScope asyncFunctionBodyScope(this, pushScope());
 
         asyncFunctionBodyScope->setSourceParseMode(sourceParseMode());
         resetImplementationVisibilityIfNeeded();
@@ -1463,7 +1463,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
          for (var/let/const varDeclarationList; expressionOpt; expressionOpt)
          */
         if (isLetDeclaration || isConstDeclaration) {
-            ScopeRef newScope = pushScope();
+            Scope* newScope = pushScope();
             newScope->setIsLexicalScope();
             newScope->preventVarDeclarations();
             lexicalScope.setIsValid(newScope, this);
@@ -1764,7 +1764,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseWithStatement
     int endLine = tokenLine();
     handleProductionOrFail(CLOSEPAREN, ")", "start", "subject of a 'with' statement");
 
-    AutoPopScopeRef withScope(this, pushScope());
+    AutoPopScope withScope(this, pushScope());
     withScope->setTaintedByWithScope();
     withScope->preventAllVariableDeclarations();
 
@@ -1792,7 +1792,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseSwitchStateme
     
     handleProductionOrFail(CLOSEPAREN, ")", "end", "subject of a 'switch'");
     handleProductionOrFail(OPENBRACE, "{", "start", "body of a 'switch'");
-    AutoPopScopeRef lexicalScope(this, pushScope());
+    AutoPopScope lexicalScope(this, pushScope());
     lexicalScope->setIsLexicalScope();
     lexicalScope->preventVarDeclarations();
     startSwitch();
@@ -1887,7 +1887,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
             DepthManager statementDepth(&m_statementDepth);
             semanticFailIfTrue(currentScope()->isStaticBlock() && match(AWAIT), "Cannot use 'await' as identifier within static block");
             m_statementDepth++;
-            AutoPopScopeRef catchScope(this, pushScope());
+            AutoPopScope catchScope(this, pushScope());
             catchScope->setIsLexicalScope();
             catchScope->preventVarDeclarations();
             const Identifier* ident = nullptr;
@@ -1956,7 +1956,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatemen
     AutoCleanupLexicalScope lexicalScope;
     bool shouldPushLexicalScope = m_statementDepth > 0 || type == BlockType::StaticBlock;
     if (shouldPushLexicalScope) {
-        ScopeRef newScope = pushScope();
+        Scope* newScope = pushScope();
         newScope->setIsLexicalScope();
         switch (type) {
         case BlockType::CatchBlock:
@@ -2142,7 +2142,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseFunctionDecla
     // function a() {
     //     if (cond) { function foo() { } }
     // }
-    AutoPopScopeRef blockScope(this, pushScope());
+    AutoPopScope blockScope(this, pushScope());
     blockScope->setIsLexicalScope();
     blockScope->preventVarDeclarations();
     JSTokenLocation location(tokenLocation());
@@ -2234,7 +2234,7 @@ static ALWAYS_INLINE SuperBinding NODELETE adjustSuperBindingForBaseConstructor(
     return SuperBinding::Needed;
 }
 
-static ALWAYS_INLINE SuperBinding NODELETE adjustSuperBindingForBaseConstructor(ConstructorKind constructorKind, SuperBinding expectedSuperBinding, SourceParseMode parseMode, ScopeRef functionScope)
+static ALWAYS_INLINE SuperBinding NODELETE adjustSuperBindingForBaseConstructor(ConstructorKind constructorKind, SuperBinding expectedSuperBinding, SourceParseMode parseMode, Scope* functionScope)
 {
     return adjustSuperBindingForBaseConstructor(constructorKind, expectedSuperBinding, parseMode, functionScope->needsSuperBinding(), functionScope->usesEval(), functionScope->innerArrowFunctionFeatures());
 }
@@ -2463,12 +2463,12 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     auto mode = sourceParseMode();
     RELEASE_ASSERT(isFunctionParseMode(mode));
 
-    ScopeRef parentScope = currentScope();
+    Scope* parentScope = currentScope();
 
     bool functionNameIsAwait = isPossiblyEscapedAwait(m_token);
     const char* isDisallowedAwaitFunctionNameReason = functionNameIsAwait && !canUseIdentifierAwait() ? disallowedIdentifierAwaitReason() : nullptr;
 
-    AutoPopScopeRef functionScope(this, pushScope());
+    AutoPopScope functionScope(this, pushScope());
 
     functionScope->setSourceParseMode(mode);
     resetImplementationVisibilityIfNeeded();
@@ -2581,7 +2581,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         {
             // Parse formal parameters with [+Yield] parameterization, in order to ban YieldExpressions
             // in ArrowFormalParameters, per ES6 #sec-arrow-function-definitions-static-semantics-early-errors.
-            Scope::MaybeParseAsGeneratorFunctionForScope parseAsGeneratorFunction(functionScope, parentScope->isGeneratorFunction());
+            Scope::MaybeParseAsGeneratorFunctionForScope parseAsGeneratorFunction(functionScope.scope(), parentScope->isGeneratorFunction());
             SetForScope overrideAllowAwait(m_parserState.allowAwait, !parentScope->isAsyncFunction() && !isAsyncFunctionParseMode(mode));
             parseFunctionParameters(syntaxChecker, functionInfo);
             propagateError();
@@ -2704,7 +2704,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
 
     ImplementationVisibility implementationVisibility = this->implementationVisibility();
     if (isGeneratorOrAsyncFunctionWrapperParseMode(mode)) {
-        AutoPopScopeRef generatorBodyScope(this, pushScope());
+        AutoPopScope generatorBodyScope(this, pushScope());
         SourceParseMode innerParseMode = isAsyncFunctionOrAsyncGeneratorWrapperParseMode(mode) ? getAsyncFunctionBodyParseMode(mode) : SourceParseMode::GeneratorBodyMode;
 
         generatorBodyScope->setSourceParseMode(innerParseMode);
@@ -2849,7 +2849,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseFunctionDecla
     failIfFalse((parseFunctionInfo(context, requirements, true, ConstructorKind::None, SuperBinding::NotNeeded, functionStart, functionInfo, FunctionDefinitionType::Declaration, functionConstructorParametersEndPosition)), "Cannot parse this function");
     ASSERT(functionInfo.name);
 
-    std::pair<DeclarationResultMask, ScopeRef> functionDeclaration = declareFunction(functionInfo.name);
+    std::pair<DeclarationResultMask, Scope*> functionDeclaration = declareFunction(functionInfo.name);
     DeclarationResultMask declarationResult = functionDeclaration.first;
     failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare a function named '", functionInfo.name->impl(), "' in strict mode");
     semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare a function that shadows a let/const/class/function variable '", functionInfo.name->impl(), "'");
@@ -2920,7 +2920,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseAsyncFunction
     failIfFalse((parseFunctionInfo(context, requirements, true, ConstructorKind::None, SuperBinding::NotNeeded, functionStart, functionInfo, FunctionDefinitionType::Declaration, functionConstructorParametersEndPosition)), "Cannot parse this async function");
     failIfFalse(functionInfo.name, "Async function statements must have a name");
 
-    std::pair<DeclarationResultMask, ScopeRef> functionDeclaration = declareFunction(functionInfo.name);
+    std::pair<DeclarationResultMask, Scope*> functionDeclaration = declareFunction(functionInfo.name);
     DeclarationResultMask declarationResult = functionDeclaration.first;
     failIfTrueIfStrict(declarationResult & DeclarationResult::InvalidStrictMode, "Cannot declare an async function named '", functionInfo.name->impl(), "' in strict mode");
     semanticFailIfTrue(declarationResult & DeclarationResult::InvalidDuplicateDeclaration, "Cannot declare an async function that shadows a let/const/class/function variable '", functionInfo.name->impl(), "'");
@@ -3008,7 +3008,7 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
     //
     // We need to create two scopes here since private name lookup will traverse scope at linking time in CodeBlock.
     // This classHeadScope is similar to functionScope in FunctionExpression with name.
-    AutoPopScopeRef classHeadScope(this, pushScope());
+    AutoPopScope classHeadScope(this, pushScope());
     classHeadScope->setIsLexicalScope();
     classHeadScope->preventVarDeclarations();
     classHeadScope->setStrictMode();
@@ -3040,7 +3040,7 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
     JSTextPosition classHeadEnd = lastTokenEndPosition();
     consumeOrFail(OPENBRACE, "Expected opening '{' at the start of a class body");
 
-    AutoPopScopeRef classScope(this, pushScope());
+    AutoPopScope classScope(this, pushScope());
     classScope->setIsLexicalScope();
     classScope->preventVarDeclarations();
     classScope->setStrictMode();
@@ -3446,7 +3446,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionOrL
         break;
     }
     const Identifier* unused = nullptr;
-    ScopeRef labelScope = currentScope();
+    Scope* labelScope = currentScope();
     for (auto& label : labels)
         pushLabel(label.m_ident, isLoop);
     m_immediateParentAllowsFunctionDeclarationInStatement = allowFunctionDeclarationAsStatement;
@@ -5294,7 +5294,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
 
     if (newCount && consume(DOT)) {
         if (matchContextualKeyword(m_vm.propertyNames->target)) [[likely]] {
-            ScopeRef closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
+            Scope* closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
             bool isClassFieldInitializer = m_parserState.isParsingClassFieldInitializer;
             bool isFunctionEvalContextType = m_isInsideOrdinaryFunction && (closestOrdinaryFunctionScope->evalContextType() == EvalContextType::FunctionEvalContext || closestOrdinaryFunctionScope->evalContextType() == EvalContextType::InstanceFieldEvalContext);
             semanticFailIfFalse(currentScope()->isFunction() || currentScope()->isStaticBlock() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is only valid inside functions or static blocks");
@@ -5310,14 +5310,21 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             failDueToUnexpectedToken();
         }
     } else if (baseIsSuper) {
-        ScopeRef closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
-        ScopeRef classScope = closestClassScopeOrTopLevelScope();
-        bool isClassFieldInitializer = classScope.index() > closestOrdinaryFunctionScope.index();
+        Scope* closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
+        Scope* classScope = closestClassScopeOrTopLevelScope();
+        // Check if classScope is deeper than closestOrdinaryFunctionScope (i.e., we're in a class field initializer).
+        bool isClassFieldInitializer = false;
+        for (Scope* scope = classScope->containingScope(); scope; scope = scope->containingScope()) {
+            if (scope == closestOrdinaryFunctionScope) {
+                isClassFieldInitializer = true;
+                break;
+            }
+        }
         semanticFailIfFalse(currentScope()->isFunction() || isClassFieldInitializer || (closestOrdinaryFunctionScope->isEvalContext() && closestOrdinaryFunctionScope->expectedSuperBinding() == SuperBinding::Needed), "super is not valid in this context");
         base = context.createSuperExpr(location);
         next();
         failIfTrue(match(OPENPAREN) && currentScope()->evalContextType() == EvalContextType::InstanceFieldEvalContext, "super call is not valid in this context");
-        ScopeRef functionScope = currentFunctionScope();
+        Scope* functionScope = currentFunctionScope();
         functionScope->setNeedsSuperBinding();
         // It unnecessary to check of using super during reparsing one more time. Also it can lead to syntax error
         // in case of arrow function because during reparsing we don't know whether we currently parse the arrow function
@@ -5442,13 +5449,13 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
 
                     failIfFalse(arguments, "Cannot parse call arguments");
                     if (baseIsSuper) {
-                        ScopeRef functionScope = currentFunctionScope();
+                        Scope* functionScope = currentFunctionScope();
                         functionScope->setHasDirectSuper();
                         // It unnecessary to check of using super during reparsing one more time. Also it can lead to syntax error
                         // in case of arrow function because during reparsing we don't know whether we currently parse the arrow function
                         // inside of the constructor or method.
                         if (!m_lexer->isReparsingFunction()) {
-                            ScopeRef closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
+                            Scope* closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
                             semanticFailIfFalse(closestOrdinaryFunctionScope->constructorKind() == ConstructorKind::Extends || (closestOrdinaryFunctionScope->isEvalContext() && closestOrdinaryFunctionScope->derivedContextType() == DerivedContextType::DerivedConstructorContext), "super is not valid in this context");
                         }
                         if (currentScope()->isArrowFunction())
@@ -5772,5 +5779,5 @@ template <typename LexerType> void Parser<LexerType>::printUnexpectedTokenText(W
 // Instantiate the two flavors of Parser we need instead of putting most of this file in Parser.h
 template class Parser<Lexer<Latin1Character>>;
 template class Parser<Lexer<char16_t>>;
-    
+
 } // namespace JSC

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -40,6 +40,7 @@
 #include <wtf/IterationStatus.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/SegmentedVector.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/MakeString.h>
 
@@ -152,8 +153,9 @@ struct Scope {
     WTF_MAKE_NONCOPYABLE(Scope);
 
 public:
-    Scope(const VM& vm, ImplementationVisibility implementationVisibility, LexicallyScopedFeatures lexicallyScopedFeatures, bool isFunction, bool isGeneratorFunction, bool isArrowFunction, bool isAsyncFunction, bool isStaticBlock)
+    Scope(const VM& vm, Scope* containingScope, ImplementationVisibility implementationVisibility, LexicallyScopedFeatures lexicallyScopedFeatures, bool isFunction, bool isGeneratorFunction, bool isArrowFunction, bool isAsyncFunction, bool isStaticBlock)
         : m_vm(vm)
+        , m_containingScope(containingScope)
         , m_implementationVisibility(implementationVisibility)
         , m_lexicallyScopedFeatures(lexicallyScopedFeatures)
         , m_isFunction(isFunction)
@@ -209,6 +211,9 @@ public:
         }
         return nullptr;
     }
+
+    Scope* containingScope() const { return m_containingScope; }
+    bool hasContainingScope() const { return m_containingScope && !isFunctionBoundary(); }
 
     void setSourceParseMode(SourceParseMode mode)
     {
@@ -965,6 +970,7 @@ private:
     }
 
     const VM& m_vm;
+    Scope* m_containingScope;
     ImplementationVisibility m_implementationVisibility;
     LexicallyScopedFeatures m_lexicallyScopedFeatures;
     bool m_shadowsArguments : 1 { false };
@@ -1001,9 +1007,9 @@ private:
     ConstructorKind m_constructorKind { ConstructorKind::None };
     DerivedContextType m_derivedContextType { DerivedContextType::None };
     SuperBinding m_expectedSuperBinding { SuperBinding::NotNeeded };
+    InnerArrowFunctionCodeFeatures m_innerArrowFunctionFeatures { 0 };
     int m_loopDepth { 0 };
     int m_switchDepth { 0 };
-    InnerArrowFunctionCodeFeatures m_innerArrowFunctionFeatures { 0 };
 
     typedef Vector<ScopeLabelInfo, 2> LabelStack;
     std::unique_ptr<LabelStack> m_labels;
@@ -1017,44 +1023,13 @@ private:
     DeclarationStacks::FunctionStack m_functionDeclarations;
 };
 
-typedef Vector<Scope, 10> ScopeStack;
-
-struct ScopeRef {
-    ScopeRef(ScopeStack* scopeStack, unsigned index)
-        : m_scopeStack(scopeStack)
-        , m_index(index)
-    {
-    }
-    Scope* operator->() { return &m_scopeStack->at(m_index); }
-    unsigned index() const { return m_index; }
-
-    bool hasContainingScope()
-    {
-        return m_index && !m_scopeStack->at(m_index).isFunctionBoundary();
-    }
-
-    ScopeRef containingScope()
-    {
-        ASSERT(hasContainingScope());
-        return ScopeRef(m_scopeStack, m_index - 1);
-    }
-
-    bool operator==(const ScopeRef& other) const
-    {
-        ASSERT(other.m_scopeStack == m_scopeStack);
-        return m_index == other.m_index;
-    }
-
-private:
-    ScopeStack* m_scopeStack;
-    unsigned m_index;
-};
+typedef SegmentedVector<Scope, 20, 10> ScopeStack;
 
 enum class ArgumentType { Normal, Spread };
 enum class ParsingContext { Normal, FunctionConstructor };
 
 template <typename LexerType>
-class Parser {
+class CACHE_LINE_ALIGNED Parser {
     WTF_MAKE_NONCOPYABLE(Parser);
     WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(Parser);
 
@@ -1117,35 +1092,36 @@ private:
         bool m_oldAllowsIn;
     };
 
-    struct AutoPopScopeRef : public ScopeRef {
-        AutoPopScopeRef(Parser* parser, ScopeRef scope)
-        : ScopeRef(scope)
-        , m_parser(parser)
+    struct AutoPopScope {
+        AutoPopScope(Parser* parser, Scope* scope)
+            : m_scope(scope)
+            , m_parser(parser)
         {
         }
-        
-        ~AutoPopScopeRef()
+
+        ~AutoPopScope()
         {
             if (m_parser)
-                m_parser->popScope(*this, false);
+                m_parser->popScope(m_scope, false);
         }
-        
-        void setPopped()
-        {
-            m_parser = nullptr;
-        }
-        
+
+        void setPopped() { m_parser = nullptr; }
+
+        Scope* operator->() { return m_scope; }
+        Scope* scope() { return m_scope; }
+
     private:
+        Scope* m_scope;
         Parser* m_parser;
     };
 
     struct AutoCleanupLexicalScope {
-        // We can allocate this object on the stack without actually knowing beforehand if we're 
+        // We can allocate this object on the stack without actually knowing beforehand if we're
         // going to create a new lexical scope. If we decide to create a new lexical scope, we
         // can pass the scope into this obejct and it will take care of the cleanup for us if the parse fails.
         // This is helpful if we may fail from syntax errors after creating a lexical scope conditionally.
         AutoCleanupLexicalScope()
-            : m_scope(nullptr, UINT_MAX)
+            : m_scope(nullptr)
             , m_parser(nullptr)
         {
         }
@@ -1153,13 +1129,13 @@ private:
         ~AutoCleanupLexicalScope()
         {
             // This should only ever be called if we fail from a syntax error. Otherwise
-            // it's the intention that a user of this class pops this scope manually on a 
-            // successful parse. 
+            // it's the intention that a user of this class pops this scope manually on a
+            // successful parse.
             if (isValid())
-                m_parser->popScope(*this, false);
+                m_parser->popScope(m_scope, false);
         }
 
-        void setIsValid(ScopeRef& scope, Parser* parser)
+        void setIsValid(Scope* scope, Parser* parser)
         {
             RELEASE_ASSERT(scope->isLexicalScope());
             m_scope = scope;
@@ -1167,16 +1143,11 @@ private:
         }
 
         bool isValid() const { return !!m_parser; }
-
-        void setPopped()
-        {
-            m_parser = nullptr;
-        }
-
-        ScopeRef& scope() { return m_scope; }
+        void setPopped() { m_parser = nullptr; }
+        Scope* scope() { return m_scope; }
 
     private:
-        ScopeRef m_scope;
+        Scope* m_scope;
         Parser* m_parser;
     };
 
@@ -1222,85 +1193,73 @@ private:
     ALWAYS_INLINE FunctionMode functionMode() const { return m_functionMode; }
     ALWAYS_INLINE bool isEvalOrArguments(const Identifier* ident) { return isEvalOrArgumentsIdentifier(m_vm, ident); }
 
-    ScopeRef upperScope(int n)
+    Scope* upperScope(int n)
     {
         ASSERT(m_scopeStack.size() >= size_t(1 + n));
-        return ScopeRef(&m_scopeStack, m_scopeStack.size() - 1 - n);
+        return &m_scopeStack[m_scopeStack.size() - 1 - n];
     }
 
-    ScopeRef currentScope()
+    Scope* currentScope()
     {
-        return ScopeRef(&m_scopeStack, m_scopeStack.size() - 1);
+        return m_currentScope;
     }
 
-    ScopeRef currentVariableScope()
+    Scope* currentVariableScope()
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
-        while (!m_scopeStack[i].allowsVarDeclarations()) {
-            i--;
-            ASSERT(i < m_scopeStack.size());
-        }
-        return ScopeRef(&m_scopeStack, i);
+        Scope* scope = currentScope();
+        while (!scope->allowsVarDeclarations())
+            scope = scope->containingScope();
+        return scope;
     }
 
-    ScopeRef currentLexicalDeclarationScope()
+    Scope* currentLexicalDeclarationScope()
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
-        while (!m_scopeStack[i].allowsLexicalDeclarations()) {
-            i--;
-            ASSERT(i < m_scopeStack.size());
-        }
-
-        return ScopeRef(&m_scopeStack, i);
+        Scope* scope = currentScope();
+        while (!scope->allowsLexicalDeclarations())
+            scope = scope->containingScope();
+        return scope;
     }
 
-    ScopeRef currentFunctionScope()
+    Scope* currentFunctionScope()
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
-        while (i && !m_scopeStack[i].isFunctionBoundary()) {
-            i--;
-            ASSERT(i < m_scopeStack.size());
-        }
+        Scope* scope = currentScope();
+        while (scope->containingScope() && !scope->isFunctionBoundary())
+            scope = scope->containingScope();
         // When reaching the top level scope (it can be non function scope), we return it.
-        return ScopeRef(&m_scopeStack, i);
+        return scope;
     }
 
-    std::optional<ScopeRef> findPrivateNameScope()
+    Scope* findPrivateNameScope()
     {
-        ASSERT(m_scopeStack.size());
-        unsigned i = m_scopeStack.size() - 1;
-        while (i && !m_scopeStack[i].isPrivateNameScope())
-            i--;
-
-        if (m_scopeStack[i].isPrivateNameScope())
-            return ScopeRef(&m_scopeStack, i);
-
-        return std::nullopt;
+        Scope* scope = currentScope();
+        while (scope->containingScope() && !scope->isPrivateNameScope())
+            scope = scope->containingScope();
+        if (scope->isPrivateNameScope())
+            return scope;
+        return nullptr;
     }
 
-    ScopeRef closestParentOrdinaryFunctionNonLexicalScope()
+    Scope* closestParentOrdinaryFunctionNonLexicalScope()
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size() && m_scopeStack.size());
-        while (i && (!m_scopeStack[i].isFunctionBoundary() || m_scopeStack[i].isGeneratorFunctionBoundary() || m_scopeStack[i].isAsyncFunctionBoundary() || m_scopeStack[i].isArrowFunctionBoundary()))
-            i--;
+        Scope* scope = currentScope();
+        while (scope->containingScope()) {
+            if (scope->isFunctionBoundary() && !scope->isGeneratorFunctionBoundary() && !scope->isAsyncFunctionBoundary() && !scope->isArrowFunctionBoundary())
+                break;
+            scope = scope->containingScope();
+        }
         // When reaching the top level scope (it can be non ordinary function scope), we return it.
-        return ScopeRef(&m_scopeStack, i);
+        return scope;
     }
 
-    ScopeRef closestClassScopeOrTopLevelScope()
+    Scope* closestClassScopeOrTopLevelScope()
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
-        while (i && !m_scopeStack[i].isClassScope())
-            i--;
-        return ScopeRef(&m_scopeStack, i);
+        Scope* scope = currentScope();
+        while (scope->containingScope() && !scope->isClassScope())
+            scope = scope->containingScope();
+        return scope;
     }
 
-    ScopeRef pushScope()
+    Scope* pushScope()
     {
         ImplementationVisibility implementationVisibility = m_implementationVisibility;
         LexicallyScopedFeatures lexicallyScopedFeatures = NoLexicallyScopedFeatures;
@@ -1309,17 +1268,18 @@ private:
         bool isArrowFunction = false;
         bool isAsyncFunction = false;
         bool isStaticBlock = false;
-        if (!m_scopeStack.isEmpty()) {
-            implementationVisibility = m_scopeStack.last().implementationVisibility();
-            lexicallyScopedFeatures = m_scopeStack.last().lexicallyScopedFeatures();
-            isFunction = m_scopeStack.last().isFunction();
-            isGeneratorFunction = m_scopeStack.last().isGeneratorFunction();
-            isArrowFunction = m_scopeStack.last().isArrowFunction();
-            isAsyncFunction = m_scopeStack.last().isAsyncFunction();
-            isStaticBlock = m_scopeStack.last().isStaticBlock();
+        Scope* parentScope = m_currentScope;
+        if (parentScope) {
+            implementationVisibility = parentScope->implementationVisibility();
+            lexicallyScopedFeatures = parentScope->lexicallyScopedFeatures();
+            isFunction = parentScope->isFunction();
+            isGeneratorFunction = parentScope->isGeneratorFunction();
+            isArrowFunction = parentScope->isArrowFunction();
+            isAsyncFunction = parentScope->isAsyncFunction();
+            isStaticBlock = parentScope->isStaticBlock();
         }
-        m_scopeStack.constructAndAppend(m_vm, implementationVisibility, lexicallyScopedFeatures, isFunction, isGeneratorFunction, isArrowFunction, isAsyncFunction, isStaticBlock);
-        return currentScope();
+        m_currentScope = &m_scopeStack.alloc(m_vm, parentScope, implementationVisibility, lexicallyScopedFeatures, isFunction, isGeneratorFunction, isArrowFunction, isAsyncFunction, isStaticBlock);
+        return m_currentScope;
     }
 
     void resetImplementationVisibilityIfNeeded()
@@ -1328,84 +1288,80 @@ private:
         // is also a function boundary). If the implementation visibility of that scope is not
         // recursive, reset the implementation visibility of the current scope.
 
-        auto& currentScope = m_scopeStack[m_scopeStack.size() - 1];
-        if (!currentScope.isFunctionBoundary())
+        if (!m_currentScope->isFunctionBoundary())
             return;
 
-        for (auto i = m_scopeStack.size() - 1; i > 0; --i) {
-            const auto& scope = m_scopeStack[i - 1];
-            if (!scope.isFunctionBoundary())
+        for (Scope* scope = m_currentScope->containingScope(); scope; scope = scope->containingScope()) {
+            if (!scope->isFunctionBoundary())
                 continue;
 
-            if (scope.implementationVisibility() != ImplementationVisibility::PrivateRecursive)
-                currentScope.resetImplementationVisibility();
+            if (scope->implementationVisibility() != ImplementationVisibility::PrivateRecursive)
+                m_currentScope->resetImplementationVisibility();
             break;
         }
     }
 
-    std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScopeInternal(ScopeRef& scope, bool shouldTrackClosedVariables)
+    std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScopeInternal(Scope* scope, bool shouldTrackClosedVariables)
     {
-        EXCEPTION_ASSERT_UNUSED(scope, scope.index() == m_scopeStack.size() - 1);
+        EXCEPTION_ASSERT_UNUSED(scope, scope == m_currentScope);
         ASSERT(m_scopeStack.size() > 1);
-        Scope& lastScope = m_scopeStack.last();
+        Scope* lastScope = m_currentScope;
+        Scope* parentScope = lastScope->containingScope();
 
         // Finalize lexical variables.
-        lastScope.finalizeLexicalEnvironment();
-        
-        Scope& parentScope = m_scopeStack[m_scopeStack.size() - 2];
-        parentScope.collectFreeVariables(&lastScope, shouldTrackClosedVariables);
+        lastScope->finalizeLexicalEnvironment();
 
-        if (lastScope.hasSloppyModeFunctionHoistingCandidates())
-            lastScope.bubbleSloppyModeFunctionHoistingCandidates(&parentScope);
+        parentScope->collectFreeVariables(lastScope, shouldTrackClosedVariables);
 
-        if (lastScope.isArrowFunction())
-            lastScope.setInnerArrowFunctionUsesEvalAndUseArgumentsIfNeeded();
-        
-        if (!(lastScope.isFunctionBoundary() && !lastScope.isArrowFunctionBoundary()))
-            parentScope.mergeInnerArrowFunctionFeatures(lastScope.innerArrowFunctionFeatures());
+        if (lastScope->hasSloppyModeFunctionHoistingCandidates())
+            lastScope->bubbleSloppyModeFunctionHoistingCandidates(parentScope);
 
-        if (!lastScope.isFunctionBoundary() && lastScope.needsFullActivation())
-            parentScope.setNeedsFullActivation();
-        std::tuple result { lastScope.takeLexicalEnvironment(), lastScope.takeFunctionDeclarations() };
+        if (lastScope->isArrowFunction())
+            lastScope->setInnerArrowFunctionUsesEvalAndUseArgumentsIfNeeded();
+
+        if (!(lastScope->isFunctionBoundary() && !lastScope->isArrowFunctionBoundary()))
+            parentScope->mergeInnerArrowFunctionFeatures(lastScope->innerArrowFunctionFeatures());
+
+        if (!lastScope->isFunctionBoundary() && lastScope->needsFullActivation())
+            parentScope->setNeedsFullActivation();
+        std::tuple result { lastScope->takeLexicalEnvironment(), lastScope->takeFunctionDeclarations() };
         m_scopeStack.removeLast();
+        m_currentScope = parentScope;
         return result;
     }
-    
-    ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(ScopeRef& scope, bool shouldTrackClosedVariables)
+
+    ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(Scope* scope, bool shouldTrackClosedVariables)
     {
         return popScopeInternal(scope, shouldTrackClosedVariables);
     }
-    
-    ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(AutoPopScopeRef& scope, bool shouldTrackClosedVariables)
+
+    ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(AutoPopScope& scope, bool shouldTrackClosedVariables)
     {
         scope.setPopped();
-        return popScopeInternal(scope, shouldTrackClosedVariables);
+        return popScopeInternal(scope.scope(), shouldTrackClosedVariables);
     }
 
     ALWAYS_INLINE std::tuple<VariableEnvironment, DeclarationStacks::FunctionStack> popScope(AutoCleanupLexicalScope& cleanupScope, bool shouldTrackClosedVariables)
     {
         RELEASE_ASSERT(cleanupScope.isValid());
-        ScopeRef& scope = cleanupScope.scope();
+        Scope* scope = cleanupScope.scope();
         cleanupScope.setPopped();
         return popScopeInternal(scope, shouldTrackClosedVariables);
     }
 
     NEVER_INLINE DeclarationResultMask declareHoistedVariable(const Identifier* ident)
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
+        Scope* scope = currentScope();
         while (true) {
             // Annex B.3.5 exempts `try {} catch (e) { var e; }` from being a syntax error.
-            if (m_scopeStack[i].hasLexicallyDeclaredVariable(*ident) && !m_scopeStack[i].isSimpleCatchParameterScope())
+            if (scope->hasLexicallyDeclaredVariable(*ident) && !scope->isSimpleCatchParameterScope())
                 return DeclarationResult::InvalidDuplicateDeclaration;
 
-            if (m_scopeStack[i].allowsVarDeclarations())
-                return m_scopeStack[i].declareVariable(ident);
+            if (scope->allowsVarDeclarations())
+                return scope->declareVariable(ident);
 
-            m_scopeStack[i].addVariableBeingHoisted(ident);
-
-            i--;
-            ASSERT(i < m_scopeStack.size());
+            scope->addVariableBeingHoisted(ident);
+            scope = scope->containingScope();
         }
     }
     
@@ -1419,25 +1375,25 @@ private:
         if (!m_lexer->isReparsingFunction() && m_statementDepth == 1 && (hasDeclaredParameter(*ident) || hasDeclaredVariable(*ident)))
             return DeclarationResult::InvalidDuplicateDeclaration;
 
-        ScopeRef scope = currentLexicalDeclarationScope();
-        if (scope->isCatchBlockScope() && scope.containingScope()->hasLexicallyDeclaredVariable(*ident))
+        Scope* scope = currentLexicalDeclarationScope();
+        if (scope->isCatchBlockScope() && scope->containingScope()->hasLexicallyDeclaredVariable(*ident))
             return DeclarationResult::InvalidDuplicateDeclaration;
 
         return scope->declareLexicalVariable(ident, type == DeclarationType::ConstDeclaration, importType);
     }
 
-    std::pair<DeclarationResultMask, ScopeRef> declareFunction(const Identifier* ident)
+    std::pair<DeclarationResultMask, Scope*> declareFunction(const Identifier* ident)
     {
         if (m_statementDepth == 1 && !currentScope()->isModuleCode()) {
             // Functions declared at the top-most scope (both in sloppy and strict mode) are declared as vars
             // for backwards compatibility, allowing us to declare functions with the same name more than once, except
             // Module code. Please see https://webkit.org/b/263269 for detailed explanation and ECMA-262 references.
-            ScopeRef variableScope = currentVariableScope();
+            Scope* variableScope = currentVariableScope();
             return std::make_pair(variableScope->declareFunctionAsVar(ident), variableScope);
         }
 
-        ScopeRef lexicalVariableScope = currentLexicalDeclarationScope();
-        if (lexicalVariableScope->isCatchBlockScope() && lexicalVariableScope.containingScope()->hasLexicallyDeclaredVariable(*ident))
+        Scope* lexicalVariableScope = currentLexicalDeclarationScope();
+        if (lexicalVariableScope->isCatchBlockScope() && lexicalVariableScope->containingScope()->hasLexicallyDeclaredVariable(*ident))
             return std::make_pair(DeclarationResult::InvalidDuplicateDeclaration, lexicalVariableScope);
 
         bool isFunctionDeclaration = m_parseMode == SourceParseMode::NormalFunctionMode;
@@ -1446,13 +1402,10 @@ private:
 
     NEVER_INLINE bool hasDeclaredVariable(const Identifier& ident)
     {
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
-        while (!m_scopeStack[i].allowsVarDeclarations()) {
-            i--;
-            ASSERT(i < m_scopeStack.size());
-        }
-        return m_scopeStack[i].hasDeclaredVariable(ident);
+        Scope* scope = currentScope();
+        while (!scope->allowsVarDeclarations())
+            scope = scope->containingScope();
+        return scope->hasDeclaredVariable(ident);
     }
 
     NEVER_INLINE bool hasDeclaredParameter(const Identifier& ident)
@@ -1463,30 +1416,24 @@ private:
         // https://bugs.webkit.org/show_bug.cgi?id=164087
         ASSERT(!m_lexer->isReparsingFunction());
 
-        unsigned i = m_scopeStack.size() - 1;
-        ASSERT(i < m_scopeStack.size());
-        while (!m_scopeStack[i].allowsVarDeclarations()) {
-            i--;
-            ASSERT(i < m_scopeStack.size());
-        }
+        Scope* scope = currentScope();
+        while (!scope->allowsVarDeclarations())
+            scope = scope->containingScope();
 
-        if (m_scopeStack[i].isGeneratorFunctionBoundary() || m_scopeStack[i].isAsyncFunctionBoundary()) {
+        if (scope->isGeneratorFunctionBoundary() || scope->isAsyncFunctionBoundary()) {
             // The formal parameters which need to be verified for Generators and Async Function bodies occur
             // in the outer wrapper function, so pick the outer scope here.
-            i--;
-            ASSERT(i < m_scopeStack.size());
+            scope = scope->containingScope();
         }
-        return m_scopeStack[i].hasDeclaredParameter(ident);
+        return scope->hasDeclaredParameter(ident);
     }
     
     bool exportName(const Identifier& ident)
     {
-        ASSERT(currentScope().index() == 0);
+        ASSERT(!currentScope()->containingScope());
         ASSERT(m_moduleScopeData);
         return m_moduleScopeData->exportName(ident);
     }
-
-    ScopeStack m_scopeStack;
     
     const SourceProviderCacheItem* findCachedFunctionInfo(int openBracePos) 
     {
@@ -1705,14 +1652,13 @@ private:
     bool strictMode() { return currentScope()->strictMode(); }
     bool isValidStrictMode()
     {
-        int i = m_scopeStack.size() - 1;
-        if (!m_scopeStack[i].isValidStrictMode())
+        if (!m_currentScope->isValidStrictMode())
             return false;
 
         // In the case of Generator or Async function bodies, also check the wrapper function, whose name or
         // arguments may be invalid.
-        if ((m_scopeStack[i].isGeneratorFunctionBoundary() || m_scopeStack[i].isAsyncFunctionBoundary()) && i) [[unlikely]]
-            return m_scopeStack[i - 1].isValidStrictMode();
+        if ((m_currentScope->isGeneratorFunctionBoundary() || m_currentScope->isAsyncFunctionBoundary()) && m_currentScope->containingScope()) [[unlikely]]
+            return m_currentScope->containingScope()->isValidStrictMode();
         return true;
     }
     DeclarationResultMask declareParameter(const Identifier* ident) { return currentScope()->declareParameter(ident); }
@@ -1720,34 +1666,34 @@ private:
 
     bool breakIsValid()
     {
-        ScopeRef current = currentScope();
+        Scope* current = currentScope();
         while (!current->breakIsValid()) {
-            if (!current.hasContainingScope() || current->isStaticBlockBoundary())
+            if (!current->hasContainingScope() || current->isStaticBlockBoundary())
                 return false;
-            current = current.containingScope();
+            current = current->containingScope();
         }
         return true;
     }
     bool continueIsValid()
     {
-        ScopeRef current = currentScope();
+        Scope* current = currentScope();
         while (!current->continueIsValid()) {
-            if (!current.hasContainingScope() || current->isStaticBlockBoundary())
+            if (!current->hasContainingScope() || current->isStaticBlockBoundary())
                 return false;
-            current = current.containingScope();
+            current = current->containingScope();
         }
         return true;
     }
     void pushLabel(const Identifier* label, bool isLoop) { currentScope()->pushLabel(label, isLoop); }
-    void popLabel(ScopeRef scope) { scope->popLabel(); }
+    void popLabel(Scope* scope) { scope->popLabel(); }
     ScopeLabelInfo* getLabel(const Identifier* label)
     {
-        ScopeRef current = currentScope();
+        Scope* current = currentScope();
         ScopeLabelInfo* result = nullptr;
         while (!(result = current->getLabel(label))) {
-            if (!current.hasContainingScope())
+            if (!current->hasContainingScope())
                 return nullptr;
-            current = current.containingScope();
+            current = current->containingScope();
         }
         return result;
     }
@@ -2091,33 +2037,40 @@ private:
         m_errorMessage = String();
     }
 
+    // Cache line 0 (hot)
     VM& m_vm;
-    const SourceCode* m_source;
-    ParserArena m_parserArena;
-    std::unique_ptr<LexerType> m_lexer;
-
-    ParserState m_parserState;
-    
-    bool m_hasStackOverflow;
-    String m_errorMessage;
-    JSToken m_token;
-    bool m_allowsIn;
+    Scope* m_currentScope { nullptr };
     JSTextPosition m_lastTokenEndPosition;
+    bool m_allowsIn;
+    bool m_immediateParentAllowsFunctionDeclarationInStatement;
+    SourceParseMode m_parseMode;
     int m_statementDepth;
+    JSParserScriptMode m_scriptMode;
+    const SourceCode* m_source;
     RefPtr<SourceProviderCache> m_functionCache;
+    FunctionMode m_functionMode;
+    SuperBinding m_superBinding;
+
+    // Cache line 1 (hot)
+    std::unique_ptr<LexerType> m_lexer;
+    JSToken m_token;
+
+    // Cache line 2 (m_parserState is hot)
+    ParserState m_parserState;
+
+    ConstructorKind m_constructorKindForTopLevelFunctionExpressions { ConstructorKind::None };
     ImplementationVisibility m_implementationVisibility;
     bool m_parsingBuiltin;
-    SourceParseMode m_parseMode;
-    FunctionMode m_functionMode;
-    JSParserScriptMode m_scriptMode;
-    SuperBinding m_superBinding;
-    ConstructorKind m_constructorKindForTopLevelFunctionExpressions { ConstructorKind::None };
     bool m_isEvalContext;
-    bool m_immediateParentAllowsFunctionDeclarationInStatement;
+    bool m_isInsideOrdinaryFunction;
+
+    ParserArena m_parserArena;
+    CallOrApplyDepthScope* m_callOrApplyDepthScope { nullptr };
+    ScopeStack m_scopeStack;
+    bool m_hasStackOverflow;
+    String m_errorMessage;
     RefPtr<ModuleScopeData> m_moduleScopeData;
     DebuggerParseData* m_debuggerParseData;
-    CallOrApplyDepthScope* m_callOrApplyDepthScope { nullptr };
-    bool m_isInsideOrdinaryFunction;
     bool m_seenTaggedTemplateInNonReparsingFunctionMode { false };
     bool m_seenPrivateNameUseInNonReparsingFunctionMode { false };
     bool m_seenArgumentsDotLength { false };

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -122,7 +122,7 @@ template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
 template<typename> class EnumSet;
 template<typename, typename = EmbeddedFixedVectorMalloc> class FixedVector;
-template<typename, size_t = 8, typename = SegmentedVectorMalloc> class SegmentedVector;
+template<typename, size_t = 8, size_t = 0, typename = SegmentedVectorMalloc> class SegmentedVector;
 template<typename> class Function;
 template<typename> struct FlatteningVariantTraits;
 template<typename> struct IsSmartPtr;
@@ -164,7 +164,7 @@ template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakPtr;
 template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakRef;
 
 template <typename T>
-using SaSegmentedVector = SegmentedVector<T, 8, SequesteredArenaMalloc>;
+using SaSegmentedVector = SegmentedVector<T, 8, 0, SequesteredArenaMalloc>;
 template <typename T>
 using SaFixedVector = FixedVector<T, SequesteredArenaMalloc>;
 template <typename T>

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2008, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,13 +35,13 @@ namespace WTF {
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SegmentedVector);
 
     // An iterator for SegmentedVector. It supports only the pre ++ operator
-    template <typename T, size_t SegmentSize, typename Malloc> class SegmentedVector;
-    template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
+    template <typename T, size_t SegmentSize, size_t InlineCapacity, typename Malloc> class SegmentedVector;
+    template <typename T, size_t SegmentSize = 8, size_t InlineCapacity = 0, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
         WTF_MAKE_CONFIGURABLE_ALLOCATED(FastMalloc);
     private:
-        friend class SegmentedVector<T, SegmentSize, Malloc>;
+        friend class SegmentedVector<T, SegmentSize, InlineCapacity, Malloc>;
     public:
-        typedef SegmentedVectorIterator<T, SegmentSize, Malloc> Iterator;
+        typedef SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc> Iterator;
 
         using iterator_category = std::forward_iterator_tag;
         using value_type = T;
@@ -66,7 +66,7 @@ namespace WTF {
             return m_index == other.m_index && &m_vector == &other.m_vector;
         }
 
-        SegmentedVectorIterator& operator=(const SegmentedVectorIterator<T, SegmentSize, Malloc>& other)
+        SegmentedVectorIterator& operator=(const SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc>& other)
         {
             m_vector = other.m_vector;
             m_index = other.m_index;
@@ -74,13 +74,13 @@ namespace WTF {
         }
 
     private:
-        SegmentedVectorIterator(SegmentedVector<T, SegmentSize, Malloc>& vector, size_t index)
+        SegmentedVectorIterator(SegmentedVector<T, SegmentSize, InlineCapacity, Malloc>& vector, size_t index)
             : m_vector(vector)
             , m_index(index)
         {
         }
 
-        SegmentedVector<T, SegmentSize, Malloc>& m_vector;
+        SegmentedVector<T, SegmentSize, InlineCapacity, Malloc>& m_vector;
         size_t m_index;
     };
 
@@ -88,15 +88,23 @@ namespace WTF {
     // stored in its buffer when it grows. Therefore, it is safe to keep
     // pointers into a SegmentedVector. The default tuning values are
     // optimized for segmented vectors that get large; you may want to use
-    // SegmentedVector<thingy, 1> if you don't expect a lot of entries.
-    template <typename T, size_t SegmentSize, typename Malloc>
+    // the inline storage option if you don't expect a lot of entries.
+    //
+    // When InlineCapacity > 0, the first InlineCapacity elements are stored
+    // inline within the vector object itself, avoiding heap allocation for
+    // small vectors. Additional elements are stored in heap-allocated segments
+    // of SegmentSize elements each. Vectors with inline storage are not
+    // movable, as moving would invalidate pointers to elements stored inline.
+    template <typename T, size_t SegmentSize, size_t InlineCapacity, typename Malloc>
     class SegmentedVector final {
-        friend class SegmentedVectorIterator<T, SegmentSize, Malloc>;
+        friend class SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc>;
         WTF_MAKE_NONCOPYABLE(SegmentedVector);
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SegmentedVector);
 
+        static constexpr bool hasInlineStorage = InlineCapacity > 0;
+
     public:
-        using Iterator = SegmentedVectorIterator<T, SegmentSize, Malloc>;
+        using Iterator = SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc>;
 
         using value_type = T;
         using iterator = Iterator;
@@ -108,29 +116,39 @@ namespace WTF {
             destroyAllItems();
         }
 
+        SegmentedVector(SegmentedVector&&) requires (hasInlineStorage) = delete;
+        SegmentedVector& operator=(SegmentedVector&&) requires (hasInlineStorage) = delete;
+
+        SegmentedVector(SegmentedVector&& other) requires (!hasInlineStorage)
+            : m_size(std::exchange(other.m_size, 0))
+            , m_segments(WTF::move(other.m_segments))
+        {
+        }
+
+        SegmentedVector& operator=(SegmentedVector&& other) requires (!hasInlineStorage)
+        {
+            destroyAllItems();
+            m_segments = WTF::move(other.m_segments);
+            m_size = std::exchange(other.m_size, 0);
+            return *this;
+        }
+
         size_t size() const { return m_size; }
         bool isEmpty() const { return !size(); }
 
-        T& at(size_t index) LIFETIME_BOUND
+        ALWAYS_INLINE T& at(size_t index) LIFETIME_BOUND
         {
             ASSERT_WITH_SECURITY_IMPLICATION(index < m_size);
-            return segmentFor(index)->entries()[subscriptFor(index)];
+            return *addressAt(index);
         }
 
-        const T& at(size_t index) const LIFETIME_BOUND
+        ALWAYS_INLINE const T& at(size_t index) const LIFETIME_BOUND
         {
-            return const_cast<SegmentedVector<T, SegmentSize, Malloc>*>(this)->at(index);
+            return const_cast<SegmentedVector*>(this)->at(index);
         }
 
-        T& operator[](size_t index) LIFETIME_BOUND
-        {
-            return at(index);
-        }
-
-        const T& operator[](size_t index) const LIFETIME_BOUND
-        {
-            return at(index);
-        }
+        T& operator[](size_t index) LIFETIME_BOUND { return at(index); }
+        const T& operator[](size_t index) const LIFETIME_BOUND { return at(index); }
 
         T& first() LIFETIME_BOUND
         {
@@ -142,12 +160,12 @@ namespace WTF {
             ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
             return at(0);
         }
-        T& last() LIFETIME_BOUND
+        ALWAYS_INLINE T& last() LIFETIME_BOUND
         {
             ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
             return at(size() - 1);
         }
-        const T& last() const LIFETIME_BOUND
+        ALWAYS_INLINE const T& last() const LIFETIME_BOUND
         {
             ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
             return at(size() - 1);
@@ -162,25 +180,38 @@ namespace WTF {
         }
 
         template<typename... Args>
-        void append(Args&&... args)
+        ALWAYS_INLINE T& alloc(Args&&... args)
         {
-            ++m_size;
-            if (!segmentExistsFor(m_size - 1))
-                allocateSegment();
-            new (NotNull, &last()) T(std::forward<Args>(args)...);
+            size_t newIndex = m_size++;
+            if constexpr (hasInlineStorage) {
+                if (newIndex >= InlineCapacity && !heapSegmentExistsFor(newIndex)) [[unlikely]]
+                    allocateSegment();
+            } else {
+                if (!segmentExistsFor(newIndex))
+                    allocateSegment();
+            }
+            T* ptr = addressAt(newIndex);
+            new (NotNull, ptr) T(std::forward<Args>(args)...);
+            return *ptr;
         }
 
         template<typename... Args>
-        T& alloc(Args&&... args)
+        ALWAYS_INLINE void append(Args&&... args)
         {
-            append(std::forward<Args>(args)...);
-            return last();
+            alloc(std::forward<Args>(args)...);
         }
 
-        void removeLast()
+        template<typename... Args>
+        ALWAYS_INLINE void constructAndAppend(Args&&... args)
         {
-            last().~T();
+            alloc(std::forward<Args>(args)...);
+        }
+
+        ALWAYS_INLINE void removeLast()
+        {
+            ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
             --m_size;
+            std::destroy_at(addressAt(m_size));
         }
 
         void grow(size_t size)
@@ -200,20 +231,10 @@ namespace WTF {
             m_size = 0;
         }
 
-        Iterator begin() LIFETIME_BOUND
-        {
-            return Iterator(*this, 0);
-        }
+        Iterator begin() LIFETIME_BOUND { return Iterator(*this, 0); }
+        Iterator end() LIFETIME_BOUND { return Iterator(*this, m_size); }
 
-        Iterator end() LIFETIME_BOUND
-        {
-            return Iterator(*this, m_size);
-        }
-        
-        void shrinkToFit()
-        {
-            m_segments.shrinkToFit();
-        }
+        void shrinkToFit() { m_segments.shrinkToFit(); }
 
     private:
         class Segment {
@@ -226,34 +247,82 @@ namespace WTF {
 
         using SegmentPtr = std::unique_ptr<Segment, NonDestructingDeleter<Segment, Malloc>>;
 
+        struct EmptyInlineStorage { };
+        struct alignas(T) InlineStorageData { std::byte m_data[sizeof(T) * InlineCapacity]; };
+
+// armv7 compiler doesn't recognize that m_data is aligned to sizeof(T) by InlineStorageData
+// and complains that the two reinterpret_cast()s below increase the alignment.
+IGNORE_WARNINGS_BEGIN("cast-align")
+
+        ALWAYS_INLINE T* inlineStorage() LIFETIME_BOUND
+        {
+            static_assert(hasInlineStorage);
+            return reinterpret_cast<T*>(m_inlineStorageMember.m_data);
+        }
+
+        ALWAYS_INLINE const T* inlineStorage() const LIFETIME_BOUND
+        {
+            static_assert(hasInlineStorage);
+            return reinterpret_cast<const T*>(m_inlineStorageMember.m_data);
+        }
+
+IGNORE_WARNINGS_END
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+        ALWAYS_INLINE T* addressAt(size_t index) LIFETIME_BOUND
+        {
+            if constexpr (hasInlineStorage) {
+                if (index < InlineCapacity) [[likely]]
+                    return &inlineStorage()[index];
+                size_t heapIndex = index - InlineCapacity;
+                return &m_segments[heapIndex / SegmentSize].get()->entries()[heapIndex % SegmentSize];
+            } else
+                return &m_segments[index / SegmentSize].get()->entries()[index % SegmentSize];
+        }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
         void destroyAllItems()
         {
             for (size_t i = 0; i < m_size; ++i)
-                at(i).~T();
+                std::destroy_at(addressAt(i));
         }
 
-        bool segmentExistsFor(size_t index)
+        ALWAYS_INLINE bool segmentExistsFor(size_t index)
         {
-            return index / SegmentSize < m_segments.size();
+            if constexpr (hasInlineStorage) {
+                if (index < InlineCapacity)
+                    return true;
+                return heapSegmentExistsFor(index);
+            } else
+                return index / SegmentSize < m_segments.size();
         }
 
-        Segment* segmentFor(size_t index) LIFETIME_BOUND
+        ALWAYS_INLINE bool heapSegmentExistsFor(size_t index)
         {
-            return m_segments[index / SegmentSize].get();
-        }
-
-        static size_t subscriptFor(size_t index)
-        {
-            return index % SegmentSize;
+            if constexpr (hasInlineStorage) {
+                ASSERT(index >= InlineCapacity);
+                return (index - InlineCapacity) / SegmentSize < m_segments.size();
+            } else
+                return index / SegmentSize < m_segments.size();
         }
 
         void ensureSegmentsFor(size_t size)
         {
-            size_t segmentCount = (m_size + SegmentSize - 1) / SegmentSize;
-            size_t neededSegmentCount = (size + SegmentSize - 1) / SegmentSize;
-
-            for (size_t i = segmentCount ? segmentCount - 1 : 0; i < neededSegmentCount; ++i)
-                ensureSegment(i);
+            if constexpr (hasInlineStorage) {
+                if (size <= InlineCapacity)
+                    return;
+                size_t currentSegmentCount = m_segments.size();
+                size_t requiredSegmentCount = (size - InlineCapacity + SegmentSize - 1) / SegmentSize;
+                for (size_t i = currentSegmentCount; i < requiredSegmentCount; ++i)
+                    allocateSegment();
+            } else {
+                size_t segmentCount = (m_size + SegmentSize - 1) / SegmentSize;
+                size_t requiredSegmentCount = (size + SegmentSize - 1) / SegmentSize;
+                for (size_t i = segmentCount ? segmentCount - 1 : 0; i < requiredSegmentCount; ++i)
+                    ensureSegment(i);
+            }
         }
 
         void ensureSegment(size_t segmentIndex)
@@ -270,6 +339,7 @@ namespace WTF {
         }
 
         size_t m_size { 0 };
+        NO_UNIQUE_ADDRESS std::conditional_t<hasInlineStorage, InlineStorageData, EmptyInlineStorage> m_inlineStorageMember;
         Vector<SegmentPtr, 0, CrashOnOverflow, 16, Malloc> m_segments;
     };
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -106,6 +106,7 @@ set(TestWTF_SOURCES
     Tests/WTF/SaturatedArithmeticOperations.cpp
     Tests/WTF/Scope.cpp
     Tests/WTF/ScopedLambda.cpp
+    Tests/WTF/SegmentedVector.cpp
     Tests/WTF/SentinelLinkedList.cpp
     Tests/WTF/SetForScope.cpp
     Tests/WTF/Signals.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 		7C83DF021D0A590C00FEBCF3 /* OSObjectPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBBA07619BB8A9100BBF025 /* OSObjectPtr.cpp */; };
 		7C83DF051D0A590C00FEBCF3 /* RunLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4C9ABC71B3DB1710040A987 /* RunLoop.cpp */; };
 		7C83DF121D0A590C00FEBCF3 /* ScopedLambda.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC69AA621CF77C6500C6272F /* ScopedLambda.cpp */; settings = {COMPILER_FLAGS = "-fno-elide-constructors"; }; };
+		AA00000015E61000000AAA02 /* SegmentedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA00000015E61000000AAA01 /* SegmentedVector.cpp */; };
 		7C83DF131D0A590C00FEBCF3 /* RedBlackTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC6C4CB141027E0005B7F0C /* RedBlackTree.cpp */; };
 		7C83DF141D0A590C00FEBCF3 /* Ref.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93A427AA180DA26400CD24D7 /* Ref.cpp */; };
 		7C83DF151D0A590C00FEBCF3 /* RefCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86BD19971A2DB05B006DCF0A /* RefCounter.cpp */; };
@@ -4168,6 +4169,7 @@
 		D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStyleChange.cpp; sourceTree = "<group>"; };
 		D8CE9D8A2D79ED180064D7B1 /* PageLoadEmptyURL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PageLoadEmptyURL.cpp; sourceTree = "<group>"; };
 		DC69AA621CF77C6500C6272F /* ScopedLambda.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedLambda.cpp; sourceTree = "<group>"; };
+		AA00000015E61000000AAA01 /* SegmentedVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SegmentedVector.cpp; sourceTree = "<group>"; };
 		DD403D4928EB932F009B4684 /* libbmalloc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbmalloc.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD5697FF2DC1320500050321 /* rdar150228472.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rdar150228472.swift; sourceTree = "<group>"; };
 		DDAA0E2029E63FED003ECAE2 /* libpas.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libpas.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6588,6 +6590,7 @@
 				14F3B11215E45EAB00210069 /* SaturatedArithmeticOperations.cpp */,
 				1A3524AC1D63A4FB0031729B /* Scope.cpp */,
 				DC69AA621CF77C6500C6272F /* ScopedLambda.cpp */,
+				AA00000015E61000000AAA01 /* SegmentedVector.cpp */,
 				E3FCFB7E274B70D5000E6B69 /* SentinelLinkedList.cpp */,
 				7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */,
 				0BCD85691485C98B00EA2003 /* SetForScope.cpp */,
@@ -7783,6 +7786,7 @@
 				7C83DF261D0A590C00FEBCF3 /* SaturatedArithmeticOperations.cpp in Sources */,
 				1A3524AE1D63A4FB0031729B /* Scope.cpp in Sources */,
 				7C83DF121D0A590C00FEBCF3 /* ScopedLambda.cpp in Sources */,
+				AA00000015E61000000AAA02 /* SegmentedVector.cpp in Sources */,
 				E3FCFB7F274B70D5000E6B69 /* SentinelLinkedList.cpp in Sources */,
 				7B06F95F2A377E23000DFC95 /* SequenceLockedTest.cpp in Sources */,
 				7C83DF3D1D0A590C00FEBCF3 /* SetForScope.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/SegmentedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SegmentedVector.cpp
@@ -1,0 +1,775 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/SegmentedVector.h>
+
+#include "MoveOnly.h"
+
+namespace TestWebKitAPI {
+
+struct DestructorCounter {
+    static unsigned s_destructorCount;
+    static void resetCount() { s_destructorCount = 0; }
+
+    int value;
+
+    DestructorCounter()
+        : value(0) { }
+    DestructorCounter(int v)
+        : value(v) { }
+    ~DestructorCounter() { ++s_destructorCount; }
+
+    DestructorCounter(const DestructorCounter& other)
+        : value(other.value) { }
+    DestructorCounter& operator=(const DestructorCounter& other)
+    {
+        value = other.value;
+        return *this;
+    }
+};
+
+unsigned DestructorCounter::s_destructorCount = 0;
+
+// ============================================================
+// Section 1: Heap-only mode (InlineCapacity = 0)
+// ============================================================
+
+TEST(WTF_SegmentedVector, HeapOnlyEmpty)
+{
+    SegmentedVector<int, 4> vector;
+    EXPECT_TRUE(vector.isEmpty());
+    EXPECT_EQ(0u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyAppendAndAccess)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(1);
+    vector.append(2);
+    vector.append(3);
+
+    EXPECT_FALSE(vector.isEmpty());
+    EXPECT_EQ(3u, vector.size());
+
+    EXPECT_EQ(1, vector.at(0));
+    EXPECT_EQ(2, vector.at(1));
+    EXPECT_EQ(3, vector.at(2));
+
+    EXPECT_EQ(1, vector[0]);
+    EXPECT_EQ(2, vector[1]);
+    EXPECT_EQ(3, vector[2]);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyFirstAndLast)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(10);
+    vector.append(20);
+    vector.append(30);
+
+    EXPECT_EQ(10, vector.first());
+    EXPECT_EQ(30, vector.last());
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyMultipleSegments)
+{
+    SegmentedVector<int, 4> vector;
+
+    // 12 elements = 3 segments of 4
+    for (int i = 0; i < 12; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(12u, vector.size());
+    for (int i = 0; i < 12; ++i)
+        EXPECT_EQ(i, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyPointerStability)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(100);
+    int* firstPtr = &vector[0];
+
+    // Add more elements, triggering additional segment allocations
+    for (int i = 1; i < 20; ++i)
+        vector.append(i * 100);
+
+    // Original pointer should still be valid
+    EXPECT_EQ(100, *firstPtr);
+
+    // Also verify pointers to later segments remain stable
+    int* laterPtr = &vector[10];
+    for (int i = 20; i < 40; ++i)
+        vector.append(i * 100);
+
+    EXPECT_EQ(1000, *laterPtr);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyRemoveLast)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(1);
+    vector.append(2);
+    vector.append(3);
+
+    EXPECT_EQ(3u, vector.size());
+
+    vector.removeLast();
+    EXPECT_EQ(2u, vector.size());
+    EXPECT_EQ(2, vector.last());
+
+    vector.removeLast();
+    EXPECT_EQ(1u, vector.size());
+    EXPECT_EQ(1, vector.last());
+
+    vector.removeLast();
+    EXPECT_TRUE(vector.isEmpty());
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyTakeLast)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(10);
+    vector.append(20);
+    vector.append(30);
+
+    EXPECT_EQ(30, vector.takeLast());
+    EXPECT_EQ(2u, vector.size());
+
+    EXPECT_EQ(20, vector.takeLast());
+    EXPECT_EQ(1u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyClear)
+{
+    SegmentedVector<int, 4> vector;
+
+    for (int i = 0; i < 20; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(20u, vector.size());
+
+    vector.clear();
+    EXPECT_TRUE(vector.isEmpty());
+    EXPECT_EQ(0u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyGrow)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(1);
+    vector.grow(10);
+
+    EXPECT_EQ(10u, vector.size());
+    EXPECT_EQ(1, vector[0]);
+
+    // Default-constructed elements should be 0
+    for (size_t i = 1; i < 10; ++i)
+        EXPECT_EQ(0, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyShrinkToFit)
+{
+    SegmentedVector<int, 4> vector;
+
+    for (int i = 0; i < 20; ++i)
+        vector.append(i);
+
+    vector.shrinkToFit();
+
+    EXPECT_EQ(20u, vector.size());
+    for (int i = 0; i < 20; ++i)
+        EXPECT_EQ(i, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyIterator)
+{
+    SegmentedVector<int, 4> vector;
+
+    vector.append(10);
+    vector.append(20);
+    vector.append(30);
+
+    auto it = vector.begin();
+    auto end = vector.end();
+
+    EXPECT_TRUE(it != end);
+
+    EXPECT_EQ(10, *it);
+    ++it;
+    EXPECT_EQ(20, *it);
+    ++it;
+    EXPECT_EQ(30, *it);
+    ++it;
+
+    EXPECT_TRUE(it == end);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyIteratorMultipleSegments)
+{
+    SegmentedVector<int, 4> vector;
+
+    for (int i = 0; i < 12; ++i)
+        vector.append(i * 10);
+
+    int expected = 0;
+    for (auto& value : vector) {
+        EXPECT_EQ(expected, value);
+        expected += 10;
+    }
+    EXPECT_EQ(120, expected);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyAlloc)
+{
+    SegmentedVector<int, 4> vector;
+
+    int& ref1 = vector.alloc(100);
+    EXPECT_EQ(100, ref1);
+    EXPECT_EQ(1u, vector.size());
+
+    int& ref2 = vector.alloc(200);
+    EXPECT_EQ(200, ref2);
+    EXPECT_EQ(2u, vector.size());
+
+    // References should remain valid
+    EXPECT_EQ(100, ref1);
+    EXPECT_EQ(200, ref2);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyAllocMultipleSegments)
+{
+    SegmentedVector<int, 4> vector;
+
+    int* refs[12];
+    for (int i = 0; i < 12; ++i)
+        refs[i] = &vector.alloc(i * 100);
+
+    // All references should remain valid
+    for (int i = 0; i < 12; ++i)
+        EXPECT_EQ(i * 100, *refs[i]);
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyMoveOnly)
+{
+    SegmentedVector<MoveOnly, 4> vector;
+
+    vector.append(MoveOnly(1));
+    vector.append(MoveOnly(2));
+    vector.append(MoveOnly(3));
+
+    EXPECT_EQ(1u, vector[0].value());
+    EXPECT_EQ(2u, vector[1].value());
+    EXPECT_EQ(3u, vector[2].value());
+
+    auto last = vector.takeLast();
+    EXPECT_EQ(3u, last.value());
+    EXPECT_EQ(2u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, HeapOnlyMoveOnlyMultipleSegments)
+{
+    SegmentedVector<MoveOnly, 4> vector;
+
+    for (unsigned i = 0; i < 12; ++i)
+        vector.append(MoveOnly(i));
+
+    EXPECT_EQ(12u, vector.size());
+
+    for (unsigned i = 0; i < 12; ++i)
+        EXPECT_EQ(i, vector[i].value());
+}
+
+// ============================================================
+// Section 2: Inline + Heap mode (InlineCapacity > 0)
+// ============================================================
+
+TEST(WTF_SegmentedVector, InlineEmpty)
+{
+    SegmentedVector<int, 4, 4> vector;
+    EXPECT_TRUE(vector.isEmpty());
+    EXPECT_EQ(0u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, InlineAppendAndAccess)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(1);
+    vector.append(2);
+    vector.append(3);
+
+    EXPECT_FALSE(vector.isEmpty());
+    EXPECT_EQ(3u, vector.size());
+
+    EXPECT_EQ(1, vector.at(0));
+    EXPECT_EQ(2, vector.at(1));
+    EXPECT_EQ(3, vector.at(2));
+
+    EXPECT_EQ(1, vector[0]);
+    EXPECT_EQ(2, vector[1]);
+    EXPECT_EQ(3, vector[2]);
+}
+
+TEST(WTF_SegmentedVector, InlineFirstAndLast)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(10);
+    vector.append(20);
+    vector.append(30);
+
+    EXPECT_EQ(10, vector.first());
+    EXPECT_EQ(30, vector.last());
+}
+
+TEST(WTF_SegmentedVector, InlineOnlyStorage)
+{
+    // Fill exactly to InlineCapacity — no heap allocation should occur
+    SegmentedVector<int, 4, 4> vector;
+
+    for (int i = 0; i < 4; ++i)
+        vector.append(i * 10);
+
+    EXPECT_EQ(4u, vector.size());
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(i * 10, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineToHeapTransition)
+{
+    // Add InlineCapacity+1 elements to trigger the first heap allocation
+    SegmentedVector<int, 4, 4> vector;
+
+    for (int i = 0; i < 5; ++i)
+        vector.append(i * 10);
+
+    EXPECT_EQ(5u, vector.size());
+    for (int i = 0; i < 5; ++i)
+        EXPECT_EQ(i * 10, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineHeapMultipleSegments)
+{
+    // Test that elements beyond inline storage go to heap segments
+    SegmentedVector<int, 4, 4> vector;
+
+    // 12 elements: 4 inline + 2 heap segments of 4
+    for (int i = 0; i < 12; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(12u, vector.size());
+    for (int i = 0; i < 12; ++i)
+        EXPECT_EQ(i, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlinePointerStability)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(100);
+    int* firstPtr = &vector[0];
+
+    // Add more elements, triggering heap segment allocation
+    for (int i = 1; i < 20; ++i)
+        vector.append(i * 100);
+
+    // Original pointer should still be valid
+    EXPECT_EQ(100, *firstPtr);
+
+    // Also verify pointers to heap elements remain stable
+    int* heapPtr = &vector[10];
+    for (int i = 20; i < 40; ++i)
+        vector.append(i * 100);
+
+    EXPECT_EQ(1000, *heapPtr);
+}
+
+TEST(WTF_SegmentedVector, InlinePointerStabilityAtBoundary)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    // Fill inline storage
+    for (int i = 0; i < 4; ++i)
+        vector.append(i);
+
+    // Pointer to last inline element
+    int* lastInlinePtr = &vector[3];
+
+    // Add one more element — first heap element
+    vector.append(99);
+    int* firstHeapPtr = &vector[4];
+
+    // Add more elements to grow further
+    for (int i = 5; i < 20; ++i)
+        vector.append(i);
+
+    // Both pointers should remain valid
+    EXPECT_EQ(3, *lastInlinePtr);
+    EXPECT_EQ(99, *firstHeapPtr);
+}
+
+TEST(WTF_SegmentedVector, InlineRemoveLast)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(1);
+    vector.append(2);
+    vector.append(3);
+
+    EXPECT_EQ(3u, vector.size());
+
+    vector.removeLast();
+    EXPECT_EQ(2u, vector.size());
+    EXPECT_EQ(2, vector.last());
+
+    vector.removeLast();
+    EXPECT_EQ(1u, vector.size());
+    EXPECT_EQ(1, vector.last());
+
+    vector.removeLast();
+    EXPECT_TRUE(vector.isEmpty());
+}
+
+TEST(WTF_SegmentedVector, InlineRemoveLastAcrossBoundary)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    // Fill past inline into heap
+    for (int i = 0; i < 6; ++i)
+        vector.append(i * 10);
+
+    EXPECT_EQ(6u, vector.size());
+
+    // Remove back into inline range
+    vector.removeLast(); // removes 50
+    vector.removeLast(); // removes 40
+    EXPECT_EQ(4u, vector.size());
+    EXPECT_EQ(30, vector.last());
+
+    // Remove within inline range
+    vector.removeLast(); // removes 30
+    EXPECT_EQ(3u, vector.size());
+    EXPECT_EQ(20, vector.last());
+}
+
+TEST(WTF_SegmentedVector, InlineTakeLast)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(10);
+    vector.append(20);
+    vector.append(30);
+
+    EXPECT_EQ(30, vector.takeLast());
+    EXPECT_EQ(2u, vector.size());
+
+    EXPECT_EQ(20, vector.takeLast());
+    EXPECT_EQ(1u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, InlineClear)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    for (int i = 0; i < 20; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(20u, vector.size());
+
+    vector.clear();
+    EXPECT_TRUE(vector.isEmpty());
+    EXPECT_EQ(0u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, InlineClearAndReuse)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    // Fill past inline into heap
+    for (int i = 0; i < 10; ++i)
+        vector.append(i);
+
+    vector.clear();
+    EXPECT_TRUE(vector.isEmpty());
+
+    // Re-append — should reuse inline storage
+    for (int i = 0; i < 3; ++i)
+        vector.append(i * 100);
+
+    EXPECT_EQ(3u, vector.size());
+    EXPECT_EQ(0, vector[0]);
+    EXPECT_EQ(100, vector[1]);
+    EXPECT_EQ(200, vector[2]);
+}
+
+TEST(WTF_SegmentedVector, InlineGrowWithinInline)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(42);
+    vector.grow(4); // grow to exactly InlineCapacity
+
+    EXPECT_EQ(4u, vector.size());
+    EXPECT_EQ(42, vector[0]);
+    for (size_t i = 1; i < 4; ++i)
+        EXPECT_EQ(0, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineGrowAcrossBoundary)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(42);
+    vector.append(43);
+    vector.grow(7); // from 2 (inline) to 7 (inline + heap)
+
+    EXPECT_EQ(7u, vector.size());
+    EXPECT_EQ(42, vector[0]);
+    EXPECT_EQ(43, vector[1]);
+    for (size_t i = 2; i < 7; ++i)
+        EXPECT_EQ(0, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineGrow)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.append(1);
+    vector.grow(10);
+
+    EXPECT_EQ(10u, vector.size());
+    EXPECT_EQ(1, vector[0]);
+
+    // Default-constructed elements should be 0
+    for (size_t i = 1; i < 10; ++i)
+        EXPECT_EQ(0, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineShrinkToFit)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    for (int i = 0; i < 20; ++i)
+        vector.append(i);
+
+    // shrinkToFit should not affect functionality
+    vector.shrinkToFit();
+
+    EXPECT_EQ(20u, vector.size());
+    for (int i = 0; i < 20; ++i)
+        EXPECT_EQ(i, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineIteratorInlineOnly)
+{
+    // Iterator over exactly InlineCapacity elements (no heap)
+    SegmentedVector<int, 4, 4> vector;
+
+    for (int i = 0; i < 4; ++i)
+        vector.append(i * 10);
+
+    int expected = 0;
+    for (auto& value : vector) {
+        EXPECT_EQ(expected, value);
+        expected += 10;
+    }
+    EXPECT_EQ(40, expected);
+}
+
+TEST(WTF_SegmentedVector, InlineIteratorSpanningSegments)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    for (int i = 0; i < 12; ++i)
+        vector.append(i * 10);
+
+    int expected = 0;
+    for (auto& value : vector) {
+        EXPECT_EQ(expected, value);
+        expected += 10;
+    }
+    EXPECT_EQ(120, expected);
+}
+
+TEST(WTF_SegmentedVector, InlineMoveOnly)
+{
+    SegmentedVector<MoveOnly, 4, 4> vector;
+
+    vector.append(MoveOnly(1));
+    vector.append(MoveOnly(2));
+    vector.append(MoveOnly(3));
+
+    EXPECT_EQ(1u, vector[0].value());
+    EXPECT_EQ(2u, vector[1].value());
+    EXPECT_EQ(3u, vector[2].value());
+
+    auto last = vector.takeLast();
+    EXPECT_EQ(3u, last.value());
+    EXPECT_EQ(2u, vector.size());
+}
+
+TEST(WTF_SegmentedVector, InlineMoveOnlySpanningSegments)
+{
+    SegmentedVector<MoveOnly, 4, 4> vector;
+
+    for (unsigned i = 0; i < 12; ++i)
+        vector.append(MoveOnly(i));
+
+    EXPECT_EQ(12u, vector.size());
+
+    for (unsigned i = 0; i < 12; ++i)
+        EXPECT_EQ(i, vector[i].value());
+}
+
+TEST(WTF_SegmentedVector, InlineAlloc)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    int& ref1 = vector.alloc(100);
+    EXPECT_EQ(100, ref1);
+    EXPECT_EQ(1u, vector.size());
+
+    int& ref2 = vector.alloc(200);
+    EXPECT_EQ(200, ref2);
+    EXPECT_EQ(2u, vector.size());
+
+    // References should remain valid
+    EXPECT_EQ(100, ref1);
+    EXPECT_EQ(200, ref2);
+}
+
+TEST(WTF_SegmentedVector, InlineAllocSpanningSegments)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    // Alloc elements across inline and heap segments
+    int* refs[12];
+    for (int i = 0; i < 12; ++i)
+        refs[i] = &vector.alloc(i * 100);
+
+    // All references should remain valid
+    for (int i = 0; i < 12; ++i)
+        EXPECT_EQ(i * 100, *refs[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineConstructAndAppend)
+{
+    SegmentedVector<int, 4, 4> vector;
+
+    vector.constructAndAppend(42);
+    vector.constructAndAppend(43);
+
+    EXPECT_EQ(2u, vector.size());
+    EXPECT_EQ(42, vector[0]);
+    EXPECT_EQ(43, vector[1]);
+}
+
+TEST(WTF_SegmentedVector, InlineDifferentSegmentSizes)
+{
+    // Test with different inline and heap segment sizes
+    SegmentedVector<int, 8, 2> vector;
+
+    for (int i = 0; i < 20; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(20u, vector.size());
+    for (int i = 0; i < 20; ++i)
+        EXPECT_EQ(i, vector[i]);
+}
+
+TEST(WTF_SegmentedVector, InlineLargeInlineSegment)
+{
+    // Test with larger inline segment
+    SegmentedVector<int, 4, 16> vector;
+
+    for (int i = 0; i < 32; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(32u, vector.size());
+    for (int i = 0; i < 32; ++i)
+        EXPECT_EQ(i, vector[i]);
+}
+
+// ============================================================
+// Section 3: Destructor verification
+// ============================================================
+
+TEST(WTF_SegmentedVector, DestructorCalledOnRemoveLast)
+{
+    SegmentedVector<DestructorCounter, 4> vector;
+
+    vector.append(DestructorCounter(1));
+    vector.append(DestructorCounter(2));
+    vector.append(DestructorCounter(3));
+
+    DestructorCounter::resetCount();
+
+    vector.removeLast();
+    EXPECT_EQ(1u, DestructorCounter::s_destructorCount);
+
+    vector.removeLast();
+    EXPECT_EQ(2u, DestructorCounter::s_destructorCount);
+}
+
+TEST(WTF_SegmentedVector, DestructorCalledOnClear)
+{
+    SegmentedVector<DestructorCounter, 4> vector;
+
+    vector.append(DestructorCounter(1));
+    vector.append(DestructorCounter(2));
+    vector.append(DestructorCounter(3));
+
+    DestructorCounter::resetCount();
+
+    vector.clear();
+    EXPECT_EQ(3u, DestructorCounter::s_destructorCount);
+}
+
+TEST(WTF_SegmentedVector, DestructorCalledOnDestruction)
+{
+    {
+        SegmentedVector<DestructorCounter, 4> vector;
+
+        vector.append(DestructorCounter(1));
+        vector.append(DestructorCounter(2));
+        vector.append(DestructorCounter(3));
+
+        // Reset count after construction
+        DestructorCounter::resetCount();
+    }
+
+    // Vector destructor should have destroyed all 3 elements
+    EXPECT_EQ(3u, DestructorCounter::s_destructorCount);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### c1a4f50e71dcaf12038d42507fd7ea1218d37876
<pre>
[JSC] Retire ScopeRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=309171">https://bugs.webkit.org/show_bug.cgi?id=309171</a>
<a href="https://rdar.apple.com/171728663">rdar://171728663</a>

Reviewed by Yusuke Suzuki.

This patch optimizes the Parser by getting rid of the ScopeRef class and the
scope access indirection it involves. It also makes Parser and Lexer classes
more cache-friendly by grouping hot fields together.

ScopeRef exists because Scopes are organized as a stack, implemented as a
WTF::Vector, and a Vector can move its elements as it grows. To deal with that,
scopes are accessed via ScopeRef instances. A ScopeRef holds a pointer to the
vector and an index, and looks up the referenced scope by index on each access.

WTF has a class SegmentedVector which doesn&apos;t move its elements. However, unlike
Vector, SegmentedVector does not support inline storage. Parser scope stack as
defined stores up to 10 elements inline, which avoids heap allocation in over
99% cases for JS3.

The key changes in this patch:

1. SegmentedVector is enhanced to allow inline storage. The default
   InlineCapacity is maintained at 0, and the code is structured so that the
   code paths at InlineCapacity = 0 are unchanged, which ensures the enhancement
   does not affect other users.

2. Parser is changed to use a SegmentedVector for its scope stack.
   InlineCapacity of 10 matches the old Vector inline capacity, and SegmentSize
   of 20 makes it allocate at most once in JS3 tests.

3. `ScopeRef` is deleted and all its users are changed to use direct `Scope*`s.
   In most cases, scope stack walking by decrementing the index becomes pointer
   chasing through Scope objects. There is one place where the new logic is
   materially different from the original: in the `baseIsSuper` branch of
   `Parser::parseMemberExpression()`, the original used stack index comparison
   while the new logic walks the scope chain. However, this is a rare case with
   no noticeable performance impact, while tracking indices to avoid pointer
   chasing would add cost across the board.

4. Lexer and Parser classes are aligned to a cache line boundary, and their
   fields are rearranged to keep the hot ones together.

Testing:

  - Tests are added for the SegmentedVector class, which previously had none
    (Tools/TestWebKitAPI/Tests/WTF/SegmentedVector.cpp).
  - Parser is validated by existing tests.

Canonical link: <a href="https://commits.webkit.org/308752@main">https://commits.webkit.org/308752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ffd18955d86dceedcec6e86539089e600ae01d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148318 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157001 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74a4f0a5-2e34-4c3e-9357-3d1a4240d030) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114360 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fb92264-4bd4-465d-ab43-30f6db8dd612) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea92140e-12b2-43da-8a43-5af2cce32e5e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4438 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140285 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159334 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9105 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122392 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33347 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76963 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18017 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9645 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84204 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46011 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20151 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->