### PR TITLE
Unreviewed, relanding with TestWTF fix

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -486,7 +486,7 @@ protected:
     Vector<Vector<IndexType, 0, UnsafeVectorOverflow, 4>, 0, UnsafeVectorOverflow> m_adjacencyList;
     Vector<IndexType, 0, UnsafeVectorOverflow> m_degrees;
 
-    using IndexTypeSet = SmallSet<IndexType, IntHash<IndexType>>;
+    using IndexTypeSet = SmallSet<IndexType, IntHash<IndexType>, WTF::UnsignedWithZeroKeyHashTraits<IndexType>>;
 
     UncheckedKeyHashMap<IndexType, IndexTypeSet, DefaultHash<IndexType>, WTF::UnsignedWithZeroKeyHashTraits<IndexType>> m_biases;
 
@@ -499,7 +499,7 @@ protected:
     Vector<MoveOperands, 0, UnsafeVectorOverflow> m_coalescingCandidates;
 
     // List of every move instruction associated with a Tmp.
-    Vector<SmallSet<unsigned, IntHash<unsigned>>> m_moveList;
+    Vector<SmallSet<unsigned, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>> m_moveList;
 
     // Colors.
     Vector<Reg, 0, UnsafeVectorOverflow> m_coloredTmp;

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -396,7 +396,7 @@ private:
     Vector<std::unique_ptr<BasicBlock>> m_blocks;
     SparseCollection<Special> m_specials;
     std::unique_ptr<CFG> m_cfg;
-    SmallSet<Tmp, DefaultHash<Tmp>, 2> m_fastTmps;
+    SmallSet<Tmp, DefaultHash<Tmp>, HashTraits<Tmp>, 2> m_fastTmps;
     CCallSpecial* m_cCallSpecial { nullptr };
     unsigned m_numGPTmps { 0 };
     unsigned m_numFPTmps { 0 };

--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -29,6 +29,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashFunctions.h>
+#include <wtf/HashTraits.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
@@ -40,10 +41,9 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SmallSet);
 // Functionally, this class is very similar to Variant<Vector<T, SmallArraySize>, HashSet<T>>
 // It is optimized primarily for space, but is also quite fast
 // Its main limitation is that it has no way to remove elements once they have been added to it
-// Also, instead of being fully parameterized by a HashTrait parameter, it always uses -1 (all ones) as its empty value
-// Relatedly, it can only store objects of up to 64 bit size (but that particular limitation should be fairly easy to lift if needed)
+// It uses HashTraits to determine its empty value.
 // Use it whenever you need to store an unbounded but probably small number of unsigned integers or pointers.
-template<typename T, typename Hash = PtrHashBase<T, false /* isSmartPtr */>, unsigned SmallArraySize = 8>
+template<typename T, typename Hash = PtrHashBase<T, false /* isSmartPtr */>, typename Traits = HashTraits<T>, unsigned SmallArraySize = 8>
 class SmallSet {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SmallSet);
     WTF_MAKE_NONCOPYABLE(SmallSet);
@@ -101,7 +101,7 @@ public:
         {
             ++m_index;
             ASSERT(m_index <= m_buffer.size());
-            while (m_index < m_buffer.size() && m_buffer[m_index] == emptyValue())
+            while (m_index < m_buffer.size() && isEmptyBucket(m_buffer[m_index]))
                 ++m_index;
             return *this;
         }
@@ -111,7 +111,7 @@ public:
         bool operator==(const iterator& other) const { ASSERT(m_buffer.data() == other.m_buffer.data()); return m_index == other.m_index; }
 
     private:
-        template<typename U, typename H, unsigned S> friend class WTF::SmallSet;
+        template<typename U, typename H, typename TR, unsigned S> friend class WTF::SmallSet;
         unsigned m_index;
         std::span<T> m_buffer;
     };
@@ -203,11 +203,9 @@ public:
     }
 
 private:
-    constexpr static T emptyValue()
+    static bool isEmptyBucket(const T& value)
     {
-        if constexpr (std::is_pointer<T>::value)
-            return static_cast<T>(std::bit_cast<void*>(std::numeric_limits<uintptr_t>::max()));
-        return std::numeric_limits<T>::max();
+        return isHashTraitsEmptyValue<Traits>(value);
     }
 
     bool equal(const T left, const T right) const
@@ -216,14 +214,12 @@ private:
             return Hash::equal(left, right);
         if (isValidEntry(left) && isValidEntry(right))
             return Hash::equal(left, right);
-        return left == right; 
+        return left == right;
     }
 
-    bool isValidEntry(const T value) const
+    bool isValidEntry(const T& value) const
     {
-        if constexpr (Hash::safeToCompareToEmptyOrDeleted)
-            return !Hash::equal(value, emptyValue());
-        return value != emptyValue();
+        return !isEmptyBucket(value);
     }
 
     inline bool isSmall() const
@@ -235,34 +231,28 @@ private:
     {
         m_size = 0;
         m_capacity = SmallArraySize;
-        memsetSpan(std::span { m_inline.smallStorage }, -1);
+        initializeBuckets(std::span { m_inline.smallStorage });
         ASSERT(isSmall());
+    }
+
+    static void initializeBuckets(std::span<T> span)
+    {
+        if constexpr (Traits::emptyValueIsZero)
+            memsetSpan(span, 0);
+        else {
+            for (auto& entry : span)
+                entry = Traits::emptyValue();
+        }
     }
 
     inline void grow(unsigned size)
     {
-        // We memset the new buffer with -1, so for consistency emptyValue() must return something which is all 1s.
-#if !defined(NDEBUG)
-        if constexpr (std::is_pointer<T>::value)
-            ASSERT(std::bit_cast<intptr_t>(emptyValue()) == -1ll);
-        else if constexpr (sizeof(T) == 8)
-            ASSERT(std::bit_cast<int64_t>(emptyValue()) == -1ll);
-        else if constexpr (sizeof(T) == 4)
-            ASSERT(std::bit_cast<int32_t>(emptyValue()) == -1);
-        else if constexpr (sizeof(T) == 2)
-            ASSERT(std::bit_cast<int16_t>(emptyValue()) == -1);
-        else if constexpr (sizeof(T) == 1)
-            ASSERT(std::bit_cast<int8_t>(emptyValue()) == -1);
-        else
-            RELEASE_ASSERT_NOT_REACHED();
-#endif
-
         size_t allocationSize = sizeof(T) * size;
         auto oldBuffer = buffer();
 
         unsigned oldCapacity = m_capacity;
         auto newBuffer = MallocSpan<T, SmallSetMalloc>::malloc(allocationSize);
-        memsetSpan(newBuffer.mutableSpan(), -1);
+        initializeBuckets(newBuffer.mutableSpan());
         m_capacity = size;
 
         for (unsigned i = 0; i < oldCapacity; i++) {

--- a/Tools/TestWebKitAPI/Tests/WTF/SmallSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SmallSet.cpp
@@ -38,7 +38,7 @@ namespace TestWebKitAPI {
 template<typename T>
 void testSmallSetOfUnsigned(unsigned n)
 {
-    SmallSet<T, IntHash<T>> set;
+    SmallSet<T, IntHash<T>, WTF::UnsignedWithZeroKeyHashTraits<T>> set;
 
     EXPECT_TRUE(set.isEmpty());
     EXPECT_EQ(set.size(), 0u);
@@ -107,7 +107,7 @@ void testSmallSetOfPointers()
 template<typename T>
 void testVectorsOfSmallSetsOfUnsigned()
 {
-    Vector<SmallSet<T, IntHash<T>>, 2> vector;
+    Vector<SmallSet<T, IntHash<T>, WTF::UnsignedWithZeroKeyHashTraits<T>>, 2> vector;
     vector.append({ });
     vector.append({ });
 


### PR DESCRIPTION
#### 0ffb482f641c829691f82ebe6ff4a17c3d2cbf25
<pre>
Unreviewed, relanding with TestWTF fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=309200">https://bugs.webkit.org/show_bug.cgi?id=309200</a>
<a href="https://rdar.apple.com/171758273">rdar://171758273</a>

Zero is empty key, so you need to use
WTF::UnsignedWithZeroKeyHashTraits explicitly.

Test: Tools/TestWebKitAPI/Tests/WTF/SmallSet.cpp

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/WTF/wtf/SmallSet.h:
* Tools/TestWebKitAPI/Tests/WTF/SmallSet.cpp:
(TestWebKitAPI::testSmallSetOfUnsigned):
(TestWebKitAPI::testVectorsOfSmallSetsOfUnsigned):

Canonical link: <a href="https://commits.webkit.org/308679@main">https://commits.webkit.org/308679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/003741d9dc953d75958c25ea210a45fa285e4bee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156869 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114236 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95006 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13410 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4306 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140153 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159202 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8973 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2336 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76830 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9525 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179606 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20287 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45986 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->