### PR TITLE
MediaCapabilities.decodingInfo() incorrectly reports VP8 as not supported

### DIFF
--- a/LayoutTests/media/mediacapabilities/vp8-expected.txt
+++ b/LayoutTests/media/mediacapabilities/vp8-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VP8 is supported and not powerEfficient for file
+

--- a/LayoutTests/media/mediacapabilities/vp8.html
+++ b/LayoutTests/media/mediacapabilities/vp8.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=../../resources/testharness.js></script>
+    <script src=../../resources/testharnessreport.js></script>
+    <script type="text/javascript">
+promise_test(async (test) => {
+    const videoConfiguration = { contentType: 'video/webm; codecs="vp8"', bitrate: 800000, height: 720, width: 1280, framerate: 30 };
+    const result = await navigator.mediaCapabilities.decodingInfo({ type: 'file', video: videoConfiguration });
+    assert_true(result.supported);
+    assert_false(result.powerEfficient);
+}, "VP8 is supported and not powerEfficient for file");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
@@ -125,6 +125,19 @@ static std::optional<PlatformMediaCapabilitiesInfo> computeMediaCapabilitiesInfo
             if (!parsedInfo)
                 return std::nullopt;
             info = *parsedInfo;
+        } else if (codec.startsWith("vp8"_s) || codec.startsWith("vp08"_s)) {
+            if (!isVP8DecoderAvailable())
+                return std::nullopt;
+            auto parameters = parseVPCodecParameters(codec);
+            if (!parameters)
+                return std::nullopt;
+            if (!isVPCodecConfigurationRecordSupported(*parameters))
+                return std::nullopt;
+            if (alphaChannel || hdrSupported)
+                return std::nullopt;
+            info.supported = true;
+            info.powerEfficient = false;
+            info.smooth = isVPSoftwareDecoderSmooth(videoConfiguration);
 #endif
 #if ENABLE(AV1)
         } else if (codec.startsWith("av01"_s)) {


### PR DESCRIPTION
#### 27303fc4cbff3f041142586f948d6ac28273b438
<pre>
MediaCapabilities.decodingInfo() incorrectly reports VP8 as not supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=273536">https://bugs.webkit.org/show_bug.cgi?id=273536</a>
<a href="https://rdar.apple.com/127339546">rdar://127339546</a>

Reviewed by Jean-Yves Avenard.

The Cocoa MediaCapabilities factory in computeMediaCapabilitiesInfo() had no
handling for VP8 codec strings. The videoCodecTypeFromRFC4281Type() function
only recognized VP9 (vp09), so VP8 codec strings (vp8, vp8.0, vp08) fell
through to the final else clause and returned unsupported. This despite all
the VP8 decoder infrastructure already existing in VP9UtilitiesCocoa and
SourceBufferParserWebM.

Add a VP8 branch that recognizes VP8 codec strings, checks decoder
availability via isVP8DecoderAvailable(), validates codec parameters via
the existing isVPCodecConfigurationRecordSupported(), and reports
powerEfficient=false since VP8 is always software-decoded.

* Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp:
(WebCore::computeMediaCapabilitiesInfo):
* LayoutTests/media/mediacapabilities/vp8.html: Added.
* LayoutTests/media/mediacapabilities/vp8-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/308789@main">https://commits.webkit.org/308789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254bf1f47833dc96c7bbda264c73e889fbfbc9fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157146 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114449 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db0712fd-f145-4966-9674-dd8c05580601) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151422 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16663 "Found 1 new test failure: fast/forms/ios/select-option-removed-update.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95219 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15776 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159479 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122493 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33369 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20955 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77107 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9756 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84348 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20295 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->