### PR TITLE
Wrong text position when you click backspace on the line below the image

### DIFF
--- a/LayoutTests/editing/deleting/merge-image-and-text-expected.txt
+++ b/LayoutTests/editing/deleting/merge-image-and-text-expected.txt
@@ -1,0 +1,25 @@
+When your cursor is after a block element, hitting delete should bring the cursor (and the content following the cursor) back at the end of the block, instead of placing the text before the block.
+
+Before Deletion:
+| "\n  "
+| <div>
+|   <span>
+|     <img>
+|       src="abe.png"
+| "\n  "
+| <div>
+|   <span>
+|     id="textSpan"
+|     <#selection-caret>
+|     "text"
+| "\n"
+
+After Deletion:
+| "\n  "
+| <div>
+|   <span>
+|     <img>
+|       src="abe.png"
+|     <#selection-caret>
+|     "text"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-image-and-text.html
+++ b/LayoutTests/editing/deleting/merge-image-and-text.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<script src=../editing.js ></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<body>
+<div id="edit" contenteditable="true">
+  <div><span><img src="abe.png"></span></div>
+  <div><span id="textSpan">text</span></div>
+</div>
+<script>
+Markup.description('When your cursor is after a block element, hitting delete should bring the cursor (and the content following the cursor) back at the end of the block, instead of placing the text before the block.');
+
+var edit = document.getElementById('edit');
+edit.focus();
+
+var text = document.getElementById('textSpan');
+getSelection().collapse(text, text.childNodes.length - 1);
+Markup.dump(edit, 'Before Deletion');
+
+deleteCommand();
+Markup.dump(edit, 'After Deletion');
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1312,13 +1312,16 @@ void ReplaceSelectionCommand::doApply()
         }
 
         if (RefPtr<Node> nodeToSplitTo = nodeToSplitToAvoidPastingIntoInlineNodesWithStyle(insertionPos)) {
-            if (nodeToSplitTo->parentNode() && insertionPos.containerNode() != nodeToSplitTo->parentNode()) {
+            RefPtr parentNode = nodeToSplitTo->parentNode();
+            if (parentNode && insertionPos.containerNode() != parentNode) {
                 RefPtr splitStart { insertionPos.computeNodeAfterPosition() };
                 if (!splitStart)
                     splitStart = insertionPos.containerNode();
                 ASSERT(splitStart);
-                nodeToSplitTo = splitTreeToNode(*splitStart, *nodeToSplitTo->parentNode()).get();
-                insertionPos = positionInParentBeforeNode(nodeToSplitTo.get());
+                if (splitStart != nodeToSplitTo) {
+                    nodeToSplitTo = splitTreeToNode(*splitStart, *parentNode).get();
+                    insertionPos = positionInParentBeforeNode(nodeToSplitTo.get());
+                }
             }
         }
     }


### PR DESCRIPTION
#### d9d2a596e24f68b71b15b89129171287b9cfa419
<pre>
Wrong text position when you click backspace on the line below the image
<a href="https://bugs.webkit.org/show_bug.cgi?id=114960">https://bugs.webkit.org/show_bug.cgi?id=114960</a>
<a href="https://rdar.apple.com/171660935">rdar://171660935</a>

Reviewed by Darin Adler.

Based on earlier work by Sudarshan C P &lt;sudarshan.cp@samsung.com&gt;

When pasting, inserting, or deleting content, WebKit tries to place it outside
any inline styled ancestors of the insertion point (elements like &lt;b&gt;, &lt;font&gt;, &lt;i&gt;,
etc.) so the pasted content doesn&apos;t inadvertently inherit those styles. It does this
by splitting the ancestor tree at the insertion point.

This fix corrects a subtle failure of that logic when the cursor is positioned
immediately adjacent to a void element (an element that can&apos;t contain children, like
&lt;img&gt;, &lt;br&gt;, or &lt;input&gt;). In that situation, the split was degenerate — there was
nothing meaningful to split — but the code still updated the insertion position as if
a real split had occurred, silently moving it to the wrong place. The result was
content being inserted at an incorrect location, such as merging into the wrong
paragraph or appearing inside a styled element it should have been placed outside of.

This fix ensures that when the split would be a no-op, the insertion position is left
alone, so content ends up exactly where the user placed the cursor.

Test: editing/deleting/merge-image-and-text.html

* LayoutTests/editing/deleting/merge-image-and-text-expected.txt: Added.
* LayoutTests/editing/deleting/merge-image-and-text.html: Added.
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/308727@main">https://commits.webkit.org/308727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/851efb4f4820ae1edd138048bee8c5dd22c5795a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101566 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114212 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81430 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1dc52fe2-bd54-404a-8556-ded60207da8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94979 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/370f4721-5119-4695-a366-c5cae5275392) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15590 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159169 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2303 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122244 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122463 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33331 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76797 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9503 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84013 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->