### PR TITLE
[JSC] Record RegExp legacy properties on limit abort in Newlines split fast paths

### DIFF
--- a/JSTests/stress/regexp-split-empty-string-record-match.js
+++ b/JSTests/stress/regexp-split-empty-string-record-match.js
@@ -1,0 +1,51 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("FAIL: " + msg + " expected " + JSON.stringify(expected) + " got " + JSON.stringify(actual));
+}
+
+// When String.prototype[@@split] is called with an empty string input,
+// it performs a RegExpExec on the splitter regexp (spec step 17.a).
+// This exec must update the legacy RegExp statics (RegExp.lastMatch,
+// RegExp.input, etc.) just like any other RegExpExec call in split.
+
+// Case 1: empty-string pattern matches the empty input → result = []
+// The match succeeds at position 0 with an empty match.
+// The legacy RegExp statics should reflect this match.
+/seed/.test("hello seed world");
+shouldBe(RegExp.lastMatch, "seed", "sanity: lastMatch before split");
+shouldBe(RegExp.input, "hello seed world", "sanity: input before split");
+
+var r1 = "".split(/(?:)/);
+shouldBe(r1.length, 0, "case1: result length");
+shouldBe(RegExp.lastMatch, "", "case1: lastMatch after empty-input split (match)");
+shouldBe(RegExp.input, "", "case1: input after empty-input split (match)");
+shouldBe(RegExp.leftContext, "", "case1: leftContext after empty-input split (match)");
+shouldBe(RegExp.rightContext, "", "case1: rightContext after empty-input split (match)");
+
+// Case 2: non-matching pattern on empty input → result = [""]
+// The match fails, so the legacy RegExp statics should remain unchanged.
+/prev/.test("some prev text");
+shouldBe(RegExp.lastMatch, "prev", "sanity: lastMatch before case2");
+
+var r2 = "".split(/nonexistent/);
+shouldBe(r2.length, 1, "case2: result length");
+shouldBe(r2[0], "", "case2: result[0]");
+// performMatch records on success only; a failed match leaves statics unchanged.
+shouldBe(RegExp.lastMatch, "prev", "case2: lastMatch unchanged after failed match");
+shouldBe(RegExp.input, "some prev text", "case2: input unchanged after failed match");
+
+// Case 3: pattern with capture groups that matches empty input.
+// The statics should reflect the match including captures.
+/./.test("X");
+var r3 = "".split(/(x)?/);
+shouldBe(r3.length, 0, "case3: result length");
+shouldBe(RegExp.lastMatch, "", "case3: lastMatch");
+shouldBe(RegExp.input, "", "case3: input");
+shouldBe(RegExp.$1, "", "case3: $1 (undefined capture → empty string)");
+
+// Case 4: consistency with non-empty input — the generic path already
+// uses performMatch(), so these are reference values for comparison.
+/x/.test("xxx");
+"a".split(/(?:)/);
+shouldBe(RegExp.lastMatch, "", "case4: non-empty input lastMatch (reference)");
+shouldBe(RegExp.input, "a", "case4: non-empty input (reference)");

--- a/JSTests/stress/regexp-split-newlines-fastpath-record-match.js
+++ b/JSTests/stress/regexp-split-newlines-fastpath-record-match.js
@@ -1,0 +1,84 @@
+function shouldBe(actual, expected, name) {
+    if (actual !== expected)
+        throw new Error("FAIL " + name + ": got=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+function test() {
+    /ZZZ/.exec("xxxZZZyyy");
+    let r = "a\nb\nc".split(/\r\n?|\n/, 1);
+    shouldBe(r.length, 1, "limit=1 length");
+    shouldBe(r[0], "a", "limit=1 [0]");
+    shouldBe(RegExp.lastMatch, "\n", "limit=1 lastMatch");
+    shouldBe(RegExp.leftContext, "a", "limit=1 leftContext");
+    shouldBe(RegExp.rightContext, "b\nc", "limit=1 rightContext");
+    shouldBe(RegExp.input, "a\nb\nc", "limit=1 input");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "a\nb\nc".split(/\r\n?|\n/, 2);
+    shouldBe(r.length, 2, "limit=2 length");
+    shouldBe(r[0], "a", "limit=2 [0]");
+    shouldBe(r[1], "b", "limit=2 [1]");
+    shouldBe(RegExp.lastMatch, "\n", "limit=2 lastMatch");
+    shouldBe(RegExp.leftContext, "a\nb", "limit=2 leftContext");
+    shouldBe(RegExp.rightContext, "c", "limit=2 rightContext");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "a\r\nb\r\nc".split(/\r\n?|\n/, 1);
+    shouldBe(r.length, 1, "CRLF limit=1 length");
+    shouldBe(r[0], "a", "CRLF limit=1 [0]");
+    shouldBe(RegExp.lastMatch, "\r\n", "CRLF limit=1 lastMatch");
+    shouldBe(RegExp.leftContext, "a", "CRLF limit=1 leftContext");
+    shouldBe(RegExp.rightContext, "b\r\nc", "CRLF limit=1 rightContext");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "a\rb".split(/\r\n?|\n/, 1);
+    shouldBe(RegExp.lastMatch, "\r", "CR limit=1 lastMatch");
+    shouldBe(RegExp.rightContext, "b", "CR limit=1 rightContext");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "a\nb\nc".split(/\r\n?|\n/);
+    shouldBe(r.length, 3, "no-limit length");
+    shouldBe(RegExp.lastMatch, "\n", "no-limit lastMatch");
+    shouldBe(RegExp.leftContext, "a\nb", "no-limit leftContext");
+    shouldBe(RegExp.rightContext, "c", "no-limit rightContext");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "abc".split(/\r\n?|\n/);
+    shouldBe(r.length, 1, "no-match length");
+    shouldBe(r[0], "abc", "no-match [0]");
+    shouldBe(RegExp.lastMatch, "ZZZ", "no-match lastMatch preserved");
+    shouldBe(RegExp.input, "xxxZZZyyy", "no-match input preserved");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "abc".split(/\r\n?|\n/, 1);
+    shouldBe(r.length, 1, "no-match-limit length");
+    shouldBe(RegExp.lastMatch, "ZZZ", "no-match-limit lastMatch preserved");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "\u3042\n\u3044\n\u3046".split(/\r\n?|\n/, 2);
+    shouldBe(r.length, 2, "16bit limit=2 length");
+    shouldBe(r[0], "\u3042", "16bit limit=2 [0]");
+    shouldBe(r[1], "\u3044", "16bit limit=2 [1]");
+    shouldBe(RegExp.lastMatch, "\n", "16bit limit=2 lastMatch");
+    shouldBe(RegExp.leftContext, "\u3042\n\u3044", "16bit limit=2 leftContext");
+    shouldBe(RegExp.rightContext, "\u3046", "16bit limit=2 rightContext");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    "a\nb\nc".split(/\r\n?|\n/, 2);
+    let fastLM = RegExp.lastMatch, fastLC = RegExp.leftContext, fastRC = RegExp.rightContext;
+
+    /ZZZ/.exec("xxxZZZyyy");
+    "a\nb\nc".split(/[\n]/, 2);
+    shouldBe(fastLM, RegExp.lastMatch, "fast vs generic lastMatch");
+    shouldBe(fastLC, RegExp.leftContext, "fast vs generic leftContext");
+    shouldBe(fastRC, RegExp.rightContext, "fast vs generic rightContext");
+
+    /ZZZ/.exec("xxxZZZyyy");
+    r = "a\r\nb".split(/\n|\r\n?/, 1);
+    shouldBe(r[0], "a", "reversed [0]");
+    shouldBe(RegExp.lastMatch, "\r\n", "reversed lastMatch");
+    shouldBe(RegExp.rightContext, "b", "reversed rightContext");
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -668,7 +668,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSplitFast, (JSGlobalObject* globalObject
         // d. Return A.
         JSArray* result = constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(scope, { });
-        auto matchResult = regexp->match(globalObject, input, 0);
+        auto matchResult = globalObject->regExpGlobalData().performMatch(globalObject, regexp, inputString, input, 0);
         RETURN_IF_EXCEPTION(scope, { });
         if (!matchResult) {
             result->putDirectIndex(globalObject, 0, inputString);
@@ -694,13 +694,15 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSplitFast, (JSGlobalObject* globalObject
                 if (newlinePos.position == WTF::notFound)
                     break;
 
+                // Record before pushing so limit-abort still reports the last match (matches genericSplit behavior).
+                lastMatchResult = MatchResult(newlinePos.position, newlinePos.position + newlinePos.length);
+
                 result->putDirectIndex(globalObject, resultLength++, jsSubstringOfResolved(vm, inputString, position, newlinePos.position - position));
                 RETURN_IF_EXCEPTION(scope, AbortSplit);
 
                 if (resultLength >= limit)
                     break;
 
-                lastMatchResult = MatchResult(newlinePos.position, newlinePos.position + newlinePos.length);
                 position = newlinePos.position + newlinePos.length;
             }
             return ContinueSplit;
@@ -712,14 +714,14 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSplitFast, (JSGlobalObject* globalObject
             processSplit(input->span16());
         RETURN_IF_EXCEPTION(scope, { });
 
+        if (lastMatchResult)
+            globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, lastMatchResult, false);
+
         if (resultLength >= limit)
             return JSValue::encode(result);
 
         result->putDirectIndex(globalObject, resultLength++, jsSubstringOfResolved(vm, inputString, position, inputSize - position));
         RETURN_IF_EXCEPTION(scope, { });
-
-        if (lastMatchResult)
-            globalObject->regExpGlobalData().recordMatch(vm, globalObject, regexp, inputString, lastMatchResult, false);
 
         return JSValue::encode(result);
     }


### PR DESCRIPTION
#### 763a3ed2aee05606091572bdb525f83c49783050
<pre>
[JSC] Record RegExp legacy properties on limit abort in Newlines split fast paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=309206">https://bugs.webkit.org/show_bug.cgi?id=309206</a>

Reviewed by Yusuke Suzuki.

Two fast paths in regExpProtoFuncSplitFast skipped updating the legacy
RegExp statics (RegExp.lastMatch/leftContext/rightContext/input from
Annex B), leaving them stale from the previous match. genericSplit
records via performMatch on every iteration, and V8 also reports the
last executed match.

(1) Empty string input path

    /seed/.exec(&quot;hello seed world&quot;);
    &quot;&quot;.split(/(?:)/);
    RegExp.lastMatch;   // was &quot;seed&quot;, should be &quot;&quot;
    RegExp.input;       // was &quot;hello seed world&quot;, should be &quot;&quot;

This path called regexp-&gt;match() directly instead of performMatch().
This was the only such call site in JSC. Replace with performMatch().

(2) SpecificPattern::Newlines fast path at limit abort

    /ZZZ/.exec(&quot;xxxZZZyyy&quot;);
    &quot;a\nb\nc&quot;.split(/\r\n?|\n/, 1);
    RegExp.lastMatch;   // was &quot;ZZZ&quot;, should be &quot;\n&quot;
    RegExp.input;       // was &quot;xxxZZZyyy&quot;, should be &quot;a\nb\nc&quot;

This path uses WTF::findNextNewline directly so it must call recordMatch
manually. When the result length reaches `limit`, the existing code
broke out before updating lastMatchResult and returned before reaching
recordMatch.

Move lastMatchResult assignment before the push and the limit check,
and move recordMatch before the early return.

* JSTests/stress/regexp-split-newlines-fastpath-record-match.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/308958@main">https://commits.webkit.org/308958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54a46259d04507872d7db5125591e4f612fe0884

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102225 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81693 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13867 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5244 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140762 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159818 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9583 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122768 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122994 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33478 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77506 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18295 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10035 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180223 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84722 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46133 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->