### PR TITLE
make sure historyItem tree after BF navigation is as same as normal navigation

### DIFF
--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
@@ -65,7 +65,7 @@ window.onmessage = (event) => dispatchMessage(event.data, {
                 sendMessageToPopup("navigate-to-other");
             } else if (page2ShowCount == 2) {
                 testPassed("Page2 displayed twice.");
-                sendMessageToPopup("back2");
+                sendMessageToPopup("back");
             }
         }
     },
@@ -73,7 +73,7 @@ window.onmessage = (event) => dispatchMessage(event.data, {
         load: () => debug("Other page loaded"),
         pageshow: ({arg}) => {
             debug("Other page displayed.");
-            sendMessageToPopup("back1");
+            sendMessageToPopup("back");
         }
     },
 });

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-other.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-other.html
@@ -11,7 +11,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
-        back1: () => history.back(),
+        back: () => history.back(),
     },
 });
 

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
@@ -13,8 +13,9 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
         'navigate-to-page2': () => navigateIframeTo("back-iframe-2.html"),
+        'navigate-to-page2-cross-site-iframe': () => navigateIframeTo(crossSiteUrl("back-iframe-2.html")),
         'navigate-to-other': () => navigateTo("back-iframe-other.html"),
-        back2: () => history.back(),
+        back: () => history.back(),
     },
     page1: () => forwardMessageToOpener(event.data),
     page2: () => forwardMessageToOpener(event.data),

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has a same-site iframe with page1 loaded initially.
+Navigate iframe to cross-site page2.
+Navigate main frame to other (same-site).
+Go back. (back-iframe-popup.html with iframe showing cross-site page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,4 +1,4 @@
-Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled, including JS-driven history.back().
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -10,7 +10,9 @@ Page2 displayed first time.
 Other page loaded
 Other page displayed.
 Page2 loaded
-PASS Page2 displayed twice.
+Page2 displayed after browser back.
+Page1 loaded
+PASS Page1 displayed again after JS history.back().
 PASS successfullyParsed is true
 
 TEST COMPLETE
@@ -18,4 +20,5 @@ Open a new window with back-iframe-popup.html. It has a same-site iframe with pa
 Navigate iframe to cross-site page2.
 Navigate main frame to other (same-site).
 Go back. (back-iframe-popup.html with iframe showing cross-site page2)
-... and ensures the nested iframe content is correctly restored to page2.
+Go back again. (iframe back to same-site page1)
+Ensures nested iframe content is correctly restored via both browser back and JS history.back().

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
@@ -6,7 +6,7 @@
 <script src="/navigation/resources/navigation-utils.js"></script>
 <script>
 
-description("Nested iframe history navigation works correctly with same-site iframe when back/forward cache is disabled.");
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
 jsTestIsAsync = true;
 
 const page = "opener";
@@ -41,8 +41,8 @@ window.onmessage = (event) => dispatchMessage(event.data, {
             page1ShowCount++;
             if (page1ShowCount == 1) {
                 debug("Page1 displayed first time.");
-                sendMessageToPopup("navigate-to-page2");
-            } else if (page1ShowCount == 2) {
+                sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else {
                 testFailed("Page1 should be displayed only once.");
                 finishJSTest();
             }
@@ -83,10 +83,10 @@ window.onmessage = (event) => dispatchMessage(event.data, {
 </head>
 <body>
 <ul>
-    <li>Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.</li>
-    <li>Navigate iframe to page2.</li>
-    <li>Navigate main frame to other.</li>
-    <li>Go back. (back-iframe-popup.html with iframe showing page2)</li>
+    <li>Open a new window with back-iframe-popup.html. It has a same-site iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to cross-site page2.</li>
+    <li>Navigate main frame to other (same-site).</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
 </ul>
 <p>... and ensures the nested iframe content is correctly restored to page2.</p>
 </body>

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
@@ -6,7 +6,7 @@
 <script src="/navigation/resources/navigation-utils.js"></script>
 <script>
 
-description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled, including JS-driven history.back().");
 jsTestIsAsync = true;
 
 const page = "opener";
@@ -42,8 +42,11 @@ window.onmessage = (event) => dispatchMessage(event.data, {
             if (page1ShowCount == 1) {
                 debug("Page1 displayed first time.");
                 sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else if (page1ShowCount == 2) {
+                testPassed("Page1 displayed again after JS history.back().");
+                finishJSTest();
             } else {
-                testFailed("Page1 should be displayed only once.");
+                testFailed("Page1 displayed too many times.");
                 finishJSTest();
             }
         }
@@ -62,10 +65,10 @@ window.onmessage = (event) => dispatchMessage(event.data, {
                 debug("Page2 displayed first time.");
                 sendMessageToPopup("navigate-to-other");
             } else if (page2ShowCount == 2) {
-                testPassed("Page2 displayed twice.");
-                finishJSTest();
+                debug("Page2 displayed after browser back.");
+                sendMessageToPopup("back");
             } else {
-                testFailed("Page2 should be displayed only twice.");
+                testFailed("Page2 displayed too many times.");
                 finishJSTest();
             }
         }
@@ -87,7 +90,8 @@ window.onmessage = (event) => dispatchMessage(event.data, {
     <li>Navigate iframe to cross-site page2.</li>
     <li>Navigate main frame to other (same-site).</li>
     <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
+    <li>Go back again. (iframe back to same-site page1)</li>
 </ul>
-<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+<p>Ensures nested iframe content is correctly restored via both browser back and JS history.back().</p>
 </body>
 </html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8839,7 +8839,8 @@ UseSystemAppearance:
 
 UseUIProcessForBackForwardItemLoading:
   type: bool
-  status: unstable
+  status: testable
+  category: security
   exposed: [ WebKit ]
   humanReadableName: "Use UIProcess for Back/Forward Item Loading"
   humanReadableDescription: "Enable UIProcess-side BackForwardListFrameItem lookup for child frames during Back/Forward navigation"

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1065,6 +1065,10 @@ void EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, Completion
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void EmptyFrameLoaderClient::dispatchGoToBackForwardItem(HistoryItem&, FrameLoadType)
+{
+}
+
 void EmptyFrameLoaderClient::saveViewStateToItem(HistoryItem&)
 {
 }

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -164,6 +164,7 @@ private:
     ShouldGoToHistoryItem NODELETE shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const final;
     bool NODELETE supportsAsyncShouldGoToHistoryItem() const final;
     void NODELETE shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const final;
+    void NODELETE dispatchGoToBackForwardItem(HistoryItem&, FrameLoadType) final;
 
     void NODELETE saveViewStateToItem(HistoryItem&) final;
     bool NODELETE canCachePage() const final;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1102,6 +1102,7 @@ bool FrameLoader::loadChildHistoryItemIntoFrame(LocalFrame& childFrame)
 {
     ASSERT(isBackForwardLoadType(loadType()));
     ASSERT(!m_frame->document()->loadEventFinished());
+    ASSERT(!m_frame->page() || !m_frame->page()->settings().useUIProcessForBackForwardItemLoading());
 
     RefPtr parentItem = history().currentItem();
     if (!parentItem || !parentItem->children().size())
@@ -4666,6 +4667,15 @@ void FrameLoader::setRequestedHistoryItem(HistoryItem& item)
 
     item.setFrameID(frame->frameID());
     m_requestedHistoryItem = item;
+
+    // When UseUIProcessForBackForwardItemLoading is enabled, each child frame receives
+    // its HistoryItem individually from UIProcess. Add it to the parent's current
+    // HistoryItem so the tree structure matches what createItemTree would have produced
+    // during a normal navigation.
+    if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent())) {
+        if (RefPtr parentItem = parentFrame->loader().history().currentItem())
+            parentItem->setChildItem(Ref { item });
+    }
 }
 
 void FrameLoader::loadRequestedHistoryItem(FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -230,6 +230,7 @@ public:
     virtual ShouldGoToHistoryItem shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const = 0;
     virtual bool supportsAsyncShouldGoToHistoryItem() const = 0;
     virtual void shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const = 0;
+    virtual void dispatchGoToBackForwardItem(HistoryItem&, FrameLoadType) = 0;
 
     virtual bool shouldFallBack(const ResourceError&) const = 0;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -51,6 +51,7 @@
 #include "HistoryItem.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrameInlines.h"
+#include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "Navigation.h"
 #include "NavigationDisabler.h"
@@ -312,7 +313,12 @@ public:
             localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;
         }
-        
+
+        if (page->settings().useUIProcessForBackForwardItemLoading()) {
+            localFrame->loader().client().dispatchGoToBackForwardItem(m_historyItem, FrameLoadType::IndexedBackForward);
+            return;
+        }
+
         Ref rootFrame = localFrame->rootFrame();
         page->goToItem(rootFrame, m_historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
     }

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -204,6 +204,9 @@ public:
     void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }
     bool isEnhancedSecurityLinkForCurrentSite() const { return m_isEnhancedSecurityLinkForCurrentSite; }
 
+    WebKit::FrameState* backForwardFrameState() const { return m_backForwardFrameState.get(); }
+    void setBackForwardFrameState(RefPtr<WebKit::FrameState>&& frameState) { m_backForwardFrameState = WTF::move(frameState); }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -243,6 +246,7 @@ private:
     RefPtr<WebKit::BrowsingWarning> m_safeBrowsingWarning;
     ListHashSet<size_t> m_ongoingSafeBrowsingChecks;
     RefPtr<WebKit::FrameProcess> m_pendingSharedProcess;
+    RefPtr<WebKit::FrameState> m_backForwardFrameState;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -689,11 +689,11 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
         auto newFrameID = frameItem->frameID();
 
         if (oldFrameID && newFrameID && oldFrameID != newFrameID)
-            updateAllFrameIDs(*oldFrameID, *newFrameID);
+            updateFrameIdentifier(*oldFrameID, *newFrameID);
     }
 }
 
-void WebBackForwardList::updateAllFrameIDs(FrameIdentifier oldFrameID, FrameIdentifier newFrameID)
+void WebBackForwardList::updateFrameIdentifier(FrameIdentifier oldFrameID, FrameIdentifier newFrameID)
 {
     for (auto& entry : m_entries)
         entry->updateFrameID(oldFrameID, newFrameID);

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -98,6 +98,7 @@ public:
     void backForwardGoToItemShared(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
 
     FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
+    void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
     String loggingString();
 
@@ -110,8 +111,6 @@ private:
     const BackForwardListItemVector& entries() const { return m_entries; }
     WebBackForwardListCounts NODELETE counts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
-
-    void updateAllFrameIDs(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5613,10 +5613,49 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
     Ref preferences = m_preferences;
     if (preferences->siteIsolationEnabled() && (!frame.isMainFrame() || newProcess->coreProcessIdentifier() == frame.process().coreProcessIdentifier())) {
+        // about:blank frames should inherit the origin of the which originated navigation.
+        // If the two frames share origins, they should share the same process.
+        //
+        // From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
+        //
+        // If url matches about:blank or is about:srcdoc, then:
+        //     Set documentState's origin to initiatorOriginSnapshot.
+        //     Set documentState's about base URL to initiatorBaseURLSnapshot.
+        std::optional<SecurityOriginData> originator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo() ? std::make_optional(navigation.originatingFrameInfo()->securityOrigin) : std::nullopt;
+
+        auto shouldTreatAsContinuingLoad = navigation.currentRequestIsRedirect() ? WebCore::ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted : WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
+
+        // When a child frame's Back/Forward navigation triggers a process swap (Site Isolation),
+        // send GoToBackForwardItem so the new process performs a proper history navigation using
+        // the FrameState stored on the Navigation object.
+        if (RefPtr frameState = navigation.backForwardFrameState()) {
+            // The FrameState from the BackForwardList may contain an old frameID from a
+            // previous incarnation of this child frame. Update it to the current frameID
+            // so the new process can find the correct frame to navigate.
+            frameState->frameID = frame.frameID();
+
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: Sending GoToBackForwardItem for child frame to new process, URL=%" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
+            auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(navigation.currentRequest().url());
+            frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
+                navigationID = navigation.navigationID(),
+                frameState = WTF::move(frameState),
+                shouldTreatAsContinuingLoad,
+                lastNavigationWasAppInitiated = m_lastNavigationWasAppInitiated,
+                publicSuffix = WTF::move(publicSuffix),
+                newProcess = newProcess.copyRef(),
+                preventProcessShutdownScope = newProcess->shutdownPreventingScope()
+            ] (std::optional<PageIdentifier> pageID) mutable {
+                if (pageID)
+                    newProcess->send(Messages::WebPage::GoToBackForwardItem({ navigationID, frameState.releaseNonNull(), FrameLoadType::IndexedBackForward, shouldTreatAsContinuingLoad, std::nullopt, lastNavigationWasAppInitiated, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), *pageID);
+            });
+            return;
+        }
+
         // FIXME: Add more parameters as appropriate. <rdar://116200985>
         LoadParameters loadParameters;
         loadParameters.request = navigation.currentRequest();
-        loadParameters.shouldTreatAsContinuingLoad = navigation.currentRequestIsRedirect() ? WebCore::ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted : WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
+        loadParameters.shouldTreatAsContinuingLoad = shouldTreatAsContinuingLoad;
         loadParameters.frameIdentifier = frame.frameID();
         loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
         loadParameters.navigationID = navigation.navigationID();
@@ -5631,17 +5670,6 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
         if (navigation.isInitialFrameSrcLoad())
             frame.setIsPendingInitialHistoryItem(true);
-
-        // about:blank frames should inherit the origin of the which originated navigation.
-        // If the two frames share origins, they should share the same process.
-        //
-        // From HTML Spec: browsing the Web, section 7.4.2.2, Item 23, sub-item 5:
-        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation
-        //
-        // If url matches about:blank or is about:srcdoc, then:
-        //     Set documentState's origin to initiatorOriginSnapshot.
-        //     Set documentState's about base URL to initiatorBaseURLSnapshot.
-        std::optional<SecurityOriginData> originator = navigation.currentRequest().url().isAboutBlank() && navigation.originatingFrameInfo() ? std::make_optional(navigation.originatingFrameInfo()->securityOrigin) : std::nullopt;
 
         frame.prepareForProvisionalLoadInProcess(newProcess, navigation, browsingContextGroup, originator, [
             loadParameters = WTF::move(loadParameters),
@@ -8517,12 +8545,11 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
     }
 
-    // Wrap completionHandler to include FrameState in response.
     auto completionHandler = [
         originalCompletionHandler = WTF::move(originalCompletionHandler),
-        frameStateForBackForwardNavigation = WTF::move(frameStateForBackForwardNavigation)
+        frameStateForBackForwardNavigation
     ](PolicyDecision&& policyDecision) mutable {
-        if (frameStateForBackForwardNavigation && (policyDecision.policyAction == PolicyAction::Use))
+        if (frameStateForBackForwardNavigation && policyDecision.policyAction == PolicyAction::Use)
             policyDecision.backForwardFrameState = WTF::move(frameStateForBackForwardNavigation);
         originalCompletionHandler(WTF::move(policyDecision));
     };
@@ -8579,6 +8606,10 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         if (!navigation)
             navigation = m_navigationState->createLoadRequestNavigation(process->coreProcessIdentifier(), ResourceRequest(request), protect(backForwardList().currentItem()));
     }
+
+    // Store frameState on navigation for Site Isolation process swap.
+    if (frameStateForBackForwardNavigation && navigation)
+        navigation->setBackForwardFrameState(frameStateForBackForwardNavigation->copy());
 
     if (!checkURLReceivedFromCurrentOrPreviousWebProcess(process, request.url())) {
         WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "Ignoring request to load this main resource because it is outside the sandbox");

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2779,6 +2779,23 @@ void WebPageProxy::shouldGoToBackForwardListItemSync(BackForwardItemIdentifier i
     shouldGoToBackForwardListItem(itemID, false, WTF::move(completionHandler));
 }
 
+void WebPageProxy::goToBackForwardItemForHistoryTraversal(BackForwardItemIdentifier itemID, FrameLoadType frameLoadType)
+{
+    WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItemForHistoryTraversal:");
+
+    RefPtr item = backForwardList().itemForID(itemID);
+    if (!item)
+        return;
+
+    Ref frameItem = item->mainFrameItem();
+    if (RefPtr currentItem = backForwardList().currentItem()) {
+        if (RefPtr childItem = currentItem->navigatedFrameID() ? frameItem->childItemForFrameID(*currentItem->navigatedFrameID()) : nullptr)
+            frameItem = childItem.releaseNonNull();
+    }
+
+    goToBackForwardItem(frameItem, frameLoadType);
+}
+
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)
 {
     RefPtr protectedPageClient { pageClient() };
@@ -5633,7 +5650,10 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
             // The FrameState from the BackForwardList may contain an old frameID from a
             // previous incarnation of this child frame. Update it to the current frameID
             // so the new process can find the correct frame to navigate.
-            frameState->frameID = frame.frameID();
+            if (auto currentFrameID = frameState->frameID; currentFrameID != frame.frameID()) {
+                frameState->frameID = frame.frameID();
+                backForwardList().updateFrameIdentifier(*currentFrameID, frame.frameID());
+            }
 
             WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: Sending GoToBackForwardItem for child frame to new process, URL=%" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
             auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(navigation.currentRequest().url());

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1027,6 +1027,7 @@ public:
     void didChangeBackForwardList(WebBackForwardListItem* addedItem, Vector<Ref<WebBackForwardListItem>>&& removed);
     void shouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier, bool inBackForwardCache, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
     void shouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
+    void goToBackForwardItemForHistoryTraversal(WebCore::BackForwardItemIdentifier, WebCore::FrameLoadType);
 
     bool shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -239,6 +239,7 @@ messages -> WebPageProxy {
     # BackForward messages
     ShouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem)
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem) Synchronous
+    GoToBackForwardItemForHistoryTraversal(WebCore::BackForwardItemIdentifier itemID, enum:uint8_t WebCore::FrameLoadType frameLoadType)
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(WebKit::WebUndoStepID commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1415,6 +1415,15 @@ void WebLocalFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem& item, Co
     webPage->sendWithAsyncReply(Messages::WebPageProxy::ShouldGoToBackForwardListItem(item.itemID(), item.isInBackForwardCache()), WTF::move(completionHandler));
 }
 
+void WebLocalFrameLoaderClient::dispatchGoToBackForwardItem(HistoryItem& item, FrameLoadType frameLoadType)
+{
+    RefPtr webPage = m_frame->page();
+    if (!webPage)
+        return;
+
+    webPage->send(Messages::WebPageProxy::GoToBackForwardItemForHistoryTraversal(item.itemID(), frameLoadType));
+}
+
 bool WebLocalFrameLoaderClient::shouldFallBack(const ResourceError& error) const
 {
     static NeverDestroyed<const ResourceError> cancelledError(WebKit::cancelledError(ResourceRequest()));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -177,6 +177,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
+    void dispatchGoToBackForwardItem(WebCore::HistoryItem&, WebCore::FrameLoadType) final;
+
     void didFinishServiceWorkerPageRegistration(bool success) final;
     
     void loadStorageAccessQuirksIfNeeded() final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -163,6 +163,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
+    void dispatchGoToBackForwardItem(WebCore::HistoryItem&, WebCore::FrameLoadType) final;
+
     void loadStorageAccessQuirksIfNeeded() final { }
 
     bool shouldFallBack(const WebCore::ResourceError&) const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1121,6 +1121,16 @@ void WebFrameLoaderClient::shouldGoToHistoryItemAsync(WebCore::HistoryItem&, Com
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void WebFrameLoaderClient::dispatchGoToBackForwardItem(WebCore::HistoryItem& item, WebCore::FrameLoadType frameLoadType)
+{
+    auto* frame = core(m_webFrame.get());
+    if (!frame)
+        return;
+    Ref rootFrame = frame->rootFrame();
+    if (RefPtr page = rootFrame->page())
+        page->goToItem(rootFrame, item, frameLoadType, WebCore::ShouldTreatAsContinuingLoad::No);
+}
+
 bool WebFrameLoaderClient::shouldFallBack(const WebCore::ResourceError& error) const
 {
     // FIXME: Needs to check domain.


### PR DESCRIPTION
#### 4619bdb0c080690dc2c340edd2ef28efa30e90f1
<pre>
make sure historyItem tree after BF navigation is as same as normal navigation
</pre>
----------------------------------------------------------------------
#### 4ef2b5a24372a69e9fdd7450e94d871fce211f82
<pre>
fix history.back()
</pre>
----------------------------------------------------------------------
#### 5056755b416c4e5d5056e2600feba8d0fd36e8e0
<pre>
set the flag testable
</pre>
----------------------------------------------------------------------
#### 5feac7d76492b77151ce2f085c1ea6cd566f1af6
<pre>
[Site Isolation] Support cross-site process swap for UIProcess-driven back/forward child frame navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=309110">https://bugs.webkit.org/show_bug.cgi?id=309110</a>
<a href="https://rdar.apple.com/171032434">rdar://171032434</a>

Reviewed by NOBODY (OOPS!).

This is a follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=308562">https://bugs.webkit.org/show_bug.cgi?id=308562</a> which routed
same-site child frame back/forward navigations through UIProcess when
UseUIProcessForBackForwardItemLoading is enabled.

When a child frame&apos;s back/forward navigation requires a cross-site process swap, send
GoToBackForwardItem with the child frame&apos;s FrameState to the new process so it can perform
a proper history navigation with full state restoration (scroll position, form data,
session state, etc.) instead of a plain LoadRequest.

In decidePolicyForNavigationAction, the FrameState found for back/forward child frame
navigations is now stored on the Navigation object in addition to the PolicyDecision.
This allows continueNavigationInNewProcess to retrieve it when a process swap is needed.
The two consumers are mutually exclusive: the completionHandler sets it on PolicyDecision
for same-site navigations (PolicyAction::Use), while the Navigation object carries it for
cross-site process swaps (PolicyAction::LoadWillContinueInAnotherProcess).

Test: http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html:
* LayoutTests/http/tests/navigation/resources/back-iframe-other.html:
* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html:
* LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html: Copied from LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html.
* LayoutTests/http/tests/site-isolation/history/back-iframe-no-bf-cache.html:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::backForwardFrameState const):
(API::Navigation::setBackForwardFrameState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):

Follow <a href="https://commits.webkit.org/308729@main">308729@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4619bdb0c080690dc2c340edd2ef28efa30e90f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157078 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150267 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20985 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114401 "Found 9 new test failures: fast/dom/location-hash.html fast/history/history-scroll-restoration.html fast/loader/form-state-restore-with-frames.html http/tests/history/back-with-fragment-change.py http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/navigation/postredirect-frames-goback1.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151354 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95171 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/140361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159411 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9181 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2545 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12654 "Found 9 new test failures: fast/css/target-fragment-match.html fast/dom/location-hash.html fast/history/history-scroll-restoration.html fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/navigation/postredirect-frames-goback1.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122440 "Found 9 new test failures: fast/dom/location-hash.html fast/history/history-scroll-restoration.html fast/loader/form-state-restore-with-frames.html http/tests/history/back-with-fragment-change.py http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/navigation/postredirect-frames-goback1.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html (failure)") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17538 "Found 9 new test failures: fast/css/target-fragment-match.html fast/dom/location-hash.html fast/history/history-scroll-restoration.html fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/navigation/postredirect-frames-goback1.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122661 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9698 "Found 8 new test failures: fast/dom/location-hash.html fast/history/history-scroll-restoration.html fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/navigation/postredirect-frames-goback1.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html (failure)") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/179821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84280 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/179821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->