### PR TITLE
Extensions with a trailing common in manifest.json don't show in Safari

### DIFF
--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -339,7 +339,7 @@ bool decodeString(std::span<const CodeUnit> data, String& output)
     return true;
 }
 
-template<typename CodeUnit>
+template<Value::ParsingMode parsingMode = Value::ParsingMode::Strict, typename CodeUnit>
 RefPtr<JSON::Value> buildValue(std::span<const CodeUnit> data, std::span<const CodeUnit>& valueTokenEnd, int depth)
 {
     if (depth > stackLimit)
@@ -384,7 +384,7 @@ RefPtr<JSON::Value> buildValue(std::span<const CodeUnit> data, std::span<const C
         data = tokenEnd;
         token = parseToken(data, tokenStart, tokenEnd);
         while (token != Token::ArrayEnd) {
-            RefPtr<JSON::Value> arrayNode = buildValue(data, tokenEnd, depth + 1);
+            RefPtr<JSON::Value> arrayNode = buildValue<parsingMode>(data, tokenEnd, depth + 1);
             if (!arrayNode)
                 return nullptr;
             array->pushValue(arrayNode.releaseNonNull());
@@ -395,8 +395,12 @@ RefPtr<JSON::Value> buildValue(std::span<const CodeUnit> data, std::span<const C
             if (token == Token::ListSeparator) {
                 data = tokenEnd;
                 token = parseToken(data, tokenStart, tokenEnd);
-                if (token == Token::ArrayEnd)
-                    return nullptr;
+                if (token == Token::ArrayEnd) {
+                    if constexpr (parsingMode != Value::ParsingMode::AllowTrailingCommas)
+                        return nullptr;
+                    else
+                        break;
+                }
             } else if (token != Token::ArrayEnd) {
                 // Unexpected value after list value. Bail out.
                 return nullptr;
@@ -425,7 +429,7 @@ RefPtr<JSON::Value> buildValue(std::span<const CodeUnit> data, std::span<const C
                 return nullptr;
             data = tokenEnd;
 
-            RefPtr<JSON::Value> value = buildValue(data, tokenEnd, depth + 1);
+            RefPtr<JSON::Value> value = buildValue<parsingMode>(data, tokenEnd, depth + 1);
             if (!value)
                 return nullptr;
             object->setValue(key, value.releaseNonNull());
@@ -437,8 +441,12 @@ RefPtr<JSON::Value> buildValue(std::span<const CodeUnit> data, std::span<const C
             if (token == Token::ListSeparator) {
                 data = tokenEnd;
                 token = parseToken(data, tokenStart, tokenEnd);
-                if (token == Token::ObjectEnd)
-                    return nullptr;
+                if (token == Token::ObjectEnd) {
+                    if constexpr (parsingMode != Value::ParsingMode::AllowTrailingCommas)
+                        return nullptr;
+                    else
+                        break;
+                }
             } else if (token != Token::ObjectEnd) {
                 // Unexpected value after last object value. Bail out.
                 return nullptr;
@@ -510,6 +518,11 @@ Ref<Value> Value::create(const String& value)
 
 RefPtr<Value> Value::parseJSON(StringView json)
 {
+    return parseJSON(json, ParsingMode::Strict);
+}
+
+RefPtr<Value> Value::parseJSON(StringView json, ParsingMode parsingMode)
+{
     auto containsNonSpace = [] (auto span) {
         if (!span.data())
             return false;
@@ -524,13 +537,19 @@ RefPtr<Value> Value::parseJSON(StringView json)
     if (json.is8Bit()) {
         auto data = json.span8();
         std::span<const Latin1Character> tokenEnd;
-        result = buildValue(data, tokenEnd, 0);
+        if (parsingMode == ParsingMode::AllowTrailingCommas)
+            result = buildValue<ParsingMode::AllowTrailingCommas>(data, tokenEnd, 0);
+        else
+            result = buildValue(data, tokenEnd, 0);
         if (containsNonSpace(tokenEnd))
             return nullptr;
     } else {
         auto data = json.span16();
         std::span<const char16_t> tokenEnd;
-        result = buildValue(data, tokenEnd, 0);
+        if (parsingMode == ParsingMode::AllowTrailingCommas)
+            result = buildValue<ParsingMode::AllowTrailingCommas>(data, tokenEnd, 0);
+        else
+            result = buildValue(data, tokenEnd, 0);
         if (containsNonSpace(tokenEnd))
             return nullptr;
     }

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -105,7 +105,10 @@ public:
     RefPtr<const Object> asObject() const;
     RefPtr<Array> asArray();
 
+    enum class ParsingMode : uint8_t { Strict, AllowTrailingCommas };
+
     static RefPtr<Value> parseJSON(StringView);
+    static RefPtr<Value> parseJSON(StringView, ParsingMode);
     static std::optional<Ref<Value>> optionalParseJSON(StringView);
 
     String toJSONString() const;

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -257,7 +257,7 @@ String WebExtension::processFileAndExtractZipArchive(const String& path)
 
 bool WebExtension::parseManifest(StringView manifestString)
 {
-    RefPtr manifestValue = JSON::Value::parseJSON(manifestString);
+    RefPtr manifestValue = JSON::Value::parseJSON(manifestString, JSON::Value::ParsingMode::AllowTrailingCommas);
     if (!manifestValue) {
         recordError(createError(Error::InvalidManifest));
         return false;

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -667,6 +667,54 @@ TEST(JSONValue, ParseJSON)
     }
 }
 
+TEST(JSONValue, ParseJSONAllowTrailingCommas)
+{
+    {
+        auto value = JSON::Value::parseJSON("[1,]"_s, JSON::Value::ParsingMode::AllowTrailingCommas);
+        EXPECT_TRUE(value);
+        auto array = value->asArray();
+        EXPECT_TRUE(array);
+        EXPECT_EQ(array->length(), 1U);
+    }
+
+    {
+        auto value = JSON::Value::parseJSON("[1, 2, 3,]"_s, JSON::Value::ParsingMode::AllowTrailingCommas);
+        EXPECT_TRUE(value);
+        auto array = value->asArray();
+        EXPECT_TRUE(array);
+        EXPECT_EQ(array->length(), 3U);
+    }
+
+    {
+        auto value = JSON::Value::parseJSON("{\"foo\": \"bar\",}"_s, JSON::Value::ParsingMode::AllowTrailingCommas);
+        EXPECT_TRUE(value);
+        auto object = value->asObject();
+        EXPECT_TRUE(object);
+        EXPECT_EQ(object->size(), 1U);
+        EXPECT_EQ(object->getString("foo"_s), "bar"_s);
+    }
+
+    {
+        auto value = JSON::Value::parseJSON("[{\"foo\":\"bar\"},{\"baz\":false},]"_s, JSON::Value::ParsingMode::AllowTrailingCommas);
+        EXPECT_TRUE(value);
+        auto array = value->asArray();
+        EXPECT_TRUE(array);
+        EXPECT_EQ(array->length(), 2U);
+    }
+
+    {
+        EXPECT_FALSE(JSON::Value::parseJSON("[1,]"_s, JSON::Value::ParsingMode::Strict));
+        EXPECT_FALSE(JSON::Value::parseJSON("{\"foo\": \"bar\",}"_s, JSON::Value::ParsingMode::Strict));
+    }
+
+    {
+        EXPECT_FALSE(JSON::Value::parseJSON("[,]"_s, JSON::Value::ParsingMode::AllowTrailingCommas));
+        EXPECT_FALSE(JSON::Value::parseJSON("{,}"_s, JSON::Value::ParsingMode::AllowTrailingCommas));
+        EXPECT_FALSE(JSON::Value::parseJSON("[1,,2]"_s, JSON::Value::ParsingMode::AllowTrailingCommas));
+        EXPECT_FALSE(JSON::Value::parseJSON("{\"foo\":bar}"_s, JSON::Value::ParsingMode::AllowTrailingCommas));
+    }
+}
+
 TEST(JSONValue, MemoryCost)
 {
     {


### PR DESCRIPTION
#### d725750b6bcdd01d5502c7385c892bb064d9ae44
<pre>
Extensions with a trailing common in manifest.json don&apos;t show in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=309203">https://bugs.webkit.org/show_bug.cgi?id=309203</a>
<a href="https://rdar.apple.com/171749937">rdar://171749937</a>

Reviewed by Timothy Hatcher.

This patch makes it so that we can optionally loosen the requirement of
no trailing commas in JSON that&apos;s parsed with the WTF JSON parser.

We need this because previously this wasn&apos;t an error when parsing
extension manifest files; however, after 550807bc4946, that was no
longer the case. To avoid breaking older extensions that were unaware
of this being invalid JSON, we shouldn&apos;t error on trailing commas when
parsing extension manifest files.

See: <a href="https://bugs.webkit.org/show_bug.cgi?id=283935">https://bugs.webkit.org/show_bug.cgi?id=283935</a> for more information
about the caused-by.

Added new tests to validate the change.

Test: Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::parseJSON):
* Source/WTF/wtf/JSONValues.h:
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::parseManifest):
* Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp:
(TestWebKitAPI::TEST(JSONValue, ParseJSONAllowTrailingCommas)):

Canonical link: <a href="https://commits.webkit.org/308935@main">https://commits.webkit.org/308935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f766fc25747cdd00aa47f8a0e55294c60353800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101755 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6053e957-c48e-41b9-ae41-f18ea1c732ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20918 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81479 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afa48ba1-3bf1-40a2-8802-40a245040a41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133189 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65edb36d-f1eb-4b60-bed0-e39ee0e2ce07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15713 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13521 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4447 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140294 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159343 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9114 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2478 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122614 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76972 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9657 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179754 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84213 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46013 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20160 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20214 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->