### PR TITLE
User's selections have the wrong anchorNode on boundaries

### DIFF
--- a/LayoutTests/editing/selection/anchor-on-boundary-expected.txt
+++ b/LayoutTests/editing/selection/anchor-on-boundary-expected.txt
@@ -1,0 +1,3 @@
+
+PASS anchor stays in inner span when extending forward from leading boundary
+

--- a/LayoutTests/editing/selection/anchor-on-boundary.html
+++ b/LayoutTests/editing/selection/anchor-on-boundary.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/assert-selection.js"></script>
+<script>
+
+selection_test(
+    '<div contenteditable> before<span>| span text </span>after</div>',
+    selection => {
+        const spanTextLength = ' span text '.length;
+        for (let i = 0; i < spanTextLength; i++)
+            selection.modify('extend', 'forward', 'character');
+    },
+    '<div contenteditable> before<span>^ span text |</span>after</div>',
+    'anchor stays in inner span when extending forward from leading boundary'
+);
+
+</script>

--- a/LayoutTests/editing/selection/extend-after-mouse-selection-expected.txt
+++ b/LayoutTests/editing/selection/extend-after-mouse-selection-expected.txt
@@ -60,10 +60,10 @@ Extending selection forward by line boundary with mac editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-focus>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-focus>bc"
 |   " "
 |   <br>
 |   "d "
@@ -117,10 +117,10 @@ Extending selection backward by one character with windows editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "d "
@@ -136,10 +136,10 @@ Extending selection forward by one character with windows editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "d "
@@ -155,10 +155,10 @@ Extending selection forward by line boundary with windows editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "d "
@@ -174,10 +174,10 @@ Extending selection backward by line boundary with windows editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "<#selection-focus>d "
@@ -212,10 +212,10 @@ Extending selection backward by one character with unix editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "d "
@@ -231,10 +231,10 @@ Extending selection forward by one character with unix editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "d "
@@ -250,10 +250,10 @@ Extending selection forward by line boundary with unix editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "d "
@@ -269,10 +269,10 @@ Extending selection backward by line boundary with unix editing behavior:
 | "\n    "
 | <span>
 |   id="test"
-|   "a <#selection-anchor>"
+|   "a "
 |   <span>
 |     id="start"
-|     "bc"
+|     "<#selection-anchor>bc"
 |   " "
 |   <br>
 |   "<#selection-focus>d "

--- a/LayoutTests/editing/style/style-3681552-fix-001-expected.txt
+++ b/LayoutTests/editing/style/style-3681552-fix-001-expected.txt
@@ -14,7 +14,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 8 of #text > SPAN > DIV > BODY > HTML > #document to 0 of #text > I > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 1 of #text > I > SPAN > DIV > BODY > HTML > #document to 1 of #text > I > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 8 of #text > SPAN > DIV > BODY > HTML > #document to 8 of #text > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 1 of #text > I > SPAN > DIV > BODY > HTML > #document to 1 of #text > I > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
 EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 1 of #text > I > SPAN > DIV > BODY > HTML > #document to 1 of #text > I > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 2 of #text > I > SPAN > DIV > BODY > HTML > #document to 2 of #text > I > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE

--- a/LayoutTests/editing/style/style-3690704-fix-expected.txt
+++ b/LayoutTests/editing/style/style-3690704-fix-expected.txt
@@ -24,7 +24,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 0 of #text > I > B > SPAN > DIV > BODY > HTML > #document to 4 of #text > B > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 0 of #text > I > B > SPAN > DIV > BODY > HTML > #document to 4 of #text > B > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 4 of #text > B > SPAN > DIV > BODY > HTML > #document to 0 of #text > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 0 of #text > I > B > SPAN > DIV > BODY > HTML > #document to 4 of #text > B > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
 here is some text

--- a/LayoutTests/platform/glib/editing/deleting/delete-ws-fixup-002-expected.txt
+++ b/LayoutTests/platform/glib/editing/deleting/delete-ws-fixup-002-expected.txt
@@ -33,7 +33,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: shouldDeleteDOMRange:range from 2 of #text > B > SPAN > DIV > BODY > HTML > #document to 4 of #text > B > SPAN > DIV > BODY > HTML > #document
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 0 of #text > B > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 7 of #text > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 7 of #text > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 7 of #text > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
 layer at (0,0) size 800x600

--- a/LayoutTests/platform/glib/editing/style/style-3681552-fix-001-expected.txt
+++ b/LayoutTests/platform/glib/editing/style/style-3681552-fix-001-expected.txt
@@ -14,7 +14,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 8 of #text > SPAN > DIV > BODY > HTML > #document to 0 of #text > I > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 1 of #text > I > SPAN > DIV > BODY > HTML > #document to 1 of #text > I > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 8 of #text > SPAN > DIV > BODY > HTML > #document to 8 of #text > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 1 of #text > I > SPAN > DIV > BODY > HTML > #document to 1 of #text > I > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
 EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 1 of #text > I > SPAN > DIV > BODY > HTML > #document to 1 of #text > I > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 2 of #text > I > SPAN > DIV > BODY > HTML > #document to 2 of #text > I > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE

--- a/LayoutTests/platform/ios/editing/deleting/delete-ws-fixup-002-expected.txt
+++ b/LayoutTests/platform/ios/editing/deleting/delete-ws-fixup-002-expected.txt
@@ -34,7 +34,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: shouldDeleteDOMRange:range from 2 of #text > B > SPAN > DIV > BODY > HTML > #document to 4 of #text > B > SPAN > DIV > BODY > HTML > #document
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 6 of #text > SPAN > DIV > BODY > HTML > #document to 0 of #text > B > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 6 of #text > SPAN > DIV > BODY > HTML > #document to 6 of #text > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 6 of #text > SPAN > DIV > BODY > HTML > #document to 6 of #text > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 6 of #text > SPAN > DIV > BODY > HTML > #document to 6 of #text > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
 layer at (0,0) size 800x600

--- a/LayoutTests/platform/mac/editing/deleting/delete-ws-fixup-002-expected.txt
+++ b/LayoutTests/platform/mac/editing/deleting/delete-ws-fixup-002-expected.txt
@@ -33,7 +33,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: shouldDeleteDOMRange:range from 2 of #text > B > SPAN > DIV > BODY > HTML > #document to 4 of #text > B > SPAN > DIV > BODY > HTML > #document
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 0 of #text > B > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 7 of #text > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 7 of #text > SPAN > DIV > BODY > HTML > #document toDOMRange:range from 7 of #text > SPAN > DIV > BODY > HTML > #document to 7 of #text > SPAN > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
 layer at (0,0) size 800x600

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1801,22 +1801,22 @@ void FrameSelection::setEnd(const VisiblePosition& position, UserTriggered trigg
 
 void FrameSelection::setBase(const VisiblePosition& position, UserTriggered userTriggered)
 {
-    setSelection(VisibleSelection(position.deepEquivalent(), m_selection.extent(), position.affinity(), Directionality::Strong), defaultSetSelectionOptions(userTriggered));
+    setSelection(VisibleSelection(position.deepEquivalent(), m_selection.focus(), position.affinity(), Directionality::Strong), defaultSetSelectionOptions(userTriggered));
 }
 
 void FrameSelection::setExtent(const VisiblePosition& position, UserTriggered userTriggered)
 {
-    setSelection(VisibleSelection(m_selection.base(), position.deepEquivalent(), position.affinity(), Directionality::Strong), defaultSetSelectionOptions(userTriggered));
+    setSelection(VisibleSelection(m_selection.anchor(), position.deepEquivalent(), position.affinity(), Directionality::Strong), defaultSetSelectionOptions(userTriggered));
 }
 
 void FrameSelection::setBase(const Position& position, Affinity affinity, UserTriggered userTriggered)
 {
-    setSelection(VisibleSelection(position, m_selection.extent(), affinity, Directionality::Strong), defaultSetSelectionOptions(userTriggered));
+    setSelection(VisibleSelection(position, m_selection.focus(), affinity, Directionality::Strong), defaultSetSelectionOptions(userTriggered));
 }
 
 void FrameSelection::setExtent(const Position& position, Affinity affinity, UserTriggered userTriggered)
 {
-    setSelection(VisibleSelection(m_selection.base(), position, affinity, Directionality::Strong), defaultSetSelectionOptions(userTriggered));
+    setSelection(VisibleSelection(m_selection.anchor(), position, affinity, Directionality::Strong), defaultSetSelectionOptions(userTriggered));
 }
 
 void CaretBase::clearCaretRect()


### PR DESCRIPTION
#### 5f26ab5d1188e9d6a5a6fa81d80aa03fc4cf93a2
<pre>
User&apos;s selections have the wrong anchorNode on boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=309205">https://bugs.webkit.org/show_bug.cgi?id=309205</a>
<a href="https://rdar.apple.com/123103456">rdar://123103456</a>

Reviewed by Ryosuke Niwa and Megan Gardner.

When setting the base for FrameSelections, we were incorrectly passing
the extent as the focus parameter. Likewise, when setting the extent,
we were incorrectly passing the base as the anchor parameter.

To fix this issue, I pass the previous anchor and focus instead, which
keeps these fields unchanged in the selection.

Test: editing/selection/anchor-on-boundary.html

* LayoutTests/editing/selection/anchor-on-boundary-expected.txt: Added.
* LayoutTests/editing/selection/anchor-on-boundary.html: Added.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setBase):
(WebCore::FrameSelection::setExtent):

Canonical link: <a href="https://commits.webkit.org/308845@main">https://commits.webkit.org/308845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4965447a59bd76a08c75e18d02bf89ef97ca32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101980 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/992df063-51f5-4727-a098-715109689c58) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114519 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81552 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7ce46fa-9596-4bdb-a236-13416a48e106) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95289 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23de46fc-10d2-439e-bf41-7cceff66b167) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15843 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13669 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4670 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159569 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122568 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77202 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9831 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84477 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20383 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20528 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->