### PR TITLE
[Site Isolation] ProcessSwap.NumberOfPrewarmedProcesses is failing

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -481,6 +481,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return count;
 }
 
+- (NSUInteger)_prewarmedProcessCountLimit
+{
+    return protect(*_processPool)->prewarmedProcessCountLimit();
+}
+
 - (size_t)_webPageContentProcessCount
 {
     auto result = _processPool->processes().size();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -140,6 +140,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 - (BOOL)_hasPrewarmedWebProcess WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (size_t)_webProcessCountIgnoringPrewarmed WK_API_AVAILABLE(macos(10.14), ios(12.0));
 - (size_t)_webProcessCountIgnoringPrewarmedAndCached WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
+- (NSUInteger)_prewarmedProcessCountLimit WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 - (size_t)_pluginProcessCount WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 - (size_t)_serviceWorkerProcessCount WK_API_AVAILABLE(macos(10.14), ios(12.0));
 - (void)_isJITDisabledInAllRemoteWorkerProcesses:(void(^)(BOOL))completionHandler;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -638,6 +638,8 @@ public:
 
     bool hasUsedSiteIsolation() const { return m_hasUsedSiteIsolation; }
 
+    unsigned prewarmedProcessCountLimit() const;
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);
@@ -651,7 +653,6 @@ private:
     void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, WebProcessProxy::IsolatedProcessType, const WebCore::Site&, const WebCore::Site& mainFrameSite, const API::Navigation&, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
 
     RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
-    unsigned prewarmedProcessCountLimit() const;
 
     void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -4133,7 +4133,7 @@ TEST(ProcessSwap, NumberOfPrewarmedProcesses)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(2u, [processPool _webProcessCount]);
+    EXPECT_EQ(1u + [processPool _prewarmedProcessCountLimit], [processPool _webProcessCount]);
     EXPECT_EQ(1u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
     EXPECT_TRUE([processPool _hasPrewarmedWebProcess]);
 
@@ -4142,8 +4142,14 @@ TEST(ProcessSwap, NumberOfPrewarmedProcesses)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_EQ(3u, [processPool _webProcessCount]);
-    EXPECT_EQ(2u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
+    EXPECT_EQ(2u + [processPool _prewarmedProcessCountLimit], [processPool _webProcessCount]);
+
+    // FIXME: The back/forward cache is currently disabled under site isolation; see rdar://161762363.
+    // With the back forward cache disabled, the web process for webkit.org will end up in the process cache.
+    if (isSiteIsolationEnabled(webView.get()))
+        EXPECT_EQ(1u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
+    else
+        EXPECT_EQ(2u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
     EXPECT_TRUE([processPool _hasPrewarmedWebProcess]);
 }
 


### PR DESCRIPTION
#### 9ad368767d989993dd463a9d4ee4dc15f9f9fce5
<pre>
[Site Isolation] ProcessSwap.NumberOfPrewarmedProcesses is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=309197">https://bugs.webkit.org/show_bug.cgi?id=309197</a>
<a href="https://rdar.apple.com/171756969">rdar://171756969</a>

Reviewed by Sihui Liu and Ryosuke Niwa.

This test enables PSON and then follows these steps:

1. Load webkit.org
2. Check that there are 2 web processes:
       - one for webkit.org
       - one prewarmed
3. Navigate to google.com
4. Check that there are 3 web processes
       - one for webkit.org
       - one for google.com
       - one prewarmed
5. Check that the webkit.org web process was put into the back/forward cache

This test fails with site isolation enabled because with site isolation on:
- The limit for the number of prewarmed web processes is 2 instead of 1
  (performance optimization made in <a href="https://commits.webkit.org/300594@main).">https://commits.webkit.org/300594@main).</a>
- The back forward cache is currently disabled
  (simply because it doesn&apos;t work yet: <a href="https://rdar.apple.com/161762363">rdar://161762363</a>).

This means that our test looks like:

1. Load webkit.org
2. There are 3 web processes:
       - one for webkit.org
       - two prewarmed
3. Navigate to google.com
4. There are 4 web processes
       - one for webkit.org
       - one for google.com
       - two prewarmed
5. Since the back forward cache is disabled, the webkit.org web process is
   put into the process cache.

Since this is correct given the behavior of site isolation, we amend the test
so that it adjusts to whatever the current limit for the number of prewarmed
web processes is (since this could change this in the future). We add a FIXME
to account for the b/f cache currently being disabled with site isolation.

So the test will now pass with site isolation on and off.

Note: The way the two prewarmed processes are created:

1. The provisional load for webkit.org begins
2. didStartProvisionalLoadForFrameShared()
   -&gt; notifyProcessPoolToPrewarm()
   -&gt; didReachGoodTimeToPrewarm()
   -&gt; prewarmProcess()
3. prewarmProcess() checks that we haven&apos;t hit the limit (currently have 0 prewarmed)
   -&gt; createNewWebProcess
4. First prewarmed process finishes launching
   -&gt; processDidFinishLaunching()
5. m_prewarmedProcesses.computeSize() (1) &lt; prewarmedProcessCountLimit() (2)
   -&gt; didReachGoodTimeToPrewarm()
   -&gt; prewarmProcess()
6. Second prewarmed process finishes launching (now we&apos;ve hit the limit).

* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _prewarmedProcessCountLimit]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, NumberOfPrewarmedProcesses)):

Canonical link: <a href="https://commits.webkit.org/308714@main">https://commits.webkit.org/308714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30fee8e02b862bf49b69e694b63f68aa144a8a4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101625 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04ab753c-25d6-4026-9c9b-f687f51fdf53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81455 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32405f41-f3a0-43fa-94e2-aa11727be593) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95030 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd85f8be-e01a-439c-b65f-d34b80d3e1da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15625 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13429 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159228 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122293 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122512 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76856 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9547 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84098 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->