### PR TITLE
https://toji.github.io/webgpu-metaballs/ fails to enter immersive mode

### DIFF
--- a/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
@@ -113,15 +113,15 @@ ExceptionOr<Ref<XRGPUSubImage>> XRGPUBinding::getSubImage(XRProjectionLayer& pro
         return Exception { ExceptionCode::AbortError, "Layer setup or texture data is missing"_s };
 
     unsigned eyeIndex = eye == XREye::Right ? 1 : 0;
-    auto physicalSize = setupData->physicalSize[eyeIndex];
-    if (!physicalSize[0] || !physicalSize[1])
-        physicalSize = setupData->physicalSize[0];
+    auto actualSize = setupData->actualSize[eyeIndex];
+    if (!actualSize[0] || !actualSize[1])
+        actualSize = setupData->actualSize[0];
     auto viewport = setupData->viewports[eyeIndex];
     if (eyeIndex)
         viewport.move(-setupData->viewports[0].width(), 0);
 
     RefPtr subImage = m_backing->getViewSubImage(static_cast<WebGPU::XRProjectionLayer&>(projectionLayer.backing()));
-    return XRGPUSubImage::create(subImage.releaseNonNull(), convertToBacking(eye), WTF::move(physicalSize), WTF::move(viewport), m_device);
+    return XRGPUSubImage::create(subImage.releaseNonNull(), convertToBacking(eye), WTF::move(actualSize), WTF::move(viewport), m_device);
 }
 
 ExceptionOr<Ref<XRGPUSubImage>> XRGPUBinding::getSubImage(XRProjectionLayer& projectionLayer, WebXRFrame&, std::optional<XREye> eye)

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -364,6 +364,9 @@ struct FrameData {
     static constexpr auto LayerSetupSizeMax = std::numeric_limits<uint16_t>::max();
     struct LayerSetupData {
         std::array<std::array<uint16_t, 2>, 2> physicalSize;
+#if PLATFORM(COCOA)
+        std::array<std::array<uint16_t, 2>, 2> actualSize;
+#endif
         std::array<WebCore::IntRect, 2> viewports;
         RateMapDescription foveationRateMapDesc;
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -129,6 +129,9 @@ header: <WebCore/PlatformXR.h>
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerSetupData {
     std::array<std::array<uint16_t, 2>, 2> physicalSize;
+#if PLATFORM(COCOA)
+    std::array<std::array<uint16_t, 2>, 2> actualSize;
+#endif
     std::array<WebCore::IntRect, 2> viewports;
     PlatformXR::RateMapDescription foveationRateMapDesc;
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 5886504be45ec5bb933078d3121f9183f807b723
<pre>
<a href="https://toji.github.io/webgpu-metaballs/">https://toji.github.io/webgpu-metaballs/</a> fails to enter immersive mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=306131">https://bugs.webkit.org/show_bug.cgi?id=306131</a>
<a href="https://rdar.apple.com/168771159">rdar://168771159</a>

Reviewed by Dan Glastonbury.

The physicalSize of a texture for its VRR map is not always the
actual width and height of a MTLTexture, as we previously assumed.

Break this assumption by tracking the texture&apos;s actual sizes separately.

* Source/WebCore/Modules/webxr/XRGPUBinding.cpp:
(WebCore::XRGPUBinding::getSubImage):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:

Canonical link: <a href="https://commits.webkit.org/308743@main">https://commits.webkit.org/308743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a60ecba78dc3b8730862c70497c16feae657871

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156971 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67185f94-b011-4962-8d91-20e92b7a9fa9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114330 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/947a7fd6-a254-4155-a96c-5145b87eac30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95100 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c79015c-928b-4512-9b80-54975b03a194) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15677 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13485 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4408 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159304 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2439 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122364 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122583 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33342 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76932 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9617 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20121 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->